### PR TITLE
Add `#defer` block for async reactivity handling

### DIFF
--- a/grammars/textmate/ripple.tmLanguage.json
+++ b/grammars/textmate/ripple.tmLanguage.json
@@ -65,6 +65,9 @@
           "include": "#jsx"
         },
         {
+          "include": "#defer-block"
+        },
+        {
           "include": "#declaration"
         },
         {
@@ -6818,6 +6821,29 @@
       "patterns": [
         {
           "include": "#statements"
+        }
+      ]
+    },
+    "defer-block": {
+      "name": "meta.defer-block.js",
+      "begin": "(#defer)\\s*(\\{)",
+      "beginCaptures": {
+        "1": {
+          "name": "storage.type.defer.js"
+        },
+        "2": {
+          "name": "punctuation.definition.block.js"
+        }
+      },
+      "end": "\\}",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.block.js"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#component-statements"
         }
       ]
     },

--- a/grammars/tree-sitter/grammar.js
+++ b/grammars/tree-sitter/grammar.js
@@ -572,9 +572,12 @@ module.exports = grammar({
 				$.jsx_element,
 				$.jsx_self_closing_element,
 				$.server_block,
+				$.defer_block,
 			),
 
 		server_block: ($) => seq('#server', '{', repeat($.statement), '}'),
+
+		defer_block: ($) => seq('#defer', '{', repeat($.statement), '}'),
 
 		unbox_expression: ($) =>
 			prec.left(

--- a/grammars/tree-sitter/queries/folds.scm
+++ b/grammars/tree-sitter/queries/folds.scm
@@ -19,6 +19,9 @@
 ; Fold server blocks
 (server_block) @fold
 
+; Fold defer blocks
+(defer_block) @fold
+
 ; Fold comments
 (comment) @fold
 

--- a/grammars/tree-sitter/queries/highlights.scm
+++ b/grammars/tree-sitter/queries/highlights.scm
@@ -2,6 +2,7 @@
 (component_declaration "component" @keyword)
 (fragment_declaration "fragment" @keyword)
 (server_block "#server" @keyword)
+(defer_block "#defer" @keyword)
 
 ; Reserved identifiers
 [

--- a/packages/nvim-plugin/queries/ripple/folds.scm
+++ b/packages/nvim-plugin/queries/ripple/folds.scm
@@ -19,6 +19,9 @@
 ; Fold server blocks
 (server_block) @fold
 
+; Fold defer blocks
+(defer_block) @fold
+
 ; Fold comments
 (comment) @fold
 

--- a/packages/nvim-plugin/queries/ripple/highlights.scm
+++ b/packages/nvim-plugin/queries/ripple/highlights.scm
@@ -2,6 +2,7 @@
 (component_declaration "component" @keyword)
 (fragment_declaration "fragment" @keyword)
 (server_block "#server" @keyword)
+(defer_block "#defer" @keyword)
 
 ; Reserved identifiers
 [

--- a/packages/zed-plugin/languages/ripple/folds.scm
+++ b/packages/zed-plugin/languages/ripple/folds.scm
@@ -19,6 +19,9 @@
 ; Fold server blocks
 (server_block) @fold
 
+; Fold defer blocks
+(defer_block) @fold
+
 ; Fold comments
 (comment) @fold
 

--- a/packages/zed-plugin/languages/ripple/highlights.scm
+++ b/packages/zed-plugin/languages/ripple/highlights.scm
@@ -2,6 +2,7 @@
 (component_declaration "component" @keyword)
 (fragment_declaration "fragment" @keyword)
 (server_block "#server" @keyword)
+(defer_block "#defer" @keyword)
 
 ; Reserved identifiers
 [


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Grammar/query updates only; risk is limited to potential parsing/highlighting/folding regressions for Ripple files in supported editors.
> 
> **Overview**
> Adds support for a new `#defer { ... }` block to the Ripple language grammars.
> 
> Updates the Tree-sitter grammar to parse `defer_block` expressions and adds corresponding highlight and fold queries across the core grammar and the Neovim and Zed editor plugins. Updates the TextMate grammar to recognize `#defer` blocks within component statements and scope `#defer`/braces for syntax highlighting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3880938acd88df886f22bc8ac7cdb3e9ce88126f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->