### PR TITLE
update pnpm version in website

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -10,7 +10,7 @@
 	"keywords": [],
 	"author": "",
 	"license": "MIT",
-	"packageManager": "pnpm@10.14.0",
+	"packageManager": "pnpm@10.18.2",
 	"dependencies": {
 		"livecodes": "catalog:default"
 	},


### PR DESCRIPTION
This PR updates pnpm version in website to satisfy the version required in [package.json engines](https://github.com/Ripple-TS/ripple/blob/e2c10f237b549925be4b9d9ce6967484bb87a68a/package.json#L10)