### PR TITLE
fix playground scroll issue

### DIFF
--- a/website/.vitepress/components/LiveCodes.vue
+++ b/website/.vitepress/components/LiveCodes.vue
@@ -366,6 +366,13 @@ const loadExample = async (example: { title: string; code: string }) => {
 	await updateUrl()
 }
 
+window.addEventListener('resize', () => {
+	if (!window.location.href.includes('playground')) return
+	// fixes the issue on mobile with landscape orientation, user scrolls down,
+	// then changes orientation to landscape and is not able to scroll back to top
+	window.scrollTo(0, 0)
+})
+
 const settingsIcon = `<svg style="height: 18px; stroke: var(--vp-c-text-1);" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg"><g id="SVGRepo_bgCarrier" stroke-width="0"></g><g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g><g id="SVGRepo_iconCarrier"><title>ionicons-v5-i</title><line x1="368" y1="128" x2="448" y2="128" style="fill:none;;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px"></line><line x1="64" y1="128" x2="304" y2="128" style="fill:none;;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px"></line><line x1="368" y1="384" x2="448" y2="384" style="fill:none;;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px"></line><line x1="64" y1="384" x2="304" y2="384" style="fill:none;;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px"></line><line x1="208" y1="256" x2="448" y2="256" style="fill:none;;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px"></line><line x1="64" y1="256" x2="144" y2="256" style="fill:none;;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px"></line><circle cx="336" cy="128" r="32" style="fill:none;;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px"></circle><circle cx="176" cy="256" r="32" style="fill:none;;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px"></circle><circle cx="336" cy="384" r="32" style="fill:none;;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px"></circle></g></svg>`
 </script>
 


### PR DESCRIPTION
The playground page fills the viewport and has `overflow: hidden` to avoid showing a scrollbar.

However, on screens with small height (e.g. on mobile with landscape orientation, or on desktop with dev tools open), scrolling is allowed to avoid hiding the lower part of the playground.

I found an issue where on mobile with landscape orientation, user scrolls down, then changes orientation to landscape and is not able to scroll back to top. This PR fixes this!
