### PR TITLE
alternative props spread to keep nested component reactivity

### DIFF
--- a/packages/ripple-compat-react/src/index.js
+++ b/packages/ripple-compat-react/src/index.js
@@ -5,7 +5,15 @@ import { jsx, jsxs, Fragment } from 'react/jsx-runtime';
 import { useSyncExternalStore, useLayoutEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { createRoot } from 'react-dom/client';
-import { branch, with_block, proxy_tracked, set, render, tracked } from 'ripple/internal/client';
+import {
+	branch,
+	with_block,
+	proxy_props,
+	set,
+	render,
+	tracked,
+	get_tracked,
+} from 'ripple/internal/client';
 import { Context } from 'ripple';
 
 /** @type {Tsx} */
@@ -138,7 +146,7 @@ export function Ripple({ component, props }) {
 		const anchor = document.createTextNode('');
 		const block = get_block_from_dom(span);
 		const tracked_props = (tracked_props_ref.current = tracked(props || {}, block));
-		const proxied_props = proxy_tracked(/** @type {any} */ (tracked_props));
+		const proxied_props = proxy_props(() => get_tracked(tracked_props));
 		frag.append(anchor);
 
 		const b = with_block(block, () => {

--- a/packages/ripple/src/runtime/internal/client/index.js
+++ b/packages/ripple/src/runtime/internal/client/index.js
@@ -47,7 +47,7 @@ export {
 	derived,
 	maybe_tracked,
 	tick,
-	proxy_tracked,
+	proxy_props,
 	with_block,
 	with_ns,
 } from './runtime.js';

--- a/packages/ripple/tests/client/composite/composite.reactivity.test.ripple
+++ b/packages/ripple/tests/client/composite/composite.reactivity.test.ripple
@@ -1,21 +1,26 @@
-import { track, flushSync, effect } from 'ripple';
+import { track, trackSplit, flushSync, effect } from 'ripple';
 
 describe('composite > reactivity', () => {
 	it('renders composite components with object state', () => {
 		component Button({ obj }: { obj: { count: Tracked<number> } }) {
-			<button class='count2' onClick={() => {
-				obj.@count++;
-			}}>{obj.@count}</button>
+			<button
+				class="count2"
+				onClick={() => {
+					obj.@count++;
+				}}
+			>
+				{obj.@count}
+			</button>
 		}
 
 		component App() {
 			<div>
 				let obj = {
-					count: track(0)
+					count: track(0),
 				};
 
-				<span class='count'>{obj.@count}</span>
-				<Button obj={obj} />
+				<span class="count">{obj.@count}</span>
+				<Button {obj} />
 			</div>
 		}
 
@@ -32,29 +37,34 @@ describe('composite > reactivity', () => {
 
 	it('renders composite components with object state wrapped in an if statement', () => {
 		component Button({ obj }: { obj: { count: Tracked<number> } }) {
-			<button class='count2' onClick={() => {
-				obj.@count++;
-			}}>{obj.@count}</button>
+			<button
+				class="count2"
+				onClick={() => {
+					obj.@count++;
+				}}
+			>
+				{obj.@count}
+			</button>
 		}
 
 		component OtherComponent({ obj }: { obj: { count: Tracked<number> } }) {
-			<div class='count3'>{obj.@count}</div>
+			<div class="count3">{obj.@count}</div>
 		}
 
 		component App() {
 			<div>
 				let obj = {
-					count: track(0)
+					count: track(0),
 				};
 
-				<span class='count'>{obj.@count}</span>
+				<span class="count">{obj.@count}</span>
 				<span>{' '}</span>
 				if (obj) {
-					<Button obj={obj} />
+					<Button {obj} />
 				}
 
 				if (obj) {
-					<OtherComponent obj={obj} />
+					<OtherComponent {obj} />
 				}
 			</div>
 		}
@@ -74,14 +84,26 @@ describe('composite > reactivity', () => {
 	it('parents and children have isolated state', () => {
 		component Button(props: { count: number }) {
 			let count = track(() => props.count);
-			<button onClick={() => { @count++; } }>{"child: " + @count}</button>
+			<button
+				onClick={() => {
+					@count++;
+				}}
+			>
+				{'child: ' + @count}
+			</button>
 		}
 
 		component App() {
 			<div>
 				let count = track(0);
 
-				<button onClick={() => { @count++; } }>{"parent: " + @count}</button>
+				<button
+					onClick={() => {
+						@count++;
+					}}
+				>
+					{'parent: ' + @count}
+				</button>
 				<Button {@count} />
 			</div>
 		}
@@ -107,16 +129,28 @@ describe('composite > reactivity', () => {
 	});
 
 	it('parents and children have isolated connected state (destructured props)', () => {
-		component Button({count}: { count: number }) {
+		component Button({ count }: { count: number }) {
 			let local_count = track(() => count);
-			<button onClick={() => { @local_count++; } }>{"child: " + @local_count}</button>
+			<button
+				onClick={() => {
+					@local_count++;
+				}}
+			>
+				{'child: ' + @local_count}
+			</button>
 		}
 
 		component App() {
 			<div>
 				let count = track(0);
 
-				<button onClick={() => { @count++; } }>{"parent: " + @count}</button>
+				<button
+					onClick={() => {
+						@count++;
+					}}
+				>
+					{'parent: ' + @count}
+				</button>
 				<Button {@count} />
 			</div>
 		}
@@ -149,15 +183,25 @@ describe('composite > reactivity', () => {
 			const b = track(2);
 			const c = track(3);
 
-			const obj = track(() => ({
-				@a,
-				@b,
-				@c,
-			}));
+			const obj = track(
+				() => ({
+					@a,
+					@b,
+					@c,
+				}),
+			);
 
 			<Child {...@obj} />
 
-			<button onClick={() => { @a++; @b++; @c++; }}>{"Increment all"}</button>
+			<button
+				onClick={() => {
+					@a++;
+					@b++;
+					@c++;
+				}}
+			>
+				{'Increment all'}
+			</button>
 		}
 
 		component Child({ a, b, c }: { a: number; b: number; c: number }) {
@@ -165,7 +209,7 @@ describe('composite > reactivity', () => {
 				logs.push(`Child effect: ${a}, ${b}, ${c}`);
 			});
 
-			<div>{a + ' ' +  b + ' ' + c}</div>
+			<div>{a + ' ' + b + ' ' + c}</div>
 		}
 
 		render(App);
@@ -181,4 +225,45 @@ describe('composite > reactivity', () => {
 		expect(container.querySelector('div').textContent).toBe('2 3 4');
 		expect(logs).toEqual(['Child effect: 1, 2, 3', 'Child effect: 2, 3, 4']);
 	});
+
+	it(
+		'keeps reactivity for spread props via intermediate components and usage of trackSplit()',
+		() => {
+			component App() {
+				const count = track(0);
+				<CounterWrapper {@count} up={() => @count++} down={() => @count--} />
+			}
+
+			component CounterWrapper(props) {
+				<div>
+					<Counter {...props} />
+				</div>
+			}
+
+			component Counter(props) {
+				const [count, up, down, rest] = trackSplit(props, ['count', 'up', 'down']);
+				<button onClick={() => @up()}>{'UP'}</button>
+				<button onClick={() => @down()}>{'DOWN'}</button>
+				<span {...@rest}>{`Counter: ${@count}`}</span>
+			}
+
+			render(App);
+
+			const buttonIncrement = container.querySelectorAll('button')[0];
+			const buttonDecrement = container.querySelectorAll('button')[1];
+			const span = container.querySelector('span');
+
+			expect(span.textContent).toBe('Counter: 0');
+
+			buttonIncrement.click();
+			flushSync();
+
+			expect(span.textContent).toBe('Counter: 1');
+
+			buttonDecrement.click();
+			flushSync();
+
+			expect(span.textContent).toBe('Counter: 0');
+		},
+	);
 });


### PR DESCRIPTION
closes #525 

Alternative for spreading props handling that allows keeping reactivity via intermediate components and usage of trackSplit()

- instead of performing an actual destructuring of props that are spread, it keeps the props intact.
- if a component instance has explicitly specified props and spreads, an array of objects is produced by the compiler.  Otherwise, it's a single object.
- The order of prop evaluation was left intact, e.g. when a prop in spread can overwrite the explicit prop or a prop in another spread or vice versa where the explicit prop provided after spread overwrite the prop in the spread.
- The `proxy_tracked` was renamed to `proxy_props`, as we no longer need to use `derived` on the spread / props for the `spread_props` function.
- The `spread_props` function was left purely for semantics.  We could use the `proxy_props` directly but the former better reflects the intent.

Pros and Cons:

Pros:
- Lazy evaluation. Before, the props were destructured `{...props}` which would cause evaluation of all props right away for any one property access.  Now, only the requested property gets evaluated.
- The props reactivity for `trackSplit()` usage stays intact when spread props are passed through via any number of component layers
- No need to use derived for the proxy since no destructuring is actually happening and no need to check the derived's dirty flag.  The reactivity encapsulation works via just a thunk.

Cons:
- There is slightly more time spent finding the property requested as the proxy needs to loop through the array of objects vs just dealing with one object.  
  - However, typically the number of objects should be very few, especially if a spread is placed last in a component call, there would be only 2. 
  - This extra time should also be offset or even dwarfed by the previous cost of evaluating the whole destructured object for every property access.
  
Further optimizations:
- If prop spreads are always evaluated last and always overwrite any explicitly provided props, then the number of objects in the resulting array should be just 2 with one spread: 1 for explicit and 1 for the spread.  Each additional spread would still add an object to the array.