### PR TITLE
fix: don't include parser.c in linguist language graph

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+packages/tree-sitter/src/parser.c -linguist-detectable


### PR DESCRIPTION
the tree sitter plugin has a 4mb generated parser.c file

all this pr does is configure linguist (what github uses for the repo language graph) to ignore that specific file, to make the graph more realistic

before:
<img width="592" height="352" alt="image" src="https://github.com/user-attachments/assets/569b57b6-5d49-4e2c-981c-3bf89afd201a" />


after:
<img width="592" height="310" alt="image" src="https://github.com/user-attachments/assets/fd3a8408-6c37-4e8d-b628-b1e81b41610f" />
