### PR TITLE
fix: set fetchpriority=high for LCP image to improve performance

### DIFF
--- a/website/public/index.html
+++ b/website/public/index.html
@@ -898,7 +898,12 @@
 
 			<div class="container">
 				<h1 class="sr-only">Ripple</h1>
-				<img src="/ripple-logo-horizontal.png" alt="Ripple Logo" class="logo" />
+				<img
+					src="/ripple-logo-horizontal.png"
+					alt="Ripple Logo"
+					class="logo"
+					fetchpriority="high"
+				/>
 				<p class="subtitle">the elegant TypeScript UI framework</p>
 
 				<div class="social-links">


### PR DESCRIPTION
- optimizes the Largest Contentful Paint (LCP) by setting fetchpriority="high" on the Ripple logo. 
- The logo is now discoverable immediately from the HTML and will load with high priority, improving performance metrics.

<img width="1051" height="416" alt="Screenshot 2025-11-11 133348" src="https://github.com/user-attachments/assets/2336de0c-c9c0-43cf-af5e-c45d18612c5f" />
