### PR TITLE
docs: correct pass text as expression inside braces in ripple template

### DIFF
--- a/website/docs/guide/syntax.md
+++ b/website/docs/guide/syntax.md
@@ -173,7 +173,7 @@ like plain HTML, but instead of quotes, we use {braces}, within which, we can
 write a JS expression that evaluates to our desired value.
 
 ```ripple
-<span data-my-attr={attr_val}>Hi there!</span>
+<span data-my-attr={attr_val}>{'Hi there!'}</span>
 ```
 
 ::: info


### PR DESCRIPTION
<img width="1440" height="780" alt="Screenshot 2025-11-22 at 8 06 30 PM" src="https://github.com/user-attachments/assets/6e2b6680-bb76-4aa2-af97-ac7880dfbac9" />

Improve docs with correct passing of text as expression inside braces in Template Syntax section under Guide in official docs.