### PR TITLE
fix: add TypeScript types for dynamic elements (#550)

### DIFF
--- a/packages/ripple/src/jsx-runtime.d.ts
+++ b/packages/ripple/src/jsx-runtime.d.ts
@@ -56,7 +56,7 @@ declare global {
 		type Element = void;
 
 		interface IntrinsicElements {
-			// HTML elements with basic attributes
+			// HTML elements with basic attributes (lowercase)
 			div: HTMLAttributes;
 			span: HTMLAttributes;
 			p: HTMLAttributes;
@@ -87,6 +87,47 @@ declare global {
 				width?: string | number;
 				height?: string | number;
 			};
+
+			// Capitalized versions for dynamic elements (e.g., <@div /> becomes <Div />)
+			// These are used when the compiler transforms tracked elements in TypeScript mode
+			Div: HTMLAttributes;
+			Span: HTMLAttributes;
+			P: HTMLAttributes;
+			H1: HTMLAttributes;
+			H2: HTMLAttributes;
+			H3: HTMLAttributes;
+			H4: HTMLAttributes;
+			H5: HTMLAttributes;
+			H6: HTMLAttributes;
+			Button: HTMLAttributes & {
+				type?: 'button' | 'submit' | 'reset';
+				disabled?: boolean;
+			};
+			Input: HTMLAttributes & {
+				type?: string;
+				value?: string | number;
+				placeholder?: string;
+				disabled?: boolean;
+			};
+			Form: HTMLAttributes;
+			A: HTMLAttributes & {
+				href?: string;
+				target?: string;
+			};
+			Img: HTMLAttributes & {
+				src?: string;
+				alt?: string;
+				width?: string | number;
+				height?: string | number;
+			};
+			Section: HTMLAttributes;
+			Article: HTMLAttributes;
+			Header: HTMLAttributes;
+			Footer: HTMLAttributes;
+			Nav: HTMLAttributes;
+			Main: HTMLAttributes;
+			Aside: HTMLAttributes;
+
 			// Add more as needed...
 			[elemName: string]: HTMLAttributes;
 		}

--- a/packages/ripple/tests/client/bug-550.test.ripple
+++ b/packages/ripple/tests/client/bug-550.test.ripple
@@ -1,0 +1,19 @@
+import { track } from 'ripple';
+
+describe('Bug #550 - Dynamic element types', () => {
+	it('should allow attributes on dynamic elements', () => {
+		component App() {
+			let div = track('div');
+			
+			// This should not cause TypeScript errors
+			<@div />
+			<@div class="container" />
+			<@div id="test" class="my-class" style={{ color: 'red' }} />
+		}
+		
+		render(App);
+		
+		const element = container.querySelector('.container');
+		expect(element).toBeTruthy();
+	});
+});


### PR DESCRIPTION
This PR adds capitalized versions of HTML element types to the
IntrinsicElements interface in jsx-runtime.d.ts:
- Basic elements: Div, Span, P, H1-H6
- Form elements: Button, Input, Form
- Link/media: A, Img
- Semantic HTML5: Section, Article, Header, Footer, Nav, Main, Aside

Each capitalized element has the same type signature as its lowercase
counterpart, ensuring dynamic elements accept HTMLAttributes and provide
proper TypeScript autocomplete and type checking.

Fixes #550