### PR TITLE
improve dynamic component heuristics

### DIFF
--- a/packages/ripple/src/compiler/phases/1-parse/index.js
+++ b/packages/ripple/src/compiler/phases/1-parse/index.js
@@ -2234,6 +2234,37 @@ function RipplePlugin(config) {
 					return node;
 				}
 
+				// &[ or &{ at statement level — lazy destructuring assignment
+				// e.g., &[data] = track(0); or &{x, y} = obj;
+				if (this.type === tt.bitwiseAND) {
+					const charAfterAmp = this.input.charCodeAt(this.end);
+					if (charAfterAmp === 123 || charAfterAmp === 91) {
+						const node = /** @type {AST.ExpressionStatement} */ (this.startNode());
+						const assign_node = /** @type {AST.AssignmentExpression} */ (this.startNode());
+						this.next(); // consume &
+						// Parse the left-hand side (array or object expression)
+						const left = /** @type {AST.ArrayPattern | AST.ObjectPattern} */ (
+							/** @type {unknown} */ (this.parseExprAtom())
+						);
+						// Convert expression to destructuring pattern
+						this.toAssignable(left, false);
+						left.lazy = true;
+						// Expect = operator
+						this.expect(tt.eq);
+						// Parse the right-hand side
+						assign_node.operator = '=';
+						assign_node.left = left;
+						assign_node.right = /** @type {AST.Expression} */ (this.parseMaybeAssign());
+						node.expression = /** @type {AST.AssignmentExpression} */ (
+							this.finishNode(assign_node, 'AssignmentExpression')
+						);
+						this.semicolon();
+						return /** @type {AST.ExpressionStatement} */ (
+							this.finishNode(node, 'ExpressionStatement')
+						);
+					}
+				}
+
 				return super.parseStatement(context, topLevel, exports);
 			}
 

--- a/packages/ripple/src/compiler/phases/2-analyze/index.js
+++ b/packages/ripple/src/compiler/phases/2-analyze/index.js
@@ -836,6 +836,30 @@ const visitors = {
 		}
 	},
 
+	ExpressionStatement(node, context) {
+		const { state, visit } = context;
+
+		// Handle standalone lazy destructuring assignment: &[data] = track(0);
+		if (
+			node.expression.type === 'AssignmentExpression' &&
+			node.expression.operator === '=' &&
+			(node.expression.left.type === 'ObjectPattern' ||
+				node.expression.left.type === 'ArrayPattern') &&
+			node.expression.left.lazy
+		) {
+			const pattern = /** @type {AST.ObjectPattern | AST.ArrayPattern} */ (node.expression.left);
+			const lazy_id = b.id(state.scope.generate('lazy'));
+			const init = /** @type {AST.Expression} */ (node.expression.right);
+			const init_is_track =
+				init?.type === 'CallExpression' && is_ripple_track_call(init.callee, context) === 'track';
+			setup_lazy_transforms(pattern, lazy_id, state, true, !!init_is_track);
+			// Store the generated identifier name on the pattern for the transform phase
+			pattern.metadata = { ...pattern.metadata, lazy_id: lazy_id.name };
+		}
+
+		context.next();
+	},
+
 	StyleIdentifier(node, context) {
 		const component = is_inside_component(context, true);
 		const parent = context.path.at(-1);

--- a/packages/ripple/src/compiler/phases/3-transform/client/index.js
+++ b/packages/ripple/src/compiler/phases/3-transform/client/index.js
@@ -916,6 +916,25 @@ const visitors = {
 		return context.next();
 	},
 
+	ExpressionStatement(node, context) {
+		// Handle standalone lazy destructuring: &[data] = track(0); → const lazy0 = track(0);
+		if (
+			node.expression.type === 'AssignmentExpression' &&
+			node.expression.left.lazy &&
+			node.expression.left.metadata?.lazy_id
+		) {
+			if (context.state.to_ts) {
+				// In TypeScript mode, convert to a regular assignment (drop the pattern)
+				node.expression.left.lazy = false;
+				delete node.expression.left.metadata.lazy_id;
+				return context.next();
+			}
+			const right = /** @type {AST.Expression} */ (context.visit(node.expression.right));
+			return b.const(b.id(node.expression.left.metadata.lazy_id), right);
+		}
+		return context.next();
+	},
+
 	VariableDeclaration(node, context) {
 		for (const declarator of node.declarations) {
 			if (!context.state.to_ts) {

--- a/packages/ripple/src/compiler/phases/3-transform/client/index.js
+++ b/packages/ripple/src/compiler/phases/3-transform/client/index.js
@@ -533,9 +533,6 @@ const visitors = {
 					if (context.state.metadata?.tracking === false) {
 						context.state.metadata.tracking = true;
 					}
-					if (node.tracked && !binding?.read_unwraps) {
-						return b.call('_$_.get', build_getter(node, context));
-					}
 				}
 				return build_getter(node, context);
 			}

--- a/packages/ripple/src/compiler/phases/3-transform/server/index.js
+++ b/packages/ripple/src/compiler/phases/3-transform/server/index.js
@@ -333,29 +333,7 @@ const visitors = {
 				binding.node !== node &&
 				(binding.kind === 'lazy' || binding.kind === 'lazy_fallback')
 			) {
-				const transformed = binding.transform.read(node);
-				if (node.tracked && !binding.read_unwraps) {
-					const is_right_side_of_assignment =
-						parent.type === 'AssignmentExpression' && parent.right === node;
-					if (
-						(parent.type !== 'AssignmentExpression' && parent.type !== 'UpdateExpression') ||
-						is_right_side_of_assignment
-					) {
-						return b.call('_$_.get', transformed);
-					}
-				}
-				return transformed;
-			}
-
-			if (node.tracked) {
-				const is_right_side_of_assignment =
-					parent.type === 'AssignmentExpression' && parent.right === node;
-				if (
-					(parent.type !== 'AssignmentExpression' && parent.type !== 'UpdateExpression') ||
-					is_right_side_of_assignment
-				) {
-					return b.call('_$_.get', node);
-				}
+				return binding.transform.read(node);
 			}
 
 			return node;
@@ -1203,8 +1181,9 @@ const visitors = {
 			/** @type {AST.Statement[]} */
 			const init = [];
 			/** @type {AST.Statement[]} */
+			const visited_id = /** @type {AST.Expression} */ (visit(node.id, state));
 			const statements = [
-				b.const(comp_id, /** @type {AST.Expression} */ (visit(node.id, state))),
+				b.const(comp_id, is_element_dynamic(node) ? b.call('_$_.get', visited_id) : visited_id),
 				b.const(args_id, b.array(args)),
 			];
 

--- a/packages/ripple/src/compiler/phases/3-transform/server/index.js
+++ b/packages/ripple/src/compiler/phases/3-transform/server/index.js
@@ -813,6 +813,19 @@ const visitors = {
 		return statements.length ? b.block(statements) : b.empty;
 	},
 
+	ExpressionStatement(node, context) {
+		// Handle standalone lazy destructuring: &[data] = track(0); → const lazy0 = track(0);
+		if (
+			node.expression.type === 'AssignmentExpression' &&
+			node.expression.left.lazy &&
+			node.expression.left.metadata?.lazy_id
+		) {
+			const right = /** @type {AST.Expression} */ (context.visit(node.expression.right));
+			return b.const(b.id(node.expression.left.metadata.lazy_id), right);
+		}
+		return context.next();
+	},
+
 	VariableDeclaration(node, context) {
 		for (const declarator of node.declarations) {
 			if (!context.state.to_ts) {
@@ -1180,8 +1193,8 @@ const visitors = {
 
 			/** @type {AST.Statement[]} */
 			const init = [];
-			/** @type {AST.Statement[]} */
 			const visited_id = /** @type {AST.Expression} */ (visit(node.id, state));
+			/** @type {AST.Statement[]} */
 			const statements = [
 				b.const(comp_id, is_element_dynamic(node) ? b.call('_$_.get', visited_id) : visited_id),
 				b.const(args_id, b.array(args)),

--- a/packages/ripple/src/runtime/internal/client/composite.js
+++ b/packages/ripple/src/runtime/internal/client/composite.js
@@ -3,7 +3,7 @@
 import { branch, destroy_block, render, render_spread } from './blocks.js';
 import { COMPOSITE_BLOCK, DEFAULT_NAMESPACE, NAMESPACE_URI } from './constants.js';
 import { hydrate_next, hydrating } from './hydration.js';
-import { active_block, active_namespace, with_ns } from './runtime.js';
+import { active_block, active_namespace, get, with_ns } from './runtime.js';
 import { top_element_to_ns } from './utils.js';
 
 /**
@@ -29,7 +29,7 @@ export function composite(get_component, node, props) {
 
 	render(
 		() => {
-			var component = get_component();
+			var component = get(get_component());
 
 			if (b !== null) {
 				destroy_block(b);

--- a/packages/ripple/tests/client/lazy-destructuring.test.ripple
+++ b/packages/ripple/tests/client/lazy-destructuring.test.ripple
@@ -260,4 +260,59 @@ describe('lazy destructuring', () => {
 		render(Test);
 		expect(container.querySelector('pre')!.textContent).toBe('Alice-30');
 	});
+
+	it('supports standalone lazy array destructuring with track()', () => {
+		component Test() {
+			let count;
+			&[count] = track(0);
+			<div>{count}</div>
+			<button
+				onClick={() => {
+					count++;
+				}}
+			>
+				{'inc'}
+			</button>
+		}
+
+		render(Test);
+		expect(container.querySelector('div')!.textContent).toBe('0');
+		container.querySelector('button')!.click();
+		flushSync();
+		expect(container.querySelector('div')!.textContent).toBe('1');
+	});
+
+	it('supports standalone lazy array destructuring with second element', () => {
+		component Test() {
+			let value;
+			let tracked;
+			&[value, tracked] = track(42);
+			<div>{value}</div>
+			<button
+				onClick={() => {
+					value = 100;
+				}}
+			>
+				{'set'}
+			</button>
+		}
+
+		render(Test);
+		expect(container.querySelector('div')!.textContent).toBe('42');
+		container.querySelector('button')!.click();
+		flushSync();
+		expect(container.querySelector('div')!.textContent).toBe('100');
+	});
+
+	it('supports standalone lazy object destructuring', () => {
+		component Test() {
+			let a;
+			let b;
+			&{ a, b } = { a: 10, b: 20 };
+			<pre>{`${a}-${b}`}</pre>
+		}
+
+		render(Test);
+		expect(container.querySelector('pre')!.textContent).toBe('10-20');
+	});
 });

--- a/packages/ripple/tests/server/lazy-destructuring.test.ripple
+++ b/packages/ripple/tests/server/lazy-destructuring.test.ripple
@@ -149,4 +149,27 @@ describe('lazy destructuring', () => {
 		const { body } = await render(Test);
 		expect(body).toBeHtml('<pre>x-yz</pre>');
 	});
+
+	it('supports standalone lazy array destructuring with track()', async () => {
+		component Test() {
+			let count;
+			&[count] = track(0);
+			<div>{count}</div>
+		}
+
+		const { body } = await render(Test);
+		expect(body).toBeHtml('<div>0</div>');
+	});
+
+	it('supports standalone lazy object destructuring', async () => {
+		component Test() {
+			let a;
+			let b;
+			&{ a, b } = { a: 10, b: 20 };
+			<pre>{`${a}-${b}`}</pre>
+		}
+
+		const { body } = await render(Test);
+		expect(body).toBeHtml('<pre>10-20</pre>');
+	});
 });

--- a/website-new/docs/guide/control-flow.md
+++ b/website-new/docs/guide/control-flow.md
@@ -246,10 +246,10 @@ and using the `<@tagName>` syntax:
 import { track } from 'ripple';
 
 export component App() {
-  let tag = track('div');
+  let &[tag] = track('div');
 
   <@tag class="dynamic">{'Hello World'}</@tag>
-  <button onClick={() => (@tag = @tag === 'div' ? 'span' : 'div')}>
+  <button onClick={() => (tag = tag === 'div' ? 'span' : 'div')}>
     {'Toggle Element'}
   </button>
 }

--- a/website-new/docs/guide/reactivity.md
+++ b/website-new/docs/guide/reactivity.md
@@ -324,10 +324,12 @@ components based on reactive state. Instead of hardcoding which component to sho
 you can store a component in a `Tracked` via `track()`, and update it at runtime.
 When the tracked value changes, Ripple automatically unmounts the previous
 component and mounts the new one. Dynamic components are written with the
-`<@Component />` tag, where the @ both unwraps the tracked reference and tells the
-compiler that the component is dynamic. This makes it straightforward to pass
-components as props or swap them directly within a component, enabling flexible,
-state-driven UIs with minimal boilerplate.
+`<@Component />` tag, where `@` is a special marker that tells the compiler the
+component or element is dynamic — it does not dereference or unwrap the value. The
+expression after `@` is treated as a `Tracked` value, and the runtime handles
+unwrapping it internally. This makes it straightforward to pass components as
+props or swap them directly within a component, enabling flexible, state-driven
+UIs with minimal boilerplate.
 
 <Code>
 
@@ -335,16 +337,16 @@ state-driven UIs with minimal boilerplate.
 import { track } from 'ripple';
 
 export component App() {
-  let swapMe = track(() => Child1);
+  let &[swapMe, swapMeTracked] = track(() => Child1);
 
-  <Child {swapMe} />
+  <Child swapMe={swapMeTracked} />
 
-  <button onClick={() => (@swapMe = @swapMe === Child1 ? Child2 : Child1)}>
+  <button onClick={() => (swapMe = swapMe === Child1 ? Child2 : Child1)}>
     {'Swap Component'}
   </button>
 }
 
-component Child({ swapMe }: { swapMe: Tracked<Component> }) {
+component Child(&{ swapMe }: { swapMe: Tracked<Component> }) {
   <@swapMe />
 }
 

--- a/website-new/docs/guide/styling.md
+++ b/website-new/docs/guide/styling.md
@@ -250,7 +250,7 @@ component Child({ cls }: { cls: string }) {
 }
 
 component Parent() {
-  let Dynamic = track(() => Child);
+  let &[Dynamic] = track(() => Child);
   <@Dynamic cls={#style.text} />
 
   <style>

--- a/website/docs/guide/reactivity.md
+++ b/website/docs/guide/reactivity.md
@@ -350,8 +350,10 @@ components based on reactive state. Instead of hardcoding which component to
 show, you can store a component in a `Tracked` via `track()`, and update it at
 runtime. When the tracked value changes, Ripple automatically unmounts the
 previous component and mounts the new one. Dynamic components are written with
-the `<@Component />` tag, where the `@` tells the compiler that the component
-is dynamic. This makes it straightforward
+the `<@Component />` tag, where `@` is a special marker that tells the compiler
+the component or element is dynamic — it does not dereference or unwrap the value.
+The expression after `@` is treated as a `Tracked` value, and the runtime handles
+unwrapping it internally. This makes it straightforward
 to pass components as props or swap them directly within a component, enabling
 flexible, state-driven UIs with minimal boilerplate.
 

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -476,7 +476,7 @@ export component App() {
 
 #### Dynamic Component Transport Pattern
 
-Ripple has built-in support for dynamic components, a way to render different components based on reactive state. Instead of hardcoding which component to show, you can store a component in a `Tracked` via `track()`, and update it at runtime. When the tracked value changes, Ripple automatically unmounts the previous component and mounts the new one. Dynamic components are written with the `<@Component />` tag, where the `@` tells the compiler that the component reference is dynamic. This makes it straightforward to pass components as props or swap them directly within a component, enabling flexible, state-driven UIs with minimal boilerplate.
+Ripple has built-in support for dynamic components, a way to render different components based on reactive state. Instead of hardcoding which component to show, you can store a component in a `Tracked` via `track()`, and update it at runtime. When the tracked value changes, Ripple automatically unmounts the previous component and mounts the new one. Dynamic components are written with the `<@Component />` tag, where `@` is a special marker that tells the compiler the component or element is dynamic — it does not dereference or unwrap the value. The expression after `@` (e.g., `swapMe` in `<@swapMe />`) is treated as a `Tracked` value, and the runtime handles unwrapping it internally. This makes it straightforward to pass components as props or swap them directly within a component, enabling flexible, state-driven UIs with minimal boilerplate.
 
 ```ripple
 import { track } from 'ripple';


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches compiler parse/analyze/transform and runtime dynamic component rendering; incorrect metadata or unwrapping could break reactivity or generate wrong JS/TS output across client/server builds.
> 
> **Overview**
> Adds statement-level lazy destructuring assignment syntax (`&[...] = expr` / `&{...} = expr`) by parsing it as an `AssignmentExpression` with a `lazy` pattern, then analyzing it to generate a synthetic `lazy_id` and set up lazy binding transforms.
> 
> Updates client and server transform phases to lower these standalone assignments into a `const <lazy_id> = <rhs>` (and to strip the lazy metadata in TS mode), and simplifies tracked identifier handling by removing extra `_$_.get` wrapping in several transform paths.
> 
> Adjusts dynamic component/element unwrapping so `<@...>` is treated as a dynamic marker while the runtime (`composite`) now calls `get(get_component)` to unwrap, and updates docs/tests to cover the new standalone lazy destructuring patterns and revised dynamic component examples.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5c8513f273b3da8e1518f266126868eae9388b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->