### PR TITLE
fix: move jsx empty to analyze, mapping, autocomplete in attr jsx expressions

### DIFF
--- a/packages/ripple/src/compiler/phases/1-parse/index.js
+++ b/packages/ripple/src/compiler/phases/1-parse/index.js
@@ -1749,15 +1749,7 @@ function RipplePlugin(config) {
 			jsx_parseAttributeValue() {
 				switch (this.type) {
 					case tt.braceL:
-						const t = this.jsx_parseExpressionContainer();
-						return (
-							t.expression.type === 'JSXEmptyExpression' &&
-								this.raise(
-									/** @type {AST.NodeWithLocation} */ (t).start,
-									'attributes must only be assigned a non-empty expression',
-								),
-							t
-						);
+						return this.jsx_parseExpressionContainer();
 					case tstt.jsxTagStart:
 					case tt.string:
 						return this.parseExprAtom();

--- a/packages/ripple/src/compiler/phases/2-analyze/index.js
+++ b/packages/ripple/src/compiler/phases/2-analyze/index.js
@@ -10,7 +10,10 @@
 	StyleClasses,
 } from '#compiler';
  */
-/** @import * as AST from 'estree' */
+/**
+@import * as AST from 'estree';
+@import * as ESTreeJSX from 'estree-jsx';
+*/
 
 import * as b from '../../../utils/builders.js';
 import { walk } from 'zimmerframe';
@@ -959,6 +962,31 @@ const visitors = {
 
 			for (const attr of node.attributes) {
 				if (attr.type === 'Attribute') {
+					if (attr.value && attr.value.type === 'JSXEmptyExpression') {
+						const value = /** @type {ESTreeJSX.JSXEmptyExpression & AST.NodeWithLocation} */ (
+							attr.value
+						);
+						error(
+							'attributes must only be assigned a non-empty expression',
+							state.analysis.module.filename,
+							{
+								...value,
+								start: value.start - 1,
+								end: value.end + 1,
+								loc: {
+									start: {
+										line: value.loc.start.line,
+										column: value.loc.start.column - 1,
+									},
+									end: {
+										line: value.loc.end.line,
+										column: value.loc.end.column + 1,
+									},
+								},
+							},
+							context.state.loose ? context.state.analysis.errors : undefined,
+						);
+					}
 					if (attr.name.type === 'Identifier') {
 						attribute_names.add(attr.name);
 

--- a/packages/ripple/src/compiler/phases/3-transform/segments.js
+++ b/packages/ripple/src/compiler/phases/3-transform/segments.js
@@ -652,6 +652,11 @@ export function convert_source_map_to_mappings(
 				}
 				return;
 			} else if (node.type === 'JSXExpressionContainer') {
+				if (node.loc) {
+					mappings.push(
+						get_mapping_from_node(node, src_to_gen_map, gen_line_offsets, mapping_data_verify_only),
+					);
+				}
 				// Visit the expression inside {}
 				if (node.expression) {
 					visit(node.expression);

--- a/packages/ripple/src/compiler/types/index.d.ts
+++ b/packages/ripple/src/compiler/types/index.d.ts
@@ -131,6 +131,7 @@ declare module 'estree' {
 		StyleIdentifier: StyleIdentifier;
 		ServerIdentifier: ServerIdentifier;
 		Text: TextNode;
+		JSXEmptyExpression: ESTreeJSX.JSXEmptyExpression;
 	}
 
 	// Missing estree type


### PR DESCRIPTION
- moves jsx empty expression from the parser to the analyzer
- adds mapping for JSXExpressionContainer
- and thus enables autocomplete inside JSXExpressions