### PR TITLE
Restore `was_expression` typing on ESTree literals

### DIFF
--- a/packages/ripple/src/compiler/types/index.d.ts
+++ b/packages/ripple/src/compiler/types/index.d.ts
@@ -118,12 +118,16 @@ declare module 'estree' {
 	// Otherwise, we only mark Identifier nodes
 	interface MemberExpression {}
 
-	interface SimpleLiteral {}
-	interface RegExpLiteral {}
-	interface BigIntLiteral {}
+	interface SimpleLiteral extends AST.LiteralNode {}
+	interface RegExpLiteral extends AST.LiteralNode {}
+	interface BigIntLiteral extends AST.LiteralNode {}
 
 	interface TrackedNode {
 		tracked?: boolean;
+	}
+
+	interface LiteralNode {
+		was_expression?: boolean;
 	}
 
 	// Include TypeScript node types and Ripple-specific nodes in NodeMap


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- restore `was_expression?: boolean` typing in compiler ESTree augmentations
- apply it to all literal variants by extending `SimpleLiteral`, `RegExpLiteral`, and `BigIntLiteral` from `AST.LiteralNode`
- keep `TrackedNode` unchanged for nodes that still use `tracked?: boolean`

## Why this shape
`was_expression` is still read and written in parser/transform paths for TSX/source-mapping fidelity, but its type augmentation was removed. Current code no longer relies on `tracked` on literal nodes, so this restores only the literal expression metadata without coupling literals back to `TrackedNode`.

## Validation
- type-level change only; no runtime code paths modified
- branch pushed successfully
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aaa5f270-df4d-4cff-8610-1ededcacde23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aaa5f270-df4d-4cff-8610-1ededcacde23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

