### PR TITLE
test: add tests for parts of `ripple/src/utils`

### DIFF
--- a/packages/ripple/tests/utils/escaping.test.js
+++ b/packages/ripple/tests/utils/escaping.test.js
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import { escape } from '../../src/utils/escaping.js';
+
+describe('escape utility', () => {
+	describe('content escaping (is_attr = false)', () => {
+		it('should escape & to &amp;', () => {
+			expect(escape('foo & bar', false)).toBe('foo &amp; bar');
+		});
+
+		it('should escape < to &lt;', () => {
+			expect(escape('foo < bar', false)).toBe('foo &lt; bar');
+		});
+
+		it('should escape multiple special characters', () => {
+			expect(escape('a & b < c', false)).toBe('a &amp; b &lt; c');
+		});
+
+		it('should not escape double quotes in content', () => {
+			expect(escape('foo "bar" baz', false)).toBe('foo "bar" baz');
+		});
+
+		it('should handle empty string', () => {
+			expect(escape('', false)).toBe('');
+		});
+
+		it('should handle string with no special characters', () => {
+			expect(escape('hello world', false)).toBe('hello world');
+		});
+
+		it('should handle null values', () => {
+			expect(escape(null, false)).toBe('');
+		});
+
+		it('should handle undefined values', () => {
+			expect(escape(undefined, false)).toBe('');
+		});
+
+		it('should handle numbers', () => {
+			expect(escape(123, false)).toBe('123');
+		});
+
+		it('should escape consecutive special characters', () => {
+			expect(escape('&&<<', false)).toBe('&amp;&amp;&lt;&lt;');
+		});
+
+		it('should handle special characters at start', () => {
+			expect(escape('&hello', false)).toBe('&amp;hello');
+		});
+
+		it('should handle special characters at end', () => {
+			expect(escape('hello<', false)).toBe('hello&lt;');
+		});
+	});
+
+	describe('attribute escaping (is_attr = true)', () => {
+		it('should escape & to &amp;', () => {
+			expect(escape('foo & bar', true)).toBe('foo &amp; bar');
+		});
+
+		it('should escape < to &lt;', () => {
+			expect(escape('foo < bar', true)).toBe('foo &lt; bar');
+		});
+
+		it('should escape " to &quot;', () => {
+			expect(escape('foo "bar" baz', true)).toBe('foo &quot;bar&quot; baz');
+		});
+
+		it('should escape all three special characters', () => {
+			expect(escape('a & b < c "d"', true)).toBe('a &amp; b &lt; c &quot;d&quot;');
+		});
+
+		it('should handle empty string', () => {
+			expect(escape('', true)).toBe('');
+		});
+
+		it('should handle string with no special characters', () => {
+			expect(escape('hello world', true)).toBe('hello world');
+		});
+
+		it('should handle null values', () => {
+			expect(escape(null, true)).toBe('');
+		});
+
+		it('should handle undefined values', () => {
+			expect(escape(undefined, true)).toBe('');
+		});
+
+		it('should escape consecutive quotes', () => {
+			expect(escape('"""', true)).toBe('&quot;&quot;&quot;');
+		});
+
+		it('should handle mixed escaping', () => {
+			expect(escape('<div class="foo & bar">', true)).toBe('&lt;div class=&quot;foo &amp; bar&quot;>');
+		});
+	});
+
+	describe('default parameter behavior', () => {
+		it('should default to content escaping when is_attr is undefined', () => {
+			expect(escape('foo "bar"')).toBe('foo "bar"');
+		});
+	});
+});

--- a/packages/ripple/tests/utils/events.test.js
+++ b/packages/ripple/tests/utils/events.test.js
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest';
+import {
+	is_delegated,
+	is_event_attribute,
+	is_capture_event,
+	get_attribute_event_name,
+	is_passive_event
+} from '../../src/utils/events.js';
+
+describe('events utility', () => {
+	describe('is_delegated', () => {
+		it('should return true for delegated events', () => {
+			expect(is_delegated('click')).toBe(true);
+			expect(is_delegated('input')).toBe(true);
+			expect(is_delegated('change')).toBe(true);
+			expect(is_delegated('mousedown')).toBe(true);
+			expect(is_delegated('keydown')).toBe(true);
+			expect(is_delegated('pointerdown')).toBe(true);
+			expect(is_delegated('touchstart')).toBe(true);
+			expect(is_delegated('focusin')).toBe(true);
+			expect(is_delegated('focusout')).toBe(true);
+		});
+
+		it('should return false for non-delegated events', () => {
+			expect(is_delegated('focus')).toBe(false);
+			expect(is_delegated('blur')).toBe(false);
+			expect(is_delegated('scroll')).toBe(false);
+			expect(is_delegated('load')).toBe(false);
+			expect(is_delegated('resize')).toBe(false);
+		});
+
+		it('should be case-sensitive', () => {
+			expect(is_delegated('Click')).toBe(false);
+			expect(is_delegated('CLICK')).toBe(false);
+		});
+	});
+
+	describe('is_event_attribute', () => {
+		it('should return true for valid event attributes', () => {
+			expect(is_event_attribute('onClick')).toBe(true);
+			expect(is_event_attribute('onInput')).toBe(true);
+			expect(is_event_attribute('onChange')).toBe(true);
+			expect(is_event_attribute('onMouseDown')).toBe(true);
+			expect(is_event_attribute('onKeyPress')).toBe(true);
+			expect(is_event_attribute('on-click')).toBe(true);
+			expect(is_event_attribute('on_click')).toBe(true);
+			expect(is_event_attribute('on$click')).toBe(true);
+			expect(is_event_attribute('on$')).toBe(true);
+			expect(is_event_attribute('on-')).toBe(true);
+			expect(is_event_attribute('on_')).toBe(true);
+			expect(is_event_attribute('on1')).toBe(true);
+			expect(is_event_attribute('on1click')).toBe(true);
+		});
+
+		it('should return false for non-event attributes', () => {
+			expect(is_event_attribute('on')).toBe(false);
+			expect(is_event_attribute('onclick')).toBe(false);
+			expect(is_event_attribute('class')).toBe(false);
+			expect(is_event_attribute('id')).toBe(false);
+			expect(is_event_attribute('value')).toBe(false);
+			expect(is_event_attribute('aria-label')).toBe(false);
+		});
+
+		it('should require uppercase third character', () => {
+			expect(is_event_attribute('onabc')).toBe(false);
+			expect(is_event_attribute('onAbc')).toBe(true);
+		});
+
+		it('should require at least 3 characters', () => {
+			expect(is_event_attribute('onA')).toBe(true);
+			expect(is_event_attribute('on')).toBe(false);
+			expect(is_event_attribute('o')).toBe(false);
+			expect(is_event_attribute('')).toBe(false);
+		});
+	});
+
+	describe('is_capture_event', () => {
+		it('should return true for capture events', () => {
+			expect(is_capture_event('clickCapture')).toBe(true);
+			expect(is_capture_event('mousedownCapture')).toBe(true);
+			expect(is_capture_event('keydownCapture')).toBe(true);
+		});
+
+		it('should return false for non-capture events', () => {
+			expect(is_capture_event('click')).toBe(false);
+			expect(is_capture_event('mousedown')).toBe(false);
+			expect(is_capture_event('mousedown')).toBe(false);
+		});
+
+		it('should exclude gotpointercapture and lostpointercapture', () => {
+			expect(is_capture_event('gotpointercapture')).toBe(false);
+			expect(is_capture_event('lostpointercapture')).toBe(false);
+			expect(is_capture_event('gotPointerCapture')).toBe(false);
+			expect(is_capture_event('lostPointerCapture')).toBe(false);
+		});
+
+		it('should be case-insensitive for pointer capture events', () => {
+			expect(is_capture_event('GOTPOINTERCAPTURE')).toBe(false);
+			expect(is_capture_event('LOSTPOINTERCAPTURE')).toBe(false);
+		});
+
+		it('should be case-sensitive for other events', () => {
+			expect(is_capture_event('clickCapture')).toBe(true);
+			expect(is_capture_event('keypressCapture')).toBe(true);
+			expect(is_capture_event('clickcapture')).toBe(false);
+			expect(is_capture_event('keypresscapture')).toBe(false);
+		})
+	});
+
+	describe('get_attribute_event_name', () => {
+		it('should convert event attribute names to lowercase and strip "on" prefix', () => {
+			expect(get_attribute_event_name('onClick')).toBe('click');
+			expect(get_attribute_event_name('onInput')).toBe('input');
+			expect(get_attribute_event_name('onMouseDown')).toBe('mousedown');
+			expect(get_attribute_event_name('onKeyPress')).toBe('keypress');
+			expect(get_attribute_event_name('onChange')).toBe('change');
+			expect(get_attribute_event_name('onFocus')).toBe('focus');
+		});
+
+		it('should handle capture events and strip both "on" and "Capture"', () => {
+			expect(get_attribute_event_name('onClickCapture')).toBe('click');
+			expect(get_attribute_event_name('onMouseDownCapture')).toBe('mousedown');
+			expect(get_attribute_event_name('onMouseDownCapture')).toBe('mousedown');
+			expect(get_attribute_event_name('onGotPointerCapture')).toBe('gotpointercapture');
+			expect(get_attribute_event_name('onLostPointerCapture')).toBe('lostpointercapture');
+		});
+	});
+
+	describe('is_passive_event', () => {
+		it('should return true for passive events', () => {
+			expect(is_passive_event('touchstart')).toBe(true);
+			expect(is_passive_event('touchmove')).toBe(true);
+		});
+
+		it('should return false for non-passive events', () => {
+			expect(is_passive_event('click')).toBe(false);
+			expect(is_passive_event('mousedown')).toBe(false);
+			expect(is_passive_event('touchend')).toBe(false);
+			expect(is_passive_event('scroll')).toBe(false);
+		});
+
+		it('should be case-sensitive', () => {
+			expect(is_passive_event('TouchStart')).toBe(false);
+			expect(is_passive_event('TOUCHMOVE')).toBe(false);
+		});
+	});
+});

--- a/packages/ripple/tests/utils/normalize_css_property_name.test.js
+++ b/packages/ripple/tests/utils/normalize_css_property_name.test.js
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { normalize_css_property_name } from '../../src/utils/normalize_css_property_name.js';
+
+describe('normalize_css_property_name utility', () => {
+	it('should convert camelCase to kebab-case', () => {
+		expect(normalize_css_property_name('backgroundColor')).toBe('background-color');
+		expect(normalize_css_property_name('fontSize')).toBe('font-size');
+		expect(normalize_css_property_name('marginTop')).toBe('margin-top');
+		expect(normalize_css_property_name('borderRadius')).toBe('border-radius');
+	});
+
+	it('should handle multiple uppercase letters', () => {
+		expect(normalize_css_property_name('WebkitTransform')).toBe('-webkit-transform');
+		expect(normalize_css_property_name('MozAppearance')).toBe('-moz-appearance');
+	});
+
+	it('should preserve CSS custom properties (starting with --)', () => {
+		expect(normalize_css_property_name('--custom-property')).toBe('--custom-property');
+		expect(normalize_css_property_name('--myColor')).toBe('--myColor');
+		expect(normalize_css_property_name('--themePrimary')).toBe('--themePrimary');
+	});
+
+	it('should handle already lowercase properties', () => {
+		expect(normalize_css_property_name('color')).toBe('color');
+		expect(normalize_css_property_name('display')).toBe('display');
+		expect(normalize_css_property_name('position')).toBe('position');
+		expect(normalize_css_property_name('z-index')).toBe('z-index');
+	});
+
+	it('should handle consecutive uppercase letters', () => {
+		expect(normalize_css_property_name('HTMLElement')).toBe('-h-t-m-l-element');
+	});
+
+	it('should handle empty string', () => {
+		expect(normalize_css_property_name('')).toBe('');
+	});
+
+	it('should handle complex property names', () => {
+		expect(normalize_css_property_name('borderTopLeftRadius')).toBe('border-top-left-radius');
+		expect(normalize_css_property_name('textDecorationColor')).toBe('text-decoration-color');
+	});
+});
+

--- a/packages/ripple/tests/utils/patterns.test.js
+++ b/packages/ripple/tests/utils/patterns.test.js
@@ -1,0 +1,382 @@
+import { describe, it, expect } from 'vitest';
+import * as patterns from '../../src/utils/patterns.js';
+
+describe('patterns utility', () => {
+	describe('regex_whitespace', () => {
+		it('should match single whitespace characters', () => {
+			expect(patterns.regex_whitespace.test(' ')).toBe(true);
+			expect(patterns.regex_whitespace.test('\t')).toBe(true);
+			expect(patterns.regex_whitespace.test('\n')).toBe(true);
+			expect(patterns.regex_whitespace.test('\r')).toBe(true);
+		});
+
+		it('should match whitespace character between characters', () => {
+			expect(patterns.regex_whitespace.test('a b')).toBe(true);
+			expect(patterns.regex_whitespace.test('a\tb')).toBe(true);
+			expect(patterns.regex_whitespace.test('a\nb')).toBe(true);
+		});
+
+		it('should match whitespace at start or end', () => {
+			expect(patterns.regex_whitespace.test(' hello')).toBe(true);
+			expect(patterns.regex_whitespace.test('hello ')).toBe(true);
+			expect(patterns.regex_whitespace.test('\thello')).toBe(true);
+			expect(patterns.regex_whitespace.test('hello\t')).toBe(true);
+		});
+
+		it('should match multiple whitespace characters', () => {
+			expect(patterns.regex_whitespace.test('  ')).toBe(true);
+			expect(patterns.regex_whitespace.test('\t\r\n   ')).toBe(true);
+		});
+
+		it('should not match non-whitespace', () => {
+			expect(patterns.regex_whitespace.test('helloworld')).toBe(false);
+			expect(patterns.regex_whitespace.test('1')).toBe(false);
+		});
+
+		it('should not match empty string', () => {
+			expect(patterns.regex_whitespace.test('')).toBe(false);
+		});
+	});
+
+	describe('regex_whitespaces', () => {
+		it('should match multiple whitespace characters', () => {
+			expect(patterns.regex_whitespaces.test('   ')).toBe(true);
+			expect(patterns.regex_whitespaces.test('\t\t')).toBe(true);
+			expect(patterns.regex_whitespaces.test(' \t\n')).toBe(true);
+		});
+
+		it('should match single whitespace character', () => {
+			expect(patterns.regex_whitespaces.test(' ')).toBe(true);
+			expect(patterns.regex_whitespaces.test('\t')).toBe(true);
+			expect(patterns.regex_whitespaces.test('\n')).toBe(true);
+		});
+
+		it('should match whitespaces between characters', () => {
+			expect(patterns.regex_whitespaces.test('a b')).toBe(true);
+			expect(patterns.regex_whitespaces.test('a\t\r\nb')).toBe(true);
+			expect(patterns.regex_whitespaces.test('a\nb')).toBe(true);
+		});
+
+		it('should match whitespaces at start or end', () => {
+			expect(patterns.regex_whitespaces.test('  hello')).toBe(true);
+			expect(patterns.regex_whitespaces.test('hello \n')).toBe(true);
+			expect(patterns.regex_whitespaces.test('\t\rhello')).toBe(true);
+			expect(patterns.regex_whitespaces.test('hello\t  ')).toBe(true);
+		});
+
+		it('should not match non-whitespace', () => {
+			expect(patterns.regex_whitespaces.test('helloworld')).toBe(false);
+			expect(patterns.regex_whitespaces.test('1')).toBe(false);
+		});
+
+		it('should not match empty string', () => {
+			expect(patterns.regex_whitespaces.test('')).toBe(false);
+		});
+	});
+
+	describe('regex_starts_with_newline', () => {
+		it('should match strings starting with newline', () => {
+			expect(patterns.regex_starts_with_newline.test('\nhello')).toBe(true);
+			expect(patterns.regex_starts_with_newline.test('\r\nworld')).toBe(true);
+		});
+
+		it('should match strings with only newline', () => {
+			expect(patterns.regex_starts_with_newline.test('\n')).toBe(true);
+			expect(patterns.regex_starts_with_newline.test('\r\n')).toBe(true);
+		});
+
+		it('should not match empty string', () => {
+			expect(patterns.regex_starts_with_newline.test('')).toBe(false);
+		});
+
+		it('should not match strings without leading newline', () => {
+			expect(patterns.regex_starts_with_newline.test('hello\n')).toBe(false);
+			expect(patterns.regex_starts_with_newline.test(' \nhello')).toBe(false);
+		});
+	});
+
+	describe('regex_starts_with_whitespace', () => {
+		it('should match strings starting with whitespace', () => {
+			expect(patterns.regex_starts_with_whitespace.test(' hello')).toBe(true);
+			expect(patterns.regex_starts_with_whitespace.test('\thello')).toBe(true);
+			expect(patterns.regex_starts_with_whitespace.test('\nhello')).toBe(true);
+		});
+
+		it('should match strings starting with multiple whitespaces', () => {
+			expect(patterns.regex_starts_with_whitespace.test('  hello')).toBe(true);
+			expect(patterns.regex_starts_with_whitespace.test('\t\nhello')).toBe(true);
+		});
+
+		it('should match strings with only whitespace', () => {
+			expect(patterns.regex_starts_with_whitespace.test('   ')).toBe(true);
+			expect(patterns.regex_starts_with_whitespace.test('\t\n\r')).toBe(true);
+		});
+
+		it('should not match empty string', () => {
+			expect(patterns.regex_starts_with_whitespace.test('')).toBe(false);
+		});
+
+		it('should not match strings without leading whitespace', () => {
+			expect(patterns.regex_starts_with_whitespace.test('hello ')).toBe(false);
+		});
+	});
+
+	describe('regex_starts_with_whitespaces', () => {
+		it('should match strings starting with a single whitespace', () => {
+			expect(patterns.regex_starts_with_whitespaces.test(' hello')).toBe(true);
+			expect(patterns.regex_starts_with_whitespaces.test('\thello')).toBe(true);
+			expect(patterns.regex_starts_with_whitespaces.test('\nhello')).toBe(true);
+		});
+
+		it('should match strings starting with multiple whitespaces', () => {
+			expect(patterns.regex_starts_with_whitespaces.test('  hello')).toBe(true);
+			expect(patterns.regex_starts_with_whitespaces.test('\t\nhello')).toBe(true);
+		});
+
+		it('should match strings with only whitespace', () => {
+			expect(patterns.regex_starts_with_whitespaces.test('   ')).toBe(true);
+			expect(patterns.regex_starts_with_whitespaces.test('\t\n\r')).toBe(true);
+		});
+
+		it('should not match empty string', () => {
+			expect(patterns.regex_starts_with_whitespaces.test('')).toBe(false);
+		});
+
+		it('should not match strings without leading whitespace', () => {
+			expect(patterns.regex_starts_with_whitespaces.test('hello ')).toBe(false);
+			expect(patterns.regex_starts_with_whitespaces.test('a b c ')).toBe(false);
+		});
+	});
+
+	describe('regex_ends_with_whitespace', () => {
+		it('should match strings ending with whitespace', () => {
+			expect(patterns.regex_ends_with_whitespace.test('hello ')).toBe(true);
+			expect(patterns.regex_ends_with_whitespace.test('hello\t')).toBe(true);
+			expect(patterns.regex_ends_with_whitespace.test('hello\n')).toBe(true);
+		});
+
+		it('should match strings ending with multiple whitespaces', () => {
+			expect(patterns.regex_ends_with_whitespace.test('hello  ')).toBe(true);
+			expect(patterns.regex_ends_with_whitespace.test('hello\t\n')).toBe(true);
+		});
+
+		it('should match strings with only whitespace', () => {
+			expect(patterns.regex_ends_with_whitespace.test('   ')).toBe(true);
+			expect(patterns.regex_ends_with_whitespace.test('\t\n\r')).toBe(true);
+		});
+
+		it('should not match empty string', () => {
+			expect(patterns.regex_ends_with_whitespace.test('')).toBe(false);
+		});
+
+		it('should not match strings without trailing whitespace', () => {
+			expect(patterns.regex_ends_with_whitespace.test(' hello')).toBe(false);
+			expect(patterns.regex_ends_with_whitespace.test('hello')).toBe(false);
+		});
+	});
+
+	describe('regex_ends_with_whitespaces', () => {
+		it('should match strings ending with multiple whitespaces', () => {
+			expect(patterns.regex_ends_with_whitespaces.test('hello  ')).toBe(true);
+			expect(patterns.regex_ends_with_whitespaces.test('hello\t\n')).toBe(true);
+		});
+
+		it('should match strings with only whitespaces', () => {
+			expect(patterns.regex_ends_with_whitespaces.test('   ')).toBe(true);
+			expect(patterns.regex_ends_with_whitespaces.test('\t\n\r')).toBe(true);
+		});
+
+		it('should not match empty string', () => {
+			expect(patterns.regex_ends_with_whitespaces.test('')).toBe(false);
+		});
+
+		it('should not match strings not ending with whitespaces', () => {
+			expect(patterns.regex_ends_with_whitespaces.test(' hello')).toBe(false);
+			expect(patterns.regex_ends_with_whitespaces.test('hello')).toBe(false);
+			expect(patterns.regex_ends_with_whitespaces.test('hello')).toBe(false);
+			expect(patterns.regex_ends_with_whitespaces.test('a b\nc')).toBe(false);
+		});
+	});
+
+	describe('regex_not_whitespace', () => {
+		it('should match non-whitespace characters', () => {
+			expect(patterns.regex_not_whitespace.test('a')).toBe(true);
+			expect(patterns.regex_not_whitespace.test('1')).toBe(true);
+			expect(patterns.regex_not_whitespace.test('hello world')).toBe(true);
+		});
+
+		it('should not match empty string', () => {
+			expect(patterns.regex_not_whitespace.test('')).toBe(false);
+		});
+
+		it('should not match only whitespace', () => {
+			expect(patterns.regex_not_whitespace.test('   ')).toBe(false);
+			expect(patterns.regex_not_whitespace.test('\t\n\r')).toBe(false);
+		});
+	});
+
+	describe('regex_only_whitespaces', () => {
+		it('should match strings with only whitespaces', () => {
+			expect(patterns.regex_only_whitespaces.test('   ')).toBe(true);
+			expect(patterns.regex_only_whitespaces.test('\t\n\r\f')).toBe(true);
+		});
+
+		it('should not match empty string', () => {
+			expect(patterns.regex_only_whitespaces.test('')).toBe(false);
+		});
+
+		it('should not match strings with content', () => {
+			expect(patterns.regex_only_whitespaces.test(' a ')).toBe(false);
+			expect(patterns.regex_only_whitespaces.test('hello')).toBe(false);
+		});
+	});
+
+	describe('regex_is_valid_identifier', () => {
+		it('should match valid JavaScript identifiers', () => {
+			expect(patterns.regex_is_valid_identifier.test('foo')).toBe(true);
+			expect(patterns.regex_is_valid_identifier.test('_private')).toBe(true);
+			expect(patterns.regex_is_valid_identifier.test('$jquery')).toBe(true);
+			expect(patterns.regex_is_valid_identifier.test('myVar123')).toBe(true);
+			expect(patterns.regex_is_valid_identifier.test('CamelCase')).toBe(true);
+		});
+
+		it('should not match invalid identifiers', () => {
+			expect(patterns.regex_is_valid_identifier.test('123abc')).toBe(false);
+			expect(patterns.regex_is_valid_identifier.test('my-var')).toBe(false);
+			expect(patterns.regex_is_valid_identifier.test('my var')).toBe(false);
+			expect(patterns.regex_is_valid_identifier.test('my.var')).toBe(false);
+			expect(patterns.regex_is_valid_identifier.test('')).toBe(false);
+			expect(patterns.regex_is_valid_identifier.test('\n')).toBe(false);
+			expect(patterns.regex_is_valid_identifier.test('my\tvar')).toBe(false);
+			expect(patterns.regex_is_valid_identifier.test('my\rvar')).toBe(false);
+		});
+	});
+
+	describe('regex_invalid_identifier_chars', () => {
+		it('should remove invalid identifier characters', () => {
+			expect('123abc'.replace(patterns.regex_invalid_identifier_chars, '_')).toBe('_23abc');
+			expect('my-var'.replace(patterns.regex_invalid_identifier_chars, '_')).toBe('my_var');
+			expect('hello.world'.replace(patterns.regex_invalid_identifier_chars, '_')).toBe('hello_world');
+			expect('\t\r\nhello.world'.replace(patterns.regex_invalid_identifier_chars, '_')).toBe('___hello_world');
+			expect('my\tvar'.replace(patterns.regex_invalid_identifier_chars, '_')).toBe('my_var');
+			expect('my\rvar'.replace(patterns.regex_invalid_identifier_chars, '_')).toBe('my_var');
+			expect(''.replace(patterns.regex_invalid_identifier_chars, '_')).toBe('');
+		});
+	});
+
+	describe('regex_starts_with_vowel', () => {
+		it('should match strings starting with vowels', () => {
+			expect(patterns.regex_starts_with_vowel.test('apple')).toBe(true);
+			expect(patterns.regex_starts_with_vowel.test('elephant')).toBe(true);
+			expect(patterns.regex_starts_with_vowel.test('ice')).toBe(true);
+			expect(patterns.regex_starts_with_vowel.test('orange')).toBe(true);
+			expect(patterns.regex_starts_with_vowel.test('umbrella')).toBe(true);
+		});
+
+		it('should not match strings starting with consonants', () => {
+			expect(patterns.regex_starts_with_vowel.test('banana')).toBe(false);
+			expect(patterns.regex_starts_with_vowel.test('cat')).toBe(false);
+			expect(patterns.regex_starts_with_vowel.test('d')).toBe(false);
+			expect(patterns.regex_starts_with_vowel.test('f')).toBe(false);
+			expect(patterns.regex_starts_with_vowel.test('g')).toBe(false);
+			expect(patterns.regex_starts_with_vowel.test('hello')).toBe(false);
+			expect(patterns.regex_starts_with_vowel.test('j')).toBe(false);
+			expect(patterns.regex_starts_with_vowel.test('k')).toBe(false);
+			expect(patterns.regex_starts_with_vowel.test('l')).toBe(false);
+			expect(patterns.regex_starts_with_vowel.test('m')).toBe(false);
+			expect(patterns.regex_starts_with_vowel.test('n')).toBe(false);
+			expect(patterns.regex_starts_with_vowel.test('p')).toBe(false);
+			expect(patterns.regex_starts_with_vowel.test('q')).toBe(false);
+			expect(patterns.regex_starts_with_vowel.test('r')).toBe(false);
+			expect(patterns.regex_starts_with_vowel.test('s')).toBe(false);
+			expect(patterns.regex_starts_with_vowel.test('t')).toBe(false);
+			expect(patterns.regex_starts_with_vowel.test('v')).toBe(false);
+			expect(patterns.regex_starts_with_vowel.test('w')).toBe(false);
+			expect(patterns.regex_starts_with_vowel.test('x')).toBe(false);
+			expect(patterns.regex_starts_with_vowel.test('y')).toBe(false);
+			expect(patterns.regex_starts_with_vowel.test('z')).toBe(false);
+		});
+
+		it('should be case-sensitive', () => {
+			expect(patterns.regex_starts_with_vowel.test('Apple')).toBe(false);
+		});
+	});
+
+	describe('regex_heading_tags', () => {
+		it('should match heading tags h1 through h6', () => {
+			expect(patterns.regex_heading_tags.test('h1')).toBe(true);
+			expect(patterns.regex_heading_tags.test('h2')).toBe(true);
+			expect(patterns.regex_heading_tags.test('h3')).toBe(true);
+			expect(patterns.regex_heading_tags.test('h4')).toBe(true);
+			expect(patterns.regex_heading_tags.test('h5')).toBe(true);
+			expect(patterns.regex_heading_tags.test('h6')).toBe(true);
+		});
+
+		it('should not match invalid heading tags', () => {
+			expect(patterns.regex_heading_tags.test('h0')).toBe(false);
+			expect(patterns.regex_heading_tags.test('h7')).toBe(false);
+			expect(patterns.regex_heading_tags.test('H1')).toBe(false);
+			expect(patterns.regex_heading_tags.test('header')).toBe(false);
+			expect(patterns.regex_heading_tags.test('h')).toBe(false);
+		});
+	});
+
+	describe('regex_illegal_attribute_character', () => {
+		it('should match illegal attribute characters', () => {
+			expect(patterns.regex_illegal_attribute_character.test('123')).toBe(true);
+			expect(patterns.regex_illegal_attribute_character.test('.class')).toBe(true);
+			expect(patterns.regex_illegal_attribute_character.test('-attr')).toBe(true);
+			expect(patterns.regex_illegal_attribute_character.test('attr^')).toBe(true);
+			expect(patterns.regex_illegal_attribute_character.test('attr$')).toBe(true);
+			expect(patterns.regex_illegal_attribute_character.test('attr@')).toBe(true);
+			expect(patterns.regex_illegal_attribute_character.test('attr%')).toBe(true);
+			expect(patterns.regex_illegal_attribute_character.test('attr&')).toBe(true);
+			expect(patterns.regex_illegal_attribute_character.test('attr#')).toBe(true);
+			expect(patterns.regex_illegal_attribute_character.test('attr?')).toBe(true);
+			expect(patterns.regex_illegal_attribute_character.test('attr!')).toBe(true);
+			expect(patterns.regex_illegal_attribute_character.test('attr|')).toBe(true);
+			expect(patterns.regex_illegal_attribute_character.test('attr[')).toBe(true);
+			expect(patterns.regex_illegal_attribute_character.test('attr]')).toBe(true);
+			expect(patterns.regex_illegal_attribute_character.test('attr{')).toBe(true);
+			expect(patterns.regex_illegal_attribute_character.test('attr}')).toBe(true);
+			expect(patterns.regex_illegal_attribute_character.test('attr*')).toBe(true);
+			expect(patterns.regex_illegal_attribute_character.test('attr+')).toBe(true);
+			expect(patterns.regex_illegal_attribute_character.test('attr~')).toBe(true);
+			expect(patterns.regex_illegal_attribute_character.test('attr;')).toBe(true);
+		});
+
+		it('should not match valid attribute names', () => {
+			expect(patterns.regex_illegal_attribute_character.test('id')).toBe(false);
+			expect(patterns.regex_illegal_attribute_character.test('class')).toBe(false);
+			expect(patterns.regex_illegal_attribute_character.test('className')).toBe(false);
+			expect(patterns.regex_illegal_attribute_character.test('className123')).toBe(false);
+			expect(patterns.regex_illegal_attribute_character.test('class-name-123')).toBe(false);
+			expect(patterns.regex_illegal_attribute_character.test('data-value')).toBe(false);
+			expect(patterns.regex_illegal_attribute_character.test('aria-label')).toBe(false);
+		});
+	});
+
+	describe('regex_newline_characters', () => {
+		it('should match newline characters globally', () => {
+			const text = 'line1\nline2\nline3';
+			const matches = text.match(patterns.regex_newline_characters);
+			expect(matches?.length).toBe(2);
+		});
+	});
+
+	describe('regex_not_newline_characters', () => {
+		it('should match non-newline characters globally', () => {
+			const text = 'ab\ncd';
+			const matches = text.match(patterns.regex_not_newline_characters);
+			expect(matches?.length).toBe(4);
+		});
+	});
+
+	describe('regex_whitespaces_strict', () => {
+		it('should match strict whitespace sequences globally', () => {
+			const text = 'a  b\tc  d';
+			const result = text.replace(patterns.regex_whitespaces_strict, '-');
+			expect(result).toBe('a-b-c-d');
+		});
+	});
+});

--- a/packages/ripple/tests/utils/sanitize_template_string.test.js
+++ b/packages/ripple/tests/utils/sanitize_template_string.test.js
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { sanitize_template_string } from '../../src/utils/sanitize_template_string.js';
+
+describe('sanitize_template_string utility', () => {
+	it('should escape backticks', () => {
+		expect(sanitize_template_string('hello `world`')).toBe('hello \\`world\\`');
+	});
+
+	it('should escape dollar brace sequences', () => {
+		expect(sanitize_template_string('hello ${world}')).toBe('hello \\${world}');
+	});
+
+	it('should escape backslashes', () => {
+		expect(sanitize_template_string('hello \\ world')).toBe('hello \\\\ world');
+	});
+
+	it('should escape all special characters together', () => {
+		expect(sanitize_template_string('`${test}\\`')).toBe('\\`\\${test}\\\\\\`');
+	});
+
+	it('should handle strings with no special characters', () => {
+		expect(sanitize_template_string('hello world')).toBe('hello world');
+	});
+
+	it('should handle empty strings', () => {
+		expect(sanitize_template_string('')).toBe('');
+	});
+
+	it('should escape multiple backticks', () => {
+		expect(sanitize_template_string('```')).toBe('\\`\\`\\`');
+	});
+
+	it('should escape multiple dollar braces', () => {
+		expect(sanitize_template_string('${a}${b}${c}')).toBe('\\${a}\\${b}\\${c}');
+	});
+
+	it('should escape multiple backslashes', () => {
+		expect(sanitize_template_string('\\\\\\')).toBe('\\\\\\\\\\\\');
+	});
+
+	it('should handle mixed content', () => {
+		expect(sanitize_template_string('Path: C:\\Users\\${name}`')).toBe('Path: C:\\\\Users\\\\\\${name}\\`');
+	});
+
+	it('should handle complex template literals', () => {
+		const input = 'const str = `Hello ${name}, path: \\${root}\\`';
+		const expected = 'const str = \\`Hello \\${name}, path: \\\\\\${root}\\\\\\`';
+		expect(sanitize_template_string(input)).toBe(expected);
+	});
+});
+

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -60,6 +60,14 @@ export default defineConfig({
 				},
 				plugins: [ripple()],
 			},
+			{
+				name: 'ripple-utils',
+				test: {
+					include: ['packages/ripple/tests/utils/**/*.test.js'],
+					environment: 'node',
+					globals: true,
+				},
+			},
 		],
 	},
 });


### PR DESCRIPTION
Added 112 tests. I didn't add tests for `ast.js` and `builders.js` because I don't know what and how to test there.