### PR TITLE
feat(language-server): add class-jump-to-style feature

### DIFF
--- a/packages/language-server/src/documentLinksPlugin.js
+++ b/packages/language-server/src/documentLinksPlugin.js
@@ -1,0 +1,109 @@
+/** @import { LanguageServicePlugin, DocumentLink } from '@volar/language-server' */
+/** @import { RippleVirtualCode } from '@ripple-ts/typescript-plugin/src/language.js') */
+
+const { URI } = require('vscode-uri');
+
+const DEBUG = process.env.RIPPLE_DEBUG === 'true';
+
+/**
+ * @param {...unknown} args
+ */
+function log(...args) {
+	if (DEBUG) {
+		console.log('[Ripple Document Links]', ...args);
+	}
+}
+
+/**
+ * @returns {LanguageServicePlugin}
+ */
+function createDocumentLinksPlugin() {
+	return {
+		name: 'ripple-document-links',
+		capabilities: {
+			documentLinkProvider: {},
+		},
+		create(context) {
+			return {
+				async provideDocumentLinks(document) {
+					const uri = URI.parse(document.uri);
+					const decoded = context.decodeEmbeddedDocumentUri(uri);
+					if (!decoded) {
+						return;
+					}
+					const [sourceUri, virtualCodeId] = decoded;
+					if (virtualCodeId !== 'root') {
+						return;
+					}
+					const sourceScript = context.language.scripts.get(sourceUri);
+					const virtualCode = /** @type {RippleVirtualCode } */ (
+						sourceScript?.generated?.embeddedCodes.get(virtualCodeId)
+					);
+
+					/** @type {DocumentLink[]} */
+					const documentLinks = [];
+
+					// Add document link for class names
+					const scopedClasses = virtualCode.scopedClasses ?? [];
+					scopedClasses.forEach((scopedClass, styleIndex) => {
+						const styleVirtualCode = virtualCode.embeddedCodes?.find(
+							({ id }) => id === 'style_' + styleIndex,
+						);
+						if (!styleVirtualCode) {
+							return;
+						}
+						const styleDocumentUri = context.encodeEmbeddedDocumentUri(
+							sourceUri,
+							'style_' + styleIndex,
+						);
+						const styleDocument = context.documents.get(
+							styleDocumentUri,
+							styleVirtualCode.languageId,
+							styleVirtualCode.snapshot,
+						);
+						const cssClasses = virtualCode.cssClasses[styleIndex];
+						/** @type {Map<string, string[]>} */
+						const cssClassesMap = new Map();
+						for (const { text, offset } of cssClasses) {
+							const start = styleDocument.positionAt(offset);
+							const end = styleDocument.positionAt(offset + text.length);
+							const target =
+								styleDocumentUri +
+								`#L${start.line + 1},${start.character + 1}-L${end.line + 1},${end.character + 1}`;
+							if (!cssClassesMap.has(text)) {
+								cssClassesMap.set(text, []);
+							}
+							// @ts-ignore
+							// CSS might have class names with the same name.
+							cssClassesMap.get(text).push(target);
+						}
+
+						for (const { className, offset } of scopedClass) {
+							const rangeStart = document.positionAt(offset);
+							const rangeEnd = document.positionAt(offset + className.length);
+
+							log('Found mapping for document link at generated offset:', offset);
+
+							const cssClassTargets = cssClassesMap.get('.' + className) ?? [];
+							cssClassTargets.forEach((styleTarget) => {
+								documentLinks.push({
+									range: {
+										start: rangeStart,
+										end: rangeEnd,
+									},
+									target: styleTarget,
+								});
+							});
+						}
+					});
+
+					return documentLinks;
+				},
+			};
+		},
+	};
+}
+
+module.exports = {
+	createDocumentLinksPlugin,
+};

--- a/packages/language-server/src/server.js
+++ b/packages/language-server/src/server.js
@@ -11,6 +11,7 @@ const { createDefinitionPlugin } = require('./definitionPlugin.js');
 const { createHoverPlugin } = require('./hoverPlugin.js');
 const { createCompletionPlugin } = require('./completionPlugin.js');
 const { createAutoInsertPlugin } = require('./autoInsertPlugin.js');
+const { createDocumentLinksPlugin } = require('./documentLinksPlugin.js');
 const { createTypeScriptDiagnosticFilterPlugin } = require('./typescriptDiagnosticPlugin.js');
 const { createDocumentHighlightPlugin } = require('./documentHighlightPlugin.js');
 const {
@@ -107,6 +108,7 @@ function createRippleLanguageServer() {
 					createTypeScriptDiagnosticFilterPlugin(),
 					createHoverPlugin(),
 					createDocumentHighlightPlugin(),
+					createDocumentLinksPlugin(),
 				],
 			);
 

--- a/packages/ripple/src/compiler/index.d.ts
+++ b/packages/ripple/src/compiler/index.d.ts
@@ -56,11 +56,26 @@ export interface CodeMapping extends VolarMapping<MappingData> {
 	data: MappingData;
 }
 
+export interface ScopedClass {
+	className: string;
+	offset: number;
+}
+
+export interface CssClass {
+	text: string;
+	offset: number;
+}
+
+/**
+ * Result of Volar mappings compilation
+ */
 export interface VolarMappingsResult {
 	code: string;
 	mappings: CodeMapping[];
 	cssMappings: CodeMapping[];
 	cssSources: string[];
+	cssClasses: CssClass[][];
+	scopedClasses: ScopedClass[][];
 }
 
 /**

--- a/packages/typescript-plugin/src/language.js
+++ b/packages/typescript-plugin/src/language.js
@@ -11,6 +11,8 @@
 /** @typedef {import('@volar/language-core').LanguagePlugin<ScriptId, VirtualCode>} RippleLanguagePlugin */
 // @ts-expect-error type-only import from ESM module into CJS is fine
 /** @typedef {import('ripple/compiler')} RippleCompiler */
+/** @typedef {ReturnType<RippleCompiler['compile_to_volar_mappings']>['scopedClasses']} ScopedClasses */
+/** @typedef {ReturnType<RippleCompiler['compile_to_volar_mappings']>['cssClasses']} CssClasses */
 
 const ts = require('typescript');
 const { forEachEmbeddedCode } = require('@volar/language-core');
@@ -200,6 +202,10 @@ class RippleVirtualCode {
 	originalCode = '';
 	/** @type {unknown[]} */
 	diagnostics = [];
+	/** @type {ScopedClasses} */
+	scopedClasses = [];
+	/** @type {CssClasses} */
+	cssClasses = [];
 	/** @type {CachedMappings | null} */
 	#mappingGenToSource = null;
 	/** @type {CachedMappings | null} */
@@ -339,6 +345,8 @@ class RippleVirtualCode {
 			this.originalCode = newCode;
 			this.generatedCode = transpiled.code;
 			this.mappings = transpiled.mappings ?? [];
+			this.scopedClasses = transpiled.scopedClasses ?? [];
+			this.cssClasses = transpiled.cssClasses ?? [];
 			this.isErrorMode = false;
 
 			const { cssMappings, cssSources } = transpiled;


### PR DESCRIPTION
## Feat (language-server)

Add class-jump-to-style feature to the Ripple IDE plugin (similar to Vue official plugin).
Support **static class** and **dynamic class** — clicking a class name in the template via `cmd + click`​ (or the link displayed on hover) jumps to the corresponding class name in the `<style>`, enhancing user experience.

## Implementation:

The core implementation is divided into the following stages:
1. Compile and parse class names in the template and their positions in the generated code — `scopedClasses` .
2. Compile and parse class names in the <style>tag and their positions in the generated code — `cssClasses`.
3. Add `documentLinksPlugin` for `language-server` to enable the jump functionality.

**Some additional details:** The class names and the `<style>` for jumping must be within the same component scope. Therefore, I used `node.css.hash` and the compilation traversal order to ensure that `scopedClassesand` and `cssClassesare` correctly matched.

## Effect

IDE screenshot:

<img width="600" alt="class-jump-to-style" src="https://github.com/user-attachments/assets/7bf57c30-9267-42a3-9dec-00788ad7dc30" />

