### PR TITLE
feat(cli): Auto-detect and pre-select package manager for improved UX

### DIFF
--- a/packages/cli/src/commands/create.js
+++ b/packages/cli/src/commands/create.js
@@ -18,7 +18,7 @@ import {
 } from '../lib/prompts.js';
 import { createProject } from '../lib/project-creator.js';
 import { isFolderEmpty } from '../lib/is-folder-empty.js';
-import { getUsedPackageManager } from '../lib/package-manager.js';
+import { getCurrentPackageManager } from '../lib/package-manager.js';
 
 /**
  * Create command handler
@@ -66,10 +66,14 @@ export async function createCommand(projectName, options) {
 
 	// Step 4: Get package manager
 	// Auto-detect the package manager used to execute this CLI
-	const detectedPackageManager = getUsedPackageManager();
-	let packageManager = options.packageManager || detectedPackageManager;
+	let packageManager;
+	const detected = getCurrentPackageManager();
 	if (!options.packageManager && !options.yes) {
-		packageManager = await promptPackageManager(detectedPackageManager);
+		// interactive mode
+		packageManager = await promptPackageManager(detected);
+	} else {
+		// non-interactive mode
+		packageManager = options.packageManager || detected;
 	}
 
 	// Step 5: Git initialization preference

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -24,7 +24,7 @@ program
 program
 	.argument('[project-name]', 'Name of the project to create')
 	.option('-t, --template <template>', 'Template to use (default: basic)')
-	.option('-p, --package-manager <pm>', 'Package manager to use (npm, yarn, pnpm)', 'npm')
+	.option('-p, --package-manager <pm>', 'Package manager to use (npm, yarn, pnpm)')
 	.option('--no-git', 'Skip Git repository initialization')
 	.option('-y, --yes', 'Skip all prompts and use defaults')
 	.action(

--- a/packages/cli/src/lib/package-manager.js
+++ b/packages/cli/src/lib/package-manager.js
@@ -1,25 +1,10 @@
-/**
- * @typedef PackageManager @type {'npm' | 'yarn' | 'pnpm'}
- */
+/** @import {PackageManager} from '../lib/project-creator.js' */
 
 /**
- * Detects the package manager used to execute the current process.
- *
- * This function analyzes environment variables set by package managers when they
- * spawn child processes. It primarily relies on `npm_execpath` and `npm_config_user_agent`
- * which are set by npm, yarn, and pnpm.
- *
- * @returns {PackageManager} The detected package manager, defaulting to 'npm'
- *
- * @example
- * // When executed via: pnpm create ripple my-app
- * const pm = getUsedPackageManager(); // Returns 'pnpm'
- *
- * @example
- * // When executed via: npm create ripple my-app
- * const pm = getUsedPackageManager(); // Returns 'npm'
+ * Detect the package manager used to run the current process
+ * @returns {PackageManager}
  */
-export function getUsedPackageManager() {
+export function getCurrentPackageManager() {
 	// Check npm_config_user_agent first (most reliable for all package managers)
 	const userAgent = process.env.npm_config_user_agent;
 	if (userAgent) {

--- a/packages/cli/src/lib/prompts.js
+++ b/packages/cli/src/lib/prompts.js
@@ -60,9 +60,10 @@ export async function promptTemplate() {
 
 /**
  * Prompt for package manager selection
+ * @param {PackageManager} defaultPackageManager - Default package manager
  * @returns {Promise<PackageManager>} - Selected package manager
  */
-export async function promptPackageManager() {
+export async function promptPackageManager(defaultPackageManager) {
 	const response = await /** @type {Promise<{packageManager: PackageManager}>} */ (
 		prompts({
 			type: 'select',
@@ -73,7 +74,7 @@ export async function promptPackageManager() {
 				{ title: 'yarn', value: 'yarn', description: 'Use Yarn for dependency management' },
 				{ title: 'pnpm', value: 'pnpm', description: 'Use pnpm for dependency management' },
 			],
-			initial: 0,
+			initial: ['npm', 'yarn', 'pnpm'].indexOf(defaultPackageManager),
 		})
 	);
 

--- a/packages/cli/tests/unit/prompts.test.js
+++ b/packages/cli/tests/unit/prompts.test.js
@@ -42,6 +42,7 @@ import {
 	promptStylingFramework,
 } from '../../src/lib/prompts.js';
 import * as templates from '../../src/lib/templates.js';
+import { getCurrentPackageManager } from '../../src/lib/package-manager.js';
 
 const mockedPrompts = /** @type {import('vitest').MockedFunction<typeof prompts>} */ (prompts);
 const mockedGetTemplateChoices =
@@ -172,7 +173,8 @@ describe('Prompts', () => {
 		it('should return selected package manager', async () => {
 			mockedPrompts.mockResolvedValue({ packageManager: 'pnpm' });
 
-			const result = await promptPackageManager();
+			const detected = getCurrentPackageManager();
+			const result = await promptPackageManager(detected);
 			expect(result).toBe('pnpm');
 			expect(mockedPrompts).toHaveBeenCalledWith({
 				type: 'select',
@@ -183,14 +185,15 @@ describe('Prompts', () => {
 					{ title: 'yarn', value: 'yarn', description: 'Use Yarn for dependency management' },
 					{ title: 'pnpm', value: 'pnpm', description: 'Use pnpm for dependency management' },
 				],
-				initial: 0,
+				initial: ['npm', 'yarn', 'pnpm'].indexOf(detected),
 			});
 		});
 
 		it('should exit when user cancels', async () => {
 			mockedPrompts.mockResolvedValue({});
 
-			await promptPackageManager();
+			const detected = getCurrentPackageManager();
+			await promptPackageManager(detected);
 			expect(mockExit).toHaveBeenCalledWith(1);
 		});
 	});


### PR DESCRIPTION
## Summary

Add automatic package manager detection to improve CLI user experience by intelligently detecting which package manager (npm, yarn, or pnpm) was used to invoke the CLI and using it as the default throughout the project creation flow.

**Key Changes:**
- Created new utility module `package-manager.js` with `getUsedPackageManager()` function
- Auto-detect package manager via environment variables (`npm_config_user_agent`, `npm_execpath`, etc.)
- Pre-select detected package manager in interactive prompts
- Use detected package manager as default in non-interactive mode (`--yes` flag)
- Graceful fallback to `npm` if detection fails

**User Experience Improvement:**
When users run:
- `pnpm create ripple-app my-app` → Automatically uses `pnpm` and shows `pnpm install` / `pnpm dev`
- `npm create ripple-app my-app` → Automatically uses `npm` and shows `npm install` / `npm run dev`
- `yarn create ripple-app my-app` → Automatically uses `yarn` and shows `yarn install` / `yarn dev`

This eliminates the need for users to manually specify their package manager via the `--package-manager` flag or select it in prompts, while still allowing override if desired.

**Technical Implementation:**
- Cross-platform compatible (Windows, Linux, macOS)
- Multiple fallback detection strategies for reliability
- Maintains backward compatibility with existing `--package-manager` option
- Type-safe with proper JSDoc annotations

## Test plan

- [x] Run `npm create ripple-app test-npm` and verify npm is detected and used
- [x] Run `pnpm create ripple-app test-pnpm` and verify pnpm is detected and used
- [x] Run `yarn create ripple-app test-yarn` and verify yarn is detected and used
- [x] Verify `--package-manager` flag still overrides auto-detection
- [x] Verify `--yes` flag uses detected package manager without prompting
- [x] Verify interactive mode pre-selects the detected package manager in prompt
- [x] Test fallback behavior when detection fails (defaults to npm)
- [x] Verify final "Next Steps" output shows correct commands for detected PM