### PR TITLE
fix: preserve parentheses around IIFE callee in prettier plugin

### DIFF
--- a/.changeset/iife-parentheses-fix.md
+++ b/.changeset/iife-parentheses-fix.md
@@ -1,0 +1,5 @@
+---
+"@ripple-ts/prettier-plugin": patch
+---
+
+fix: preserve parentheses around IIFE callee in prettier plugin

--- a/packages/prettier-plugin/src/index.js
+++ b/packages/prettier-plugin/src/index.js
@@ -1406,8 +1406,11 @@ function printRippleNode(node, path, options, print, args) {
 			/** @type {Doc[]} */
 			const parts = [];
 			let calleePart = path.call(print, 'callee');
-			// Preserve parentheses around the callee (e.g. IIFEs like `(() => {})()`)
-			if (node.callee.metadata?.parenthesized) {
+			const calleeNeedsParens =
+				node.callee.metadata?.parenthesized &&
+				(node.callee.type === 'ArrowFunctionExpression' ||
+					node.callee.type === 'FunctionExpression');
+			if (calleeNeedsParens) {
 				calleePart = ['(', calleePart, ')'];
 			}
 			parts.push(calleePart);

--- a/packages/prettier-plugin/src/index.test.js
+++ b/packages/prettier-plugin/src/index.test.js
@@ -1750,6 +1750,13 @@ files = [...(files ?? []), ...dt.files];`;
 			expect(result).toBeWithNewline(expected);
 		});
 
+		it('should not double-parenthesize a parenthesized identifier callee', async () => {
+			const expected = `const s = (foo)();`;
+
+			const result = await format(expected, { singleQuote: true, printWidth: 80 });
+			expect(result).toBeWithNewline(expected);
+		});
+
 		it('should preserve parentheses around IIFE arrow function callee', async () => {
 			const expected = `const s = (() => {
   return true;


### PR DESCRIPTION
## Summary

Fixes #783.

The prettier plugin was stripping the wrapping parentheses from IIFE callees, turning valid syntax like:

```js
const s = (() => {
  return true;
})();
```

into invalid syntax:

```js
const s = () => {
  return true;
}();
```

The parser already marks parenthesized expressions with `metadata.parenthesized = true`, but the `CallExpression` printer never checked this flag on the callee node. The fix wraps the printed callee in `()` when `node.callee.metadata?.parenthesized` is true, consistent with how other node types handle this flag throughout the printer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Small but correctness-sensitive change in the core call-expression printer that can affect formatted output across many files; risk is mitigated by targeted regression tests for the previously broken IIFE cases.
> 
> **Overview**
> Fixes the prettier plugin’s `CallExpression` printing to **preserve required parentheses** when the callee was originally parenthesized and is an `ArrowFunctionExpression`/`FunctionExpression`, preventing IIFE output from being reformatted into invalid syntax.
> 
> Adds regression tests covering IIFE arrow/function callees and ensuring already-parenthesized identifier callees aren’t double-wrapped, and includes a patch changeset for `@ripple-ts/prettier-plugin`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 76bb4487f347a97ccb9a0346561968073083a459. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->