### PR TITLE
added default exports in vite-plugin-ripple

### DIFF
--- a/packages/vite-plugin-ripple/package.json
+++ b/packages/vite-plugin-ripple/package.json
@@ -10,7 +10,8 @@
   "exports": {
     ".": {
       "types": "./types/index.d.ts",
-      "import": "./src/index.js"
+      "import": "./src/index.js",
+      "default": "./src/index.js"
     }
   },
   "homepage": "https://ripplejs.com",


### PR DESCRIPTION
after taking the latest code changes, my vite plugin code is breaking due to missing default exports in vite-plugin-ripple