### PR TITLE
fix: destroys lone text nodes in client mode

### DIFF
--- a/packages/ripple/src/runtime/internal/client/template.js
+++ b/packages/ripple/src/runtime/internal/client/template.js
@@ -123,7 +123,9 @@ export function text(data = '') {
 		assign_nodes(/** @type {Node} */ (hydrate_node), /** @type {Node} */ (hydrate_node));
 		return /** @type {Node} */ (hydrate_node);
 	}
-	return create_text(data);
+	const node = create_text(data);
+	assign_nodes(node, node);
+	return node;
 }
 
 /**

--- a/packages/ripple/tests/client/dynamic-elements.test.ripple
+++ b/packages/ripple/tests/client/dynamic-elements.test.ripple
@@ -1,4 +1,4 @@
-import type { Props, PropsWithChildren, PropsNoChildren, PropsWithExtras } from 'ripple';
+import type { PropsWithExtras } from 'ripple';
 import { flushSync, track, createRefKey, trackSplit } from 'ripple';
 
 describe('dynamic DOM elements', () => {
@@ -591,5 +591,34 @@ describe('dynamic DOM elements', () => {
 
 		expect(outerScopes).toHaveLength(1);
 		expect(innerScopes).toHaveLength(0);
+	});
+
+	it('should remove and add back a text node in a conditional statement with a tracked', () => {
+		component App() {
+			let b = track(true);
+			<div>
+				if (@b) {
+					{'Inside if'}
+				}
+			</div>
+			<button onClick={() => (@b = !@b)}>{'Toggle b'}</button>
+		}
+
+		render(App);
+
+		const button = container.querySelector('button');
+		const div = container.querySelector('div');
+
+		expect(div.textContent).toBe('Inside if');
+
+		button.click();
+		flushSync();
+
+		expect(div.textContent).toBe('');
+
+		button.click();
+		flushSync();
+
+		expect(div.textContent).toBe('Inside if');
 	});
 });


### PR DESCRIPTION
closes #643 

Not 100% sure if this is the right place to fix this.  I traced it down through calls stacks to destroy_block that needs state start and end to remove a dom node.