### PR TITLE
chore: set up pkg.pr.new

### DIFF
--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -3,9 +3,10 @@ on:
   push:
     branches: [main, develop]
     tags: ["!**"]
-    paths: ["!**.md", "packages/**"]
+    paths: ["packages/**"]
   pull_request:
     types: [opened, synchronize]
+    paths: ["packages/**"]
   pull_request_review:
     types: [submitted]
 


### PR DESCRIPTION
Closes #88 
> I don't know if it actually works, I have nothing to test it on.

> Repo owner has to add the [pr.pkg.new app](https://github.com/apps/pkg-pr-new) to the repo before this works

Setup is slightly more complex than others I've seen.

Only triggered under the following conditions:
- Pushes to main, develop
- Does not rerun for tags
- Runs on PRs from collaborators, external PRs need approval to run. (is this too strict?)
- Only runs if PR affects package files (might be broken, seems to have triggered here regardless?)

