### PR TITLE
fix(runtime): remove duplicate block.d assignment in destroy_block cleanup chain

### DIFF
--- a/packages/ripple/src/runtime/internal/client/blocks.js
+++ b/packages/ripple/src/runtime/internal/client/blocks.js
@@ -440,5 +440,5 @@ export function destroy_block(block, remove_dom = true) {
 		unlink_block(block);
 	}
 
-	block.fn = block.s = block.d = block.p = block.d = block.co = block.t = null;
+	block.fn = block.s = block.d = block.p = block.co = block.t = null;
 }


### PR DESCRIPTION
## Summary

- Removes the duplicate `block.d = null` from the nulling chain in `destroy_block`
- The original chain was `block.fn = block.s = block.d = block.p = block.d = block.co = block.t = null` — `block.d` appeared twice
- Fixes the chain to `block.fn = block.s = block.d = block.p = block.co = block.t = null`

Closes #795

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Trivial cleanup-only change in a teardown path; behavior should be unchanged aside from eliminating redundant assignment.
> 
> **Overview**
> Fixes `destroy_block` cleanup in `blocks.js` by removing a duplicated `block.d = null` in the property-nulling assignment chain after teardown/unlink, without changing destruction behavior otherwise.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 43ee201d08d899888f5b30e4f05fdad22fa342ba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->