### PR TITLE
fix: correct typo in progress selector from lsat-child to last-child

### DIFF
--- a/playground/demo.css
+++ b/playground/demo.css
@@ -176,7 +176,7 @@ progress:first-child {
 	margin-top: 0;
 }
 
-progress:lsat-child {
+progress:last-child {
 	margin-bottom: 0;
 }
 


### PR DESCRIPTION
Fixed typo in demo.css progress selector from lsat-child to last-child