### PR TITLE
add helper TrackedObjectDeep and TrackedObjectShallow types

### DIFF
--- a/packages/ripple/types/index.d.ts
+++ b/packages/ripple/types/index.d.ts
@@ -107,3 +107,27 @@ export function on(
 	handler: EventListener,
 	options?: AddEventListenerOptions | undefined
 ): () => void;
+
+export type TrackedObjectShallow<T> = {
+  [K in keyof T]: T[K] | Tracked<T[K]>;
+};
+
+export type TrackedObjectDeep<T> =
+  T extends string | number | boolean | null | undefined | symbol | bigint
+    ? T | Tracked<T>
+    : T extends TrackedArray<infer U>
+      ? TrackedArray<U> | Tracked<TrackedArray<U>>
+    : T extends TrackedSet<infer U>
+      ? TrackedSet<U> | Tracked<TrackedSet<U>>
+    : T extends TrackedMap<infer K, infer V>
+      ? TrackedMap<K, V> | Tracked<TrackedMap<K, V>>
+    : T extends Array<infer U>
+      ? Array<TrackedObjectDeep<U>> | Tracked<Array<TrackedObjectDeep<U>>>
+    : T extends Set<infer U>
+      ? Set<TrackedObjectDeep<U>> | Tracked<Set<TrackedObjectDeep<U>>>
+    : T extends Map<infer K, infer V>
+      ? Map<TrackedObjectDeep<K>, TrackedObjectDeep<V>> |
+        Tracked<Map<TrackedObjectDeep<K>, TrackedObjectDeep<V>>>
+    : T extends object
+      ? { [K in keyof T]: TrackedObjectDeep<T[K]> | Tracked<TrackedObjectDeep<T[K]>> }
+    : T | Tracked<T>;


### PR DESCRIPTION
Adds helper types for typing shallow and deep objects.

Usage examples:

```ts
interface User {
  id: number;
  name: string;
  friends: TrackedArray<{ id: number; name: string }>;
  tags: TrackedSet<string>;
  prefs: TrackedMap<string, string | Tracked<string>>;
}

// SHALLOW
const sUser: TrackedObjectShallow<User> = {
  id: track(1),
  name: "Alice",
  friends: new TrackedArray({ id: 2, name: "Bob" }),
  tags: new TrackedSet(["admin", "beta"]),
  prefs: new TrackedMap([["theme", "dark"]]),
};

// DEEP
const dUser: TrackedObjectDeep<User> = {
  id: track(1),
  name: track("Alice"),
  friends: new TrackedArray(
    { id: 2, name: "Bob" },
    { id: 3, name: "Charlie" }
  ),
  tags: new TrackedSet(["admin", "beta"]), // can still track inside
  prefs: new TrackedMap<string, string | Tracked<string>>([
    ["theme", "dark"],
    ["layout", track("grid")],
  ]),
};
```