### PR TITLE
fix: ssr await conditional logic

### DIFF
--- a/packages/ripple/tests/server/__snapshots__/compiler.test.ripple.snap
+++ b/packages/ripple/tests/server/__snapshots__/compiler.test.ripple.snap
@@ -12,3 +12,26 @@ const stringBox = makeStringBox('abc');
 const ErrorMap = (Map);
 const errorMap = new ErrorMap();"
 `;
+
+exports[`compiler success tests > compiles imported component with conditional async in SSR 1`] = `
+"import * as _$_ from 'ripple/internal/server';
+
+import { ChildComponent } from './Child.ripple';
+
+export async function App(__output) {
+	return _$_.async(async () => {
+		_$_.push_component();
+		__output.push('<div');
+		__output.push('>');
+
+		if (ChildComponent.async) {
+			await ChildComponent(__output, { message: "hello" });
+		} else {
+			ChildComponent(__output, { message: "hello" });
+		}
+
+		__output.push('</div>');
+		_$_.pop_component();
+	});
+}"
+`;

--- a/packages/ripple/tests/server/compiler.test.ripple
+++ b/packages/ripple/tests/server/compiler.test.ripple
@@ -18,4 +18,22 @@ const errorMap = new ErrorMap();`;
 
 		expect(result.js.code).toMatchSnapshot();
 	});
+
+	it('compiles imported component with conditional async in SSR', () => {
+		const source =
+`import { ChildComponent } from './Child.ripple';
+
+export component App() {
+	<div>
+		<ChildComponent message="hello" />
+	</div>
+}`;
+
+		const result = compile(source, 'test.ripple', { mode: 'server' });
+
+		// Should use if-statement instead of ternary to avoid parser issues
+		expect(result.js.code).toContain('if (ChildComponent.async)');
+		expect(result.js.code).toContain('await ChildComponent');
+		expect(result.js.code).toMatchSnapshot();
+	});
 });


### PR DESCRIPTION
### Fixed the await parsing issue in transformer. 
Changed from using a ternary conditional expression with await (which confused Rollup's parser) to using an if-statement.