### PR TITLE
docs(LSP): add information about the language server for IntelliJ and Sublime Text

### DIFF
--- a/website/docs/quick-start.md
+++ b/website/docs/quick-start.md
@@ -26,7 +26,7 @@ npm run dev // [!=npm auto]
 
 ## Editor Integration
 
-### VSCode Extension
+### VS Code
 Ripple maintains a Volar-based [VSCode extension](https://marketplace.visualstudio.com/items?itemName=ripplejs.ripple-vscode-plugin).
 
 It provides syntax highlighting for `.ripple` files, real-time diagnostics for
@@ -34,9 +34,54 @@ compilation errors, typescript integration for type checking and autocompletion.
 
 If you're using a fork of VSCode, the extension is also available on [OpenVSX](https://open-vsx.org/extension/ripplejs/ripple-vscode-plugin).
 
-::: info Are you a Zed, NeoVim, or IntelliJ/WebStorm user?
-Help us port the Ripple extension to your platforms!
-:::
+### WebStorm/IntelliJ
+There isn't a dedicated plugin at the moment, but you can use the [TextMate bundle](#textmate-bundle)
+to add syntax highlighting and the language server for diagnostics and autocompletion:
+
+1. Install the Ripple language server:
+```sh
+npm install -g ripple-language-server // [!=npm auto]
+```
+2. Install the [LSP4IJ plugin](https://plugins.jetbrains.com/plugin/23257-lsp4ij).
+3. Go to `Settings` > `Languages & Frameworks` > `Language Servers`.
+4. Click `+` to add a new language server.
+5. Specify `Ripple` as the name and `ripple-language-server --stdio` as the command.
+6. In the `Mappings` > `File name patterns`, click `+` to add a new pattern.
+7. Specify `*.ripple` as the pattern and `ripple` as the language id.
+
+You should see diagnostics and autocompletion in `.ripple` files now.
+
+### Sublime Text
+There isn't a dedicated plugin at the moment, but you can use the [TextMate bundle](#textmate-bundle)
+to add syntax highlighting and the language server for diagnostics and autocompletion:
+
+1. Install the Ripple language server:
+```sh
+npm install -g ripple-language-server // [!=npm auto]
+```
+2. Press <kbd>Ctrl/Cmd+Shift+P</kbd>, type `Install Package Control`, and press <kbd>Enter</kbd>.
+4. Restart Sublime Text.
+5. Press <kbd>Ctrl/Cmd+Shift+P</kbd>, type `Upgrade Package`, and press <kbd>Enter</kbd>.
+6. Type `Package Control` and press <kbd>Enter</kbd>.
+7. Restart Sublime Text.
+5. Press <kbd>Ctrl/Cmd+Shift+P</kbd>, type `Install Package`, and press <kbd>Enter</kbd>.
+6. Type `LSP` and press <kbd>Enter</kbd>.
+7. Restart Sublime Text.
+8. Press <kbd>Ctrl/Cmd+Shift+P</kbd>, type `Preferences: LSP Settings`, and press <kbd>Enter</kbd>.
+9. Paste the following configuration:
+```json
+{
+	"clients": {
+		"Ripple": {
+			"enabled": true,
+			"command": ["ripple-language-server", "--stdio"],
+			"selector": "source.ripple"
+		}
+	}
+}
+```
+
+You should see diagnostics and autocompletion in `.ripple` files now.
 
 ### TextMate bundle
 Ripple also maintains a TextMate bundle that provides syntax highlighting for
@@ -58,6 +103,10 @@ and Sublime Text.
 	* **Sublime Text**:
 		1. Go to `Preferences` > `Browse Packages`, and move the `Ripple.tmbundle` directory into the opened folder.
 		2. You should now be able to select `Ripple` in `View` > `Syntax`.
+
+::: info Are you a Zed, NeoVim, or IntelliJ/WebStorm user?
+Help us port the Ripple extension to your platforms!
+:::
 
 ## Getting Help
 


### PR DESCRIPTION
Follow up to #423. Added instructions on using the language server in IntelliJ/WebStorm and Sublime Text. It's also possible to do in NeoVim, but I'm not sure how to do it properly, and also it doesn't make sense to me until we can get syntax highlighting in NeoVim.