### PR TITLE
docs: Refactor context2 display and clean up info note

### DIFF
--- a/website/docs/guide/state-management.md
+++ b/website/docs/guide/state-management.md
@@ -49,15 +49,11 @@ export component App() {
 
   // context's reactive property count gets updated
   <pre>{'Context: '}{context.get().@count}</pre>
-  <pre>{'Context2: '}{@count2}</pre>
+  <pre>{'Context2: '}{@(context2.get())}</pre>
 }
 ```
 
 </Code>
-
-::: info
-`@(context2.get())` usage with `@()` wrapping syntax will be enabled in the near future
-:::
 
 Passing data between components:
 


### PR DESCRIPTION
It seems like the `@(reactive)` syntax has been implemented, so I updated the syntax for displaying `context2` and removed outdated info note.