### PR TITLE
fix(types): update server render function return type

### DIFF
--- a/packages/ripple/types/server.d.ts
+++ b/packages/ripple/types/server.d.ts
@@ -1,4 +1,4 @@
 
-export declare async function render(
+export declare function render(
 	component: () => void,
-): { head: string; body: string };
+): Promise<{ head: string; body: string; css: Set<string> }>;


### PR DESCRIPTION
## Changes
- Updated the return type of the [render](cci:1://file:///home/aniket/Desktop/ripple/packages/ripple/types/server.d.ts:1:0-3:61) function in [server.d.ts](cci:7://file:///home/aniket/Desktop/ripple/packages/ripple/types/server.d.ts:0:0-0:0) to properly reflect that it returns a Promise
- Added missing `css: Set<string>` property to the return type
- Fixed TypeScript error about async function return types

## Testing
- Verified that the type definition matches the actual implementation in [src/runtime/internal/server/index.js](cci:7://file:///home/aniket/Desktop/ripple/packages/ripple/src/runtime/internal/server/index.js:0:0-0:0)
- Confirmed that server-side tests continue to pass with the updated type

## Notes
- The function was previously missing the `Promise` wrapper in its return type
- The `css` property was missing from the return type definition
- This is a type-level change only - no runtime behavior is affected