### PR TITLE
fix(docs): correct invalid Html attribute in Attribute Binding example

### DIFF
--- a/website/docs/guide/syntax.md
+++ b/website/docs/guide/syntax.md
@@ -179,7 +179,7 @@ write a JS expression that evaluates to our desired value.
 ::: info
 Plain attributes can still be used.
 ```ripple
-<input type="textarea" />
+<input type="text" />
 ```
 :::
 


### PR DESCRIPTION
The current Attribute Binding example in the Ripple documentation
uses <input type="textarea" /> which is not a valid HTML input type.
Replaced  <input type="textarea" />  with <input type="text" />.