### PR TITLE
support for nested destructions & missing ripple_map server func

### DIFF
--- a/.cursor/rules/project.mdc
+++ b/.cursor/rules/project.mdc
@@ -181,17 +181,17 @@ and once with `mode: 'server'`.
 
 ### Key AST Node Types (`packages/ripple/src/compiler/types/`)
 
-| Node Type           | Description                                              |
-| ------------------- | -------------------------------------------------------- |
-| `Component`         | Component declaration with `id`, `params`, `body`, `css` |
-| `Element`           | HTML/SVG element with `id`, `attributes`, `children`     |
-| `Text`              | Text node wrapping an expression                         |
-| `ServerBlock`       | `#server { ... }` block with exports tracking            |
-| `Attribute`         | Element attribute with `name`, `value`, `shorthand`      |
-| `RefAttribute`      | `ref={...}` reference binding                            |
-| `SpreadAttribute`   | `{...props}` spread                                      |
-| `StyleIdentifier`   | `#style` compile-time identifier for scoped CSS classes  |
-| `CSS.StyleSheet`    | Parsed CSS with `hash` for scoping                       |
+| Node Type         | Description                                              |
+| ----------------- | -------------------------------------------------------- |
+| `Component`       | Component declaration with `id`, `params`, `body`, `css` |
+| `Element`         | HTML/SVG element with `id`, `attributes`, `children`     |
+| `Text`            | Text node wrapping an expression                         |
+| `ServerBlock`     | `#server { ... }` block with exports tracking            |
+| `Attribute`       | Element attribute with `name`, `value`, `shorthand`      |
+| `RefAttribute`    | `ref={...}` reference binding                            |
+| `SpreadAttribute` | `{...props}` spread                                      |
+| `StyleIdentifier` | `#style` compile-time identifier for scoped CSS classes  |
+| `CSS.StyleSheet`  | Parsed CSS with `hash` for scoping                       |
 
 ## Runtime Architecture
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -176,17 +176,17 @@ and once with `mode: 'server'`.
 
 ### Key AST Node Types (`packages/ripple/src/compiler/types/`)
 
-| Node Type           | Description                                              |
-| ------------------- | -------------------------------------------------------- |
-| `Component`         | Component declaration with `id`, `params`, `body`, `css` |
-| `Element`           | HTML/SVG element with `id`, `attributes`, `children`     |
-| `Text`              | Text node wrapping an expression                         |
-| `ServerBlock`       | `#server { ... }` block with exports tracking            |
-| `Attribute`         | Element attribute with `name`, `value`, `shorthand`      |
-| `RefAttribute`      | `ref={...}` reference binding                            |
-| `SpreadAttribute`   | `{...props}` spread                                      |
-| `StyleIdentifier`   | `#style` compile-time identifier for scoped CSS classes  |
-| `CSS.StyleSheet`    | Parsed CSS with `hash` for scoping                       |
+| Node Type         | Description                                              |
+| ----------------- | -------------------------------------------------------- |
+| `Component`       | Component declaration with `id`, `params`, `body`, `css` |
+| `Element`         | HTML/SVG element with `id`, `attributes`, `children`     |
+| `Text`            | Text node wrapping an expression                         |
+| `ServerBlock`     | `#server { ... }` block with exports tracking            |
+| `Attribute`       | Element attribute with `name`, `value`, `shorthand`      |
+| `RefAttribute`    | `ref={...}` reference binding                            |
+| `SpreadAttribute` | `{...props}` spread                                      |
+| `StyleIdentifier` | `#style` compile-time identifier for scoped CSS classes  |
+| `CSS.StyleSheet`  | Parsed CSS with `hash` for scoping                       |
 
 ## Runtime Architecture
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,17 +180,17 @@ and once with `mode: 'server'`.
 
 ### Key AST Node Types (`packages/ripple/src/compiler/types/`)
 
-| Node Type           | Description                                              |
-| ------------------- | -------------------------------------------------------- |
-| `Component`         | Component declaration with `id`, `params`, `body`, `css` |
-| `Element`           | HTML/SVG element with `id`, `attributes`, `children`     |
-| `Text`              | Text node wrapping an expression                         |
-| `ServerBlock`       | `#server { ... }` block with exports tracking            |
-| `Attribute`         | Element attribute with `name`, `value`, `shorthand`      |
-| `RefAttribute`      | `ref={...}` reference binding                            |
-| `SpreadAttribute`   | `{...props}` spread                                      |
-| `StyleIdentifier`   | `#style` compile-time identifier for scoped CSS classes  |
-| `CSS.StyleSheet`    | Parsed CSS with `hash` for scoping                       |
+| Node Type         | Description                                              |
+| ----------------- | -------------------------------------------------------- |
+| `Component`       | Component declaration with `id`, `params`, `body`, `css` |
+| `Element`         | HTML/SVG element with `id`, `attributes`, `children`     |
+| `Text`            | Text node wrapping an expression                         |
+| `ServerBlock`     | `#server { ... }` block with exports tracking            |
+| `Attribute`       | Element attribute with `name`, `value`, `shorthand`      |
+| `RefAttribute`    | `ref={...}` reference binding                            |
+| `SpreadAttribute` | `{...props}` spread                                      |
+| `StyleIdentifier` | `#style` compile-time identifier for scoped CSS classes  |
+| `CSS.StyleSheet`  | Parsed CSS with `hash` for scoping                       |
 
 ## Runtime Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,17 +176,17 @@ and once with `mode: 'server'`.
 
 ### Key AST Node Types (`packages/ripple/src/compiler/types/`)
 
-| Node Type           | Description                                              |
-| ------------------- | -------------------------------------------------------- |
-| `Component`         | Component declaration with `id`, `params`, `body`, `css` |
-| `Element`           | HTML/SVG element with `id`, `attributes`, `children`     |
-| `Text`              | Text node wrapping an expression                         |
-| `ServerBlock`       | `#server { ... }` block with exports tracking            |
-| `Attribute`         | Element attribute with `name`, `value`, `shorthand`      |
-| `RefAttribute`      | `ref={...}` reference binding                            |
-| `SpreadAttribute`   | `{...props}` spread                                      |
-| `StyleIdentifier`   | `#style` compile-time identifier for scoped CSS classes  |
-| `CSS.StyleSheet`    | Parsed CSS with `hash` for scoping                       |
+| Node Type         | Description                                              |
+| ----------------- | -------------------------------------------------------- |
+| `Component`       | Component declaration with `id`, `params`, `body`, `css` |
+| `Element`         | HTML/SVG element with `id`, `attributes`, `children`     |
+| `Text`            | Text node wrapping an expression                         |
+| `ServerBlock`     | `#server { ... }` block with exports tracking            |
+| `Attribute`       | Element attribute with `name`, `value`, `shorthand`      |
+| `RefAttribute`    | `ref={...}` reference binding                            |
+| `SpreadAttribute` | `{...props}` spread                                      |
+| `StyleIdentifier` | `#style` compile-time identifier for scoped CSS classes  |
+| `CSS.StyleSheet`  | Parsed CSS with `hash` for scoping                       |
 
 ## Runtime Architecture
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -180,17 +180,17 @@ and once with `mode: 'server'`.
 
 ### Key AST Node Types (`packages/ripple/src/compiler/types/`)
 
-| Node Type           | Description                                              |
-| ------------------- | -------------------------------------------------------- |
-| `Component`         | Component declaration with `id`, `params`, `body`, `css` |
-| `Element`           | HTML/SVG element with `id`, `attributes`, `children`     |
-| `Text`              | Text node wrapping an expression                         |
-| `ServerBlock`       | `#server { ... }` block with exports tracking            |
-| `Attribute`         | Element attribute with `name`, `value`, `shorthand`      |
-| `RefAttribute`      | `ref={...}` reference binding                            |
-| `SpreadAttribute`   | `{...props}` spread                                      |
-| `StyleIdentifier`   | `#style` compile-time identifier for scoped CSS classes  |
-| `CSS.StyleSheet`    | Parsed CSS with `hash` for scoping                       |
+| Node Type         | Description                                              |
+| ----------------- | -------------------------------------------------------- |
+| `Component`       | Component declaration with `id`, `params`, `body`, `css` |
+| `Element`         | HTML/SVG element with `id`, `attributes`, `children`     |
+| `Text`            | Text node wrapping an expression                         |
+| `ServerBlock`     | `#server { ... }` block with exports tracking            |
+| `Attribute`       | Element attribute with `name`, `value`, `shorthand`      |
+| `RefAttribute`    | `ref={...}` reference binding                            |
+| `SpreadAttribute` | `{...props}` spread                                      |
+| `StyleIdentifier` | `#style` compile-time identifier for scoped CSS classes  |
+| `CSS.StyleSheet`  | Parsed CSS with `hash` for scoping                       |
 
 ## Runtime Architecture
 

--- a/packages/ripple/src/compiler/phases/2-analyze/index.js
+++ b/packages/ripple/src/compiler/phases/2-analyze/index.js
@@ -330,14 +330,176 @@ function setup_lazy_array_transforms(pattern, source_id, state, writable) {
 }
 
 /**
- * Checks if a function parameter has a Tracked<T> type annotation imported from ripple.
+ * @param {AST.Pattern} pattern
+ * @returns {AST.TypeNode | undefined}
+ */
+function get_pattern_type_annotation(pattern) {
+	return pattern.typeAnnotation?.typeAnnotation;
+}
+
+/**
+ * @param {AST.TypeNode | undefined} type_annotation
+ * @returns {AST.TypeNode | undefined}
+ */
+function unwrap_type_annotation(type_annotation) {
+	/** @type {AST.TypeNode | undefined} */
+	let annotation = type_annotation;
+
+	while (annotation) {
+		if (annotation.type === 'TSParenthesizedType') {
+			annotation = annotation.typeAnnotation;
+			continue;
+		}
+		if (annotation.type === 'TSOptionalType') {
+			annotation = annotation.typeAnnotation;
+			continue;
+		}
+		break;
+	}
+
+	return annotation;
+}
+
+/**
+ * @param {AST.TypeNode} type_annotation
+ * @returns {AST.TypeNode}
+ */
+function normalize_tuple_element_type(type_annotation) {
+	/** @type {AST.TypeNode} */
+	let annotation = type_annotation;
+
+	while (true) {
+		if (annotation.type === 'TSNamedTupleMember') {
+			annotation = annotation.elementType;
+			continue;
+		}
+		if (annotation.type === 'TSParenthesizedType') {
+			annotation = annotation.typeAnnotation;
+			continue;
+		}
+		if (annotation.type === 'TSOptionalType') {
+			annotation = annotation.typeAnnotation;
+			continue;
+		}
+		break;
+	}
+
+	return annotation;
+}
+
+/**
+ * @param {AST.Expression} key
+ * @returns {string | null}
+ */
+function get_object_pattern_key_name(key) {
+	if (key.type === 'Identifier') {
+		return key.name;
+	}
+	if (key.type === 'Literal' && (typeof key.value === 'string' || typeof key.value === 'number')) {
+		return String(key.value);
+	}
+	return null;
+}
+
+/**
+ * @param {AST.PropertyNameNonComputed} key
+ * @returns {string | null}
+ */
+function get_type_property_key_name(key) {
+	if (key.type === 'Identifier') {
+		return key.name;
+	}
+	if (key.type === 'Literal' && (typeof key.value === 'string' || typeof key.value === 'number')) {
+		return String(key.value);
+	}
+	return null;
+}
+
+/**
+ * @param {AST.TypeNode | undefined} type_annotation
+ * @param {AST.Property | AST.RestElement} property
+ * @returns {AST.TypeNode | undefined}
+ */
+function get_object_property_type_annotation(type_annotation, property) {
+	if (property.type === 'RestElement' || property.computed) {
+		return undefined;
+	}
+
+	const object_type_annotation = unwrap_type_annotation(type_annotation);
+	if (object_type_annotation?.type !== 'TSTypeLiteral') {
+		return undefined;
+	}
+
+	const key_name = get_object_pattern_key_name(property.key);
+	if (key_name === null) {
+		return undefined;
+	}
+
+	for (const member of object_type_annotation.members) {
+		if (member.type !== 'TSPropertySignature' || member.computed) {
+			continue;
+		}
+		const member_key_name = get_type_property_key_name(member.key);
+		if (member_key_name === key_name) {
+			return member.typeAnnotation?.typeAnnotation;
+		}
+	}
+
+	return undefined;
+}
+
+/**
+ * @param {AST.TypeNode | undefined} type_annotation
+ * @param {number} index
+ * @param {boolean} is_rest
+ * @returns {AST.TypeNode | undefined}
+ */
+function get_array_element_type_annotation(type_annotation, index, is_rest) {
+	const array_type_annotation = unwrap_type_annotation(type_annotation);
+
+	if (array_type_annotation?.type === 'TSArrayType') {
+		return array_type_annotation.elementType;
+	}
+	if (array_type_annotation?.type !== 'TSTupleType') {
+		return undefined;
+	}
+
+	if (is_rest) {
+		for (let i = array_type_annotation.elementTypes.length - 1; i >= 0; i -= 1) {
+			const element_type = normalize_tuple_element_type(array_type_annotation.elementTypes[i]);
+			if (element_type.type === 'TSRestType') {
+				return element_type.typeAnnotation;
+			}
+		}
+		return undefined;
+	}
+
+	if (index < array_type_annotation.elementTypes.length) {
+		const element_type = normalize_tuple_element_type(array_type_annotation.elementTypes[index]);
+		return element_type.type === 'TSRestType' ? element_type.typeAnnotation : element_type;
+	}
+
+	const last_element = array_type_annotation.elementTypes.at(-1);
+	if (!last_element) {
+		return undefined;
+	}
+	const normalized_last_element = normalize_tuple_element_type(last_element);
+	if (normalized_last_element.type === 'TSRestType') {
+		return normalized_last_element.typeAnnotation;
+	}
+
+	return undefined;
+}
+
+/**
+ * Checks if a parameter source has a Tracked<T> type annotation imported from ripple.
  * This is used to determine if lazy array destructuring should use the track tuple fast path.
- * @param {AST.ArrayPattern} param - The parameter pattern node
+ * @param {AST.TypeNode | undefined} type_annotation - The source type annotation
  * @param {AnalysisContext} context - The analysis context
  * @returns {boolean}
  */
-function is_param_tracked_type(param, context) {
-	const annotation = param.typeAnnotation?.typeAnnotation;
+function is_param_tracked_type(type_annotation, context) {
+	const annotation = unwrap_type_annotation(type_annotation);
 
 	if (
 		annotation?.type === 'TSTypeReference' &&
@@ -362,15 +524,18 @@ function is_param_tracked_type(param, context) {
  * Sets up lazy transforms for any lazy subpatterns nested inside a function or component param.
  * @param {AST.Pattern} pattern
  * @param {AnalysisContext} context
+ * @param {AST.TypeNode | undefined} [type_annotation]
  */
-function setup_nested_lazy_param_transforms(pattern, context) {
+function setup_nested_lazy_param_transforms(pattern, context, type_annotation = undefined) {
+	const pattern_type_annotation = get_pattern_type_annotation(pattern) ?? type_annotation;
+
 	switch (pattern.type) {
 		case 'AssignmentPattern':
-			setup_nested_lazy_param_transforms(pattern.left, context);
+			setup_nested_lazy_param_transforms(pattern.left, context, pattern_type_annotation);
 			return;
 
 		case 'RestElement':
-			setup_nested_lazy_param_transforms(pattern.argument, context);
+			setup_nested_lazy_param_transforms(pattern.argument, context, pattern_type_annotation);
 			return;
 
 		case 'ObjectPattern':
@@ -378,7 +543,8 @@ function setup_nested_lazy_param_transforms(pattern, context) {
 			if (pattern.lazy) {
 				const param_id = b.id(context.state.scope.generate('lazy'));
 				const is_tracked_type =
-					pattern.type === 'ArrayPattern' && is_param_tracked_type(pattern, context);
+					pattern.type === 'ArrayPattern' &&
+					is_param_tracked_type(pattern_type_annotation, context);
 
 				setup_lazy_transforms(pattern, param_id, context.state, true, is_tracked_type);
 				pattern.metadata = { ...pattern.metadata, lazy_id: param_id.name };
@@ -387,16 +553,37 @@ function setup_nested_lazy_param_transforms(pattern, context) {
 
 			if (pattern.type === 'ObjectPattern') {
 				for (const property of pattern.properties) {
+					const property_type_annotation = get_object_property_type_annotation(
+						pattern_type_annotation,
+						property,
+					);
 					if (property.type === 'RestElement') {
-						setup_nested_lazy_param_transforms(property.argument, context);
+						setup_nested_lazy_param_transforms(
+							property.argument,
+							context,
+							property_type_annotation,
+						);
 					} else {
-						setup_nested_lazy_param_transforms(property.value, context);
+						setup_nested_lazy_param_transforms(
+							property.value,
+							context,
+							property_type_annotation,
+						);
 					}
 				}
 			} else {
-				for (const element of pattern.elements) {
+				for (let i = 0; i < pattern.elements.length; i += 1) {
+					const element = pattern.elements[i];
 					if (element !== null) {
-						setup_nested_lazy_param_transforms(element, context);
+						setup_nested_lazy_param_transforms(
+							element,
+							context,
+							get_array_element_type_annotation(
+								pattern_type_annotation,
+								i,
+								element.type === 'RestElement',
+							),
+						);
 					}
 				}
 			}
@@ -420,9 +607,11 @@ function visit_function(node, context) {
 	for (let i = 0; i < node.params.length; i++) {
 		const param_node = node.params[i];
 		const param = param_node.type === 'AssignmentPattern' ? param_node.left : param_node;
+		const param_type_annotation =
+			get_pattern_type_annotation(param) ?? param_node.typeAnnotation?.typeAnnotation;
 
 		if (param.type === 'ObjectPattern' || param.type === 'ArrayPattern') {
-			setup_nested_lazy_param_transforms(param, context);
+			setup_nested_lazy_param_transforms(param, context, param_type_annotation);
 		}
 	}
 
@@ -970,7 +1159,11 @@ const visitors = {
 				if (props.lazy) {
 					setup_lazy_transforms(props, b.id('__props'), context.state, true, false);
 				} else {
-					setup_nested_lazy_param_transforms(props, context);
+					setup_nested_lazy_param_transforms(
+						props,
+						context,
+						get_pattern_type_annotation(props),
+					);
 				}
 			} else if (props.type === 'AssignmentPattern') {
 				error(

--- a/packages/ripple/src/compiler/phases/2-analyze/index.js
+++ b/packages/ripple/src/compiler/phases/2-analyze/index.js
@@ -359,6 +359,50 @@ function is_param_tracked_type(param, context) {
 }
 
 /**
+ * Sets up lazy transforms for any lazy subpatterns nested inside a function or component param.
+ * @param {AST.Pattern} pattern
+ * @param {AnalysisContext} context
+ */
+function setup_nested_lazy_param_transforms(pattern, context) {
+	switch (pattern.type) {
+		case 'AssignmentPattern':
+			setup_nested_lazy_param_transforms(pattern.left, context);
+			return;
+
+		case 'ObjectPattern':
+		case 'ArrayPattern': {
+			if (pattern.lazy) {
+				const param_id = b.id(context.state.scope.generate('lazy'));
+				const is_tracked_type =
+					pattern.type === 'ArrayPattern' && is_param_tracked_type(pattern, context);
+
+				setup_lazy_transforms(pattern, param_id, context.state, true, is_tracked_type);
+				pattern.metadata = { ...pattern.metadata, lazy_id: param_id.name };
+				return;
+			}
+
+			if (pattern.type === 'ObjectPattern') {
+				for (const property of pattern.properties) {
+					if (property.type === 'RestElement') {
+						setup_nested_lazy_param_transforms(property.argument, context);
+					} else {
+						setup_nested_lazy_param_transforms(property.value, context);
+					}
+				}
+			} else {
+				for (const element of pattern.elements) {
+					if (element !== null) {
+						setup_nested_lazy_param_transforms(element, context);
+					}
+				}
+			}
+
+			return;
+		}
+	}
+}
+
+/**
  * @param {AST.Function} node
  * @param {AnalysisContext} context
  */
@@ -373,15 +417,8 @@ function visit_function(node, context) {
 		const param_node = node.params[i];
 		const param = param_node.type === 'AssignmentPattern' ? param_node.left : param_node;
 
-		if ((param.type === 'ObjectPattern' || param.type === 'ArrayPattern') && param.lazy) {
-			const param_id = b.id(context.state.scope.generate('param'));
-			// For ArrayPattern params with a Tracked<T> type annotation from ripple,
-			// use the track tuple fast path (get/set instead of source[0]/source[1])
-			const is_tracked_type =
-				param.type === 'ArrayPattern' && is_param_tracked_type(param, context);
-			setup_lazy_transforms(param, param_id, context.state, true, is_tracked_type);
-			// Store the generated identifier name on the pattern for the transform phase
-			param.metadata = { ...param.metadata, lazy_id: param_id.name };
+		if (param.type === 'ObjectPattern' || param.type === 'ArrayPattern') {
+			setup_nested_lazy_param_transforms(param, context);
 		}
 	}
 
@@ -924,9 +961,13 @@ const visitors = {
 		if (node.params.length > 0) {
 			const props = node.params[0];
 
-			if ((props.type === 'ObjectPattern' || props.type === 'ArrayPattern') && props.lazy) {
+			if (props.type === 'ObjectPattern' || props.type === 'ArrayPattern') {
 				// Lazy destructuring: &{...} or &[...] — set up lazy transforms
-				setup_lazy_transforms(props, b.id('__props'), context.state, true, false);
+				if (props.lazy) {
+					setup_lazy_transforms(props, b.id('__props'), context.state, true, false);
+				} else {
+					setup_nested_lazy_param_transforms(props, context);
+				}
 			} else if (props.type === 'AssignmentPattern') {
 				error(
 					'Props are always an object, use destructured props with default values instead',

--- a/packages/ripple/src/compiler/phases/2-analyze/index.js
+++ b/packages/ripple/src/compiler/phases/2-analyze/index.js
@@ -564,11 +564,7 @@ function setup_nested_lazy_param_transforms(pattern, context, type_annotation = 
 							property_type_annotation,
 						);
 					} else {
-						setup_nested_lazy_param_transforms(
-							property.value,
-							context,
-							property_type_annotation,
-						);
+						setup_nested_lazy_param_transforms(property.value, context, property_type_annotation);
 					}
 				}
 			} else {
@@ -1159,11 +1155,7 @@ const visitors = {
 				if (props.lazy) {
 					setup_lazy_transforms(props, b.id('__props'), context.state, true, false);
 				} else {
-					setup_nested_lazy_param_transforms(
-						props,
-						context,
-						get_pattern_type_annotation(props),
-					);
+					setup_nested_lazy_param_transforms(props, context, get_pattern_type_annotation(props));
 				}
 			} else if (props.type === 'AssignmentPattern') {
 				error(

--- a/packages/ripple/src/compiler/phases/2-analyze/index.js
+++ b/packages/ripple/src/compiler/phases/2-analyze/index.js
@@ -369,6 +369,10 @@ function setup_nested_lazy_param_transforms(pattern, context) {
 			setup_nested_lazy_param_transforms(pattern.left, context);
 			return;
 
+		case 'RestElement':
+			setup_nested_lazy_param_transforms(pattern.argument, context);
+			return;
+
 		case 'ObjectPattern':
 		case 'ArrayPattern': {
 			if (pattern.lazy) {

--- a/packages/ripple/src/compiler/phases/2-analyze/index.js
+++ b/packages/ripple/src/compiler/phases/2-analyze/index.js
@@ -476,7 +476,13 @@ function get_array_element_type_annotation(type_annotation, index, is_rest) {
 
 	if (index < array_type_annotation.elementTypes.length) {
 		const element_type = normalize_tuple_element_type(array_type_annotation.elementTypes[index]);
-		return element_type.type === 'TSRestType' ? element_type.typeAnnotation : element_type;
+		if (element_type.type === 'TSRestType') {
+			const rest_type_annotation = unwrap_type_annotation(element_type.typeAnnotation);
+			return rest_type_annotation?.type === 'TSArrayType'
+				? rest_type_annotation.elementType
+				: element_type.typeAnnotation;
+		}
+		return element_type;
 	}
 
 	const last_element = array_type_annotation.elementTypes.at(-1);
@@ -485,7 +491,10 @@ function get_array_element_type_annotation(type_annotation, index, is_rest) {
 	}
 	const normalized_last_element = normalize_tuple_element_type(last_element);
 	if (normalized_last_element.type === 'TSRestType') {
-		return normalized_last_element.typeAnnotation;
+		const rest_type_annotation = unwrap_type_annotation(normalized_last_element.typeAnnotation);
+		return rest_type_annotation?.type === 'TSArrayType'
+			? rest_type_annotation.elementType
+			: normalized_last_element.typeAnnotation;
 	}
 
 	return undefined;

--- a/packages/ripple/src/compiler/phases/3-transform/client/index.js
+++ b/packages/ripple/src/compiler/phases/3-transform/client/index.js
@@ -58,6 +58,7 @@ import {
 	flatten_switch_consequent,
 	get_ripple_namespace_call_name,
 	is_ripple_import,
+	replace_lazy_param_pattern,
 	ripple_import_requires_block,
 } from '../../../utils.js';
 import {
@@ -111,16 +112,12 @@ function visit_function(node, context) {
 	// Replace lazy destructuring params with generated identifiers
 	const transformed_params = node.params.map((param) => {
 		const pattern = param.type === 'AssignmentPattern' ? param.left : param;
-		if (
-			(pattern.type === 'ObjectPattern' || pattern.type === 'ArrayPattern') &&
-			pattern.lazy &&
-			pattern.metadata?.lazy_id
-		) {
-			const id = b.id(pattern.metadata.lazy_id);
+		if (pattern.type === 'ObjectPattern' || pattern.type === 'ArrayPattern') {
+			const transformed_pattern = replace_lazy_param_pattern(pattern);
 			if (param.type === 'AssignmentPattern') {
-				return /** @type {AST.AssignmentPattern} */ ({ ...param, left: id });
+				return /** @type {AST.AssignmentPattern} */ ({ ...param, left: transformed_pattern });
 			}
-			return id;
+			return transformed_pattern;
 		}
 		return param;
 	});
@@ -1926,7 +1923,9 @@ const visitors = {
 				delete props_param.typeAnnotation;
 				if (!props_param.lazy) {
 					// Non-lazy destructuring: use the pattern directly as the function param
-					props = props_param;
+					props = /** @type {AST.ObjectPattern | AST.ArrayPattern} */ (
+						replace_lazy_param_pattern(props_param)
+					);
 				}
 				// Lazy destructuring: props stays as __props, bindings resolved via transforms
 			}

--- a/packages/ripple/src/compiler/phases/3-transform/server/index.js
+++ b/packages/ripple/src/compiler/phases/3-transform/server/index.js
@@ -27,7 +27,7 @@ import {
 	is_element_dynamic,
 	is_ripple_track_call,
 	is_ripple_import,
-	ripple_import_requires_block,
+	replace_lazy_param_pattern,
 	hash,
 	flatten_switch_consequent,
 	get_ripple_namespace_call_name,
@@ -355,7 +355,7 @@ const visitors = {
 					// Lazy destructuring: use __props identifier, bindings resolved via transforms
 					props_param_output = b.id('__props');
 				} else {
-					props_param_output = props_param;
+					props_param_output = replace_lazy_param_pattern(props_param);
 				}
 			} else {
 				props_param_output = props_param;
@@ -597,16 +597,12 @@ const visitors = {
 				}
 				// Replace lazy destructuring params with generated identifiers
 				const pattern = param.type === 'AssignmentPattern' ? param.left : param;
-				if (
-					(pattern.type === 'ObjectPattern' || pattern.type === 'ArrayPattern') &&
-					pattern.lazy &&
-					pattern.metadata?.lazy_id
-				) {
-					const id = b.id(pattern.metadata.lazy_id);
+				if (pattern.type === 'ObjectPattern' || pattern.type === 'ArrayPattern') {
+					const transformed_pattern = replace_lazy_param_pattern(pattern);
 					node.params[i] =
 						param.type === 'AssignmentPattern'
-							? /** @type {AST.AssignmentPattern} */ ({ ...param, left: id })
-							: id;
+							? /** @type {AST.AssignmentPattern} */ ({ ...param, left: transformed_pattern })
+							: transformed_pattern;
 				}
 			}
 		}
@@ -626,16 +622,12 @@ const visitors = {
 				}
 				// Replace lazy destructuring params with generated identifiers
 				const pattern = param.type === 'AssignmentPattern' ? param.left : param;
-				if (
-					(pattern.type === 'ObjectPattern' || pattern.type === 'ArrayPattern') &&
-					pattern.lazy &&
-					pattern.metadata?.lazy_id
-				) {
-					const id = b.id(pattern.metadata.lazy_id);
+				if (pattern.type === 'ObjectPattern' || pattern.type === 'ArrayPattern') {
+					const transformed_pattern = replace_lazy_param_pattern(pattern);
 					node.params[i] =
 						param.type === 'AssignmentPattern'
-							? /** @type {AST.AssignmentPattern} */ ({ ...param, left: id })
-							: id;
+							? /** @type {AST.AssignmentPattern} */ ({ ...param, left: transformed_pattern })
+							: transformed_pattern;
 				}
 			}
 		}
@@ -665,16 +657,12 @@ const visitors = {
 			}
 			// Replace lazy destructuring params with generated identifiers
 			const pattern = param.type === 'AssignmentPattern' ? param.left : param;
-			if (
-				(pattern.type === 'ObjectPattern' || pattern.type === 'ArrayPattern') &&
-				pattern.lazy &&
-				pattern.metadata?.lazy_id
-			) {
-				const id = b.id(pattern.metadata.lazy_id);
+			if (pattern.type === 'ObjectPattern' || pattern.type === 'ArrayPattern') {
+				const transformed_pattern = replace_lazy_param_pattern(pattern);
 				node.params[i] =
 					param.type === 'AssignmentPattern'
-						? /** @type {AST.AssignmentPattern} */ ({ ...param, left: id })
-						: id;
+						? /** @type {AST.AssignmentPattern} */ ({ ...param, left: transformed_pattern })
+						: transformed_pattern;
 			}
 		}
 

--- a/packages/ripple/src/compiler/utils.js
+++ b/packages/ripple/src/compiler/utils.js
@@ -674,6 +674,52 @@ function normalize_child(node, normalized, context) {
 }
 
 /**
+ * Replaces any lazy subpatterns in a parameter pattern with their generated identifiers.
+ * This is used by client and server transforms so nested lazy destructuring can coexist
+ * with otherwise normal object/array params.
+ * @param {AST.Pattern} pattern
+ * @returns {AST.Pattern}
+ */
+export function replace_lazy_param_pattern(pattern) {
+	switch (pattern.type) {
+		case 'AssignmentPattern':
+			return { ...pattern, left: replace_lazy_param_pattern(pattern.left) };
+
+		case 'ObjectPattern':
+			if (pattern.lazy && pattern.metadata?.lazy_id) {
+				return /** @type {AST.Pattern} */ (b.id(pattern.metadata.lazy_id));
+			}
+
+			return {
+				...pattern,
+				properties: pattern.properties.map((property) =>
+					property.type === 'RestElement'
+						? { ...property, argument: replace_lazy_param_pattern(property.argument) }
+						: { ...property, value: replace_lazy_param_pattern(property.value) },
+				),
+			};
+
+		case 'ArrayPattern':
+			if (pattern.lazy && pattern.metadata?.lazy_id) {
+				return /** @type {AST.Pattern} */ (b.id(pattern.metadata.lazy_id));
+			}
+
+			return {
+				...pattern,
+				elements: pattern.elements.map((element) =>
+					element === null ? null : replace_lazy_param_pattern(element),
+				),
+			};
+
+		case 'RestElement':
+			return { ...pattern, argument: replace_lazy_param_pattern(pattern.argument) };
+
+		default:
+			return pattern;
+	}
+}
+
+/**
  * @param {CommonContext} context
  */
 export function get_parent_block_node(context) {

--- a/packages/ripple/src/runtime/internal/server/index.js
+++ b/packages/ripple/src/runtime/internal/server/index.js
@@ -866,6 +866,15 @@ export function ripple_object(obj) {
 }
 
 /**
+ * @template K, V
+ * @param {Iterable<readonly [K, V]>} [iterable]
+ * @returns {Map<K, V>}
+ */
+export function ripple_map(iterable) {
+	return new Map(iterable);
+}
+
+/**
  * Returns the fallback value if the given value is undefined.
  * @template T
  * @param {T | undefined} value

--- a/packages/ripple/tests/client/compiler/compiler.basic.test.ripple
+++ b/packages/ripple/tests/client/compiler/compiler.basic.test.ripple
@@ -385,6 +385,21 @@ function use_nested({ value: &[count, tracked] }: { value: Tracked<number> }) {
 		expect(js.code).not.toContain('[1]');
 	});
 
+	it('uses tracked fast path for nested lazy params at tuple rest positions', () => {
+		const source = `
+import type { Tracked } from 'ripple';
+function use_tuple_rest({ value: [head, &[count, tracked]] }: { value: [number, ...Tracked<number>[]] }) {
+	count++;
+	return tracked;
+}
+`;
+		const { js } = compile(source, 'tracked-nested-lazy-tuple-rest.ripple', { mode: 'client' });
+
+		// Tuple rest element access should resolve to Tracked<number>, not Tracked<number>[].
+		expect(js.code).toContain('_$_.update(');
+		expect(js.code).not.toContain('[1]');
+	});
+
 	it('preserves generic type args in interface extends for Volar mappings', () => {
 		const source = `
 interface PolymorphicProps<T extends keyof HTMLElementTagNameMap> {

--- a/packages/ripple/tests/client/compiler/compiler.basic.test.ripple
+++ b/packages/ripple/tests/client/compiler/compiler.basic.test.ripple
@@ -369,6 +369,22 @@ component App() {
 		expect(track_result).not.toContain('lazy0');
 	});
 
+	it('uses tracked fast path for nested lazy params typed as Tracked', () => {
+		const source = `
+import type { Tracked } from 'ripple';
+function use_nested({ value: &[count, tracked] }: { value: Tracked<number> }) {
+	count++;
+	return tracked;
+}
+`;
+		const { js } = compile(source, 'tracked-nested-lazy.ripple', { mode: 'client' });
+
+		// Nested lazy array should still use tracked tuple fast path from outer annotation.
+		expect(js.code).toContain('_$_.update(');
+		expect(js.code).not.toContain('[0]');
+		expect(js.code).not.toContain('[1]');
+	});
+
 	it('preserves generic type args in interface extends for Volar mappings', () => {
 		const source = `
 interface PolymorphicProps<T extends keyof HTMLElementTagNameMap> {

--- a/packages/ripple/tests/client/lazy-destructuring.test.ripple
+++ b/packages/ripple/tests/client/lazy-destructuring.test.ripple
@@ -140,20 +140,23 @@ describe('lazy destructuring', () => {
 		expect(container.querySelector('pre')!.textContent).toBe('2-2');
 	});
 
-	it('preserves lazy getter/setter behavior for nested rest destructuring in non-lazy component params', () => {
-		component Inner({ values: [head, ...&{ length: rest_length, 0: first_rest }] }) {
-			const before = `${first_rest?.value ?? 'nil'}-${rest_length}`;
-			rest_length = 0;
-			<pre>{`${head}-${before}-${first_rest?.value ?? 'nil'}-${rest_length}`}</pre>
-		}
+	it(
+		'preserves lazy getter/setter behavior for nested rest destructuring in non-lazy component params',
+		() => {
+			component Inner({ values: [head, ...&{ length: rest_length, 0: first_rest }] }) {
+				const before = `${first_rest?.value ?? 'nil'}-${rest_length}`;
+				rest_length = 0;
+				<pre>{`${head}-${before}-${first_rest?.value ?? 'nil'}-${rest_length}`}</pre>
+			}
 
-		component Test() {
-			<Inner values={[10, track(20), track(30)]} />
-		}
+			component Test() {
+				<Inner values={[10, track(20), track(30)]} />
+			}
 
-		render(Test);
-		expect(container.querySelector('pre')!.textContent).toBe('10-20-2-nil-0');
-	});
+			render(Test);
+			expect(container.querySelector('pre')!.textContent).toBe('10-20-2-nil-0');
+		},
+	);
 
 	it('supports lazy destructuring in function params', () => {
 		component Test() {
@@ -185,21 +188,24 @@ describe('lazy destructuring', () => {
 		expect(container.querySelector('pre')!.textContent).toBe('2-2');
 	});
 
-	it('preserves lazy getter/setter behavior for nested rest destructuring in non-lazy function params', () => {
-		component Test() {
-			function summarize({ values: [head, ...&{ length: rest_length, 0: first_rest }] }) {
-				const before = `${first_rest?.value ?? 'nil'}-${rest_length}`;
-				rest_length = 0;
-				return `${head}-${before}-${first_rest?.value ?? 'nil'}-${rest_length}`;
+	it(
+		'preserves lazy getter/setter behavior for nested rest destructuring in non-lazy function params',
+		() => {
+			component Test() {
+				function summarize({ values: [head, ...&{ length: rest_length, 0: first_rest }] }) {
+					const before = `${first_rest?.value ?? 'nil'}-${rest_length}`;
+					rest_length = 0;
+					return `${head}-${before}-${first_rest?.value ?? 'nil'}-${rest_length}`;
+				}
+
+				const result = summarize({ values: [5, track(6), track(7)] });
+				<pre>{result}</pre>
 			}
 
-			const result = summarize({ values: [5, track(6), track(7)] });
-			<pre>{result}</pre>
-		}
-
-		render(Test);
-		expect(container.querySelector('pre')!.textContent).toBe('5-6-2-nil-0');
-	});
+			render(Test);
+			expect(container.querySelector('pre')!.textContent).toBe('5-6-2-nil-0');
+		},
+	);
 
 	it('supports let lazy destructuring with assignment writeback', () => {
 		component Test() {

--- a/packages/ripple/tests/client/lazy-destructuring.test.ripple
+++ b/packages/ripple/tests/client/lazy-destructuring.test.ripple
@@ -140,6 +140,19 @@ describe('lazy destructuring', () => {
 		expect(container.querySelector('pre')!.textContent).toBe('2-2');
 	});
 
+	it('supports nested lazy rest destructuring in non-lazy component params', () => {
+		component Inner({ values: [head, ...&{ length: rest_length }] }) {
+			<pre>{`${head}-${rest_length}`}</pre>
+		}
+
+		component Test() {
+			<Inner values={[10, 20, 30]} />
+		}
+
+		render(Test);
+		expect(container.querySelector('pre')!.textContent).toBe('10-2');
+	});
+
 	it('supports lazy destructuring in function params', () => {
 		component Test() {
 			function getInfo(&{ x, y }: { x: number; y: number }) {
@@ -168,6 +181,20 @@ describe('lazy destructuring', () => {
 
 		render(Test);
 		expect(container.querySelector('pre')!.textContent).toBe('2-2');
+	});
+
+	it('supports nested lazy rest destructuring in non-lazy function params', () => {
+		component Test() {
+			function summarize({ values: [head, ...&{ length: rest_length }] }) {
+				return `${head}-${rest_length}`;
+			}
+
+			const result = summarize({ values: [5, 6, 7, 8] });
+			<pre>{result}</pre>
+		}
+
+		render(Test);
+		expect(container.querySelector('pre')!.textContent).toBe('5-3');
 	});
 
 	it('supports let lazy destructuring with assignment writeback', () => {

--- a/packages/ripple/tests/client/lazy-destructuring.test.ripple
+++ b/packages/ripple/tests/client/lazy-destructuring.test.ripple
@@ -126,6 +126,20 @@ describe('lazy destructuring', () => {
 		expect(container.querySelector('pre')!.textContent).toBe('1');
 	});
 
+	it('supports nested lazy destructuring in non-lazy component params', () => {
+		component Inner({ something: &[first, second] }) {
+			first = second.value + 1;
+			<pre>{`${first}-${second.value}`}</pre>
+		}
+
+		component Test() {
+			<Inner something={track(1)} />
+		}
+
+		render(Test);
+		expect(container.querySelector('pre')!.textContent).toBe('2-2');
+	});
+
 	it('supports lazy destructuring in function params', () => {
 		component Test() {
 			function getInfo(&{ x, y }: { x: number; y: number }) {
@@ -137,6 +151,23 @@ describe('lazy destructuring', () => {
 
 		render(Test);
 		expect(container.querySelector('pre')!.textContent).toBe('10');
+	});
+
+	it('supports nested lazy destructuring in non-lazy function params', () => {
+		component Test() {
+			const something = track(1);
+
+			function getInfo({ something: &[first, second] }) {
+				first = second.value + 1;
+				return `${first}-${second.value}`;
+			}
+
+			const result = getInfo({ something });
+			<pre>{result}</pre>
+		}
+
+		render(Test);
+		expect(container.querySelector('pre')!.textContent).toBe('2-2');
 	});
 
 	it('supports let lazy destructuring with assignment writeback', () => {

--- a/packages/ripple/tests/client/lazy-destructuring.test.ripple
+++ b/packages/ripple/tests/client/lazy-destructuring.test.ripple
@@ -140,17 +140,19 @@ describe('lazy destructuring', () => {
 		expect(container.querySelector('pre')!.textContent).toBe('2-2');
 	});
 
-	it('supports nested lazy rest destructuring in non-lazy component params', () => {
-		component Inner({ values: [head, ...&{ length: rest_length }] }) {
-			<pre>{`${head}-${rest_length}`}</pre>
+	it('preserves lazy getter/setter behavior for nested rest destructuring in non-lazy component params', () => {
+		component Inner({ values: [head, ...&{ length: rest_length, 0: first_rest }] }) {
+			const before = `${first_rest?.value ?? 'nil'}-${rest_length}`;
+			rest_length = 0;
+			<pre>{`${head}-${before}-${first_rest?.value ?? 'nil'}-${rest_length}`}</pre>
 		}
 
 		component Test() {
-			<Inner values={[10, 20, 30]} />
+			<Inner values={[10, track(20), track(30)]} />
 		}
 
 		render(Test);
-		expect(container.querySelector('pre')!.textContent).toBe('10-2');
+		expect(container.querySelector('pre')!.textContent).toBe('10-20-2-nil-0');
 	});
 
 	it('supports lazy destructuring in function params', () => {
@@ -183,18 +185,20 @@ describe('lazy destructuring', () => {
 		expect(container.querySelector('pre')!.textContent).toBe('2-2');
 	});
 
-	it('supports nested lazy rest destructuring in non-lazy function params', () => {
+	it('preserves lazy getter/setter behavior for nested rest destructuring in non-lazy function params', () => {
 		component Test() {
-			function summarize({ values: [head, ...&{ length: rest_length }] }) {
-				return `${head}-${rest_length}`;
+			function summarize({ values: [head, ...&{ length: rest_length, 0: first_rest }] }) {
+				const before = `${first_rest?.value ?? 'nil'}-${rest_length}`;
+				rest_length = 0;
+				return `${head}-${before}-${first_rest?.value ?? 'nil'}-${rest_length}`;
 			}
 
-			const result = summarize({ values: [5, 6, 7, 8] });
+			const result = summarize({ values: [5, track(6), track(7)] });
 			<pre>{result}</pre>
 		}
 
 		render(Test);
-		expect(container.querySelector('pre')!.textContent).toBe('5-3');
+		expect(container.querySelector('pre')!.textContent).toBe('5-6-2-nil-0');
 	});
 
 	it('supports let lazy destructuring with assignment writeback', () => {

--- a/packages/ripple/tests/server/lazy-destructuring.test.ripple
+++ b/packages/ripple/tests/server/lazy-destructuring.test.ripple
@@ -137,35 +137,41 @@ describe('lazy destructuring', () => {
 		expect(body).toBeHtml('<pre>2-2</pre>');
 	});
 
-	it('preserves lazy getter/setter behavior for RestElement nested destructuring in non-lazy component params', async () => {
-		component Inner({ values: [head, ...&{ 0: first_rest, length: rest_length }] }) {
-			const before = `${first_rest}-${rest_length}`;
-			rest_length = 0;
-			<pre>{`${head}-${before}-${first_rest}-${rest_length}`}</pre>
-		}
-
-		component Test() {
-			<Inner values={[10, 20, 30]} />
-		}
-
-		const { body } = await render(Test);
-		expect(body).toBeHtml('<pre>10-20-2-undefined-0</pre>');
-	});
-
-	it('preserves lazy getter/setter behavior for RestElement nested destructuring in non-lazy function params', async () => {
-		component Test() {
-			function getInfo({ values: [head, ...&{ 0: first_rest, length: rest_length }] }) {
+	it(
+		'preserves lazy getter/setter behavior for RestElement nested destructuring in non-lazy component params',
+		async () => {
+			component Inner({ values: [head, ...&{ 0: first_rest, length: rest_length }] }) {
 				const before = `${first_rest}-${rest_length}`;
 				rest_length = 0;
-				return `${head}-${before}-${first_rest}-${rest_length}`;
+				<pre>{`${head}-${before}-${first_rest}-${rest_length}`}</pre>
 			}
 
-			<pre>{getInfo({ values: [5, 6, 7] })}</pre>
-		}
+			component Test() {
+				<Inner values={[10, 20, 30]} />
+			}
 
-		const { body } = await render(Test);
-		expect(body).toBeHtml('<pre>5-6-2-undefined-0</pre>');
-	});
+			const { body } = await render(Test);
+			expect(body).toBeHtml('<pre>10-20-2-undefined-0</pre>');
+		},
+	);
+
+	it(
+		'preserves lazy getter/setter behavior for RestElement nested destructuring in non-lazy function params',
+		async () => {
+			component Test() {
+				function getInfo({ values: [head, ...&{ 0: first_rest, length: rest_length }] }) {
+					const before = `${first_rest}-${rest_length}`;
+					rest_length = 0;
+					return `${head}-${before}-${first_rest}-${rest_length}`;
+				}
+
+				<pre>{getInfo({ values: [5, 6, 7] })}</pre>
+			}
+
+			const { body } = await render(Test);
+			expect(body).toBeHtml('<pre>5-6-2-undefined-0</pre>');
+		},
+	);
 
 	it('supports member access on lazy destructured objects', async () => {
 		component Test() {

--- a/packages/ripple/tests/server/lazy-destructuring.test.ripple
+++ b/packages/ripple/tests/server/lazy-destructuring.test.ripple
@@ -1,3 +1,4 @@
+import type { Tracked } from 'ripple';
 import { track, trackSplit } from 'ripple';
 
 describe('lazy destructuring', () => {
@@ -30,13 +31,27 @@ describe('lazy destructuring', () => {
 
 	it('supports default values in lazy object destructuring', async () => {
 		component Test() {
-			const obj = { a: 5 };
+			const obj: { a: number; b?: number } = { a: 5 };
 			const &{ a, b = 99 } = obj;
 			<pre>{`${a}-${b}`}</pre>
 		}
 
 		const { body } = await render(Test);
 		expect(body).toBeHtml('<pre>5-99</pre>');
+	});
+
+	it('supports nested lazy destructuring in non-lazy component params', async () => {
+		component Inner({ something: &[first, second] }: { something: Tracked<number> }) {
+			first = second.value + 1;
+			<pre>{`${first}-${second.value}`}</pre>
+		}
+
+		component Test() {
+			<Inner something={track(1)} />
+		}
+
+		const { body } = await render(Test);
+		expect(body).toBeHtml('<pre>2-2</pre>');
 	});
 
 	it('supports let lazy destructuring with assignment writeback', async () => {
@@ -104,6 +119,22 @@ describe('lazy destructuring', () => {
 
 		const { body } = await render(Test);
 		expect(body).toBeHtml('<pre>15-105</pre>');
+	});
+
+	it('supports nested lazy destructuring in non-lazy function params', async () => {
+		component Test() {
+			const something = track(1);
+
+			function getInfo({ something: &[first, second] }: { something: Tracked<number> }) {
+				first = second.value + 1;
+				return `${first}-${second.value}`;
+			}
+
+			<pre>{getInfo({ something })}</pre>
+		}
+
+		const { body } = await render(Test);
+		expect(body).toBeHtml('<pre>2-2</pre>');
 	});
 
 	it('supports member access on lazy destructured objects', async () => {

--- a/packages/ripple/tests/server/lazy-destructuring.test.ripple
+++ b/packages/ripple/tests/server/lazy-destructuring.test.ripple
@@ -137,6 +137,32 @@ describe('lazy destructuring', () => {
 		expect(body).toBeHtml('<pre>2-2</pre>');
 	});
 
+	it('supports RestElement nested lazy destructuring in non-lazy component params', async () => {
+		component Inner({ values: [head, ...&{ length: rest_length }] }) {
+			<pre>{`${head}-${rest_length}`}</pre>
+		}
+
+		component Test() {
+			<Inner values={[10, 20, 30]} />
+		}
+
+		const { body } = await render(Test);
+		expect(body).toBeHtml('<pre>10-2</pre>');
+	});
+
+	it('supports RestElement nested lazy destructuring in non-lazy function params', async () => {
+		component Test() {
+			function getInfo({ values: [head, ...&{ length: rest_length }] }) {
+				return `${head}-${rest_length}`;
+			}
+
+			<pre>{getInfo({ values: [5, 6, 7, 8] })}</pre>
+		}
+
+		const { body } = await render(Test);
+		expect(body).toBeHtml('<pre>5-3</pre>');
+	});
+
 	it('supports member access on lazy destructured objects', async () => {
 		component Test() {
 			const obj = { user: { name: 'Alice', age: 30 } };

--- a/packages/ripple/tests/server/lazy-destructuring.test.ripple
+++ b/packages/ripple/tests/server/lazy-destructuring.test.ripple
@@ -137,9 +137,11 @@ describe('lazy destructuring', () => {
 		expect(body).toBeHtml('<pre>2-2</pre>');
 	});
 
-	it('supports RestElement nested lazy destructuring in non-lazy component params', async () => {
-		component Inner({ values: [head, ...&{ length: rest_length }] }) {
-			<pre>{`${head}-${rest_length}`}</pre>
+	it('preserves lazy getter/setter behavior for RestElement nested destructuring in non-lazy component params', async () => {
+		component Inner({ values: [head, ...&{ 0: first_rest, length: rest_length }] }) {
+			const before = `${first_rest}-${rest_length}`;
+			rest_length = 0;
+			<pre>{`${head}-${before}-${first_rest}-${rest_length}`}</pre>
 		}
 
 		component Test() {
@@ -147,20 +149,22 @@ describe('lazy destructuring', () => {
 		}
 
 		const { body } = await render(Test);
-		expect(body).toBeHtml('<pre>10-2</pre>');
+		expect(body).toBeHtml('<pre>10-20-2-undefined-0</pre>');
 	});
 
-	it('supports RestElement nested lazy destructuring in non-lazy function params', async () => {
+	it('preserves lazy getter/setter behavior for RestElement nested destructuring in non-lazy function params', async () => {
 		component Test() {
-			function getInfo({ values: [head, ...&{ length: rest_length }] }) {
-				return `${head}-${rest_length}`;
+			function getInfo({ values: [head, ...&{ 0: first_rest, length: rest_length }] }) {
+				const before = `${first_rest}-${rest_length}`;
+				rest_length = 0;
+				return `${head}-${before}-${first_rest}-${rest_length}`;
 			}
 
-			<pre>{getInfo({ values: [5, 6, 7, 8] })}</pre>
+			<pre>{getInfo({ values: [5, 6, 7] })}</pre>
 		}
 
 		const { body } = await render(Test);
-		expect(body).toBeHtml('<pre>5-3</pre>');
+		expect(body).toBeHtml('<pre>5-6-2-undefined-0</pre>');
 	});
 
 	it('supports member access on lazy destructured objects', async () => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches Ripple’s compiler analyze/transform pipeline for parameter handling, which can affect generated JS across many components/functions. Changes are well-covered by new client/server tests but could still introduce edge-case regressions in destructuring/type-annotation handling.
> 
> **Overview**
> Adds support for *nested* lazy destructuring (`&{}` / `&[]`) inside otherwise non-lazy component and function parameters by teaching the analyzer to walk subpatterns, propagate relevant TypeScript type annotations (including tuples/rest), and emit lazy transforms for nested patterns.
> 
> Updates both client and server transforms to consistently replace any lazy subpatterns with generated identifiers via a new `replace_lazy_param_pattern()` utility, enabling mixed normal + nested-lazy parameter patterns.
> 
> Also adds missing server runtime helper `ripple_map()` (parity with other collection constructors) and expands test coverage for nested lazy params (including `Tracked<T>` fast-path behavior and rest destructuring), plus minor markdown table formatting cleanup in generated agent docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef47e2f8f6c83336ed95d3efbb1d0b9feb406105. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->