### PR TITLE
fix(cli): update Tailwind scaffolding to v4 CSS-first config

### DIFF
--- a/.changeset/fix-tailwind-v4-config.md
+++ b/.changeset/fix-tailwind-v4-config.md
@@ -1,0 +1,5 @@
+---
+'@ripple-ts/cli': patch
+---
+
+fix(cli): update Tailwind scaffolding to v4 CSS-first config

--- a/packages/cli/src/lib/project-creator.js
+++ b/packages/cli/src/lib/project-creator.js
@@ -228,10 +228,10 @@ import { ripple } from '@ripple-ts/vite-plugin';
 import tailwindcss from '@tailwindcss/vite';
 
 export default defineConfig({
-\tplugins: [ripple(), tailwindcss()],
-\tserver: {
-\t\tport: 3000
-\t}
+	plugins: [ripple(), tailwindcss()],
+	server: {
+		port: 3000
+	}
 });
 `;
 		writeFileSync(join(projectPath, 'vite.config.js'), viteConfig);
@@ -243,6 +243,13 @@ export default defineConfig({
 			{
 				'tailwindCSS.includeLanguages': {
 					ripple: 'html',
+				},
+				'tailwindCSS.classAttributes': ['class', 'className'],
+				'files.associations': {
+					'*.ripple': 'ripple',
+				},
+				'editor.quickSuggestions': {
+					strings: true,
 				},
 			},
 			null,

--- a/packages/cli/src/lib/project-creator.js
+++ b/packages/cli/src/lib/project-creator.js
@@ -211,21 +211,9 @@ function updatePackageJson(projectPath, projectName, packageManager, stylingFram
  */
 function configureStyling(projectPath, stylingFramework) {
 	if (stylingFramework === 'tailwind') {
-		const tailwindConfig = `import type { Config } from 'tailwindcss';
-export default {
-	content: [
-		"./index.html",
-		"./src/**/*.{ts,ripple}",
-	],
-	theme: {
-		extend: {},
-	},
-	plugins: []
-} satisfies Config
-`;
-		writeFileSync(join(projectPath, 'tailwind.config.ts'), tailwindConfig);
-		const mainCss = `@import "tailwindcss";
-@config "../tailwind.config.ts";`;
+		// Tailwind v4 uses CSS-first configuration — no JS config file needed.
+		// Content sources are auto-detected, and theme customization uses @theme in CSS.
+		const mainCss = `@import "tailwindcss";\n`;
 		writeFileSync(join(projectPath, 'src', 'index.css'), mainCss);
 
 		const mainTs = readFileSync(join(projectPath, 'src', 'index.ts'), 'utf-8');
@@ -240,13 +228,27 @@ import { ripple } from '@ripple-ts/vite-plugin';
 import tailwindcss from '@tailwindcss/vite';
 
 export default defineConfig({
-	plugins: [ripple(), tailwindcss()],
-	server: {
-		port: 3000
-	}
+\tplugins: [ripple(), tailwindcss()],
+\tserver: {
+\t\tport: 3000
+\t}
 });
 `;
 		writeFileSync(join(projectPath, 'vite.config.js'), viteConfig);
+
+		// Add VS Code settings for Tailwind IntelliSense in .ripple files
+		const vscodePath = join(projectPath, '.vscode');
+		mkdirSync(vscodePath, { recursive: true });
+		const vscodeSettings = JSON.stringify(
+			{
+				'tailwindCSS.includeLanguages': {
+					ripple: 'html',
+				},
+			},
+			null,
+			'\t',
+		);
+		writeFileSync(join(vscodePath, 'settings.json'), vscodeSettings + '\n');
 	} else if (stylingFramework === 'bootstrap') {
 		const mainTs = readFileSync(join(projectPath, 'src', 'index.ts'), 'utf-8');
 		const newMainTs = "import 'bootstrap/dist/css/bootstrap.min.css';\n" + mainTs;

--- a/packages/cli/tests/integration/project-creator.test.js
+++ b/packages/cli/tests/integration/project-creator.test.js
@@ -312,6 +312,9 @@ describe('createProject integration tests', () => {
 			readFileSync(join(projectPath, '.vscode', 'settings.json'), 'utf-8'),
 		);
 		expect(vscodeSettings['tailwindCSS.includeLanguages']).toEqual({ ripple: 'html' });
+		expect(vscodeSettings['tailwindCSS.classAttributes']).toEqual(['class', 'className']);
+		expect(vscodeSettings['files.associations']).toEqual({ '*.ripple': 'ripple' });
+		expect(vscodeSettings['editor.quickSuggestions']).toEqual({ strings: true });
 	});
 
 	it('should configure Bootstrap correctly', async () => {

--- a/packages/cli/tests/integration/project-creator.test.js
+++ b/packages/cli/tests/integration/project-creator.test.js
@@ -293,14 +293,25 @@ describe('createProject integration tests', () => {
 		expect(packageJson.devDependencies).toHaveProperty('tailwindcss');
 		expect(packageJson.devDependencies).toHaveProperty('@tailwindcss/vite');
 
-		expect(existsSync(join(projectPath, 'tailwind.config.ts'))).toBe(true);
+		// Tailwind v4 uses CSS-first config — no JS/TS config file should be generated
+		expect(existsSync(join(projectPath, 'tailwind.config.ts'))).toBe(false);
+
 		expect(readFileSync(join(projectPath, 'src', 'index.ts'), 'utf-8')).toContain(
 			"import './index.css';\n",
 		);
 		expect(existsSync(join(projectPath, 'src', 'index.css'))).toBe(true);
-		expect(readFileSync(join(projectPath, 'src', 'index.css'), 'utf-8')).toContain(
-			'@import "tailwindcss"',
+
+		const cssContent = readFileSync(join(projectPath, 'src', 'index.css'), 'utf-8');
+		expect(cssContent).toContain('@import "tailwindcss"');
+		// v4 should NOT use @config directive (crashes with .ts files)
+		expect(cssContent).not.toContain('@config');
+
+		// VS Code settings should be generated for .ripple IntelliSense
+		expect(existsSync(join(projectPath, '.vscode', 'settings.json'))).toBe(true);
+		const vscodeSettings = JSON.parse(
+			readFileSync(join(projectPath, '.vscode', 'settings.json'), 'utf-8'),
 		);
+		expect(vscodeSettings['tailwindCSS.includeLanguages']).toEqual({ ripple: 'html' });
 	});
 
 	it('should configure Bootstrap correctly', async () => {


### PR DESCRIPTION
Fixes #843

### Problem

When scaffolding a new Ripple project with the TailwindCSS option, the CLI generates a v3-style setup that breaks under Tailwind v4:

1. **`tailwind.config.ts`** — Tailwind v4 dropped `.ts` support in the `@config` directive
2. **`@config "../tailwind.config.ts"`** in `index.css` — crashes the Tailwind v4 parser, which silently kills the Tailwind CSS Language Server (IntelliSense)
3. **`.ripple` files** aren't mapped in VS Code settings, so IntelliSense never triggers in Ripple components even if Tailwind compiles

### Fix

- **Removed** `tailwind.config.ts` generation — v4 uses CSS-first config and auto-detects content sources
- **Removed** `@config` directive — `index.css` now only contains `@import "tailwindcss";`
- **Added** `.vscode/settings.json` generation with `tailwindCSS.includeLanguages: { ripple: "html" }` so IntelliSense works in `.ripple` files

### Changed Files

- `packages/cli/src/lib/project-creator.js` — updated `configureStyling()` function
- `packages/cli/tests/integration/project-creator.test.js` — updated Tailwind test assertions

### Testing

All 71 CLI tests pass (`pnpm test --project cli`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CLI project scaffolding for Tailwind and corresponding integration test updates, with no runtime app logic or security-sensitive behavior affected.
> 
> **Overview**
> Updates `create-ripple` Tailwind scaffolding to match Tailwind v4’s *CSS-first* setup by **stopping generation of `tailwind.config.ts`** and **removing the `@config` directive** from the generated `src/index.css` (now only `@import "tailwindcss";`).
> 
> Also **generates `.vscode/settings.json`** to enable Tailwind IntelliSense in `*.ripple` files, and updates the Tailwind integration test to assert the new outputs. A changeset publishes this as a patch for `@ripple-ts/cli`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6eaf590ed01ecc5ab845e6ce7752e226f6454411. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->