### PR TITLE
fix: inject __block for track() in class constructors

### DIFF
--- a/packages/ripple/src/compiler/phases/3-transform/client/index.js
+++ b/packages/ripple/src/compiler/phases/3-transform/client/index.js
@@ -116,7 +116,6 @@ function visit_function(node, context) {
 	if (
 		metadata?.tracked === true &&
 		!is_inside_component(context, true) &&
-		is_component_level_function(context) &&
 		body.type === 'BlockStatement'
 	) {
 		body = { ...body, body: [b.var('__block', b.call('_$_.scope')), ...body.body] };

--- a/packages/ripple/tests/client/compiler/compiler.basic.test.ripple
+++ b/packages/ripple/tests/client/compiler/compiler.basic.test.ripple
@@ -357,4 +357,28 @@ export component App() {
 `;
 		expect(() => compile(code, 'test.ripple')).not.toThrow();
 	});
+
+	it('should inject __block for track() calls inside class constructors', () => {
+		const source = `
+import { track } from 'ripple';
+
+class Store {
+	constructor() {
+		this.count = track(0);
+		this.items = #[1, 2, 3];
+	}
+}
+
+export component App() {
+	const store = new Store();
+	<div>{store.count}</div>
+}
+`;
+		const result = compile(source, 'test.ripple', { mode: 'client' });
+		const code = result.js.code;
+
+		// The constructor's compiled output should contain __block = _$_.scope()
+		expect(code).toContain('__block');
+		expect(code).toContain('_$_.scope()');
+	});
 });


### PR DESCRIPTION
## Summary

- Fix `track()` crashing with `Cannot set properties of undefined (setting 'tracking')` when used inside class constructors/methods outside a component
- The compiler's `visit_function` had an overly restrictive condition (`is_component_level_function`) that prevented `var __block = _$_.scope()` from being injected into class constructors
- Simplify the condition to inject `__block` for all tracked functions outside a component context

## Test plan

- [x] Added compilation test verifying `__block` and `_$_.scope()` are present in compiled output for a class with `track()` and `#[]` in its constructor
- [x] All existing tests pass (1088 passed, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)