### PR TITLE
feat: add missing llms entry for early returns

### DIFF
--- a/website/docs/guide/control-flow.md
+++ b/website/docs/guide/control-flow.md
@@ -26,6 +26,34 @@ export component Truthy({ x }) {
 
 </Code>
 
+## Early return (guard clauses)
+
+You can pair `if` blocks with `return;` to short-circuit the rest of the
+component body once a guard branch is hit.
+
+<Code>
+
+```ripple
+import { track } from 'ripple';
+
+export component AuthGate() {
+  let is_logged_in = track(false);
+
+  if (!@is_logged_in) {
+    <p>{'Please sign in.'}</p>
+    return;
+  }
+
+  <h1>{'Dashboard'}</h1>
+  <p>{'Private content'}</p>
+}
+```
+
+</Code>
+
+`return` in components is only valid as `return;`. Returning a value (including
+templates) is invalid.
+
 ## Switch statements
 
 Switch statements let you conditionally render content based on a value. They work with both static and reactive values.

--- a/website/docs/guide/syntax.md
+++ b/website/docs/guide/syntax.md
@@ -71,6 +71,31 @@ component App() {
 }
 ```
 
+## Early Returns in Components
+
+Ripple supports early exits from component/template execution via guard clauses.
+Use `return;` to stop evaluating the rest of the current render path after a
+condition is met.
+
+```ripple
+component Profile({ user }) {
+	if (!user) {
+		<p>{'Please sign in to continue.'}</p>
+		return;
+	}
+
+	<h1>{user.name}</h1>
+	<p>{user.email}</p>
+}
+```
+
+**Rules:**
+
+- Use only `return;` (without a value) inside component/template scopes.
+- `return` with a value (for example `return 'x'` or `return <div />`) is a compile error.
+- `return` is not allowed at module top level.
+- `return` is a control-flow exit, not a JSX return value mechanism.
+
 ## Concept: Expressions
 
 In Ripple (and JSX), we can interpolate expressions into the template with a

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -103,6 +103,48 @@ component App() {
 
 This design enforces clear separation between component templates and regular JavaScript logic, making code more predictable and easier to analyze.
 
+### ⚠️ Critical: Early Returns Are Guard Exits, Not JSX Returns
+
+**IMPORTANT**: Inside Ripple components, use early returns only as `return;` (no value). This exits the current component render path and skips statements that follow.
+
+```ripple
+// ✅ CORRECT - Guard clause with early return
+component AuthGate({ is_logged_in }) {
+  if (!is_logged_in) {
+    <p>{'Please sign in.'}</p>
+    return;
+  }
+
+  <h1>{'Dashboard'}</h1>
+}
+
+// ❌ WRONG - Returning templates from components
+component App() {
+  if (loading) {
+    return <p>{'Loading...'}</p>;  // Compilation error
+  }
+}
+
+// ❌ WRONG - Returning values from components
+component App() {
+  if (error) {
+    return 'failed';  // Compilation error
+  }
+}
+```
+
+**LLM DO:**
+- Use `if (...) { <Fallback /> return; }` guard clauses to short-circuit rendering.
+- Place any guard/fallback template statements before `return;`.
+- Keep helper functions separate for computing/returning data.
+- Use early return when it improves readability over deeply nested `if/else`.
+
+**LLM DON'T:**
+- Do not generate `return <JSX />` in Ripple components.
+- Do not generate `return someValue;` inside Ripple components.
+- Do not generate top-level/module `return;`.
+- Do not translate React-style `return (...)` component patterns directly to Ripple.
+
 ### Template Lexical Scoping
 
 **Unique Feature**: Ripple templates act as lexical scopes, allowing you to declare variables, call functions, and execute JavaScript statements directly within JSX elements - similar to block statements in regular JavaScript.


### PR DESCRIPTION
Add missing early return detail in `llms.txt`.
Updated also `syntax` and `control-flow` documentation page to reflect current ripple state.