### PR TITLE
Fix prettier formatter to not remove async keyword

### DIFF
--- a/packages/prettier-plugin-ripple/src/index.js
+++ b/packages/prettier-plugin-ripple/src/index.js
@@ -1184,6 +1184,11 @@ function printTryStatement(node, path, options, print) {
 		parts.push(path.call(print, 'finalizer'));
 	}
 
+	if (node.async) {
+		parts.push(' async ');
+		parts.push(path.call(print, 'async'));
+	}
+
 	return parts;
 }
 


### PR DESCRIPTION
This fix resolves an issue with prettier formatter, where it was removing the `async` keyword from the try block.
Issue reference: #144  