### PR TITLE
fix: correct parser handling of JSX tags misinterpreted as less than operator #610

### DIFF
--- a/packages/ripple/src/compiler/phases/1-parse/index.js
+++ b/packages/ripple/src/compiler/phases/1-parse/index.js
@@ -2133,6 +2133,16 @@ function RipplePlugin(config) {
 					const node = this.parseStatement(null);
 					body.push(node);
 
+					// Rewind the parser to the start of the current token 
+					// This is the token that was wrongly interpreted as "Less Than" < operator
+					this.pos = this.start;
+
+				
+					// We pass the character code of the current position (the '<' character code, usually 60).
+					// This forces the parser to re-evaluate it, correctly seeing it as a JSX Tag now.
+					this.readToken(this.input.charCodeAt(this.pos));
+
+
 					// Ensure we're not in JSX context before recursing
 					// This is important when elements are parsed at statement level
 					if (this.curContext() === tstc.tc_expr) {


### PR DESCRIPTION
### Description #610 
This PR fixes a parser bug where nested lexical declarations (e.g., const or let) inside markup caused an Unterminated JSX contents error.
#610

### The Issue
When the parser encounters a statement like const a = 1; inside a nested element, it enters "Script Mode." After finishing the statement, Acorn automatically reads ahead to the next token.

Because the parser was just in Script Mode, it interprets the next character (often the < of a closing </div> tag) as a Relational Operator (Less Than) instead of a JSX Tag Start. This desynchronizes the parser, causing it to miss the closing tag and eventually crash.

## Failing Example:
``` 
component ErrorComponent() {
  <div>
    <div>
      <div>const a = 1;</div> // Works (deepest level)
      const a = 1; // Works
    </div>
    const a = 1; // CRASHES HERE: The parser reads `</div>` as `<` (operator) + `/div>` (regex)
  </div>
} 
```
## The Fix
In parseTemplateBody, immediately after this.parseStatement(null) returns:

We reset the parser position (this.pos) back to this.start.

We explicitly call this.readToken(code) to force re-tokenization.

This ensures that the next token is evaluated using the correct context (checking for JSX tags via getTokenFromCode) rather than assuming it is a continuation of a JavaScript expression.

## Type of Change
[x] Bug fix (non-breaking change which fixes an issue)
[ ] New feature (non-breaking change which adds functionality)
[ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Screenshot of the solution 
<img width="1196" height="578" alt="Screenshot 2026-01-20 144704" src="https://github.com/user-attachments/assets/2c58efa2-4367-4874-ae2e-b7779da6d36c" />

## Solution as code
```
// Rewind the parser to the start of the current token 
// This is the token that was wrongly interpreted as "Less Than" < operator
this.pos = this.start;

				
// We pass the character code of the current position (the '<' character code, usually 60).
// This forces the parser to re-evaluate it, correctly seeing it as a JSX Tag now.
this.readToken(this.input.charCodeAt(this.pos));
```
## File path on local machine
D:\Developer\RippleJS\610Bug\rippleCompiler\ripple\packages\ripple\src\compiler\phases\1-parse\index.js