### PR TITLE
fix: empty literal string in child, optimize fast path

### DIFF
--- a/packages/ripple/src/runtime/internal/client/index.js
+++ b/packages/ripple/src/runtime/internal/client/index.js
@@ -3,6 +3,7 @@ export {
 	child_frag,
 	next_sibling as sibling,
 	document,
+	create_text,
 } from './operations.js';
 
 export {

--- a/packages/ripple/tests/client/basic/basic.components.test.ripple
+++ b/packages/ripple/tests/client/basic/basic.components.test.ripple
@@ -268,4 +268,20 @@ describe('basic client > components & composition', () => {
 		expect(span.textContent).toBe('Hello from Span');
 		expect(buttonSpan.textContent).toBe('Click me!');
 	});
+
+	it('handles empty string children', () => {
+		component Button({ children }) {
+			<children />
+		}
+
+		component App() {
+			let text = '';
+			<Button>{''}</Button>
+			<Button>{text}</Button>
+		}
+
+		expect(() => {
+			render(App);
+		}).not.toThrow();
+	});
 });


### PR DESCRIPTION
- alternative to #531 
- closes #530 

