### PR TITLE
feat: [eslint] add for..of key validator rule

### DIFF
--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -5,6 +5,7 @@ import noReturnInComponent from './rules/no-return-in-component.js';
 import unboxTrackedValues from './rules/unbox-tracked-values.js';
 import controlFlowJsx from './rules/control-flow-jsx.js';
 import noIntrospectInModules from './rules/no-introspect-in-modules.js';
+import validForOfKey from './rules/valid-for-of-key.js';
 
 const plugin = {
 	meta: {
@@ -18,6 +19,7 @@ const plugin = {
 		'unbox-tracked-values': unboxTrackedValues,
 		'control-flow-jsx': controlFlowJsx,
 		'no-introspect-in-modules': noIntrospectInModules,
+		'valid-for-of-key': validForOfKey,
 	},
 	configs: {} as any,
 };
@@ -57,6 +59,7 @@ function createConfig(name: string, files: string[], parser: any) {
 			'ripple/unbox-tracked-values': 'error',
 			'ripple/control-flow-jsx': 'error',
 			'ripple/no-introspect-in-modules': 'error',
+			'ripple/valid-for-of-key': 'error',
 		},
 	};
 

--- a/packages/eslint-plugin/src/rules/valid-for-of-key.ts
+++ b/packages/eslint-plugin/src/rules/valid-for-of-key.ts
@@ -1,0 +1,134 @@
+import type { Rule } from 'eslint';
+
+const rule: Rule.RuleModule = {
+	meta: {
+		type: 'problem',
+		docs: {
+			description: 'Ensure variables used in for..of key expression are defined',
+			recommended: true,
+		},
+		messages: {
+			undefinedVariable: "Variable '{{name}}' is not defined.",
+		},
+		schema: [],
+	},
+	create(context) {
+		return {
+			ForOfStatement(node: any) {
+				if (!node.key) {
+					return;
+				}
+
+				const checkIdentifier = (identifier: any) => {
+					const scope = context.sourceCode.getScope(node);
+					const variable = findVariable(scope, identifier.name);
+
+					if (!variable) {
+						context.report({
+							node: identifier,
+							messageId: 'undefinedVariable',
+							data: {
+								name: identifier.name,
+							},
+						});
+					}
+				};
+
+				const traverse = (node: any) => {
+					if (!node) return;
+
+					switch (node.type) {
+						case 'Identifier':
+							checkIdentifier(node);
+
+							break;
+						case 'MemberExpression':
+							traverse(node.object);
+
+							if (node.computed) {
+								traverse(node.property);
+							}
+
+							break;
+						case 'BinaryExpression':
+						case 'LogicalExpression':
+							traverse(node.left);
+							traverse(node.right);
+
+							break;
+						case 'UnaryExpression':
+							traverse(node.argument);
+
+							break;
+						case 'CallExpression':
+							traverse(node.callee);
+							node.arguments.forEach(traverse);
+
+							break;
+						case 'ArrayExpression':
+							node.elements.forEach(traverse);
+
+							break;
+						case 'ObjectExpression':
+							node.properties.forEach((prop: any) => {
+								if (prop.type === 'Property') {
+									if (prop.computed) {
+										traverse(prop.key);
+									}
+
+									traverse(prop.value);
+								} else if (prop.type === 'SpreadElement') {
+									traverse(prop.argument);
+								}
+							});
+
+							break;
+						case 'ConditionalExpression':
+							traverse(node.test);
+							traverse(node.consequent);
+							traverse(node.alternate);
+
+							break;
+						case 'TemplateLiteral':
+							node.expressions.forEach(traverse);
+
+							break;
+					}
+				};
+
+				traverse(node.key);
+			},
+		};
+	},
+};
+
+function findVariable(scope: any, name: string) {
+	let currentScope = scope;
+
+	while (currentScope) {
+		const variable = currentScope.variables.find((v: { name: string }) => v.name === name);
+
+		if (variable) {
+			return variable;
+		}
+
+		// Also check references for global variables or variables defined in the loop itself (like the loop variable)
+		// The loop variable might not be in the 'variables' list of the surrounding scope yet if we are inside the loop statement
+		// But for 'for-of', the loop variable is in a special scope or the upper scope.
+		// Let's rely on standard scope analysis.
+
+		// Special case: check if the variable is the loop variable itself (left side of for-of)
+		// The scope analysis might handle this, but let's be sure.
+
+		currentScope = currentScope.upper;
+	}
+
+	// If not found in scopes, it might be a global variable.
+	// ESLint scope analysis usually includes globals in the global scope.
+	// However, if we are in a module, we might need to check if it's an implicit global or defined elsewhere.
+	// For now, let's assume standard scope resolution works.
+
+	return null;
+}
+
+export default rule;

--- a/packages/eslint-plugin/tests/rules/valid-for-of-key.test.ts
+++ b/packages/eslint-plugin/tests/rules/valid-for-of-key.test.ts
@@ -1,0 +1,103 @@
+import { RuleTester } from 'eslint';
+import rule from '../../src/rules/valid-for-of-key.js';
+import * as parser from '@ripple-ts/eslint-parser';
+
+const ruleTester = new RuleTester({
+	languageOptions: {
+		parser,
+		parserOptions: {
+			ecmaVersion: 2022,
+			sourceType: 'module',
+		},
+	},
+});
+
+ruleTester.run('valid-for-of-key', rule, {
+	valid: [
+		// Valid: for...of with valid key (variable defined in loop)
+		{
+			code: `
+				component App() {
+					const items = [{id: 1}, {id: 2}];
+					for (const item of items; key item.id) {
+						<div>{item.id}</div>
+					}
+				}
+			`,
+		},
+		// Valid: for...of with valid key (variable defined in outer scope)
+		{
+			code: `
+				component App() {
+					const items = [1, 2];
+					const globalId = 123;
+					for (const item of items; key globalId) {
+						<div>{item}</div>
+					}
+				}
+			`,
+		},
+		// Valid: for...of without key
+		{
+			code: `
+				component App() {
+					const items = [1, 2];
+					for (const item of items) {
+						<div>{item}</div>
+					}
+				}
+			`,
+		},
+		// Valid: for...of with index and key
+		{
+			code: `
+        component App() {
+          const items = [{id: 1}, {id: 2}];
+          for (const item of items; index i; key item.id) {
+            <div>{item.id}</div>
+          }
+        }
+      `,
+		},
+	],
+	invalid: [
+		// Invalid: key uses undefined variable
+		{
+			code: `
+				component App() {
+					const items = [{id: 1}, {id: 2}];
+					for (const item of items; key unknownVariable) {
+						<div>{item.id}</div>
+					}
+				}
+			`,
+			errors: [
+				{
+					messageId: 'undefinedVariable',
+					data: {
+						name: 'unknownVariable',
+					},
+				},
+			],
+		},
+		// Invalid: key uses undefined variable in expression
+		{
+			code: `
+				component App() {
+					const items = [{id: 1}, {id: 2}];
+					for (const item of items; key item.id + unknownVariable) {
+						<div>{item.id}</div>
+					}
+				}
+			`,
+			errors: [
+				{
+					messageId: 'undefinedVariable',
+					data: {
+						name: 'unknownVariable',
+					},
+				},
+			],
+		},
+	],
+});


### PR DESCRIPTION
This PR introduces a new ESLint rule, `valid-for-of-key`, to the `@ripple-ts/eslint-plugin`.

What it does:
- Validates that variables used in the key expression of Ripple's custom `for..of` loops are defined in the current scope.
- Prevents runtime errors caused by referencing undefined variables in keys.
- Supports checking identifiers within complex expressions (e.g., member expressions, binary operations).

Fixes: https://github.com/Ripple-TS/ripple/issues/433
