### PR TITLE
fix(runtime): pass blocks array to destroy_block in reconcile_by_key Map path

### DIFF
--- a/packages/ripple/src/runtime/internal/client/for.js
+++ b/packages/ripple/src/runtime/internal/client/for.js
@@ -436,7 +436,7 @@ function reconcile_by_key(anchor, block, b, render_fn, is_controlled, is_indexed
 						if (fast_path_removal) {
 							fast_path_removal = false;
 							while (i > a_start) {
-								destroy_block(a[a_start++]);
+								destroy_block(a_blocks[a_start++]);
 							}
 						}
 						sources[j - b_start] = i + 1;


### PR DESCRIPTION
## Summary

- Fixes `destroy_block(a[a_start++])` → `destroy_block(a_blocks[a_start++])` in `reconcile_by_key`'s Map-based path
- `a` is `state.array` (values), `a_blocks` is `state.blocks` (blocks); `destroy_block` requires a `Block` object
- Without this fix, destroying old items during a keyed list reconciliation (32+ items, fast-path removal) passes plain values to `destroy_block`, causing a `TypeError`

Closes #787

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small runtime bugfix limited to keyed `for` reconciliation; low risk aside from affecting list diffing behavior in controlled keyed lists.
> 
> **Overview**
> Fixes a keyed list reconciliation bug in `packages/ripple/src/runtime/internal/client/for.js` where the Map-based fast-path removal logic could call `destroy_block` with an item value instead of the corresponding `Block`.
> 
> During `reconcile_by_key` when trimming removed items from the start, the code now correctly destroys from `state.blocks` (`a_blocks`) so removed keyed items are torn down without throwing and DOM updates proceed correctly for larger lists.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1736f034dab28d980b9103fcca3f3f21b3910e33. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->