### PR TITLE
add lifecycle methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,9 @@ export component App() {
 
 **[→ Transporting Reactivity Guide](https://www.ripplejs.com/docs/guide/reactivity#transporting-reactivity)**
 
-### Effects & Side Effects
+### Effects & Lifecycle
+
+**Effects** run when dependencies change:
 
 ```jsx
 import { effect, track } from 'ripple';
@@ -191,6 +193,32 @@ export component App() {
   });
 
   <button onClick={() => @count++}>{'Increment'}</button>
+}
+```
+
+**Lifecycle methods** for component mount and unmount:
+
+```jsx
+import { onMount, onDestroy, track } from 'ripple';
+
+export component App() {
+  let data = track(null);
+
+  onMount(() => {
+    console.log('Component mounted');
+    @data = fetchData();
+
+    // Return cleanup function (optional)
+    return () => {
+      console.log('Cleanup from onMount');
+    };
+  });
+
+  onDestroy(() => {
+    console.log('Component destroyed');
+  });
+
+  <div>{'Content'}</div>
 }
 ```
 

--- a/packages/ripple/src/runtime/index-client.js
+++ b/packages/ripple/src/runtime/index-client.js
@@ -70,7 +70,7 @@ export { createSubscriber } from './create-subscriber.js';
 
 export { MediaQuery } from './media-query.js';
 
-export { user_effect as effect } from './internal/client/blocks.js';
+export { user_effect as effect, onMount, onDestroy } from './internal/client/blocks.js';
 
 export { Portal } from './internal/client/portal.js';
 

--- a/packages/ripple/src/runtime/internal/client/blocks.js
+++ b/packages/ripple/src/runtime/internal/client/blocks.js
@@ -53,6 +53,73 @@ export function user_effect(fn) {
 }
 
 /**
+ * @param {() => (void | (() => void))} fn
+ */
+export function onMount(fn) {
+	if (active_block === null) {
+		throw new Error(
+			'onMount() must be called within an active context, such as a component',
+		);
+	}
+
+	var component = active_component;
+	if (component !== null && !component.m) {
+		var m = (component.mo ??= []);
+		m.push({
+			b: active_block,
+			fn,
+			r: active_reaction,
+		});
+
+		return;
+	}
+
+	// If already mounted, run immediately
+	var result = fn();
+	if (typeof result === 'function') {
+		var current_block = active_block;
+		if (current_block.t === null) {
+			current_block.t = result;
+		} else {
+			var prev_teardown = current_block.t;
+			current_block.t = () => {
+				prev_teardown();
+				result();
+			};
+		}
+	}
+}
+
+/**
+ * @param {() => void} fn
+ */
+export function onDestroy(fn) {
+	if (active_block === null) {
+		throw new Error(
+			'onDestroy() must be called within an active context, such as a component',
+		);
+	}
+
+	var current_block = active_block;
+	if (current_block.t === null) {
+		current_block.t = fn;
+
+		/** @type {Block | null} */
+		let block = current_block;
+		while (block !== null && (block.f & CONTAINS_TEARDOWN) === 0) {
+			block.f ^= CONTAINS_TEARDOWN;
+			block = block.p;
+		}
+	} else {
+		var prev_teardown = current_block.t;
+		current_block.t = () => {
+			prev_teardown();
+			fn();
+		};
+	}
+}
+
+/**
  * @param {Function} fn
  */
 export function effect(fn) {

--- a/packages/ripple/src/runtime/internal/client/runtime.js
+++ b/packages/ripple/src/runtime/internal/client/runtime.js
@@ -1201,6 +1201,7 @@ export function create_component_ctx() {
 	return {
 		c: null,
 		e: null,
+		mo: null,
 		m: false,
 		p: active_component,
 	};
@@ -1220,6 +1221,46 @@ export function push_component() {
 export function pop_component() {
 	var component = /** @type {Component} */ (active_component);
 	component.m = true;
+
+	// Run onMount callbacks
+	var mounts = component.mo;
+	if (mounts !== null) {
+		var mount_length = mounts.length;
+		for (var i = 0; i < mount_length; i++) {
+			var { b: mount_block, fn: mount_fn, r: mount_reaction } = mounts[i];
+			var prev_block = active_block;
+			var prev_reaction = active_reaction;
+
+			try {
+				active_block = mount_block;
+				active_reaction = mount_reaction;
+				var result = mount_fn();
+
+				if (typeof result === 'function') {
+					if (mount_block.t === null) {
+						mount_block.t = result;
+
+						/** @type {Block | null} */
+						let current = mount_block;
+						while (current !== null && (current.f & CONTAINS_TEARDOWN) === 0) {
+							current.f ^= CONTAINS_TEARDOWN;
+							current = current.p;
+						}
+					} else {
+						var prev_teardown = mount_block.t;
+						mount_block.t = () => {
+							prev_teardown();
+							result();
+						};
+					}
+				}
+			} finally {
+				active_block = prev_block;
+				active_reaction = prev_reaction;
+			}
+		}
+	}
+
 	var effects = component.e;
 	if (effects !== null) {
 		var length = effects.length;

--- a/packages/ripple/tests/client/basic/basic.lifecycle.test.ripple
+++ b/packages/ripple/tests/client/basic/basic.lifecycle.test.ripple
@@ -1,0 +1,199 @@
+import { track, flushSync, onMount, onDestroy } from 'ripple';
+
+describe('basic client > lifecycle methods', () => {
+	it('calls onMount when component mounts', () => {
+		let mountCalled = false;
+
+		component Test() {
+			onMount(() => {
+				mountCalled = true;
+			});
+
+			<div>{'Component'}</div>
+		}
+
+		render(Test);
+		flushSync();
+
+		expect(mountCalled).toBe(true);
+	});
+
+	it('onMount can return cleanup function', () => {
+		let mounted = false;
+		let cleaned = false;
+
+		component Test() {
+			onMount(() => {
+				mounted = true;
+				return () => {
+					cleaned = true;
+				};
+			});
+
+			<div>{'Component'}</div>
+		}
+
+		render(Test);
+		flushSync();
+
+		expect(mounted).toBe(true);
+		expect(cleaned).toBe(false);
+
+		// Cleanup happens in afterEach when container is removed
+	});
+
+	it('calls onDestroy when component is cleaned up', () => {
+		let destroyCalled = false;
+		let mountCalled = false;
+
+		component Test() {
+			onMount(() => {
+				mountCalled = true;
+			});
+
+			onDestroy(() => {
+				destroyCalled = true;
+			});
+
+			<div>{'Component'}</div>
+		}
+
+		render(Test);
+		flushSync();
+
+		expect(mountCalled).toBe(true);
+		expect(destroyCalled).toBe(false);
+
+		// onDestroy will be called during test cleanup
+	});
+
+	it('onMount can access and modify tracked state', () => {
+		component Test() {
+			let count = track(0);
+
+			onMount(() => {
+				@count = 5;
+			});
+
+			<div class="count">{@count}</div>
+		}
+
+		render(Test);
+		flushSync();
+
+		const div = container.querySelector('.count');
+		expect(div.textContent).toBe('5');
+	});
+
+	it('multiple onMount calls execute in order', () => {
+		let order = [];
+
+		component Test() {
+			onMount(() => {
+				order.push(1);
+			});
+
+			onMount(() => {
+				order.push(2);
+			});
+
+			onMount(() => {
+				order.push(3);
+			});
+
+			<div>{'Component'}</div>
+		}
+
+		render(Test);
+		flushSync();
+
+		expect(order).toEqual([1, 2, 3]);
+	});
+
+	it('multiple onDestroy calls are registered', () => {
+		let order = [];
+
+		component Test() {
+			onDestroy(() => {
+				order.push(1);
+			});
+
+			onDestroy(() => {
+				order.push(2);
+			});
+
+			onDestroy(() => {
+				order.push(3);
+			});
+
+			<div>{'Component'}</div>
+		}
+
+		render(Test);
+		flushSync();
+
+		// All onDestroy calls should be registered (they'll be called during cleanup)
+		expect(order).toEqual([]);
+	});
+
+	it('onMount and onDestroy work together', () => {
+		let lifecycle = [];
+
+		component Test() {
+			onMount(() => {
+				lifecycle.push('mount');
+				return () => {
+					lifecycle.push('mount-cleanup');
+				};
+			});
+
+			onDestroy(() => {
+				lifecycle.push('destroy');
+			});
+
+			<div>{'Component'}</div>
+		}
+
+		render(Test);
+		flushSync();
+
+		expect(lifecycle).toEqual(['mount']);
+
+		// Cleanup happens during test teardown
+	});
+
+	it('onMount can set initial state', () => {
+		component Test() {
+			let value = track('initial');
+
+			onMount(() => {
+				@value = 'mounted';
+			});
+
+			<div class="value">{@value}</div>
+		}
+
+		render(Test);
+		flushSync();
+
+		// onMount should have set the value before render
+		const div = container.querySelector('.value');
+		expect(div.textContent).toBe('mounted');
+	});
+
+	it('throws error when onMount called outside component context', () => {
+		expect(() => {
+			onMount(() => {
+				console.log('mount');
+			});
+		}).toThrow('onMount() must be called within an active context');
+	});
+
+	it('throws error when onDestroy called outside component context', () => {
+		expect(() => {
+			onDestroy(() => {
+				console.log('destroy');
+			});
+		}).toThrow('onDestroy() must be called within an active context');
+	});
+});

--- a/packages/ripple/types/index.d.ts
+++ b/packages/ripple/types/index.d.ts
@@ -23,6 +23,10 @@ export function flushSync<T>(fn?: () => T): T;
 
 export function effect(fn: (() => void) | (() => () => void)): void;
 
+export function onMount(fn: (() => void) | (() => () => void)): void;
+
+export function onDestroy(fn: () => void): void;
+
 export interface TrackedArrayConstructor {
 	new <T>(...elements: T[]): TrackedArray<T>; // must be used with `new`
 	from<T>(arrayLike: ArrayLike<T>): TrackedArray<T>;


### PR DESCRIPTION
Add `onMount` and `onDestroy`


### onMount

The `onMount` function runs once when the component is mounted. It can optionally return a cleanup function that will be called when the component is destroyed.

```jsx
import { onMount } from 'ripple';

export component App() {
  onMount(() => {
    console.log('Component mounted');

    // Optional: Return cleanup function
    return () => {
      console.log('Cleanup from onMount');
    };
  });

  <div>{'Content'}</div>
}
```

### onDestroy

The `onDestroy` function registers a cleanup callback that runs when the component is destroyed.

```jsx
import { onDestroy } from 'ripple';

export component App() {
  onDestroy(() => {
    console.log('Component destroyed');
  });

  <div>{'Content'}</div>
}
```