### PR TITLE
fix(compiler): strip TypeScript type arguments from class extends clauses

### DIFF
--- a/packages/ripple/src/compiler/phases/3-transform/client/index.js
+++ b/packages/ripple/src/compiler/phases/3-transform/client/index.js
@@ -4945,9 +4945,7 @@ function create_tsx_with_typescript_support(comments) {
 			if (node.superClass) {
 				context.write(' extends ');
 				context.visit(node.superClass);
-				if (node.superTypeArguments) {
-					context.visit(node.superTypeArguments);
-				}
+				// superTypeArguments is TypeScript-only and should not be emitted to JavaScript
 			}
 			if (node.implements && node.implements.length > 0) {
 				context.write(' implements ');
@@ -4971,9 +4969,7 @@ function create_tsx_with_typescript_support(comments) {
 			if (node.superClass) {
 				context.write(' extends ');
 				context.visit(node.superClass);
-				if (node.superTypeArguments) {
-					context.visit(node.superTypeArguments);
-				}
+				// superTypeArguments is TypeScript-only and should not be emitted to JavaScript
 			}
 			if (node.implements && node.implements.length > 0) {
 				context.write(' implements ');

--- a/packages/ripple/tests/client/typescript-generics.test.ripple
+++ b/packages/ripple/tests/client/typescript-generics.test.ripple
@@ -199,4 +199,30 @@ describe('generic patterns', () => {
 
 		render(App);
 	});
+
+	it('tests class extending generic type with type arguments', () => {
+		component App() {
+			// This tests that type arguments in class extends are stripped from JS output
+			// See: https://github.com/Ripple-TS/ripple/issues/813
+			class StringMap extends Map<string, string> {
+				constructor() {
+					super();
+				}
+				
+				getFirstKey(): string | undefined {
+					for (const key of this.keys()) {
+						return key;
+					}
+					return undefined;
+				}
+			}
+
+			const map = new StringMap();
+			map.set('hello', 'world');
+
+			<div>{map.get('hello')}</div>
+		}
+
+		render(App);
+	});
 });


### PR DESCRIPTION
## Bug Description

TypeScript type arguments in class extends clauses were being incorrectly emitted to JavaScript output, causing syntax errors like "Unexpected token '<'".

For example:
```typescript
class StringMap extends Map<string, string> {
    constructor() {
        super();
    }
}
```

Was being compiled to invalid JavaScript:
```javascript
class StringMap extends Map<string, string> {  // <-- Syntax error!
    constructor() {
        super();
    }
}
```

## Fix

Removed the superTypeArguments visit in both ClassDeclaration and ClassExpression handlers in the client transform phase. These are TypeScript-only constructs that should not appear in compiled JavaScript.

## Test

Added a test case in typescript-generics.test.ripple to verify that classes extending generic types with type arguments compile correctly.

## Related Issue

Fixes #813

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the client transform’s class codegen, which is core compiler output, but the change is narrowly scoped to omitting TypeScript-only `superTypeArguments` to prevent invalid JavaScript emission.
> 
> **Overview**
> Fixes JavaScript emission for `class ... extends ...<T>` by no longer printing `superTypeArguments` in the client transform’s `ClassDeclaration` and `ClassExpression` printers (preventing `Unexpected token '<'` syntax errors).
> 
> Adds a regression test in `typescript-generics.test.ripple` covering a class extending a generic `Map<string, string>` to ensure type arguments are stripped from JS output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fdcaf3f1e0bbd60c4bfd4643d1e8185c42f924a0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->