### PR TITLE
fix: eslint parsing error in template

### DIFF
--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -40,14 +40,6 @@
     "@typescript-eslint/parser": "catalog:peer",
     "@ripple-ts/eslint-parser": "workspace:*"
   },
-  "peerDependenciesMeta": {
-    "@typescript-eslint/parser": {
-      "optional": true
-    },
-    "@ripple-ts/eslint-parser": {
-      "optional": true
-    }
-  },
   "devDependencies": {
     "@types/eslint": "catalog:default",
     "@types/estree": "catalog:default",

--- a/templates/basic/package.json
+++ b/templates/basic/package.json
@@ -21,6 +21,7 @@
 		"@ripple-ts/eslint-plugin": "latest",
 		"prettier": "^3.6.2",
 		"@ripple-ts/prettier-plugin": "latest",
+		"@ripple-ts/eslint-parser": "latest",
 		"typescript": "^5.9.2",
 		"@typescript-eslint/parser": "^8.20.0",
 		"vite": "^7.1.4",


### PR DESCRIPTION
fix: #576

Needs ts parser dependency for eslint in templates.

<img width="564" height="153" alt="image" src="https://github.com/user-attachments/assets/aec2f77d-77b9-40da-8bc0-5d89ce617945" />
