### PR TITLE
Fix TS types and add CI typecheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,3 +87,25 @@ jobs:
 
       - name: Check formatting
         run: pnpm format:check
+
+  typecheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Type check
+        run: pnpm typecheck

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "devDependencies": {
     "@changesets/changelog-github": "catalog:default",
     "@changesets/cli": "catalog:default",
+    "@types/node": "catalog:default",
     "@ripple-ts/eslint-plugin": "workspace:*",
     "@ripple-ts/prettier-plugin": "workspace:*",
     "@ripple-ts/vite-plugin": "workspace:*",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "changeset:publish": "changeset publish",
     "regenerate-textmate": "node scripts/regenerate-textmate.js",
     "copy-tree-sitter-queries": "node ./scripts/copy-tree-sitter-queries.js",
-    "bench": "node benchmarks/tracked-values.js"
+    "bench": "node benchmarks/tracked-values.js",
+    "typecheck": "tsc --noEmit -p packages/ripple/tsconfig.typecheck.json && tsc --noEmit -p packages/cli/tsconfig.json && tsc --noEmit -p packages/prettier-plugin/tsconfig.json"
   },
   "devDependencies": {
     "@changesets/changelog-github": "catalog:default",

--- a/packages/ripple/src/compiler/phases/1-parse/index.js
+++ b/packages/ripple/src/compiler/phases/1-parse/index.js
@@ -413,8 +413,9 @@ function RipplePlugin(config) {
 						/** @type {AST.Property} */ (prop).method = true;
 						/** @type {AST.Property} */ (prop).kind = 'init';
 						/** @type {AST.Property} */ (prop).value = this.parseMethod(false, false);
-						/** @type {AST.FunctionExpression} */ (/** @type {AST.Property} */ (prop).value).typeParameters =
-							typeParameters;
+						/** @type {AST.FunctionExpression} */ (
+							/** @type {AST.Property} */ (prop).value
+						).typeParameters = typeParameters;
 						return;
 					}
 				}

--- a/packages/ripple/src/compiler/phases/1-parse/index.js
+++ b/packages/ripple/src/compiler/phases/1-parse/index.js
@@ -413,7 +413,8 @@ function RipplePlugin(config) {
 						/** @type {AST.Property} */ (prop).method = true;
 						/** @type {AST.Property} */ (prop).kind = 'init';
 						/** @type {AST.Property} */ (prop).value = this.parseMethod(false, false);
-						/** @type {AST.Property} */ (prop).value.typeParameters = typeParameters;
+						/** @type {any} */ (/** @type {AST.Property} */ (prop).value).typeParameters =
+							typeParameters;
 						return;
 					}
 				}
@@ -705,7 +706,7 @@ function RipplePlugin(config) {
 						// & directly followed by { or [ — lazy destructuring
 						this.next(); // consume &, now current token is { or [
 						const pattern = super.parseBindingAtom();
-						pattern.lazy = true;
+						/** @type {AST.ObjectPattern | AST.ArrayPattern} */ (pattern).lazy = true;
 						return pattern;
 					}
 				}
@@ -898,6 +899,7 @@ function RipplePlugin(config) {
 					return this.parseFor(node, null);
 				}
 
+				// @ts-ignore — acorn internal: isLet accepts 0 args at runtime
 				let isLet = this.isLet();
 				if (this.type === tt._var || this.type === tt._const || isLet) {
 					let init = /** @type {AST.VariableDeclaration} */ (this.startNode()),
@@ -940,7 +942,10 @@ function RipplePlugin(config) {
 				}
 
 				let containsEsc = this.containsEsc;
-				let refDestructuringErrors = new DestructuringErrors();
+				// @ts-ignore — constructor function, not a class
+				let refDestructuringErrors = /** @type {Parse.DestructuringErrors} */ (
+					new DestructuringErrors()
+				);
 				let initPos = this.start;
 				let init_expr =
 					awaitAt > -1
@@ -1557,8 +1562,9 @@ function RipplePlugin(config) {
 								if (expression.type === 'Literal') {
 									expression.was_expression = true;
 								}
-								/** @type {ESTreeJSX.JSXExpressionContainer['expression']} */ (attr.value) =
-									expression;
+								// @ts-ignore — intentional AST node conversion from JSX to Ripple
+								/** @type {ESTreeJSX.JSXAttribute} */ (attr).value =
+									/** @type {ESTreeJSX.JSXExpressionContainer['expression']} */ (expression);
 							}
 						}
 					}

--- a/packages/ripple/src/compiler/phases/1-parse/index.js
+++ b/packages/ripple/src/compiler/phases/1-parse/index.js
@@ -413,7 +413,7 @@ function RipplePlugin(config) {
 						/** @type {AST.Property} */ (prop).method = true;
 						/** @type {AST.Property} */ (prop).kind = 'init';
 						/** @type {AST.Property} */ (prop).value = this.parseMethod(false, false);
-						/** @type {any} */ (/** @type {AST.Property} */ (prop).value).typeParameters =
+						/** @type {AST.FunctionExpression} */ (/** @type {AST.Property} */ (prop).value).typeParameters =
 							typeParameters;
 						return;
 					}
@@ -942,10 +942,9 @@ function RipplePlugin(config) {
 				}
 
 				let containsEsc = this.containsEsc;
-				// @ts-ignore — constructor function, not a class
-				let refDestructuringErrors = /** @type {Parse.DestructuringErrors} */ (
-					new DestructuringErrors()
-				);
+				let refDestructuringErrors = new /** @type {new () => Parse.DestructuringErrors} */ (
+					/** @type {unknown} */ (DestructuringErrors)
+				)();
 				let initPos = this.start;
 				let init_expr =
 					awaitAt > -1

--- a/packages/ripple/src/compiler/utils.js
+++ b/packages/ripple/src/compiler/utils.js
@@ -606,7 +606,7 @@ export function is_element_dynamic(node) {
  * @returns {boolean}
  */
 function is_id_dynamic(node) {
-	if (node.type === 'Identifier' || node.type === 'Literal') {
+	if (node.type === 'Identifier') {
 		return !!node.tracked;
 	}
 

--- a/packages/ripple/src/runtime/internal/client/bindings.js
+++ b/packages/ripple/src/runtime/internal/client/bindings.js
@@ -186,7 +186,9 @@ function select_option(select, value, mounting = false) {
 
 		// Otherwise, update the selection
 		for (var option of select.options) {
-			option.selected = /** @type {string[]} */ (value).includes(get_option_value(option));
+			option.selected = /** @type {string[]} */ (value).includes(
+				/** @type {string} */ (get_option_value(option)),
+			);
 		}
 
 		return;

--- a/packages/ripple/src/runtime/internal/client/composite.js
+++ b/packages/ripple/src/runtime/internal/client/composite.js
@@ -29,6 +29,7 @@ export function composite(get_component, node, props) {
 
 	render(
 		() => {
+			// @ts-ignore — get() handles non-tracked values via is_ripple_object() check
 			var component = get(get_component());
 
 			if (b !== null) {

--- a/packages/ripple/src/runtime/internal/client/events.js
+++ b/packages/ripple/src/runtime/internal/client/events.js
@@ -168,7 +168,7 @@ export function handle_event_propagation(event) {
 				null;
 
 			try {
-				var delegated = current_target['__' + event_name];
+				var delegated = /** @type {Record<string, any>} */ (current_target)['__' + event_name];
 
 				if (delegated !== undefined && !(/** @type {any} */ (current_target).disabled)) {
 					if (is_array(delegated)) {

--- a/packages/ripple/src/runtime/internal/client/head.js
+++ b/packages/ripple/src/runtime/internal/client/head.js
@@ -1,4 +1,3 @@
-/** @import { TemplateNode } from '#client' */
 import { render } from './blocks.js';
 import { HEAD_BLOCK } from './constants.js';
 import { COMMENT_NODE } from '../../../constants.js';
@@ -38,8 +37,8 @@ export function head(hash, render_fn) {
 		if (head_anchor === null) {
 			set_hydrating(false);
 		} else {
-			var start = /** @type {TemplateNode} */ (get_next_sibling(head_anchor));
-			head_anchor.remove(); // in case this component is repeated
+			var start = get_next_sibling(head_anchor);
+			/** @type {ChildNode} */ (head_anchor).remove(); // in case this component is repeated
 
 			set_hydrate_node(start);
 		}
@@ -54,7 +53,7 @@ export function head(hash, render_fn) {
 	} finally {
 		if (was_hydrating) {
 			set_hydrating(true);
-			set_hydrate_node(/** @type {TemplateNode} */ (previous_hydrate_node));
+			set_hydrate_node(previous_hydrate_node);
 		}
 	}
 }

--- a/packages/ripple/src/runtime/internal/server/index.js
+++ b/packages/ripple/src/runtime/internal/server/index.js
@@ -1,6 +1,6 @@
 /**
 @import { Component, Dependency, Derived, Tracked } from '#server';
-@import { SSRComponent, renderToStream, render } from 'ripple/server';
+@import { SSRComponent } from 'ripple/server';
 */
 
 import { Readable } from 'stream';
@@ -231,12 +231,12 @@ class Output {
 	}
 }
 
-/** @type {render} */
+/** @type {import('ripple/server').render} */
 export async function render(component) {
 	const output = new Output(null, null);
 	let head = '';
 	let body = '';
-	let css = new Set();
+	let css = /** @type {Set<string>} */ (new Set());
 
 	// Reset dev-mode element tracking state at the start of each render
 	reset_element_state();
@@ -262,7 +262,7 @@ export async function render(component) {
 	return { head, body, css };
 }
 
-/** @type {renderToStream} */
+/** @type {import('ripple/server').renderToStream} */
 export function renderToStream(component) {
 	const stream = new Readable({
 		read() {},

--- a/packages/ripple/tsconfig.typecheck.json
+++ b/packages/ripple/tsconfig.typecheck.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["./src/runtime/"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -232,7 +232,7 @@ importers:
         version: 0.6.0(encoding@0.1.13)
       '@changesets/cli':
         specifier: catalog:default
-        version: 2.30.0(@types/node@25.3.3)
+        version: 2.30.0(@types/node@24.11.0)
       '@ripple-ts/eslint-plugin':
         specifier: workspace:*
         version: link:packages/eslint-plugin
@@ -242,6 +242,9 @@ importers:
       '@ripple-ts/vite-plugin':
         specifier: workspace:*
         version: link:packages/vite-plugin
+      '@types/node':
+        specifier: catalog:default
+        version: 24.11.0
       eslint:
         specifier: catalog:default
         version: 10.0.2(jiti@2.6.1)
@@ -268,7 +271,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:default
-        version: 4.0.18(@types/node@25.3.3)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.32.0)
+        version: 4.0.18(@types/node@24.11.0)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.32.0)
       wait-on:
         specifier: catalog:default
         version: 9.0.4
@@ -5627,7 +5630,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@changesets/cli@2.30.0(@types/node@25.3.3)':
+  '@changesets/cli@2.30.0(@types/node@24.11.0)':
     dependencies:
       '@changesets/apply-release-plan': 7.1.0
       '@changesets/assemble-release-plan': 6.0.9
@@ -5643,7 +5646,7 @@ snapshots:
       '@changesets/should-skip-package': 0.1.2
       '@changesets/types': 6.1.0
       '@changesets/write': 0.4.0
-      '@inquirer/external-editor': 1.0.3(@types/node@25.3.3)
+      '@inquirer/external-editor': 1.0.3(@types/node@24.11.0)
       '@manypkg/get-packages': 1.1.3
       ansi-colors: 4.1.3
       enquirer: 2.4.1
@@ -5941,12 +5944,12 @@ snapshots:
 
   '@iconify/types@2.0.0': {}
 
-  '@inquirer/external-editor@1.0.3(@types/node@25.3.3)':
+  '@inquirer/external-editor@1.0.3(@types/node@24.11.0)':
     dependencies:
       chardet: 2.1.1
       iconv-lite: 0.7.2
     optionalDependencies:
-      '@types/node': 25.3.3
+      '@types/node': 24.11.0
 
   '@isaacs/cliui@9.0.0': {}
 
@@ -6847,13 +6850,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0))':
+  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.32.0))':
     dependencies:
       '@vitest/spy': 4.0.18
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)
+      vite: 7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.32.0)
 
   '@vitest/pretty-format@4.0.18':
     dependencies:
@@ -9989,7 +9992,7 @@ snapshots:
   vitest@4.0.18(@types/node@24.11.0)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.32.0):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0))
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.32.0))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -10027,7 +10030,7 @@ snapshots:
   vitest@4.0.18(@types/node@25.3.3)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.32.0):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0))
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.32.0))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new CI `typecheck` gate and adjusts compiler/runtime code to satisfy stricter TS checking, including a small behavior tweak in dynamic element detection that could affect compilation output.
> 
> **Overview**
> **Adds CI typechecking** by introducing a new `typecheck` GitHub Actions job and a root `pnpm typecheck` script that runs `tsc --noEmit` across multiple packages (with a new `packages/ripple/tsconfig.typecheck.json` scoped to runtime sources).
> 
> **Fixes TS/JSdoc typing issues** throughout the Ripple compiler and runtime (casts, `@ts-ignore` where needed, and more precise types in parser/runtime code), and updates `is_element_dynamic` to only treat tracked `Identifier`s (not `Literal`s) as dynamic. Also adds `@types/node` and updates the lockfile accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b48eaea6652a0a282842a680a3c9c6f9bba0e03f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->