### PR TITLE
Fix launch.json extensionDevelopmentPath pointing to old vscode dir name

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -3,14 +3,14 @@
 // Hover to view descriptions of existing attributes.
 // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
 {
-	"version": "0.2.0",
-	"configurations": [
-		{
-			"name": "Extension",
-			"type": "extensionHost",
-			"request": "launch",
-			"autoAttachChildProcesses": true,
-			"args": ["--extensionDevelopmentPath=${workspaceFolder}/packages/ripple-vscode-plugin/"]
-		}
-	]
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Extension",
+      "type": "extensionHost",
+      "request": "launch",
+      "autoAttachChildProcesses": true,
+      "args": ["--extensionDevelopmentPath=${workspaceFolder}/packages/vscode-plugin/"]
+    }
+  ]
 }


### PR DESCRIPTION
launch.json is currently pointing to 
`"--extensionDevelopmentPath=${workspaceFolder}/packages/ripple-vscode-plugin/"`
updating to
`"--extensionDevelopmentPath=${workspaceFolder}/packages/vscode-plugin/"`