### PR TITLE
trigger playground preview after publishing to pkg.pr.new

### DIFF
--- a/.github/workflows/livecodes-preview.yml
+++ b/.github/workflows/livecodes-preview.yml
@@ -1,11 +1,18 @@
 name: livecodes
 
-on: [pull_request]
+on:
+  workflow_run:
+    workflows: ['Publish to pkg.pr.new']
+    types:
+      - completed
 
 jobs:
   build_and_prepare:
     runs-on: ubuntu-latest
-    name: Generate Playgrounds
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.jobs[1].steps['Publish'].outcome == 'success'
+    name: Generate Playground
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
As [suggested](https://github.com/trueadm/ripple/pull/116#issuecomment-3281539167), this PR changes the trigger of the preview playground in PR to run after publishing to pkg.pr.new (which currently only runs after approval)