### PR TITLE
fix: disable ripple extension in launch configuration

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,6 +7,7 @@
       "request": "launch",
       "autoAttachChildProcesses": true,
       "args": [
+				"--disable-extension=ripple-ts.ripple-ts-vscode-plugin",
         "--extensionDevelopmentPath=${workspaceFolder}/packages/vscode-plugin/",
         "${workspaceFolder}/playground"
       ],
@@ -31,12 +32,10 @@
       "name": "Debug All Tests - Vitest",
       "type": "node",
       "request": "launch",
-      "console": "integratedTerminal",
       "runtimeExecutable": "pnpm",
       "runtimeArgs": ["run", "test", "--", "--inspect-brk", "--no-file-parallelism"],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen",
-      "port": 9229,
       "skipFiles": ["<node_internals>/**"]
     },
     {
@@ -44,12 +43,10 @@
       "type": "node",
       "request": "launch",
       "cwd": "${workspaceFolder}/playground",
-      "console": "integratedTerminal",
       "runtimeExecutable": "pnpm",
       "runtimeArgs": ["run", "debug-volar"],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen",
-      "port": 9229,
       "skipFiles": ["<node_internals>/**"]
     }
   ]


### PR DESCRIPTION
- Disable ripple extension in launch configuration

| Before | After |
| ---- | ---- |
| <img width="1358" height="418" alt="CleanShot 2025-11-20 at 14 14 55@2x" src="https://github.com/user-attachments/assets/b292847d-2ea4-4d28-be1d-c844239695ec" />  | <img width="1596" height="536" alt="CleanShot 2025-11-20 at 14 14 40@2x" src="https://github.com/user-attachments/assets/b3d0c82b-f95f-411c-b7d9-5c4d75ba9f49" />



- Remove unused settings

<img height="170" alt="CleanShot 2025-11-20 at 14 15 41@2x" src="https://github.com/user-attachments/assets/bfe1dae7-bfaf-4bd8-b85e-53b6ebdf28c6" />
