### PR TITLE
feat: add hydration on early return

### DIFF
--- a/.changeset/hydration-early-return-markers.md
+++ b/.changeset/hydration-early-return-markers.md
@@ -1,0 +1,7 @@
+---
+'ripple': patch
+---
+
+Fix SSR hydration output for early-return guarded content by emitting hydration
+block markers around return-guarded regions, and add hydration/server coverage for
+early return scenarios.

--- a/packages/ripple/src/compiler/phases/3-transform/server/index.js
+++ b/packages/ripple/src/compiler/phases/3-transform/server/index.js
@@ -211,7 +211,13 @@ function transform_children(children, context) {
 
 		state.init = saved_init;
 		if (wrapped.length > 0) {
+			state.init?.push(
+				b.stmt(b.call(b.member(b.id('__output'), b.id('push')), b.literal(BLOCK_OPEN))),
+			);
 			state.init?.push(b.if(guard, b.block(wrapped)));
+			state.init?.push(
+				b.stmt(b.call(b.member(b.id('__output'), b.id('push')), b.literal(BLOCK_CLOSE))),
+			);
 		}
 	};
 

--- a/packages/ripple/tests/hydration/compiled/client/return.js
+++ b/packages/ripple/tests/hydration/compiled/client/return.js
@@ -1,0 +1,176 @@
+import * as _$_ from 'ripple/internal/client';
+
+var root_1 = _$_.template(`<div class="before">Before</div>`, 1);
+var root_2 = _$_.template(`<div class="after">After</div>`, 0);
+var root = _$_.template(`<!><!>`, 1);
+var root_4 = _$_.template(`<div class="before">Before</div>`, 1);
+var root_5 = _$_.template(`<div class="after">After</div>`, 0);
+var root_3 = _$_.template(`<!><!>`, 1);
+var root_7 = _$_.template(`<div class="stop">Stopped</div>`, 1);
+var root_8 = _$_.template(`<div class="after">After</div>`, 0);
+var root_6 = _$_.template(`<button class="toggle">Toggle</button><!><!>`, 1);
+var root_10 = _$_.template(`<div class="after-lone">After lone</div>`, 0);
+var root_9 = _$_.template(`<button class="toggle-lone">Toggle lone</button><!><!>`, 1);
+
+import { track } from 'ripple';
+
+export function EarlyReturnStaticTrue(__anchor, _, __block) {
+	_$_.push_component();
+
+	var __r = false;
+	var fragment = root();
+	var node = _$_.first_child_frag(fragment);
+
+	{
+		var consequent = (__anchor) => {
+			var fragment_1 = root_1();
+
+			__r = true;
+			_$_.append(__anchor, fragment_1);
+		};
+
+		_$_.if(node, (__render) => {
+			__r = false;
+
+			if (true) __render(consequent);
+		});
+	}
+
+	var node_1 = _$_.sibling(node);
+
+	var content = (__anchor) => {
+		var div_1 = root_2();
+
+		_$_.append(__anchor, div_1);
+	};
+
+	_$_.if(node_1, (__render) => {
+		if (!__r) __render(content);
+	});
+
+	_$_.append(__anchor, fragment);
+	_$_.pop_component();
+}
+
+export function EarlyReturnStaticFalse(__anchor, _, __block) {
+	_$_.push_component();
+
+	var __r_1 = false;
+	var fragment_2 = root_3();
+	var node_2 = _$_.first_child_frag(fragment_2);
+
+	{
+		var consequent_1 = (__anchor) => {
+			var fragment_3 = root_4();
+
+			__r_1 = true;
+			_$_.append(__anchor, fragment_3);
+		};
+
+		_$_.if(node_2, (__render) => {
+			__r_1 = false;
+
+			if (false) __render(consequent_1);
+		});
+	}
+
+	var node_3 = _$_.sibling(node_2);
+
+	var content_1 = (__anchor) => {
+		var div_2 = root_5();
+
+		_$_.append(__anchor, div_2);
+	};
+
+	_$_.if(node_3, (__render) => {
+		if (!__r_1) __render(content_1);
+	});
+
+	_$_.append(__anchor, fragment_2);
+	_$_.pop_component();
+}
+
+export function ReactiveEarlyReturn(__anchor, _, __block) {
+	_$_.push_component();
+
+	var __r_2 = _$_.tracked(false);
+	let stop = track(true, void 0, void 0, __block);
+	var fragment_4 = root_6();
+	var button_1 = _$_.first_child_frag(fragment_4);
+
+	button_1.__click = () => {
+		_$_.set(stop, !_$_.get(stop));
+	};
+
+	var node_4 = _$_.sibling(button_1);
+
+	{
+		var consequent_2 = (__anchor) => {
+			var fragment_5 = root_7();
+
+			_$_.set(__r_2, true);
+			_$_.append(__anchor, fragment_5);
+		};
+
+		_$_.if(node_4, (__render) => {
+			_$_.set(__r_2, false);
+
+			if (_$_.get(stop)) __render(consequent_2);
+		});
+	}
+
+	var node_5 = _$_.sibling(node_4);
+
+	var content_2 = (__anchor) => {
+		var div_3 = root_8();
+
+		_$_.append(__anchor, div_3);
+	};
+
+	_$_.if(node_5, (__render) => {
+		if (!_$_.get(__r_2)) __render(content_2);
+	});
+
+	_$_.append(__anchor, fragment_4);
+	_$_.pop_component();
+}
+
+export function ReactiveLoneReturn(__anchor, _, __block) {
+	_$_.push_component();
+
+	var __r_3 = _$_.tracked(false);
+	let stop = track(true, void 0, void 0, __block);
+	var fragment_6 = root_9();
+	var button_2 = _$_.first_child_frag(fragment_6);
+
+	button_2.__click = () => {
+		_$_.set(stop, !_$_.get(stop));
+	};
+
+	var node_6 = _$_.sibling(button_2);
+
+	{
+		_$_.if(node_6, (__render) => {
+			_$_.set(__r_3, false);
+
+			if (_$_.get(stop)) _$_.set(__r_3, true);
+		});
+	}
+
+	var node_7 = _$_.sibling(node_6);
+
+	var content_3 = (__anchor) => {
+		var div_4 = root_10();
+
+		_$_.append(__anchor, div_4);
+	};
+
+	_$_.if(node_7, (__render) => {
+		if (!_$_.get(__r_3)) __render(content_3);
+	});
+
+	_$_.append(__anchor, fragment_6);
+	_$_.pop_component();
+}
+
+_$_.delegate(['click']);

--- a/packages/ripple/tests/hydration/compiled/server/return.js
+++ b/packages/ripple/tests/hydration/compiled/server/return.js
@@ -1,0 +1,170 @@
+import * as _$_ from 'ripple/internal/server';
+
+import { track } from 'ripple/server';
+
+export function EarlyReturnStaticTrue(__output) {
+	_$_.push_component();
+
+	var __r = false;
+
+	__output.push('<!--[-->');
+
+	if (true) {
+		__output.push('<div');
+		__output.push(' class="before"');
+		__output.push('>');
+
+		{
+			__output.push('Before');
+		}
+
+		__output.push('</div>');
+		__r = true;
+	}
+
+	__output.push('<!--]-->');
+	__output.push('<!--[-->');
+
+	if (!__r) {
+		__output.push('<div');
+		__output.push(' class="after"');
+		__output.push('>');
+
+		{
+			__output.push('After');
+		}
+
+		__output.push('</div>');
+	}
+
+	__output.push('<!--]-->');
+	_$_.pop_component();
+}
+
+export function EarlyReturnStaticFalse(__output) {
+	_$_.push_component();
+
+	var __r_1 = false;
+
+	__output.push('<!--[-->');
+
+	if (false) {
+		__output.push('<div');
+		__output.push(' class="before"');
+		__output.push('>');
+
+		{
+			__output.push('Before');
+		}
+
+		__output.push('</div>');
+		__r_1 = true;
+	}
+
+	__output.push('<!--]-->');
+	__output.push('<!--[-->');
+
+	if (!__r_1) {
+		__output.push('<div');
+		__output.push(' class="after"');
+		__output.push('>');
+
+		{
+			__output.push('After');
+		}
+
+		__output.push('</div>');
+	}
+
+	__output.push('<!--]-->');
+	_$_.pop_component();
+}
+
+export function ReactiveEarlyReturn(__output) {
+	_$_.push_component();
+
+	var __r_2 = false;
+	let stop = track(true);
+
+	__output.push('<button');
+	__output.push(' class="toggle"');
+	__output.push('>');
+
+	{
+		__output.push('Toggle');
+	}
+
+	__output.push('</button>');
+	__output.push('<!--[-->');
+
+	if (_$_.get(stop)) {
+		__output.push('<div');
+		__output.push(' class="stop"');
+		__output.push('>');
+
+		{
+			__output.push('Stopped');
+		}
+
+		__output.push('</div>');
+		__r_2 = true;
+	}
+
+	__output.push('<!--]-->');
+	__output.push('<!--[-->');
+
+	if (!__r_2) {
+		__output.push('<div');
+		__output.push(' class="after"');
+		__output.push('>');
+
+		{
+			__output.push('After');
+		}
+
+		__output.push('</div>');
+	}
+
+	__output.push('<!--]-->');
+	_$_.pop_component();
+}
+
+export function ReactiveLoneReturn(__output) {
+	_$_.push_component();
+
+	var __r_3 = false;
+	let stop = track(true);
+
+	__output.push('<button');
+	__output.push(' class="toggle-lone"');
+	__output.push('>');
+
+	{
+		__output.push('Toggle lone');
+	}
+
+	__output.push('</button>');
+	__output.push('<!--[-->');
+
+	if (_$_.get(stop)) {
+		__r_3 = true;
+	}
+
+	__output.push('<!--]-->');
+	__output.push('<!--[-->');
+
+	if (!__r_3) {
+		__output.push('<div');
+		__output.push(' class="after-lone"');
+		__output.push('>');
+
+		{
+			__output.push('After lone');
+		}
+
+		__output.push('</div>');
+	}
+
+	__output.push('<!--]-->');
+	_$_.pop_component();
+}

--- a/packages/ripple/tests/hydration/components/return.ripple
+++ b/packages/ripple/tests/hydration/components/return.ripple
@@ -1,0 +1,59 @@
+// Early return components for hydration testing
+import { track } from 'ripple';
+
+export component EarlyReturnStaticTrue() {
+	if (true) {
+		<div class="before">{'Before'}</div>
+		return;
+	}
+
+	<div class="after">{'After'}</div>
+}
+
+export component EarlyReturnStaticFalse() {
+	if (false) {
+		<div class="before">{'Before'}</div>
+		return;
+	}
+
+	<div class="after">{'After'}</div>
+}
+
+export component ReactiveEarlyReturn() {
+	let stop = track(true);
+
+	<button
+		class="toggle"
+		onClick={() => {
+			@stop = !@stop;
+		}}
+	>
+		{'Toggle'}
+	</button>
+
+	if (@stop) {
+		<div class="stop">{'Stopped'}</div>
+		return;
+	}
+
+	<div class="after">{'After'}</div>
+}
+
+export component ReactiveLoneReturn() {
+	let stop = track(true);
+
+	<button
+		class="toggle-lone"
+		onClick={() => {
+			@stop = !@stop;
+		}}
+	>
+		{'Toggle lone'}
+	</button>
+
+	if (@stop) {
+		return;
+	}
+
+	<div class="after-lone">{'After lone'}</div>
+}

--- a/packages/ripple/tests/hydration/return.test.js
+++ b/packages/ripple/tests/hydration/return.test.js
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { flushSync } from 'ripple';
+import { hydrateComponent, container } from '../setup-hydration.js';
+
+// Import server-compiled components
+import * as ServerComponents from './compiled/server/return.js';
+// Import client-compiled components
+import * as ClientComponents from './compiled/client/return.js';
+
+describe('hydration > early returns', () => {
+	it('hydrates early return when guard returns before trailing content', async () => {
+		await hydrateComponent(
+			ServerComponents.EarlyReturnStaticTrue,
+			ClientComponents.EarlyReturnStaticTrue,
+		);
+
+		expect(container.querySelector('.before')?.textContent).toBe('Before');
+		expect(container.querySelector('.after')).toBeNull();
+	});
+
+	it('hydrates early return when guard does not return and trailing content renders', async () => {
+		await hydrateComponent(
+			ServerComponents.EarlyReturnStaticFalse,
+			ClientComponents.EarlyReturnStaticFalse,
+		);
+
+		expect(container.querySelector('.before')).toBeNull();
+		expect(container.querySelector('.after')?.textContent).toBe('After');
+	});
+
+	it('hydrates reactive early return and toggles between branches', async () => {
+		await hydrateComponent(
+			ServerComponents.ReactiveEarlyReturn,
+			ClientComponents.ReactiveEarlyReturn,
+		);
+
+		const button = container.querySelector('.toggle');
+		expect(container.querySelector('.stop')?.textContent).toBe('Stopped');
+		expect(container.querySelector('.after')).toBeNull();
+
+		button?.click();
+		flushSync();
+		expect(container.querySelector('.stop')).toBeNull();
+		expect(container.querySelector('.after')?.textContent).toBe('After');
+
+		button?.click();
+		flushSync();
+		expect(container.querySelector('.stop')?.textContent).toBe('Stopped');
+		expect(container.querySelector('.after')).toBeNull();
+	});
+
+	it('hydrates lone return guard and toggles trailing content', async () => {
+		await hydrateComponent(
+			ServerComponents.ReactiveLoneReturn,
+			ClientComponents.ReactiveLoneReturn,
+		);
+
+		const button = container.querySelector('.toggle-lone');
+		expect(container.querySelector('.after-lone')).toBeNull();
+
+		button?.click();
+		flushSync();
+		expect(container.querySelector('.after-lone')?.textContent).toBe('After lone');
+
+		button?.click();
+		flushSync();
+		expect(container.querySelector('.after-lone')).toBeNull();
+	});
+});

--- a/packages/ripple/tests/server/return.test.ripple
+++ b/packages/ripple/tests/server/return.test.ripple
@@ -43,6 +43,26 @@ describe('early return in SSR', () => {
 		expect(body).toBeHtml('<div>rest</div>');
 	});
 
+	it('emits hydration markers for content guarded by early return flags', async () => {
+		component App() {
+			let condition = true;
+
+			if (condition) {
+				return;
+			}
+
+			<div>{'rest'}</div>
+		}
+
+		const { body } = await render(App);
+		const open_markers = body.match(/<!--\[-->/g) || [];
+		const close_markers = body.match(/<!--\]-->/g) || [];
+		expect(open_markers.length).toBeGreaterThanOrEqual(3);
+		expect(close_markers.length).toBeGreaterThanOrEqual(3);
+		expect(open_markers.length).toBe(close_markers.length);
+		expect(body).toBeHtml('');
+	});
+
 	it('handles nested ifs with return', async () => {
 		component App() {
 			let a = true;


### PR DESCRIPTION
Updated server transform to emit hydration block markers around return-guarded regions so client hydration can correctly claim trailing guarded content.

Added new hydration fixtures and tests for:
- static early return (return path and non-return path)
- reactive early return with toggling
- lone return guard behavior