### PR TITLE
fix apply_updates, fix shorthand mapping, types

### DIFF
--- a/packages/ripple/package.json
+++ b/packages/ripple/package.json
@@ -71,7 +71,8 @@
     "#server": "./src/runtime/internal/server/types.d.ts",
     "#compiler": "./src/compiler/types/index.d.ts",
     "#parser": "./src/compiler/types/parse.d.ts",
-    "#public": "./types/index.d.ts"
+    "#public": "./types/index.d.ts",
+    "#helpers": "./src/helpers.d.ts"
   },
   "dependencies": {
     "@jridgewell/sourcemap-codec": "catalog:default",

--- a/packages/ripple/src/compiler/types/index.d.ts
+++ b/packages/ripple/src/compiler/types/index.d.ts
@@ -5,6 +5,8 @@ import type { NAMESPACE_URI } from '../../runtime/internal/client/constants.js';
 import type { Parse } from '#parser';
 import type * as ESRap from 'esrap';
 import type { RippleCompileError, CompileOptions } from 'ripple/compiler';
+import type { Position } from 'acorn';
+import type { RequireAllOrNone } from '#helpers';
 
 export type RpcModules = Map<string, [string, string]>;
 
@@ -995,8 +997,6 @@ declare module 'estree' {
 	}
 }
 
-import type { Comment, Position } from 'acorn';
-
 /**
  * Parse error information
  */
@@ -1213,13 +1213,18 @@ export interface TransformServerState extends BaseState {
 	applyParentCssScope?: AST.CSS.StyleSheet['hash'];
 }
 
-type UpdateList = Array<{
-	identity?: AST.Identifier | AST.Expression;
-	initial?: AST.Expression;
-	operation: (expr?: AST.Expression, prev?: AST.Expression) => AST.ExpressionStatement;
-	expression?: AST.Expression;
-	needsPrevTracking?: boolean;
-}> & { async?: boolean };
+type UpdateList = Array<
+	RequireAllOrNone<
+		{
+			identity?: AST.Identifier | AST.Expression;
+			initial?: AST.Expression;
+			operation: (expr?: AST.Expression, prev?: AST.Expression) => AST.ExpressionStatement;
+			expression?: AST.Expression;
+			needsPrevTracking?: boolean;
+		},
+		'initial' | 'identity' | 'expression'
+	>
+> & { async?: boolean };
 
 export interface TransformClientState extends BaseState {
 	events: Set<string>;

--- a/packages/ripple/src/helpers.d.ts
+++ b/packages/ripple/src/helpers.d.ts
@@ -1,0 +1,5 @@
+export type RequireAllOrNone<T, K extends keyof T> =
+	| (T & Required<Pick<T, K>>)
+	| (T & { [P in K]?: never });
+
+export type RequiredPresent<T, K extends keyof T> = Omit<T, K> & Required<Pick<T, K>>;

--- a/packages/ripple/tests/client/composite/composite.props.test.ripple
+++ b/packages/ripple/tests/client/composite/composite.props.test.ripple
@@ -1,4 +1,5 @@
-import { track, trackSplit, effect, flushSync, type Props } from 'ripple';
+import type { Tracked, Props } from 'ripple';
+import { track, trackSplit, effect, flushSync } from 'ripple';
 
 describe('composite > props', () => {
 	it('correctly handles default prop values', () => {
@@ -56,7 +57,7 @@ describe('composite > props', () => {
 	});
 
 	it('correctly handles no props #2', () => {
-		component Child({ foo }) {
+		component Child({ foo }: { foo?: number }) {
 			<div>{foo}</div>
 		}
 
@@ -76,7 +77,7 @@ describe('composite > props', () => {
 	it('mutating a tracked value prop should work as intended', () => {
 		const logs: number[] = [];
 
-		component Counter({ count }) {
+		component Counter({ count }: { count: Tracked<number> }) {
 			effect(() => {
 				logs.push(@count);
 			});
@@ -120,7 +121,7 @@ describe('composite > props', () => {
 			</style>
 		}
 
-		component Toggle(props) {
+		component Toggle(props: { pressed: Tracked<boolean> }) {
 			const [pressed, rest] = trackSplit(props, ['pressed']);
 			const onClick = () => (@pressed = !@pressed);
 			<Button {...@rest} class={@pressed ? 'on' : 'off'} {onClick}>{'button 1'}</Button>
@@ -145,5 +146,49 @@ describe('composite > props', () => {
 
 		expect(button1.className).toContain('off');
 		expect(button2.className).toContain('off');
+	});
+
+	it('correctly renders destructured props', () => {
+		interface ProductInfo {
+			id: string;
+			name: string;
+			organizationName: string;
+			description: string;
+			imageUrl: string;
+			price: number;
+		}
+
+		component Product({ id, name, organizationName, description, imageUrl, price }: ProductInfo) {
+			<article class="no-padding">
+				<img class="responsive small" src={imageUrl} alt={name} />
+				<span>{id}</span>
+				<h5>{name}</h5>
+				<h3>{organizationName}</h3>
+				<p>{description}</p>
+				<price class="price">{price}</price>
+			</article>
+		}
+
+		component App() {
+			<Product
+				id="1"
+				name="Product 1"
+				organizationName="Org 1"
+				description="Description 1"
+				imageUrl="https://picsum.photos/300/200"
+				price={15}
+			/>
+		}
+
+		render(App);
+
+		expect(container.querySelector('img').getAttribute('src')).toBe(
+			'https://picsum.photos/300/200',
+		);
+		expect(container.querySelector('span').textContent).toBe('1');
+		expect(container.querySelector('h5').textContent).toBe('Product 1');
+		expect(container.querySelector('h3').textContent).toBe('Org 1');
+		expect(container.querySelector('p').textContent).toBe('Description 1');
+		expect(container.querySelector('price').textContent).toBe('15');
 	});
 });

--- a/packages/ripple/tests/server/composite.props.test.ripple
+++ b/packages/ripple/tests/server/composite.props.test.ripple
@@ -1,0 +1,161 @@
+import type { Tracked, Props } from 'ripple';
+import { track, trackSplit } from 'ripple';
+
+describe('composite > props', () => {
+	it('correctly handles default prop values', async () => {
+		component Child({ foo = 456 }) {
+			<div>{foo}</div>
+		}
+
+		component App() {
+			let foo = track(123);
+
+			<Child />
+			<Child {@foo} />
+		}
+
+		const { body } = await render(App);
+		const { document } = parseHtml(body);
+
+		expect(document.querySelectorAll('div')[0].textContent).toBe('456');
+		expect(document.querySelectorAll('div')[1].textContent).toBe('123');
+	});
+
+	it('correctly handles default prop values #2', async () => {
+		component Child({ foo = 456 }) {
+			<div>{foo}</div>
+		}
+
+		component App() {
+			let foo = 123;
+
+			<Child />
+			<Child {foo} />
+		}
+
+		const { body } = await render(App);
+		const { document } = parseHtml(body);
+
+		expect(document.querySelectorAll('div')[0].textContent).toBe('456');
+		expect(document.querySelectorAll('div')[1].textContent).toBe('123');
+	});
+
+	it('correctly handles no props', async () => {
+		component Child(props: { foo?: Tracked<number> }) {
+			<div>{props.@foo}</div>
+		}
+
+		component App() {
+			let foo = track(123);
+
+			<Child />
+			<Child {foo} />
+		}
+
+		const { body } = await render(App);
+		const { document } = parseHtml(body);
+
+		expect(document.querySelectorAll('div')[0].textContent).toBe('');
+		expect(document.querySelectorAll('div')[1].textContent).toBe('123');
+	});
+
+	it('correctly handles no props #2', async () => {
+		component Child({ foo }: { foo?: number }) {
+			<div>{foo}</div>
+		}
+
+		component App() {
+			let foo = track(123);
+
+			<Child />
+			<Child {@foo} />
+		}
+
+		const { body } = await render(App);
+		const { document } = parseHtml(body);
+
+		expect(document.querySelectorAll('div')[0].textContent).toBe('');
+		expect(document.querySelectorAll('div')[1].textContent).toBe('123');
+	});
+
+	it('correctly retains prop accessors and reactivity when using rest props', async () => {
+		component Button(props: Props) {
+			const [children, rest] = trackSplit(props, ['children']);
+			<button {...@rest}>
+				<@children />
+			</button>
+			<style>
+				.on {
+					color: blue;
+				}
+				.off {
+					color: red;
+				}
+			</style>
+		}
+
+		component Toggle(props: { pressed: Tracked<boolean> }) {
+			const [pressed, rest] = trackSplit(props, ['pressed']);
+			const onClick = () => (@pressed = !@pressed);
+			<Button {...@rest} class={@pressed ? 'on' : 'off'} {onClick}>{'button 1'}</Button>
+			<Button class={@pressed ? 'on' : 'off'} {onClick}>{'button 2'}</Button>
+		}
+
+		component App() {
+			const pressed = track(true);
+			<Toggle {pressed} />
+		}
+
+		const { body } = await render(App);
+		const { document } = parseHtml(body);
+		const button1 = document.querySelectorAll('button')[0];
+
+		const button2 = document.querySelectorAll('button')[1];
+
+		expect(button1.className).toContain('on');
+		expect(button2.className).toContain('on');
+	});
+
+	it('correctly renders destructured props', async () => {
+		interface ProductInfo {
+			id: string;
+			name: string;
+			organizationName: string;
+			description: string;
+			imageUrl: string;
+			price: number;
+		}
+
+		component Product({ id, name, organizationName, description, imageUrl, price }: ProductInfo) {
+			<article class="no-padding">
+				<img class="responsive small" src={imageUrl} alt={name} />
+				<span>{id}</span>
+				<h5>{name}</h5>
+				<h3>{organizationName}</h3>
+				<p>{description}</p>
+				<price class="price">{price}</price>
+			</article>
+		}
+
+		component App() {
+			<Product
+				id="1"
+				name="Product 1"
+				organizationName="Org 1"
+				description="Description 1"
+				imageUrl="https://picsum.photos/300/200"
+				price={15}
+			/>
+		}
+
+		const { body } = await render(App);
+		const { document } = parseHtml(body);
+
+		expect(document.querySelector('img').getAttribute('src')).toBe('https://picsum.photos/300/200');
+		expect(document.querySelector('span').textContent).toBe('1');
+		expect(document.querySelector('h5').textContent).toBe('Product 1');
+		expect(document.querySelector('h3').textContent).toBe('Org 1');
+		expect(document.querySelector('p').textContent).toBe('Description 1');
+		expect(document.querySelector('price').textContent).toBe('15');
+	});
+});


### PR DESCRIPTION
- Fixes `apply_updates` by using the scope binding for the node vs initial that is used for the map.  It serves the same purpose but node is always present whereas initial could be null. Otherwise, with null, map entries were pointing to the same null key and thus resulted in the generated code that assigned the same value to disparate variables.
- also fixes a mapping where the Property shorthand wasn't visiting the value. it should've only visited the value vs just the key.