### PR TITLE
fix(hmr): force page reload if ssr files like .md cannot be selfAccepting

### DIFF
--- a/packages/vite-plugin/src/index.js
+++ b/packages/vite-plugin/src/index.js
@@ -648,7 +648,7 @@ export function ripple(inlineOptions = {}) {
 
 				// Full reload — the only reliable way to pick up the change
 				// for files that don't self-accept but are consumed by the app.
-				server.hot.send({ type: 'full-reload' });
+				this.environment.hot.send({ type: 'full-reload' });
 				return [];
 			},
 


### PR DESCRIPTION
- for cases where deps are loaded during ssr, like .md files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches dev-server HMR behavior and forces full page reloads for certain file changes, which can impact developer workflow and potentially reload more often than intended if SSR graph matching is too broad.
> 
> **Overview**
> Improves dev HMR handling in `@ripple-ts/vite-plugin` by adding a `hotUpdate` hook that detects changes which can’t be safely refreshed via module-level HMR (e.g. SSR-consumed deps like `.md`).
> 
> If all changed modules are self-accepting, it defers to Vite; otherwise it checks the SSR module graph, invalidates matching SSR modules, and triggers a client `full-reload` to avoid serving stale SSR-cached content.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3550df7e2aedb6b6f3c61e27a4e446383e146c1c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->