### PR TITLE
chore: unifiy compiler init and setup phases

### DIFF
--- a/packages/ripple/src/compiler/phases/3-transform/client/index.js
+++ b/packages/ripple/src/compiler/phases/3-transform/client/index.js
@@ -1481,7 +1481,7 @@ const visitors = {
 					);
 				} else if (attr.type === 'RefAttribute') {
 					const ref_id = state.scope.generate('ref');
-					state.setup?.push(b.var(ref_id, b.call('_$_.ref_prop')));
+					state.init?.push(b.var(ref_id, b.call('_$_.ref_prop')));
 					props.push(
 						b.prop(
 							'init',
@@ -2753,7 +2753,7 @@ function transform_children(children, context) {
 		const id = is_fragment ? b.id(state.scope.generate('fragment')) : get_id(node);
 		initial = id;
 		template_id = state.scope.generate('root');
-		state.setup?.push(b.var(id, b.call(template_id)));
+		state.init?.push(b.var(id, b.call(template_id)));
 	};
 
 	for (const node of normalized) {
@@ -2803,13 +2803,13 @@ function transform_children(children, context) {
 					return cached;
 				} else if (current_prev !== null) {
 					const id = get_id(node);
-					state.setup?.push(b.var(id, b.call('_$_.sibling', current_prev())));
+					state.init?.push(b.var(id, b.call('_$_.sibling', current_prev())));
 					cached = id;
 					return id;
 				} else if (initial !== null) {
 					if (is_fragment) {
 						const id = get_id(node);
-						state.setup?.push(b.var(id, b.call('_$_.child_frag', initial)));
+						state.init?.push(b.var(id, b.call('_$_.child_frag', initial)));
 						cached = id;
 						return id;
 					}
@@ -2820,7 +2820,7 @@ function transform_children(children, context) {
 					}
 
 					const id = get_id(node);
-					state.setup?.push(b.var(id, b.call('_$_.child', state.flush_node?.())));
+					state.init?.push(b.var(id, b.call('_$_.child', state.flush_node?.())));
 					cached = id;
 					return id;
 				} else {
@@ -3008,7 +3008,6 @@ function transform_body(body, { visit, state }) {
 	const body_state = {
 		...state,
 		template: [],
-		setup: [],
 		init: [],
 		update: [],
 		final: [],
@@ -3036,7 +3035,6 @@ function transform_body(body, { visit, state }) {
 	}
 
 	return [
-		.../** @type {NonNullable<TransformClientState['setup']>} */ (body_state.setup),
 		.../** @type {AST.Statement[]} */ (body_state.init),
 		.../** @type {NonNullable<TransformClientState['final']>} */ (body_state.final),
 	];
@@ -3716,7 +3714,6 @@ export function transform_client(filename, source, analysis, to_ts, minify_css) 
 		events: new Set(),
 		template: null,
 		hoisted: [],
-		setup: null,
 		init: null,
 		inside_head: false,
 		update: null,

--- a/packages/ripple/src/compiler/types/index.d.ts
+++ b/packages/ripple/src/compiler/types/index.d.ts
@@ -1180,7 +1180,6 @@ export interface TransformClientState extends BaseState {
 	init: Array<AST.Statement> | null;
 	metadata: BaseStateMetaData;
 	namespace: NameSpace;
-	setup: Array<AST.Statement> | null;
 	stylesheets: Array<AST.CSS.StyleSheet>;
 	template: Array<string | AST.Expression> | null;
 	update: UpdateList | null;


### PR DESCRIPTION
In order to get hydration working, we need the DOM `child` and `sibling` calls to be in order of control flow, not just added at the top of a component block. So they need to be in the `init` phase.