### PR TITLE
fix: function visitor would visit everyhting 2x because of context.next()

### DIFF
--- a/packages/ripple/tests/client/basic/basic.rendering.test.ripple
+++ b/packages/ripple/tests/client/basic/basic.rendering.test.ripple
@@ -231,4 +231,47 @@ describe('basic client > rendering & text', () => {
 		render(App);
 		expect(container).toMatchSnapshot();
 	});
+
+	it('should handle consecutive text nodes without duplication', () => {
+		component App() {
+			const Something = conditional('a');
+
+			<Something />
+
+			function conditional(item: 'a') {
+				let hello = 'Hello';
+				const obj = {
+					a: component() {
+						<div>
+							{'a'}
+							{' '}
+							{hello}
+						</div>
+					},
+				};
+
+				return obj[item];
+			}
+		}
+
+		render(App);
+		const div = container.querySelector('div');
+		expect(div.textContent).toEqual('a Hello');
+	});
+
+	it('should handle multiple consecutive text expressions', () => {
+		component App() {
+			let name = 'World';
+			<div>
+				{'Hello'}
+				{' '}
+				{name}
+				{'!'}
+			</div>
+		}
+
+		render(App);
+		const div = container.querySelector('div');
+		expect(div.textContent).toEqual('Hello World!');
+	});
 });


### PR DESCRIPTION
pretty nasty bug, took me a while to track it down. noticed it as we were getting duplicate text nodes via normalize_children.

we were visiting functions twice in visit_function: once ourselves and then defaulting to the walker via context.next(state)

so, the solution is to return the node since we're visiting the body.

this also refactors the if conditions as we really only needed one there.

**the diff best viewed with the `Hide Whitespace` option**