### PR TITLE
auto-detect playground root component

### DIFF
--- a/website/.vitepress/components/Code.vue
+++ b/website/.vitepress/components/Code.vue
@@ -31,12 +31,6 @@ const modifyContent = (content: string) => {
 	if (content.startsWith('ripple')) {
 		content = content.slice('ripple'.length)
 	}
-	if (!content.includes('export default component')) {
-		content = content.replace('export component', 'export default component')
-	}
-	if (!content.includes('export default component')) {
-		content = content.replace('component', 'export default component')
-	}
 	return content
 }
 

--- a/website/.vitepress/components/LiveCodes.vue
+++ b/website/.vitepress/components/LiveCodes.vue
@@ -103,6 +103,25 @@ export default component Counter() {
 }
 `.trimStart()
 
+const mountRoot =
+	'<scr' +
+	`ipt type="module">
+	import { mount } from 'ripple';
+	import * as script from "./script.ripple";
+
+  const exports = Object.keys(script);
+  const App = exports.length === 1
+		? script[exports[0]]
+		: (script.default || script.App || script[exports.find(e => typeof script[e] === 'function' )]);
+  if (typeof App !== 'function') {
+    throw new Error('No valid export found');
+  }
+  mount(App, {
+    target: document.body.appendChild(document.createElement('div')),
+  });
+</scr` +
+	'ipt>'
+
 const getStyle = () => ({
 	language: 'css' as const,
 	content: props.styles ?? '',
@@ -123,6 +142,7 @@ const config: Partial<Config> = {
 	},
 	markup: {
 		language: 'html',
+		content: mountRoot,
 		hideTitle: true,
 	},
 	style: getStyle(),
@@ -176,9 +196,13 @@ const onReady = (sdk: Playground) => {
 		}
 
 		let newConfig: Partial<Config> = {}
-		if (!config.markup.hideTitle || !config.style.hideTitle) {
+		if (
+			!config.markup.content ||
+			!config.markup.hideTitle ||
+			!config.style.hideTitle
+		) {
 			newConfig = {
-				markup: { ...config.markup, hideTitle: true },
+				markup: { ...config.markup, content: mountRoot, hideTitle: true },
 				style: { ...config.style, hideTitle: true },
 			}
 		}


### PR DESCRIPTION
This PR auto-detects the root component in playground code.

The root component will be selected in the following order:
1. The only export
2. default export
3. The named export `App`
4. The first export with `typeof x === 'function'`

otherwise it throws `new Error('No valid export found')`

Based on this, adding `export default` for docs snippets in no longer needed and is removed.