### PR TITLE
fix: dynamic svg / mathml generation

### DIFF
--- a/packages/ripple/src/constants.js
+++ b/packages/ripple/src/constants.js
@@ -4,4 +4,3 @@ export const IS_CONTROLLED = 1 << 2;
 export const IS_INDEXED = 1 << 3;
 export const TEMPLATE_SVG_NAMESPACE = 1 << 5;
 export const TEMPLATE_MATHML_NAMESPACE = 1 << 6;
-

--- a/packages/ripple/src/runtime/internal/client/composite.js
+++ b/packages/ripple/src/runtime/internal/client/composite.js
@@ -1,8 +1,8 @@
 /** @import { Block, Component } from '#client' */
 
 import { branch, destroy_block, render, render_spread } from './blocks.js';
-import { COMPOSITE_BLOCK } from './constants.js';
-import { active_block } from './runtime.js';
+import { COMPOSITE_BLOCK, NAMESPACE_URI, DEFAULT_NAMESPACE } from './constants.js';
+import { active_block, active_namespace } from './runtime.js';
 
 /**
  * @typedef {((anchor: Node, props: Record<string, any>, block: Block | null) => void)} ComponentFunction
@@ -36,9 +36,14 @@ export function composite(get_component, node, props) {
 				b = branch(() => {
 					var block = /** @type {Block} */ (active_block);
 
-					var element = document.createElement(
-						/** @type {keyof HTMLElementTagNameMap} */ (component),
-					);
+					var element =
+						active_namespace !== DEFAULT_NAMESPACE
+							? document.createElementNS(
+									NAMESPACE_URI[active_namespace],
+									/** @type {keyof HTMLElementTagNameMap} */ (component),
+								)
+							: document.createElement(/** @type {keyof HTMLElementTagNameMap} */ (component));
+
 					/** @type {ChildNode} */ (anchor).before(element);
 
 					if (block.s === null) {

--- a/packages/ripple/src/runtime/internal/client/constants.js
+++ b/packages/ripple/src/runtime/internal/client/constants.js
@@ -30,3 +30,9 @@ export var REF_PROP = 'ref';
 /** @type {unique symbol} */
 export const ARRAY_SET_INDEX_AT = Symbol();
 export const MAX_ARRAY_LENGTH = 2 ** 32 - 1;
+export const DEFAULT_NAMESPACE = 'html';
+export const NAMESPACE_URI = {
+	html: 'http://www.w3.org/1999/xhtml',
+	svg: 'http://www.w3.org/2000/svg',
+	mathml: 'http://www.w3.org/1998/Math/MathML',
+};

--- a/packages/ripple/src/runtime/internal/client/index.js
+++ b/packages/ripple/src/runtime/internal/client/index.js
@@ -49,6 +49,7 @@ export {
 	tick,
 	proxy_tracked,
 	with_block,
+	with_ns,
 } from './runtime.js';
 
 export { composite } from './composite.js';

--- a/packages/ripple/src/runtime/internal/client/runtime.js
+++ b/packages/ripple/src/runtime/internal/client/runtime.js
@@ -1,4 +1,5 @@
 /** @import { Block, Component, Dependency, Derived, Tracked } from '#client' */
+/** @import { NAMESPACE_URI } from './constants.js' */
 
 import { DEV } from 'esm-env';
 import {
@@ -26,6 +27,7 @@ import {
 	UNINITIALIZED,
 	REF_PROP,
 	TRACKED_OBJECT,
+	DEFAULT_NAMESPACE,
 } from './constants.js';
 import { capture, suspend } from './try.js';
 import {
@@ -48,6 +50,8 @@ export let active_reaction = null;
 export let active_scope = null;
 /** @type {null | Component} */
 export let active_component = null;
+/** @type {keyof NAMESPACE_URI} */
+export let active_namespace = DEFAULT_NAMESPACE;
 /** @type {boolean} */
 export let is_mutating_allowed = true;
 
@@ -1161,6 +1165,22 @@ export function pop_component() {
 		}
 	}
 	active_component = component.p;
+}
+
+/**
+ * @template T
+ * @param {() => T} fn
+ * @param {keyof NAMESPACE_URI} namespace
+ * @returns {T}
+ */
+export function with_ns(namespace, fn) {
+	var previous_namespace = active_namespace;
+	active_namespace = namespace;
+	try {
+		return fn();
+	} finally {
+		active_namespace = previous_namespace;
+	}
 }
 
 /**

--- a/packages/ripple/tests/client/svg.test.ripple
+++ b/packages/ripple/tests/client/svg.test.ripple
@@ -1,3 +1,5 @@
+import { track } from 'ripple';
+
 describe('SVG namespace handling', () => {
 	it('should render static SVG elements with correct namespace', () => {
 		component App() {
@@ -226,6 +228,107 @@ describe('SVG namespace handling', () => {
 		// HTML content inside foreignObject should have HTML namespace
 		expect(div.namespaceURI).toBe('http://www.w3.org/1999/xhtml');
 		expect(div.textContent).toBe('HTML inside SVG');
+	});
+
+	it('should render SVG with children as svg elements', () => {
+		component SVG({ children }) {
+			<svg width={20} height={20} fill="blue" viewBox="0 0 30 10" preserveAspectRatio="none">
+				<children />
+			</svg>
+		}
+
+		component App() {
+			let isDiamond = true;
+			<SVG>
+				if (isDiamond) {
+					<polygon points="0,0 30,0 15,10" />
+				} else {
+					<polygon points="0,0 30,0 15,10" />
+				}
+			</SVG>
+		}
+
+		render(App);
+
+		const svg = container.querySelector('svg');
+		const polygon = container.querySelector('polygon');
+
+		expect(svg.namespaceURI).toBe('http://www.w3.org/2000/svg');
+		expect(polygon.namespaceURI).toBe('http://www.w3.org/2000/svg');
+	});
+
+	it('should render SVG with props as svg elements', () => {
+		component SVG({ Polygon }) {
+			<svg width={20} height={20} fill="blue" viewBox="0 0 30 10" preserveAspectRatio="none">
+				<Polygon />
+			</svg>
+		}
+
+		component App() {
+			<SVG {Polygon} />
+		}
+
+		component Polygon() {
+			<polygon points="0,0 30,0 15,10" />
+		}
+
+		render(App);
+
+		const svg = container.querySelector('svg');
+		const polygon = container.querySelector('polygon');
+
+		expect(svg.namespaceURI).toBe('http://www.w3.org/2000/svg');
+		expect(polygon.namespaceURI).toBe('http://www.w3.org/2000/svg');
+	});
+
+	it('should render SVG with children as dynamic elements', () => {
+		component SVG({ children }) {
+			<svg width={20} height={20} fill="blue" viewBox="0 0 30 10" preserveAspectRatio="none">
+				<children />
+			</svg>
+		}
+
+		component App() {
+			let dynTag = track('polygon');
+			<SVG>
+				<@dynTag points="0,0 30,0 15,10" />
+			</SVG>
+		}
+
+		render(App);
+
+		const svg = container.querySelector('svg');
+		const polygon = container.querySelector('polygon');
+
+		expect(svg.namespaceURI).toBe('http://www.w3.org/2000/svg');
+		expect(polygon.namespaceURI).toBe('http://www.w3.org/2000/svg');
+	});
+
+	it('should render SVG with children as dynamic components', () => {
+		component SVG({ children }) {
+			<svg width={20} height={20} fill="blue" viewBox="0 0 30 10" preserveAspectRatio="none">
+				<children />
+			</svg>
+		}
+
+		component Polygon({ points }) {
+			<polygon {points} />
+		}
+
+		component App() {
+			let Component = track(() => Polygon);
+			<SVG>
+				<@Component points="0,0 30,0 15,10" />
+			</SVG>
+		}
+
+		render(App);
+
+		const svg = container.querySelector('svg');
+		const polygon = container.querySelector('polygon');
+
+		expect(svg.namespaceURI).toBe('http://www.w3.org/2000/svg');
+		expect(polygon.namespaceURI).toBe('http://www.w3.org/2000/svg');
 	});
 
 	it('should compare static vs dynamic SVG rendering (original problem case)', () => {


### PR DESCRIPTION
closes #498 

- introduces a `with_ns()` wrapper function to set `active_namespace` so that namespaces for svg or mathml that take components as props, children, dynamic elements or dynamic components can be properly set.  Otherwise, the browser doesn't paint them.
- prevents comments `<!>` from being unnecessarily created with namespaces (performance)
- minor performance adjustment in `from_namespace()` in the while loop. 