### PR TITLE
Update import statements to include file extensions

### DIFF
--- a/packages/ripple/src/runtime/internal/client/compat.js
+++ b/packages/ripple/src/runtime/internal/client/compat.js
@@ -1,7 +1,7 @@
 /** @import { CompatApi } from '#client' */
 
-import { ROOT_BLOCK } from "./constants";
-import { active_block } from "./runtime";
+import { ROOT_BLOCK } from "./constants.js";
+import { active_block } from "./runtime.js";
 
 /**
  * @param {string} kind


### PR DESCRIPTION
Currently the playground loads the runtime (`ripple/internal/client`, `ripple/jsx-runtime`, etc) from [esm.sh](https://esm.sh) which  minifies the code and makes sure that it is esm compatible.

I want to be able to use the runtime from CDNs (e.g. [jsdelivr](https://www.jsdelivr.com/) or [unpkg](https://unpkg.com/)) without having to do any transformations. This is probably faster, removes dependency on the behaviour of esm.sh and allows debugging (~~esm.sh does not provide source maps~~)

I was able to do that except with this code (due to lack of file extensions):
```js
import { ROOT_BLOCK } from "./constants";
import { active_block } from "./runtime";
```

This PR adds file extensions for these imports.