### PR TITLE
fix: prevent rendering <undefined> tags when children prop is not passed

### DIFF
--- a/packages/ripple/src/runtime/internal/client/composite.js
+++ b/packages/ripple/src/runtime/internal/client/composite.js
@@ -1,7 +1,7 @@
 /** @import { Block } from '#client' */
 
 import { branch, destroy_block, render, render_spread } from './blocks.js';
-import { COMPOSITE_BLOCK, NAMESPACE_URI, DEFAULT_NAMESPACE } from './constants.js';
+import { COMPOSITE_BLOCK, DEFAULT_NAMESPACE, NAMESPACE_URI } from './constants.js';
 import { active_block, active_namespace, with_ns } from './runtime.js';
 import { top_element_to_ns } from './utils.js';
 
@@ -32,8 +32,8 @@ export function composite(get_component, node, props) {
 					var block = active_block;
 					/** @type {ComponentFunction} */ (component)(anchor, props, block);
 				});
-			} else {
-				// Custom element
+			} else if (component != null) {
+				// Custom element - only create if component is not null/undefined
 				var run = () => {
 					var block = /** @type {Block} */ (active_block);
 

--- a/packages/ripple/tests/client/bug-497.test.ripple
+++ b/packages/ripple/tests/client/bug-497.test.ripple
@@ -1,0 +1,33 @@
+import { track } from 'ripple';
+
+describe('bug reproduction #497', () => {
+	it('should not render <undefined> tag when children is not passed', () => {
+		component Span({ children, id: key = 2, ...props }) {
+			const renderredHtml = track('');
+			const refNode = (node) => {
+				console.log(node.outerHTML);
+				@renderredHtml = node.outerHTML;
+			};
+			<span {ref refNode} {...props}>
+				<@children />
+			</span>
+			{@renderredHtml}
+		}
+
+		component App() {
+			<Span class="red" />
+		}
+
+		render(App);
+
+		const span = container.querySelector('span');
+		const undefinedTag = container.querySelector('undefined');
+
+		expect(span).toBeTruthy();
+		expect(span.className).toBe('red');
+		// The bug: undefined tag should not exist
+		expect(undefinedTag).toBeNull();
+		// The span should not contain <undefined></undefined> in its HTML
+		expect(span.innerHTML).not.toContain('<undefined');
+	});
+});


### PR DESCRIPTION
## Description
Fixes #497 - Components with no children were rendering `<undefined></undefined>` tags.

## Changes
- Added null check in [composite.js] to prevent creating elements when the component is undefined

## Root Cause
When a component like `<Span />` is used without passing children, the `children` prop is `undefined`. The template `<@children />` would try to render this undefined value, creating an `<undefined>` element in the DOM.

## Solution
Added a conditional check `else if (component != null)` to prevent element creation when the component/tag is null or undefined.

## Testing
- ✅ Added reproduction test that verifies no `<undefined>` tag is created
- ✅ Test passes with the fix applied


