### PR TITLE
remove magical component children prop support

### DIFF
--- a/packages/ripple/src/compiler/phases/2-analyze/index.js
+++ b/packages/ripple/src/compiler/phases/2-analyze/index.js
@@ -26,6 +26,7 @@ import {
 	is_inside_component,
 	is_ripple_track_call,
 	is_void_element,
+	is_children_template_expression as is_children_template_expression_in_scope,
 	normalize_children,
 	is_binding_function,
 	is_inside_try_block,
@@ -689,80 +690,16 @@ function error_return_keyword(node, context, message) {
 
 /**
  * @param {AST.Expression} expression
- * @returns {AST.Expression}
- */
-function unwrap_template_expression(expression) {
-	/** @type {AST.Expression} */
-	let node = expression;
-
-	while (true) {
-		if (
-			node.type === 'ParenthesizedExpression' ||
-			node.type === 'TSAsExpression' ||
-			node.type === 'TSSatisfiesExpression' ||
-			node.type === 'TSNonNullExpression' ||
-			node.type === 'TSInstantiationExpression'
-		) {
-			node = /** @type {AST.Expression} */ (node.expression);
-			continue;
-		}
-
-		if (node.type === 'ChainExpression') {
-			node = /** @type {AST.Expression} */ (node.expression);
-			continue;
-		}
-
-		break;
-	}
-
-	return node;
-}
-
-/**
- * @param {AST.Expression} expression
  * @param {Context<AST.Node, AnalysisState>} context
  * @returns {boolean}
  */
 function is_children_template_expression(expression, context) {
 	const component = context.path.findLast((node) => node.type === 'Component');
 	const component_scope = component ? context.state.scopes.get(component) : null;
-	const unwrapped = unwrap_template_expression(expression);
-
-	if (unwrapped.type === 'MemberExpression') {
-		let property_name = null;
-
-		if (!unwrapped.computed && unwrapped.property.type === 'Identifier') {
-			property_name = unwrapped.property.name;
-		} else if (
-			unwrapped.computed &&
-			unwrapped.property.type === 'Literal' &&
-			typeof unwrapped.property.value === 'string'
-		) {
-			property_name = unwrapped.property.value;
-		}
-
-		if (property_name === 'children') {
-			const target = unwrap_template_expression(/** @type {AST.Expression} */ (unwrapped.object));
-
-			if (target.type === 'Identifier') {
-				const binding = context.state.scope.get(target.name);
-				return binding?.declaration_kind === 'param' && binding.scope === component_scope;
-			}
-		}
-	}
-
-	if (unwrapped.type !== 'Identifier' || unwrapped.name !== 'children') {
-		return false;
-	}
-
-	const binding = context.state.scope.get(unwrapped.name);
-	return (
-		(binding?.declaration_kind === 'param' ||
-			binding?.kind === 'prop' ||
-			binding?.kind === 'prop_fallback' ||
-			binding?.kind === 'lazy' ||
-			binding?.kind === 'lazy_fallback') &&
-		binding.scope === component_scope
+	return is_children_template_expression_in_scope(
+		expression,
+		context.state.scope,
+		component_scope,
 	);
 }
 

--- a/packages/ripple/src/compiler/phases/2-analyze/index.js
+++ b/packages/ripple/src/compiler/phases/2-analyze/index.js
@@ -999,7 +999,7 @@ const visitors = {
 			is_children_template_expression(/** @type {AST.Expression} */ (callee), context)
 		) {
 			error(
-				'`children` cannot be called like a regular function. Use element syntax instead, e.g. `<children />` or `<props.children />`.',
+				'`children` cannot be called like a regular function. Render it with `{children}` or `{props.children}` instead.',
 				context.state.analysis.module.filename,
 				callee,
 				context.state.loose ? context.state.analysis.errors : undefined,
@@ -1718,6 +1718,19 @@ const visitors = {
 
 		mark_control_flow_has_template(path);
 
+		if (
+			!is_dom_element &&
+			is_children_template_expression(/** @type {AST.Expression} */ (node.id), context)
+		) {
+			error(
+				'`children` cannot be rendered as a component. Render it with `{children}` or `{props.children}` instead.',
+				state.analysis.module.filename,
+				node.id,
+				context.state.loose ? context.state.analysis.errors : undefined,
+				context.state.analysis.comments,
+			);
+		}
+
 		validate_nesting(node, context);
 
 		// Store capitalized name for dynamic components/elements
@@ -1964,16 +1977,6 @@ const visitors = {
 	RippleExpression(node, context) {
 		mark_control_flow_has_template(context.path);
 
-		if (is_children_template_expression(/** @type {AST.Expression} */ (node.expression), context)) {
-			error(
-				'`children` cannot be rendered using text interpolation. Use `<children />` instead.',
-				context.state.analysis.module.filename,
-				node.expression,
-				context.state.loose ? context.state.analysis.errors : undefined,
-				context.state.analysis.comments,
-			);
-		}
-
 		context.next();
 	},
 
@@ -1982,7 +1985,7 @@ const visitors = {
 
 		if (is_children_template_expression(/** @type {AST.Expression} */ (node.expression), context)) {
 			error(
-				'`children` cannot be rendered using text interpolation. Use `<children />` instead.',
+				'`children` cannot be rendered using explicit text interpolation. Use `{children}` or `{props.children}` instead.',
 				context.state.analysis.module.filename,
 				node.expression,
 				context.state.loose ? context.state.analysis.errors : undefined,

--- a/packages/ripple/src/compiler/phases/2-analyze/index.js
+++ b/packages/ripple/src/compiler/phases/2-analyze/index.js
@@ -696,11 +696,7 @@ function error_return_keyword(node, context, message) {
 function is_children_template_expression(expression, context) {
 	const component = context.path.findLast((node) => node.type === 'Component');
 	const component_scope = component ? context.state.scopes.get(component) : null;
-	return is_children_template_expression_in_scope(
-		expression,
-		context.state.scope,
-		component_scope,
-	);
+	return is_children_template_expression_in_scope(expression, context.state.scope, component_scope);
 }
 
 /** @type {Visitors<AST.Node, AnalysisState>} */

--- a/packages/ripple/src/compiler/phases/2-analyze/index.js
+++ b/packages/ripple/src/compiler/phases/2-analyze/index.js
@@ -1919,31 +1919,21 @@ const visitors = {
 			}
 			/** @type {(AST.Node | AST.Expression)[]} */
 			let implicit_children = [];
-			/** @type {AST.Identifier[]} */
-			let explicit_children = [];
 
 			for (const child of node.children) {
 				if (child.type === 'Component') {
-					if (child.id?.name === 'children') {
-						explicit_children.push(child.id);
-					}
+					error(
+						'Component declarations cannot be used inside composite component children. Pass them as explicit props on the template element instead.',
+						state.analysis.module.filename,
+						child.id || child,
+						context.state.loose ? context.state.analysis.errors : undefined,
+						context.state.analysis.comments,
+					);
 				} else if (child.type !== 'EmptyStatement') {
 					implicit_children.push(
 						child.type === 'RippleExpression' || child.type === 'Text' || child.type === 'Html'
 							? child.expression
 							: child,
-					);
-				}
-			}
-
-			if (implicit_children.length > 0 && explicit_children.length > 0) {
-				for (const item of [...explicit_children, ...implicit_children]) {
-					error(
-						'Cannot have both implicit and explicit children',
-						state.analysis.module.filename,
-						item,
-						context.state.loose ? context.state.analysis.errors : undefined,
-						context.state.analysis.comments,
 					);
 				}
 			}

--- a/packages/ripple/src/compiler/phases/3-transform/client/index.js
+++ b/packages/ripple/src/compiler/phases/3-transform/client/index.js
@@ -1695,26 +1695,7 @@ const visitors = {
 				}
 			}
 
-			const children_filtered = [];
-
-			for (const child of node.children) {
-				if (child.type === 'Component') {
-					// in this case, id cannot be null
-					// as these are direct children of the component
-					const id = /** @type {AST.Identifier} */ (child.id);
-					props.push(
-						b.prop(
-							'init',
-							id,
-							/** @type {AST.Expression} */ (
-								visit(child, { ...state, namespace: child_namespace })
-							),
-						),
-					);
-				} else {
-					children_filtered.push(child);
-				}
-			}
+			const children_filtered = node.children.filter((child) => child.type !== 'EmptyStatement');
 
 			if (children_filtered.length > 0) {
 				const component_scope = state.scopes.get(node);

--- a/packages/ripple/src/compiler/phases/3-transform/client/index.js
+++ b/packages/ripple/src/compiler/phases/3-transform/client/index.js
@@ -1692,7 +1692,7 @@ const visitors = {
 			const is_spreading = node.attributes.some((attr) => attr.type === 'SpreadAttribute');
 			/** @type {(AST.Property | AST.SpreadElement)[]} */
 			const props = [];
-			/** @type {AST.Expression | AST.BlockStatement | null} */
+			/** @type {AST.Property | null} */
 			let children_prop = null;
 
 			for (const attr of node.attributes) {
@@ -1714,7 +1714,11 @@ const visitors = {
 
 						if (metadata.tracking || attr.name.tracked) {
 							if (attr.name.name === 'children') {
-								children_prop = b.thunk(b.call('_$_.normalize_children', property));
+								children_prop = b.prop(
+									'get',
+									b.id('children'),
+									b.function(null, [], b.block([b.return(b.call('_$_.normalize_children', property))])),
+								);
 								continue;
 							}
 
@@ -1726,13 +1730,20 @@ const visitors = {
 								),
 							);
 						} else {
+							if (attr.name.name === 'children') {
+								children_prop = b.prop(
+									'init',
+									b.id('children'),
+									b.call('_$_.normalize_children', property),
+								);
+								continue;
+							}
+
 							props.push(
 								b.prop(
 									'init',
 									b.key(attr.name.name),
-									attr.name.name === 'children'
-										? b.call('_$_.normalize_children', property)
-										: property,
+									property,
 								),
 							);
 						}
@@ -1809,16 +1820,32 @@ const visitors = {
 				);
 
 				if (children_prop) {
-					/** @type {AST.ArrowFunctionExpression} */ (children_prop).body = b.logical(
-						'??',
-						/** @type {AST.Expression} */ (
-							/** @type {AST.ArrowFunctionExpression} */ (children_prop).body
-						),
-						children,
-					);
+					if (children_prop.kind === 'get') {
+						/** @type {AST.ReturnStatement} */ (
+							/** @type {AST.FunctionExpression} */ (children_prop.value).body.body[0]
+						).argument = b.logical(
+							'??',
+							/** @type {AST.Expression} */ (
+								/** @type {AST.ReturnStatement} */ (
+									/** @type {AST.FunctionExpression} */ (children_prop.value).body.body[0]
+								).argument
+							),
+							children,
+						);
+					} else {
+						children_prop.value = b.logical(
+							'??',
+							/** @type {AST.Expression} */ (children_prop.value),
+							children,
+						);
+					}
 				} else {
-					props.push(b.prop('init', b.id('children'), children));
+					children_prop = b.prop('init', b.id('children'), children);
 				}
+			}
+
+			if (children_prop) {
+				props.push(children_prop);
 			}
 
 			const metadata = { tracking: false, await: false };

--- a/packages/ripple/src/compiler/phases/3-transform/client/index.js
+++ b/packages/ripple/src/compiler/phases/3-transform/client/index.js
@@ -1713,7 +1713,7 @@ const visitors = {
 				}
 			}
 
-			const children_filtered = node.children.filter((child) => child.type !== 'EmptyStatement');
+			const children_filtered = node.children.filter((child) => child.type !== 'EmptyStatement' && child.type !== 'Component');
 
 			if (children_filtered.length > 0) {
 				const component_scope = state.scopes.get(node);

--- a/packages/ripple/src/compiler/phases/3-transform/client/index.js
+++ b/packages/ripple/src/compiler/phases/3-transform/client/index.js
@@ -1713,7 +1713,9 @@ const visitors = {
 				}
 			}
 
-			const children_filtered = node.children.filter((child) => child.type !== 'EmptyStatement' && child.type !== 'Component');
+			const children_filtered = node.children.filter(
+				(child) => child.type !== 'EmptyStatement' && child.type !== 'Component',
+			);
 
 			if (children_filtered.length > 0) {
 				const component_scope = state.scopes.get(node);

--- a/packages/ripple/src/compiler/phases/3-transform/client/index.js
+++ b/packages/ripple/src/compiler/phases/3-transform/client/index.js
@@ -3380,7 +3380,7 @@ function transform_children(children, context) {
 			normalized.some(
 				(node) =>
 					node.type === 'RippleExpression' &&
-						is_children_template_expression(node.expression, state.scope),
+					is_children_template_expression(node.expression, state.scope),
 			)) ||
 		normalized.filter(
 			(node) => node.type !== 'VariableDeclaration' && node.type !== 'EmptyStatement',

--- a/packages/ripple/src/compiler/phases/3-transform/client/index.js
+++ b/packages/ripple/src/compiler/phases/3-transform/client/index.js
@@ -53,6 +53,7 @@ import {
 	determine_namespace_for_children,
 	index_to_key,
 	is_element_dynamic,
+	is_children_template_expression,
 	is_inside_left_side_assignment,
 	hash,
 	flatten_switch_consequent,
@@ -78,86 +79,6 @@ import {
 import { createHash } from 'node:crypto';
 import { should_preserve_comment, format_comment } from '../../../comment-utils.js';
 import { set_location } from '../../../../utils/builders.js';
-
-/**
- * @param {AST.Expression} expression
- * @returns {AST.Expression}
- */
-function unwrap_template_expression(expression) {
-	/** @type {AST.Expression} */
-	let node = expression;
-
-	while (true) {
-		if (
-			node.type === 'ParenthesizedExpression' ||
-			node.type === 'TSAsExpression' ||
-			node.type === 'TSSatisfiesExpression' ||
-			node.type === 'TSNonNullExpression' ||
-			node.type === 'TSInstantiationExpression'
-		) {
-			node = /** @type {AST.Expression} */ (node.expression);
-			continue;
-		}
-
-		if (node.type === 'ChainExpression') {
-			node = /** @type {AST.Expression} */ (node.expression);
-			continue;
-		}
-
-		break;
-	}
-
-	return node;
-}
-
-/**
- * @param {AST.Expression} expression
- * @param {TransformClientState} state
- * @returns {boolean}
- */
-function is_children_render_expression(expression, state) {
-	if (state.scope == null) {
-		return false;
-	}
-
-	const unwrapped = unwrap_template_expression(expression);
-
-	if (unwrapped.type === 'MemberExpression') {
-		let property_name = null;
-
-		if (!unwrapped.computed && unwrapped.property.type === 'Identifier') {
-			property_name = unwrapped.property.name;
-		} else if (
-			unwrapped.computed &&
-			unwrapped.property.type === 'Literal' &&
-			typeof unwrapped.property.value === 'string'
-		) {
-			property_name = unwrapped.property.value;
-		}
-
-		if (property_name === 'children') {
-			const target = unwrap_template_expression(/** @type {AST.Expression} */ (unwrapped.object));
-
-			if (target.type === 'Identifier') {
-				const binding = state.scope.get(target.name);
-				return binding?.declaration_kind === 'param';
-			}
-		}
-	}
-
-	if (unwrapped.type !== 'Identifier' || unwrapped.name !== 'children') {
-		return false;
-	}
-
-	const binding = state.scope.get(unwrapped.name);
-	return (
-		binding?.declaration_kind === 'param' ||
-		binding?.kind === 'prop' ||
-		binding?.kind === 'prop_fallback' ||
-		binding?.kind === 'lazy' ||
-		binding?.kind === 'lazy_fallback'
-	);
-}
 
 /**
  *
@@ -3458,7 +3379,8 @@ function transform_children(children, context) {
 		).length === 1 &&
 			normalized.some(
 				(node) =>
-					node.type === 'RippleExpression' && is_children_render_expression(node.expression, state),
+					node.type === 'RippleExpression' &&
+						is_children_template_expression(node.expression, state.scope),
 			)) ||
 		normalized.filter(
 			(node) => node.type !== 'VariableDeclaration' && node.type !== 'EmptyStatement',
@@ -3797,7 +3719,10 @@ function transform_children(children, context) {
 				});
 			} else if (node.type === 'RippleExpression') {
 				const expr = /** @type {AST.Expression} */ (expression);
-				const is_children_expression = is_children_render_expression(node.expression, state);
+				const is_children_expression = is_children_template_expression(
+					node.expression,
+					state.scope,
+				);
 
 				if (expr.type === 'Literal') {
 					if (normalized.length === 1) {

--- a/packages/ripple/src/compiler/phases/3-transform/client/index.js
+++ b/packages/ripple/src/compiler/phases/3-transform/client/index.js
@@ -80,6 +80,86 @@ import { should_preserve_comment, format_comment } from '../../../comment-utils.
 import { set_location } from '../../../../utils/builders.js';
 
 /**
+ * @param {AST.Expression} expression
+ * @returns {AST.Expression}
+ */
+function unwrap_template_expression(expression) {
+	/** @type {AST.Expression} */
+	let node = expression;
+
+	while (true) {
+		if (
+			node.type === 'ParenthesizedExpression' ||
+			node.type === 'TSAsExpression' ||
+			node.type === 'TSSatisfiesExpression' ||
+			node.type === 'TSNonNullExpression' ||
+			node.type === 'TSInstantiationExpression'
+		) {
+			node = /** @type {AST.Expression} */ (node.expression);
+			continue;
+		}
+
+		if (node.type === 'ChainExpression') {
+			node = /** @type {AST.Expression} */ (node.expression);
+			continue;
+		}
+
+		break;
+	}
+
+	return node;
+}
+
+/**
+ * @param {AST.Expression} expression
+ * @param {TransformClientState} state
+ * @returns {boolean}
+ */
+function is_children_render_expression(expression, state) {
+	if (state.scope == null) {
+		return false;
+	}
+
+	const unwrapped = unwrap_template_expression(expression);
+
+	if (unwrapped.type === 'MemberExpression') {
+		let property_name = null;
+
+		if (!unwrapped.computed && unwrapped.property.type === 'Identifier') {
+			property_name = unwrapped.property.name;
+		} else if (
+			unwrapped.computed &&
+			unwrapped.property.type === 'Literal' &&
+			typeof unwrapped.property.value === 'string'
+		) {
+			property_name = unwrapped.property.value;
+		}
+
+		if (property_name === 'children') {
+			const target = unwrap_template_expression(/** @type {AST.Expression} */ (unwrapped.object));
+
+			if (target.type === 'Identifier') {
+				const binding = state.scope.get(target.name);
+				return binding?.declaration_kind === 'param';
+			}
+		}
+	}
+
+	if (unwrapped.type !== 'Identifier' || unwrapped.name !== 'children') {
+		return false;
+	}
+
+	const binding = state.scope.get(unwrapped.name);
+	return (
+		binding?.declaration_kind === 'param' ||
+		binding?.kind === 'prop' ||
+		binding?.kind === 'prop_fallback' ||
+		binding?.kind === 'lazy' ||
+		binding?.kind === 'lazy_fallback'
+	);
+}
+
+/**
  *
  * @param {AST.FunctionDeclaration | AST.FunctionExpression | AST.ArrowFunctionExpression} node
  * @param {TransformClientContext} context
@@ -1634,7 +1714,7 @@ const visitors = {
 
 						if (metadata.tracking || attr.name.tracked) {
 							if (attr.name.name === 'children') {
-								children_prop = b.thunk(property);
+								children_prop = b.thunk(b.call('_$_.normalize_children', property));
 								continue;
 							}
 
@@ -1646,7 +1726,15 @@ const visitors = {
 								),
 							);
 						} else {
-							props.push(b.prop('init', b.key(attr.name.name), property));
+							props.push(
+								b.prop(
+									'init',
+									b.key(attr.name.name),
+									attr.name.name === 'children'
+										? b.call('_$_.normalize_children', property)
+										: property,
+								),
+							);
 						}
 					} else {
 						props.push(
@@ -1699,22 +1787,25 @@ const visitors = {
 
 			if (children_filtered.length > 0) {
 				const component_scope = state.scopes.get(node);
-				const children_component = b.component(b.id('children'), [], children_filtered);
+				const children_component = b.component(b.id('render_children'), [], children_filtered);
 
-				const children = /** @type {AST.Expression} */ (
-					visit(children_component, {
-						...state,
-						...(apply_parent_css_scope ||
-						(is_dynamic_element && node.metadata.scoped && state.component?.css)
-							? {
-									applyParentCssScope:
-										apply_parent_css_scope ||
-										/** @type {AST.CSS.StyleSheet} */ (state.component?.css).hash,
-								}
-							: {}),
-						scope: /** @type {ScopeInterface} */ (component_scope),
-						namespace: child_namespace,
-					})
+				const children = b.call(
+					'_$_.ripple_element',
+					/** @type {AST.Expression} */ (
+						visit(children_component, {
+							...state,
+							...(apply_parent_css_scope ||
+							(is_dynamic_element && node.metadata.scoped && state.component?.css)
+								? {
+										applyParentCssScope:
+											apply_parent_css_scope ||
+											/** @type {AST.CSS.StyleSheet} */ (state.component?.css).hash,
+									}
+								: {}),
+							scope: /** @type {ScopeInterface} */ (component_scope),
+							namespace: child_namespace,
+						})
+					),
 				);
 
 				if (children_prop) {
@@ -3337,6 +3428,13 @@ function transform_children(children, context) {
 				(node.type === 'Element' &&
 					(node.id.type !== 'Identifier' || !is_element_dom_element(node))),
 		) ||
+		(normalized.filter(
+			(node) => node.type !== 'VariableDeclaration' && node.type !== 'EmptyStatement',
+		).length === 1 &&
+			normalized.some(
+				(node) =>
+					node.type === 'RippleExpression' && is_children_render_expression(node.expression, state),
+			)) ||
 		normalized.filter(
 			(node) => node.type !== 'VariableDeclaration' && node.type !== 'EmptyStatement',
 		).length > 1;
@@ -3672,7 +3770,83 @@ function transform_children(children, context) {
 							),
 						),
 				});
-			} else if (node.type === 'RippleExpression' || node.type === 'Text') {
+			} else if (node.type === 'RippleExpression') {
+				const expr = /** @type {AST.Expression} */ (expression);
+				const is_children_expression = is_children_render_expression(node.expression, state);
+
+				if (expr.type === 'Literal') {
+					if (normalized.length === 1) {
+						skipped++;
+						if (
+							/** @type {NonNullable<TransformClientState['template']>} */ (state.template).length >
+							0
+						) {
+							state.template?.push(escape_html(expr.value));
+						} else {
+							const id = flush_node(true);
+							state.init?.push(b.var(/** @type {AST.Identifier} */ (id), b.call('_$_.text', expr)));
+							state.final?.push(b.stmt(b.call('_$_.append', b.id('__anchor'), id)));
+						}
+					} else {
+						skipped++;
+						state.template?.push(escape_html(expr.value));
+					}
+				} else if (is_children_expression) {
+					skipped = 0;
+					state.template?.push('<!>');
+					const id = flush_node(false);
+					state.update?.push({
+						operation: () => {
+							const call = b.call('_$_.expression', id, b.thunk(expr));
+							return state.namespace !== DEFAULT_NAMESPACE
+								? b.stmt(b.call('_$_.with_ns', b.literal(state.namespace), b.thunk(call)))
+								: b.stmt(call);
+						},
+					});
+					if (metadata?.await) {
+						/** @type {NonNullable<TransformClientState['update']>} */ (state.update).async = true;
+					}
+				} else if (metadata?.tracking) {
+					skipped = 0;
+					state.template?.push(' ');
+					const id = flush_node(true);
+					state.update?.push({
+						operation: (key) => b.stmt(b.call('_$_.set_text', id, key)),
+						expression: expr,
+						identity: node.expression,
+						initial: b.literal(' '),
+					});
+					if (metadata.await) {
+						/** @type {NonNullable<TransformClientState['update']>} */ (state.update).async = true;
+					}
+				} else if (normalized.length === 1) {
+					skipped++;
+					const id = flush_node(true);
+					state.template?.push(' ');
+					state.init?.push(
+						b.stmt(
+							b.assignment(
+								'=',
+								b.member(/** @type {AST.Identifier} */ (id), b.id('nodeValue')),
+								expr,
+							),
+						),
+					);
+				} else {
+					skipped++;
+					state.template?.push(' ');
+					const id = flush_node(true);
+					state.update?.push({
+						operation: (key) => b.stmt(b.call('_$_.set_text', id, key)),
+						expression: expr,
+						identity: node.expression,
+						initial: b.literal(' '),
+					});
+					if (metadata?.await) {
+						/** @type {NonNullable<TransformClientState['update']>} */ (state.update).async = true;
+					}
+				}
+			} else if (node.type === 'Text') {
 				if (metadata?.tracking) {
 					skipped = 0;
 					state.template?.push(' ');

--- a/packages/ripple/src/compiler/phases/3-transform/client/index.js
+++ b/packages/ripple/src/compiler/phases/3-transform/client/index.js
@@ -1717,7 +1717,11 @@ const visitors = {
 								children_prop = b.prop(
 									'get',
 									b.id('children'),
-									b.function(null, [], b.block([b.return(b.call('_$_.normalize_children', property))])),
+									b.function(
+										null,
+										[],
+										b.block([b.return(b.call('_$_.normalize_children', property))]),
+									),
 								);
 								continue;
 							}
@@ -1739,13 +1743,7 @@ const visitors = {
 								continue;
 							}
 
-							props.push(
-								b.prop(
-									'init',
-									b.key(attr.name.name),
-									property,
-								),
-							);
+							props.push(b.prop('init', b.key(attr.name.name), property));
 						}
 					} else {
 						props.push(

--- a/packages/ripple/src/compiler/phases/3-transform/server/index.js
+++ b/packages/ripple/src/compiler/phases/3-transform/server/index.js
@@ -44,6 +44,86 @@ import {
 import { BLOCK_CLOSE, BLOCK_OPEN } from '../../../../constants.js';
 
 /**
+ * @param {AST.Expression} expression
+ * @returns {AST.Expression}
+ */
+function unwrap_template_expression(expression) {
+	/** @type {AST.Expression} */
+	let node = expression;
+
+	while (true) {
+		if (
+			node.type === 'ParenthesizedExpression' ||
+			node.type === 'TSAsExpression' ||
+			node.type === 'TSSatisfiesExpression' ||
+			node.type === 'TSNonNullExpression' ||
+			node.type === 'TSInstantiationExpression'
+		) {
+			node = /** @type {AST.Expression} */ (node.expression);
+			continue;
+		}
+
+		if (node.type === 'ChainExpression') {
+			node = /** @type {AST.Expression} */ (node.expression);
+			continue;
+		}
+
+		break;
+	}
+
+	return node;
+}
+
+/**
+ * @param {AST.Expression} expression
+ * @param {TransformServerState} state
+ * @returns {boolean}
+ */
+function is_children_render_expression(expression, state) {
+	if (state.scope == null) {
+		return false;
+	}
+
+	const unwrapped = unwrap_template_expression(expression);
+
+	if (unwrapped.type === 'MemberExpression') {
+		let property_name = null;
+
+		if (!unwrapped.computed && unwrapped.property.type === 'Identifier') {
+			property_name = unwrapped.property.name;
+		} else if (
+			unwrapped.computed &&
+			unwrapped.property.type === 'Literal' &&
+			typeof unwrapped.property.value === 'string'
+		) {
+			property_name = unwrapped.property.value;
+		}
+
+		if (property_name === 'children') {
+			const target = unwrap_template_expression(/** @type {AST.Expression} */ (unwrapped.object));
+
+			if (target.type === 'Identifier') {
+				const binding = state.scope.get(target.name);
+				return binding?.declaration_kind === 'param';
+			}
+		}
+	}
+
+	if (unwrapped.type !== 'Identifier' || unwrapped.name !== 'children') {
+		return false;
+	}
+
+	const binding = state.scope.get(unwrapped.name);
+	return (
+		binding?.declaration_kind === 'param' ||
+		binding?.kind === 'prop' ||
+		binding?.kind === 'prop_fallback' ||
+		binding?.kind === 'lazy' ||
+		binding?.kind === 'lazy_fallback'
+	);
+}
+
+/**
  * Checks if a node is template or control-flow content that should be wrapped when return flags are active
  * @param {AST.Node} node
  * @returns {boolean}
@@ -1103,7 +1183,9 @@ const visitors = {
 									);
 
 						if (attr.name.name === 'children') {
-							children_prop = attr.name.tracked ? b.thunk(property) : property;
+							children_prop = attr.name.tracked
+								? b.thunk(b.call('_$_.normalize_children', property))
+								: b.call('_$_.normalize_children', property);
 							continue;
 						}
 
@@ -1128,20 +1210,23 @@ const visitors = {
 
 			if (children_filtered.length > 0) {
 				const component_scope = /** @type {ScopeInterface} */ (context.state.scopes.get(node));
-				const children = /** @type {AST.Expression} */ (
-					visit(b.component(b.id('children'), [], children_filtered), {
-						...context.state,
-						...(apply_parent_css_scope ||
-						(is_element_dynamic(node) && node.metadata.scoped && state.component?.css)
-							? {
-									applyParentCssScope:
-										apply_parent_css_scope ||
-										/** @type {AST.CSS.StyleSheet} */ (state.component?.css).hash,
-								}
-							: {}),
-						scope: component_scope,
-						namespace: child_namespace,
-					})
+				const children = b.call(
+					'_$_.ripple_element',
+					/** @type {AST.Expression} */ (
+						visit(b.component(b.id('render_children'), [], children_filtered), {
+							...context.state,
+							...(apply_parent_css_scope ||
+							(is_element_dynamic(node) && node.metadata.scoped && state.component?.css)
+								? {
+										applyParentCssScope:
+											apply_parent_css_scope ||
+											/** @type {AST.CSS.StyleSheet} */ (state.component?.css).hash,
+									}
+								: {}),
+							scope: component_scope,
+							namespace: child_namespace,
+						})
+					),
 				);
 
 				props.push(b.prop('init', b.id('children'), children));
@@ -1600,6 +1685,7 @@ const visitors = {
 	RippleExpression(node, { visit, state }) {
 		const metadata = { await: false };
 		let expression = /** @type {AST.Expression} */ (visit(node.expression, { ...state, metadata }));
+		const is_children_expression = is_children_render_expression(node.expression, state);
 
 		if (expression.type === 'Literal') {
 			state.init?.push(
@@ -1607,6 +1693,8 @@ const visitors = {
 					b.call(b.member(b.id('__output'), b.id('push')), b.literal(escape(expression.value))),
 				),
 			);
+		} else if (is_children_expression) {
+			state.init?.push(b.stmt(b.call('_$_.render_expression', b.id('__output'), expression)));
 		} else {
 			state.init?.push(
 				b.stmt(b.call(b.member(b.id('__output'), b.id('push')), b.call('_$_.escape', expression))),

--- a/packages/ripple/src/compiler/phases/3-transform/server/index.js
+++ b/packages/ripple/src/compiler/phases/3-transform/server/index.js
@@ -1120,26 +1120,7 @@ const visitors = {
 				}
 			}
 
-			const children_filtered = [];
-
-			for (const child of node.children) {
-				if (child.type === 'Component') {
-					// in this case, id cannot be null
-					// as these are direct children of the component
-					const id = /** @type {AST.Identifier} */ (child.id);
-					props.push(
-						b.prop(
-							'init',
-							id,
-							/** @type {AST.Expression} */ (
-								visit(child, { ...state, namespace: child_namespace })
-							),
-						),
-					);
-				} else {
-					children_filtered.push(child);
-				}
-			}
+			const children_filtered = node.children.filter((child) => child.type !== 'EmptyStatement');
 
 			if (children_prop) {
 				props.push(b.prop('init', b.id('children'), children_prop));

--- a/packages/ripple/src/compiler/phases/3-transform/server/index.js
+++ b/packages/ripple/src/compiler/phases/3-transform/server/index.js
@@ -23,6 +23,7 @@ import {
 	is_inside_component,
 	is_void_element,
 	normalize_children,
+	is_children_template_expression,
 	is_binding_function,
 	is_element_dynamic,
 	is_ripple_track_call,
@@ -42,86 +43,6 @@ import {
 	obfuscate_identifier,
 } from '../../../identifier-utils.js';
 import { BLOCK_CLOSE, BLOCK_OPEN } from '../../../../constants.js';
-
-/**
- * @param {AST.Expression} expression
- * @returns {AST.Expression}
- */
-function unwrap_template_expression(expression) {
-	/** @type {AST.Expression} */
-	let node = expression;
-
-	while (true) {
-		if (
-			node.type === 'ParenthesizedExpression' ||
-			node.type === 'TSAsExpression' ||
-			node.type === 'TSSatisfiesExpression' ||
-			node.type === 'TSNonNullExpression' ||
-			node.type === 'TSInstantiationExpression'
-		) {
-			node = /** @type {AST.Expression} */ (node.expression);
-			continue;
-		}
-
-		if (node.type === 'ChainExpression') {
-			node = /** @type {AST.Expression} */ (node.expression);
-			continue;
-		}
-
-		break;
-	}
-
-	return node;
-}
-
-/**
- * @param {AST.Expression} expression
- * @param {TransformServerState} state
- * @returns {boolean}
- */
-function is_children_render_expression(expression, state) {
-	if (state.scope == null) {
-		return false;
-	}
-
-	const unwrapped = unwrap_template_expression(expression);
-
-	if (unwrapped.type === 'MemberExpression') {
-		let property_name = null;
-
-		if (!unwrapped.computed && unwrapped.property.type === 'Identifier') {
-			property_name = unwrapped.property.name;
-		} else if (
-			unwrapped.computed &&
-			unwrapped.property.type === 'Literal' &&
-			typeof unwrapped.property.value === 'string'
-		) {
-			property_name = unwrapped.property.value;
-		}
-
-		if (property_name === 'children') {
-			const target = unwrap_template_expression(/** @type {AST.Expression} */ (unwrapped.object));
-
-			if (target.type === 'Identifier') {
-				const binding = state.scope.get(target.name);
-				return binding?.declaration_kind === 'param';
-			}
-		}
-	}
-
-	if (unwrapped.type !== 'Identifier' || unwrapped.name !== 'children') {
-		return false;
-	}
-
-	const binding = state.scope.get(unwrapped.name);
-	return (
-		binding?.declaration_kind === 'param' ||
-		binding?.kind === 'prop' ||
-		binding?.kind === 'prop_fallback' ||
-		binding?.kind === 'lazy' ||
-		binding?.kind === 'lazy_fallback'
-	);
-}
 
 /**
  * Checks if a node is template or control-flow content that should be wrapped when return flags are active
@@ -1705,7 +1626,10 @@ const visitors = {
 	RippleExpression(node, { visit, state }) {
 		const metadata = { await: false };
 		let expression = /** @type {AST.Expression} */ (visit(node.expression, { ...state, metadata }));
-		const is_children_expression = is_children_render_expression(node.expression, state);
+		const is_children_expression = is_children_template_expression(
+			node.expression,
+			state.scope,
+		);
 
 		if (expression.type === 'Literal') {
 			state.init?.push(

--- a/packages/ripple/src/compiler/phases/3-transform/server/index.js
+++ b/packages/ripple/src/compiler/phases/3-transform/server/index.js
@@ -1151,19 +1151,11 @@ const visitors = {
 				);
 
 				if (children_prop) {
-					if (children_prop.value.type === 'ArrowFunctionExpression') {
-						children_prop.value.body = b.logical(
-							'??',
-							/** @type {AST.Expression} */ (children_prop.value.body),
-							children,
-						);
-					} else {
-						children_prop.value = b.logical(
-							'??',
-							/** @type {AST.Expression} */ (children_prop.value),
-							children,
-						);
-					}
+					children_prop.value = b.logical(
+						'??',
+						/** @type {AST.Expression} */ (children_prop.value),
+						children,
+					);
 				} else {
 					children_prop = b.prop('init', b.id('children'), children);
 				}

--- a/packages/ripple/src/compiler/phases/3-transform/server/index.js
+++ b/packages/ripple/src/compiler/phases/3-transform/server/index.js
@@ -1107,9 +1107,7 @@ const visitors = {
 							children_prop = b.prop(
 								'init',
 								b.id('children'),
-								attr.name.tracked
-									? b.thunk(b.call('_$_.normalize_children', property))
-									: b.call('_$_.normalize_children', property),
+								b.call('_$_.normalize_children', property),
 							);
 							continue;
 						}

--- a/packages/ripple/src/compiler/phases/3-transform/server/index.js
+++ b/packages/ripple/src/compiler/phases/3-transform/server/index.js
@@ -1125,7 +1125,9 @@ const visitors = {
 				}
 			}
 
-			const children_filtered = node.children.filter((child) => child.type !== 'EmptyStatement' && child.type !== 'Component');
+			const children_filtered = node.children.filter(
+				(child) => child.type !== 'EmptyStatement' && child.type !== 'Component',
+			);
 
 			if (children_filtered.length > 0) {
 				const component_scope = /** @type {ScopeInterface} */ (context.state.scopes.get(node));

--- a/packages/ripple/src/compiler/phases/3-transform/server/index.js
+++ b/packages/ripple/src/compiler/phases/3-transform/server/index.js
@@ -1626,10 +1626,7 @@ const visitors = {
 	RippleExpression(node, { visit, state }) {
 		const metadata = { await: false };
 		let expression = /** @type {AST.Expression} */ (visit(node.expression, { ...state, metadata }));
-		const is_children_expression = is_children_template_expression(
-			node.expression,
-			state.scope,
-		);
+		const is_children_expression = is_children_template_expression(node.expression, state.scope);
 
 		if (expression.type === 'Literal') {
 			state.init?.push(

--- a/packages/ripple/src/compiler/phases/3-transform/server/index.js
+++ b/packages/ripple/src/compiler/phases/3-transform/server/index.js
@@ -1163,7 +1163,7 @@ const visitors = {
 		} else {
 			/** @type {(AST.Property | AST.SpreadElement)[]} */
 			const props = [];
-			/** @type {AST.Expression | null} */
+			/** @type {AST.Property | null} */
 			let children_prop = null;
 
 			const apply_parent_css_scope = state.applyParentCssScope;
@@ -1183,9 +1183,13 @@ const visitors = {
 									);
 
 						if (attr.name.name === 'children') {
-							children_prop = attr.name.tracked
-								? b.thunk(b.call('_$_.normalize_children', property))
-								: b.call('_$_.normalize_children', property);
+							children_prop = b.prop(
+								'init',
+								b.id('children'),
+								attr.name.tracked
+									? b.thunk(b.call('_$_.normalize_children', property))
+									: b.call('_$_.normalize_children', property),
+							);
 							continue;
 						}
 
@@ -1203,10 +1207,6 @@ const visitors = {
 			}
 
 			const children_filtered = node.children.filter((child) => child.type !== 'EmptyStatement');
-
-			if (children_prop) {
-				props.push(b.prop('init', b.id('children'), children_prop));
-			}
 
 			if (children_filtered.length > 0) {
 				const component_scope = /** @type {ScopeInterface} */ (context.state.scopes.get(node));
@@ -1229,7 +1229,27 @@ const visitors = {
 					),
 				);
 
-				props.push(b.prop('init', b.id('children'), children));
+				if (children_prop) {
+					if (children_prop.value.type === 'ArrowFunctionExpression') {
+						children_prop.value.body = b.logical(
+							'??',
+							/** @type {AST.Expression} */ (children_prop.value.body),
+							children,
+						);
+					} else {
+						children_prop.value = b.logical(
+							'??',
+							/** @type {AST.Expression} */ (children_prop.value),
+							children,
+						);
+					}
+				} else {
+					children_prop = b.prop('init', b.id('children'), children);
+				}
+			}
+
+			if (children_prop) {
+				props.push(children_prop);
 			}
 
 			// For SSR, determine if we should await based on component metadata

--- a/packages/ripple/src/compiler/phases/3-transform/server/index.js
+++ b/packages/ripple/src/compiler/phases/3-transform/server/index.js
@@ -1125,7 +1125,7 @@ const visitors = {
 				}
 			}
 
-			const children_filtered = node.children.filter((child) => child.type !== 'EmptyStatement');
+			const children_filtered = node.children.filter((child) => child.type !== 'EmptyStatement' && child.type !== 'Component');
 
 			if (children_filtered.length > 0) {
 				const component_scope = /** @type {ScopeInterface} */ (context.state.scopes.get(node));

--- a/packages/ripple/src/compiler/utils.js
+++ b/packages/ripple/src/compiler/utils.js
@@ -636,9 +636,9 @@ export function normalize_children(children, context) {
 		) {
 			if (
 				(child.type === 'RippleExpression' &&
-					is_children_template_expression_for_normalization(child.expression, context)) ||
+					is_children_template_expression(child.expression, context.state.scope)) ||
 				(prev_child.type === 'RippleExpression' &&
-					is_children_template_expression_for_normalization(prev_child.expression, context))
+					is_children_template_expression(prev_child.expression, context.state.scope))
 			) {
 				continue;
 			}
@@ -668,7 +668,7 @@ export function normalize_children(children, context) {
  * @param {AST.Expression} expression
  * @returns {AST.Expression}
  */
-function unwrap_template_expression_for_normalization(expression) {
+export function unwrap_template_expression(expression) {
 	/** @type {AST.Expression} */
 	let node = expression;
 
@@ -697,11 +697,16 @@ function unwrap_template_expression_for_normalization(expression) {
 
 /**
  * @param {AST.Expression} expression
- * @param {CommonContext} context
+	 * @param {ScopeInterface | null | undefined} scope
+	 * @param {ScopeInterface | null} [component_scope]
  * @returns {boolean}
  */
-function is_children_template_expression_for_normalization(expression, context) {
-	const unwrapped = unwrap_template_expression_for_normalization(expression);
+export function is_children_template_expression(expression, scope, component_scope = null) {
+	if (scope == null) {
+		return false;
+	}
+
+	const unwrapped = unwrap_template_expression(expression);
 
 	if (unwrapped.type === 'MemberExpression') {
 		let property_name = null;
@@ -717,13 +722,16 @@ function is_children_template_expression_for_normalization(expression, context) 
 		}
 
 		if (property_name === 'children') {
-			const target = unwrap_template_expression_for_normalization(
+			const target = unwrap_template_expression(
 				/** @type {AST.Expression} */ (unwrapped.object),
 			);
 
 			if (target.type === 'Identifier') {
-				const binding = context.state.scope.get(target.name);
-				return binding?.declaration_kind === 'param';
+				const binding = scope.get(target.name);
+				return (
+					binding?.declaration_kind === 'param' &&
+					(component_scope === null || binding.scope === component_scope)
+				);
 			}
 		}
 	}
@@ -732,13 +740,16 @@ function is_children_template_expression_for_normalization(expression, context) 
 		return false;
 	}
 
-	const binding = context.state.scope.get(unwrapped.name);
+	const binding = scope.get(unwrapped.name);
 	return (
-		binding?.declaration_kind === 'param' ||
-		binding?.kind === 'prop' ||
-		binding?.kind === 'prop_fallback' ||
-		binding?.kind === 'lazy' ||
-		binding?.kind === 'lazy_fallback'
+		(
+			binding?.declaration_kind === 'param' ||
+			binding?.kind === 'prop' ||
+			binding?.kind === 'prop_fallback' ||
+			binding?.kind === 'lazy' ||
+			binding?.kind === 'lazy_fallback'
+		) &&
+		(component_scope === null || binding.scope === component_scope)
 	);
 }
 

--- a/packages/ripple/src/compiler/utils.js
+++ b/packages/ripple/src/compiler/utils.js
@@ -113,6 +113,8 @@ const DOM_BOOLEAN_ATTRIBUTES = [
 	'controls',
 	'default',
 	'disabled',
+	'formnovalidate',
+	'hidden',
 	'inert',
 	'ismap',
 	'loop',

--- a/packages/ripple/src/compiler/utils.js
+++ b/packages/ripple/src/compiler/utils.js
@@ -697,8 +697,8 @@ export function unwrap_template_expression(expression) {
 
 /**
  * @param {AST.Expression} expression
-	 * @param {ScopeInterface | null | undefined} scope
-	 * @param {ScopeInterface | null} [component_scope]
+ * @param {ScopeInterface | null | undefined} scope
+ * @param {ScopeInterface | null} [component_scope]
  * @returns {boolean}
  */
 export function is_children_template_expression(expression, scope, component_scope = null) {
@@ -722,9 +722,7 @@ export function is_children_template_expression(expression, scope, component_sco
 		}
 
 		if (property_name === 'children') {
-			const target = unwrap_template_expression(
-				/** @type {AST.Expression} */ (unwrapped.object),
-			);
+			const target = unwrap_template_expression(/** @type {AST.Expression} */ (unwrapped.object));
 
 			if (target.type === 'Identifier') {
 				const binding = scope.get(target.name);
@@ -742,13 +740,11 @@ export function is_children_template_expression(expression, scope, component_sco
 
 	const binding = scope.get(unwrapped.name);
 	return (
-		(
-			binding?.declaration_kind === 'param' ||
+		(binding?.declaration_kind === 'param' ||
 			binding?.kind === 'prop' ||
 			binding?.kind === 'prop_fallback' ||
 			binding?.kind === 'lazy' ||
-			binding?.kind === 'lazy_fallback'
-		) &&
+			binding?.kind === 'lazy_fallback') &&
 		(component_scope === null || binding.scope === component_scope)
 	);
 }

--- a/packages/ripple/src/compiler/utils.js
+++ b/packages/ripple/src/compiler/utils.js
@@ -115,6 +115,7 @@ const DOM_BOOLEAN_ATTRIBUTES = [
 	'disabled',
 	'formnovalidate',
 	'hidden',
+	'indeterminate',
 	'inert',
 	'ismap',
 	'loop',

--- a/packages/ripple/src/compiler/utils.js
+++ b/packages/ripple/src/compiler/utils.js
@@ -113,9 +113,6 @@ const DOM_BOOLEAN_ATTRIBUTES = [
 	'controls',
 	'default',
 	'disabled',
-	'formnovalidate',
-	'hidden',
-	'indeterminate',
 	'inert',
 	'ismap',
 	'loop',
@@ -635,6 +632,15 @@ export function normalize_children(children, context) {
 			(child.type === 'RippleExpression' || child.type === 'Text') &&
 			(prev_child?.type === 'RippleExpression' || prev_child?.type === 'Text')
 		) {
+			if (
+				(child.type === 'RippleExpression' &&
+					is_children_template_expression_for_normalization(child.expression, context)) ||
+				(prev_child.type === 'RippleExpression' &&
+					is_children_template_expression_for_normalization(prev_child.expression, context))
+			) {
+				continue;
+			}
+
 			if (prev_child.type === 'Text' || child.type === 'Text') {
 				prev_child.type = 'Text';
 			}
@@ -654,6 +660,84 @@ export function normalize_children(children, context) {
 	}
 
 	return normalized;
+}
+
+/**
+ * @param {AST.Expression} expression
+ * @returns {AST.Expression}
+ */
+function unwrap_template_expression_for_normalization(expression) {
+	/** @type {AST.Expression} */
+	let node = expression;
+
+	while (true) {
+		if (
+			node.type === 'ParenthesizedExpression' ||
+			node.type === 'TSAsExpression' ||
+			node.type === 'TSSatisfiesExpression' ||
+			node.type === 'TSNonNullExpression' ||
+			node.type === 'TSInstantiationExpression'
+		) {
+			node = /** @type {AST.Expression} */ (node.expression);
+			continue;
+		}
+
+		if (node.type === 'ChainExpression') {
+			node = /** @type {AST.Expression} */ (node.expression);
+			continue;
+		}
+
+		break;
+	}
+
+	return node;
+}
+
+/**
+ * @param {AST.Expression} expression
+ * @param {CommonContext} context
+ * @returns {boolean}
+ */
+function is_children_template_expression_for_normalization(expression, context) {
+	const unwrapped = unwrap_template_expression_for_normalization(expression);
+
+	if (unwrapped.type === 'MemberExpression') {
+		let property_name = null;
+
+		if (!unwrapped.computed && unwrapped.property.type === 'Identifier') {
+			property_name = unwrapped.property.name;
+		} else if (
+			unwrapped.computed &&
+			unwrapped.property.type === 'Literal' &&
+			typeof unwrapped.property.value === 'string'
+		) {
+			property_name = unwrapped.property.value;
+		}
+
+		if (property_name === 'children') {
+			const target = unwrap_template_expression_for_normalization(
+				/** @type {AST.Expression} */ (unwrapped.object),
+			);
+
+			if (target.type === 'Identifier') {
+				const binding = context.state.scope.get(target.name);
+				return binding?.declaration_kind === 'param';
+			}
+		}
+	}
+
+	if (unwrapped.type !== 'Identifier' || unwrapped.name !== 'children') {
+		return false;
+	}
+
+	const binding = context.state.scope.get(unwrapped.name);
+	return (
+		binding?.declaration_kind === 'param' ||
+		binding?.kind === 'prop' ||
+		binding?.kind === 'prop_fallback' ||
+		binding?.kind === 'lazy' ||
+		binding?.kind === 'lazy_fallback'
+	);
 }
 
 /**

--- a/packages/ripple/src/constants.js
+++ b/packages/ripple/src/constants.js
@@ -7,14 +7,10 @@ export const TEMPLATE_MATHML_NAMESPACE = 1 << 6;
 
 export const HYDRATION_START = '[';
 export const HYDRATION_END = ']';
-export const HYDRATION_EXPRESSION_START = 'r';
-export const HYDRATION_EXPRESSION_END = '/r';
 export const HYDRATION_ERROR = {};
 
 export const BLOCK_OPEN = `<!--${HYDRATION_START}-->`;
 export const BLOCK_CLOSE = `<!--${HYDRATION_END}-->`;
-export const EXPRESSION_OPEN = `<!--${HYDRATION_EXPRESSION_START}-->`;
-export const EXPRESSION_CLOSE = `<!--${HYDRATION_EXPRESSION_END}-->`;
 export const EMPTY_COMMENT = `<!---->`;
 
 export const ELEMENT_NODE = 1;

--- a/packages/ripple/src/constants.js
+++ b/packages/ripple/src/constants.js
@@ -7,10 +7,14 @@ export const TEMPLATE_MATHML_NAMESPACE = 1 << 6;
 
 export const HYDRATION_START = '[';
 export const HYDRATION_END = ']';
+export const HYDRATION_EXPRESSION_START = 'r';
+export const HYDRATION_EXPRESSION_END = '/r';
 export const HYDRATION_ERROR = {};
 
 export const BLOCK_OPEN = `<!--${HYDRATION_START}-->`;
 export const BLOCK_CLOSE = `<!--${HYDRATION_END}-->`;
+export const EXPRESSION_OPEN = `<!--${HYDRATION_EXPRESSION_START}-->`;
+export const EXPRESSION_CLOSE = `<!--${HYDRATION_EXPRESSION_END}-->`;
 export const EMPTY_COMMENT = `<!---->`;
 
 export const ELEMENT_NODE = 1;

--- a/packages/ripple/src/runtime/element.js
+++ b/packages/ripple/src/runtime/element.js
@@ -1,0 +1,39 @@
+const RIPPLE_ELEMENT = Symbol.for('ripple.element');
+
+/**
+ * @typedef {{
+ * 	render: Function;
+ * 	[RIPPLE_ELEMENT]: true;
+ * }} RippleElement
+ */
+
+/**
+ * @param {Function} render
+ * @returns {RippleElement}
+ */
+export function ripple_element(render) {
+	return {
+		render,
+		[RIPPLE_ELEMENT]: true,
+	};
+}
+
+/**
+ * @param {any} value
+ * @returns {value is RippleElement}
+ */
+export function is_ripple_element(value) {
+	return value != null && value[RIPPLE_ELEMENT] === true;
+}
+
+/**
+ * @param {any} value
+ * @returns {any}
+ */
+export function normalize_children(value) {
+	if (value == null || is_ripple_element(value) || typeof value !== 'function') {
+		return value;
+	}
+
+	return ripple_element(value);
+}

--- a/packages/ripple/src/runtime/internal/client/composite.js
+++ b/packages/ripple/src/runtime/internal/client/composite.js
@@ -5,6 +5,7 @@ import { COMPOSITE_BLOCK, DEFAULT_NAMESPACE, NAMESPACE_URI } from './constants.j
 import { hydrate_next, hydrating } from './hydration.js';
 import { active_block, active_namespace, get, with_ns } from './runtime.js';
 import { top_element_to_ns } from './utils.js';
+import { is_ripple_element } from '../../element.js';
 
 /**
  * @typedef {((anchor: Node, props: Record<string, any>, block: Block | null) => void)} ComponentFunction
@@ -45,13 +46,14 @@ export function composite(get_component, node, props) {
 				});
 			} else if (component != null) {
 				// Custom element - only create if component is not null/undefined
+				const ns = top_element_to_ns(component, active_namespace);
 				var run = () => {
 					var block = /** @type {Block} */ (active_block);
 
 					var element =
-						active_namespace !== DEFAULT_NAMESPACE
+						ns !== DEFAULT_NAMESPACE
 							? document.createElementNS(
-									NAMESPACE_URI[active_namespace],
+									NAMESPACE_URI[ns],
 									/** @type {keyof HTMLElementTagNameMap} */ (component),
 								)
 							: document.createElement(/** @type {keyof HTMLElementTagNameMap} */ (component));
@@ -67,15 +69,17 @@ export function composite(get_component, node, props) {
 
 					render_spread(element, () => props || {});
 
-					if (typeof props?.children === 'function') {
+					if (is_ripple_element(props?.children)) {
 						var child_anchor = document.createComment('');
 						element.appendChild(child_anchor);
 
-						props?.children?.(child_anchor, {}, block);
+						if (ns !== DEFAULT_NAMESPACE) {
+							with_ns(ns, () => props.children.render(child_anchor, {}, block));
+						} else {
+							props.children.render(child_anchor, {}, block);
+						}
 					}
 				};
-
-				const ns = top_element_to_ns(component, active_namespace);
 
 				if (ns !== active_namespace) {
 					// support top-level dynamic element svg/math <@tag />

--- a/packages/ripple/src/runtime/internal/client/expression.js
+++ b/packages/ripple/src/runtime/internal/client/expression.js
@@ -1,13 +1,12 @@
 /** @import { Block } from '#client' */
 
 import { branch, destroy_block, render } from './blocks.js';
+import { UNINITIALIZED } from './constants.js';
 import { create_text, get_next_sibling } from './operations.js';
 import { active_block } from './runtime.js';
 import { hydrating, set_hydrate_node } from './hydration.js';
 import { COMMENT_NODE, HYDRATION_END, HYDRATION_START, TEXT_NODE } from '../../../constants.js';
 import { is_ripple_element } from '../../element.js';
-
-const UNINITIALIZED = Symbol();
 
 /**
  * @param {Node} node
@@ -98,6 +97,7 @@ export function expression(node, get_value) {
 			if (next_text === '') {
 				if (text !== null) {
 					text.remove();
+					text = null;
 				}
 			} else if (text === null) {
 				text = create_text(next_text);

--- a/packages/ripple/src/runtime/internal/client/expression.js
+++ b/packages/ripple/src/runtime/internal/client/expression.js
@@ -1,0 +1,218 @@
+/** @import { Block } from '#client' */
+
+import { branch, destroy_block, render } from './blocks.js';
+import { create_text, get_next_sibling } from './operations.js';
+import { active_block } from './runtime.js';
+import { hydrating, set_hydrate_node } from './hydration.js';
+import { COMMENT_NODE, HYDRATION_END, HYDRATION_START, TEXT_NODE } from '../../../constants.js';
+import { is_ripple_element } from '../../element.js';
+
+const UNINITIALIZED = Symbol();
+
+/**
+ * @param {Node} node
+ * @param {() => any} get_value
+ * @returns {void}
+ */
+export function expression(node, get_value) {
+	var anchor = /** @type {ChildNode} */ (node);
+	/** @type {Block | null} */
+	var child_block = null;
+	/** @type {Comment | null} */
+	var end = null;
+	/** @type {Text | null} */
+	var text = null;
+	/** @type {string | import('../../element.js').RippleElement | typeof UNINITIALIZED} */
+	var value = UNINITIALIZED;
+	var is_element = false;
+	var initialized = false;
+
+	render(() => {
+		var next_value = get_value();
+		var next_is_element = is_ripple_element(next_value);
+		var is_hydration_marker = hydrating && anchor.nodeType === COMMENT_NODE;
+
+		if (is_hydration_marker) {
+			end ??= ensure_expression_end(anchor);
+		}
+
+		if (next_is_element) {
+			if (initialized && is_element && value === next_value) {
+				if (end !== null) {
+					advance_hydration(end);
+				}
+				return;
+			}
+
+			if (anchor.nodeType === TEXT_NODE) {
+				/** @type {Text} */ (anchor).nodeValue = '';
+			} else if (text !== null) {
+				text.remove();
+				text = null;
+			}
+
+			if (child_block !== null) {
+				destroy_block(child_block);
+				child_block = null;
+			}
+
+			if (end !== null && (initialized || !hydrating)) {
+				clear_expression_range(anchor, end);
+			}
+
+			if (is_hydration_marker) {
+				set_hydrate_node(get_next_sibling(anchor) ?? end);
+			}
+
+			child_block = branch(() => {
+				var block = active_block;
+				next_value.render(end ?? anchor, {}, block);
+			});
+
+			value = next_value;
+			is_element = true;
+			initialized = true;
+			if (end !== null) {
+				advance_hydration(end);
+			}
+			return;
+		}
+
+		var next_text = (next_value ?? '') + '';
+
+		if (initialized && !is_element && value === next_text) {
+			if (end !== null) {
+				advance_hydration(end);
+			}
+			return;
+		}
+
+		if (child_block !== null) {
+			destroy_block(child_block);
+			child_block = null;
+		}
+
+		if (is_hydration_marker) {
+			text = get_hydrated_text(anchor, /** @type {Comment} */ (end));
+
+			if (next_text === '') {
+				if (text !== null) {
+					text.remove();
+				}
+			} else if (text === null) {
+				text = create_text(next_text);
+				/** @type {Comment} */ (end).before(text);
+			} else if (text.nodeValue !== next_text) {
+				text.nodeValue = next_text;
+			}
+		} else if (anchor.nodeType === COMMENT_NODE) {
+			if (next_text === '') {
+				if (text !== null) {
+					text.remove();
+					text = null;
+				}
+			} else if (text === null) {
+				text = create_text(next_text);
+				anchor.before(text);
+			} else if (text.nodeValue !== next_text) {
+				text.nodeValue = next_text;
+			}
+		} else if (anchor.nodeType === TEXT_NODE) {
+			/** @type {Text} */ (anchor).nodeValue = next_text;
+		}
+
+		value = next_text;
+		is_element = false;
+		initialized = true;
+		if (end !== null) {
+			advance_hydration(end);
+		}
+	});
+}
+
+/**
+ * @param {Node} anchor
+ * @returns {Comment}
+ */
+function ensure_expression_end(anchor) {
+	if (hydrating) {
+		/** @type {Node | null} */
+		var current = get_next_sibling(anchor);
+		var depth = 0;
+
+		while (current !== null) {
+			if (current.nodeType === COMMENT_NODE) {
+				var data = /** @type {Comment} */ (current).data;
+
+				if (data === HYDRATION_START) {
+					depth += 1;
+				} else if (data === HYDRATION_END) {
+					if (depth === 0) {
+						return /** @type {Comment} */ (current);
+					}
+
+					depth -= 1;
+				}
+			}
+
+			current = get_next_sibling(current);
+		}
+
+		throw new Error('Hydration mismatch: expected end marker for expression block');
+	}
+
+	var end = document.createComment(HYDRATION_END);
+	/** @type {ChildNode} */ (anchor).after(end);
+	return end;
+}
+
+/**
+ * @param {Node} anchor
+ * @param {Node} end
+ * @returns {Text | null}
+ */
+function get_hydrated_text(anchor, end) {
+	var first = get_next_sibling(anchor);
+
+	if (first === end) {
+		return null;
+	}
+
+	if (first?.nodeType === TEXT_NODE && get_next_sibling(first) === end) {
+		return /** @type {Text} */ (first);
+	}
+
+	clear_expression_range(anchor, end);
+	return null;
+}
+
+/**
+ * @param {Node} anchor
+ * @param {Node} end
+ * @returns {void}
+ */
+function clear_expression_range(anchor, end) {
+	var current = get_next_sibling(anchor);
+
+	while (current !== null && current !== end) {
+		var next = get_next_sibling(current);
+		/** @type {ChildNode} */ (current).remove();
+		current = next;
+	}
+}
+
+/**
+ * @param {Comment} end
+ * @returns {void}
+ */
+function advance_hydration(end) {
+	if (!hydrating) {
+		return;
+	}
+
+	var next = get_next_sibling(end);
+
+	if (next !== null) {
+		set_hydrate_node(next);
+	}
+}

--- a/packages/ripple/src/runtime/internal/client/expression.js
+++ b/packages/ripple/src/runtime/internal/client/expression.js
@@ -113,7 +113,7 @@ export function expression(node, get_value) {
 				}
 			} else if (text === null) {
 				text = create_text(next_text);
-				anchor.before(text);
+				(end ?? anchor).before(text);
 			} else if (text.nodeValue !== next_text) {
 				text.nodeValue = next_text;
 			}

--- a/packages/ripple/src/runtime/internal/client/index.js
+++ b/packages/ripple/src/runtime/internal/client/index.js
@@ -105,6 +105,8 @@ export { script } from './script.js';
 
 export { html } from './html.js';
 
+export { expression } from './expression.js';
+
 export { rpc } from './rpc.js';
 
 export { tsx_compat } from './compat.js';
@@ -114,3 +116,5 @@ export { TRY_BLOCK, HMR } from './constants.js';
 export { hmr } from './hmr.js';
 
 export { pop, next } from './hydration.js';
+
+export { ripple_element, normalize_children } from '../../element.js';

--- a/packages/ripple/src/runtime/internal/client/portal.js
+++ b/packages/ripple/src/runtime/internal/client/portal.js
@@ -12,10 +12,11 @@ import {
 	set_hydrating,
 	set_hydrate_node,
 } from './hydration.js';
+import { is_ripple_element } from '../../element.js';
 
 /**
  * @param {any} _
- * @param {{ target: Element, children: (anchor: Node, props: {}, block: Block) => void }} props
+ * @param {{ target: Element, children: import('../../element.js').RippleElement }} props
  * @returns {void}
  */
 export function Portal(_, props) {
@@ -26,7 +27,7 @@ export function Portal(_, props) {
 
 	/** @type {Element | symbol} */
 	let target = UNINITIALIZED;
-	/** @type {((anchor: Node, props: {}, block: Block) => void) | symbol} */
+	/** @type {import('../../element.js').RippleElement | symbol} */
 	let children = UNINITIALIZED;
 	/** @type {Block | null} */
 	var b = null;
@@ -44,8 +45,13 @@ export function Portal(_, props) {
 
 	try {
 		render(() => {
-			if (target === (target = props.target)) return;
-			if (children === (children = props.children)) return;
+			const next_target = props.target;
+			const next_children = props.children;
+
+			if (target === next_target && children === next_children) return;
+
+			target = next_target;
+			children = next_children;
 
 			if (b !== null) {
 				destroy_block(b);
@@ -65,8 +71,8 @@ export function Portal(_, props) {
 			var block = /** @type {Block} */ (active_block);
 
 			b = branch(() => {
-				if (typeof children === 'function') {
-					children(/** @type {Text} */ (anchor), {}, block);
+				if (is_ripple_element(children)) {
+					children.render(/** @type {Text} */ (anchor), {}, block);
 				}
 			});
 

--- a/packages/ripple/src/runtime/internal/server/index.js
+++ b/packages/ripple/src/runtime/internal/server/index.js
@@ -17,6 +17,7 @@ import { is_boolean_attribute } from '../../../compiler/utils.js';
 import { clsx } from 'clsx';
 import { normalize_css_property_name } from '../../../utils/normalize_css_property_name.js';
 import { BLOCK_CLOSE, BLOCK_OPEN } from '../../../constants.js';
+import { is_ripple_element, normalize_children, ripple_element } from '../../element.js';
 import {
 	is_tag_valid_with_parent,
 	is_tag_valid_with_ancestor,
@@ -27,6 +28,24 @@ export { register_component_css as register_css } from './css-registry.js';
 export { hash } from '../../../utils/hashing.js';
 export { context } from './context.js';
 export { array_slice };
+export { ripple_element, normalize_children };
+
+/**
+ * @param {Output} output
+ * @param {any} value
+ * @returns {void}
+ */
+export function render_expression(output, value) {
+	output.push(BLOCK_OPEN);
+
+	if (is_ripple_element(value)) {
+		value.render(output, {});
+	} else {
+		output.push(escape(value ?? ''));
+	}
+
+	output.push(BLOCK_CLOSE);
+}
 
 /** @type {null | Component} */
 export let active_component = null;
@@ -596,7 +615,7 @@ export function spread_attrs(attrs, css_hash) {
 	for (name in attrs) {
 		var value = attrs[name];
 
-		if (typeof value === 'function') continue;
+		if (name === 'children' || typeof value === 'function' || is_ripple_element(value)) continue;
 
 		if (is_ripple_object(value)) {
 			value = get(value);

--- a/packages/ripple/src/runtime/internal/server/index.js
+++ b/packages/ripple/src/runtime/internal/server/index.js
@@ -39,7 +39,13 @@ export function render_expression(output, value) {
 	output.push(BLOCK_OPEN);
 
 	if (is_ripple_element(value)) {
-		value.render(output, {});
+		var result = value.render(output, {});
+
+		if (result && typeof result.then === 'function') {
+			return result.then(() => {
+				output.push(BLOCK_CLOSE);
+			});
+		}
 	} else {
 		output.push(escape(value ?? ''));
 	}

--- a/packages/ripple/tests/client/basic/basic.components.test.ripple
+++ b/packages/ripple/tests/client/basic/basic.components.test.ripple
@@ -18,11 +18,11 @@ describe('basic client > components & composition', () => {
 		}
 
 		component Basic() {
-			<Card>
-				component children() {
-					<p>{'Card content here'}</p>
-				}
-			</Card>
+			component children() {
+				<p>{'Card content here'}</p>
+			}
+
+			<Card {children} />
 		}
 
 		render(Basic);
@@ -44,11 +44,11 @@ describe('basic client > components & composition', () => {
 		}
 
 		component Basic() {
-			<Card>
-				component test() {
-					<p>{'Card content here'}</p>
-				}
-			</Card>
+			component test() {
+				<p>{'Card content here'}</p>
+			}
+
+			<Card {test} />
 		}
 
 		render(Basic);
@@ -60,7 +60,7 @@ describe('basic client > components & composition', () => {
 		expect(paragraph).toBeFalsy();
 	});
 
-	it('allows tracked variable and slot component with same name in nested scope', () => {
+	it('allows tracked variables alongside explicit component props', () => {
 		component Card(props: PropsWithChildrenOptional<{ test?: Component }>) {
 			<div class="card">
 				if (props.children) {
@@ -71,11 +71,12 @@ describe('basic client > components & composition', () => {
 
 		component Basic() {
 			let &[test] = track(false);
-			<Card>
-				component test() {
-					<p>{'Card content here'}</p>
-				}
-			</Card>
+
+			component TestSlot() {
+				<p>{'Card content here'}</p>
+			}
+
+			<Card test={TestSlot} />
 			<div>{test ? 'yes' : 'no'}</div>
 		}
 
@@ -334,14 +335,14 @@ describe('basic client > components & composition', () => {
 		};
 
 		component App() {
+			component children() {
+				<span>{'Click me!'}</span>
+			}
+
 			<div>
 				<h1>{'Component as Property Test'}</h1>
 				<UI.span />
-				<UI.button>
-					component children() {
-						<span>{'Click me!'}</span>
-					}
-				</UI.button>
+				<UI.button {children} />
 			</div>
 		}
 

--- a/packages/ripple/tests/client/basic/basic.components.test.ripple
+++ b/packages/ripple/tests/client/basic/basic.components.test.ripple
@@ -12,9 +12,7 @@ import { did_error } from '../capture-error.js';
 describe('basic client > components & composition', () => {
 	it('renders with component composition and children', () => {
 		component Card(props: PropsWithChildren<{}>) {
-			<div class="card">
-				<props.children />
-			</div>
+			<div class="card">{props.children}</div>
 		}
 
 		component Basic() {
@@ -38,7 +36,7 @@ describe('basic client > components & composition', () => {
 		component Card(props: PropsWithChildrenOptional<{ test?: Component }>) {
 			<div class="card">
 				if (props.children) {
-					<props.children />
+					{props.children}
 				}
 			</div>
 		}
@@ -64,7 +62,7 @@ describe('basic client > components & composition', () => {
 		component Card(props: PropsWithChildrenOptional<{ test?: Component }>) {
 			<div class="card">
 				if (props.children) {
-					<props.children />
+					{props.children}
 				}
 			</div>
 		}
@@ -92,9 +90,7 @@ describe('basic client > components & composition', () => {
 
 	it('renders a component when children is set a component prop', () => {
 		component Card(props: PropsWithChildren<{}>) {
-			<div class="card">
-				<props.children />
-			</div>
+			<div class="card">{props.children}</div>
 		}
 
 		component Basic() {
@@ -328,9 +324,7 @@ describe('basic client > components & composition', () => {
 				<span>{'Hello from Span'}</span>
 			},
 			button: component({ children }: PropsWithChildren<{}>) {
-				<button>
-					<children />
-				</button>
+				<button>{children}</button>
 			},
 		};
 
@@ -360,7 +354,7 @@ describe('basic client > components & composition', () => {
 
 	it('handles empty string children', () => {
 		component Button({ children }: PropsWithChildren<{}>) {
-			<children />
+			{children}
 		}
 
 		component App() {

--- a/packages/ripple/tests/client/basic/basic.components.test.ripple
+++ b/packages/ripple/tests/client/basic/basic.components.test.ripple
@@ -209,6 +209,28 @@ describe('basic client > components & composition', () => {
 		expect(countDiv.textContent).toBe('3');
 	});
 
+	it('updates explicit text children props reactively', () => {
+		component TextProp(&{ children }: PropsWithChildren<{}>) {
+			<div class="text-prop">{children}</div>
+		}
+
+		component Basic() {
+			let &[show] = track(false);
+
+			<TextProp children={show ? 'hello' : ''} />
+			<button class="show-text" onClick={() => (show = true)}>{'Show'}</button>
+		}
+
+		render(Basic);
+
+		expect(container.querySelector('.text-prop')?.textContent).toBe('');
+
+		container.querySelector('.show-text')?.click();
+		flushSync();
+
+		expect(container.querySelector('.text-prop')?.textContent).toBe('hello');
+	});
+
 	it('it retains this context with bracketed prop functions and keeps original chaining', () => {
 		component App() {
 			const SYMBOL_PROP = Symbol();

--- a/packages/ripple/tests/client/basic/basic.errors.test.ripple
+++ b/packages/ripple/tests/client/basic/basic.errors.test.ripple
@@ -70,9 +70,7 @@ describe('basic client > errors', () => {
 
 		expect(() => {
 			compile(code, 'test.ripple');
-		}).toThrow(
-			'`children` cannot be rendered using text interpolation. Use `<children />` instead.',
-		);
+		}).not.toThrow();
 	});
 
 	it('should throw error for interpolating props.children as text', () => {
@@ -84,9 +82,7 @@ describe('basic client > errors', () => {
 
 		expect(() => {
 			compile(code, 'test.ripple');
-		}).toThrow(
-			'`children` cannot be rendered using text interpolation. Use `<children />` instead.',
-		);
+		}).not.toThrow();
 	});
 
 	it('should throw error for calling children as a function', () => {
@@ -99,7 +95,7 @@ describe('basic client > errors', () => {
 		expect(() => {
 			compile(code, 'test.ripple');
 		}).toThrow(
-			'`children` cannot be called like a regular function. Use element syntax instead, e.g. `<children />` or `<props.children />`.',
+			'`children` cannot be called like a regular function. Render it with `{children}` or `{props.children}` instead.',
 		);
 	});
 
@@ -113,7 +109,7 @@ describe('basic client > errors', () => {
 		expect(() => {
 			compile(code, 'test.ripple');
 		}).toThrow(
-			'`children` cannot be called like a regular function. Use element syntax instead, e.g. `<children />` or `<props.children />`.',
+			'`children` cannot be called like a regular function. Render it with `{children}` or `{props.children}` instead.',
 		);
 	});
 

--- a/packages/ripple/tests/client/basic/basic.rendering.test.ripple
+++ b/packages/ripple/tests/client/basic/basic.rendering.test.ripple
@@ -85,13 +85,13 @@ describe('basic client > rendering & text', () => {
 	it('renders tick template literal for nested children', () => {
 		component Child({ level, children }: { level: number; children: any }) {
 			if (level == 1) {
-				<h1><children /></h1>
+				<h1>{children}</h1>
 			}
 			if (level == 2) {
-				<h2><children /></h2>
+				<h2>{children}</h2>
 			}
 			if (level == 3) {
-				<h3><children /></h3>
+				<h3>{children}</h3>
 			}
 		}
 

--- a/packages/ripple/tests/client/compiler/compiler.basic.test.ripple
+++ b/packages/ripple/tests/client/compiler/compiler.basic.test.ripple
@@ -518,6 +518,27 @@ export component App() {
 		expect(result).not.toContain('children={() =>');
 	});
 
+	it('merges explicit children prop with implicit children in client output', () => {
+		const source = `
+component Card(props) {
+	<div>{props.children}</div>
+}
+
+export component App() {
+	const fallback = 'fallback';
+
+	<Card children={fallback}>
+		<span>{'content'}</span>
+	</Card>
+}
+`;
+
+		const result = compile(source, 'test.ripple', { mode: 'client' }).js.code;
+
+		expect((result.match(/children:/g) || []).length).toBe(1);
+		expect(result).toContain('children: _$_.normalize_children(fallback) ?? _$_.ripple_element(');
+	});
+
 	it('should not error on `this` MemberExpression with a UpdateExpression', () => {
 		const code = `
 class Test {

--- a/packages/ripple/tests/client/compiler/compiler.basic.test.ripple
+++ b/packages/ripple/tests/client/compiler/compiler.basic.test.ripple
@@ -467,7 +467,7 @@ export component App() {
 		const code = `
 component Card(props) {
 	<div class="card">
-		<props.children />
+		{props.children}
 	</div>
 }
 

--- a/packages/ripple/tests/client/compiler/compiler.basic.test.ripple
+++ b/packages/ripple/tests/client/compiler/compiler.basic.test.ripple
@@ -472,11 +472,11 @@ component Card(props) {
 }
 
 export component App() {
-	<Card>
 		component children() {
 			<p>{'Card content here'}</p>
 		}
-	</Card>
+
+		<Card {children} />
 
 	const test = 5;
 
@@ -486,7 +486,7 @@ export component App() {
 		expect(() => compile(code, 'test.ripple')).not.toThrow();
 	});
 
-	it('converts nested component children into props in Volar mappings', () => {
+	it('rejects component declarations inside composite children', () => {
 		const source = `
 export component App() {
 	<ark.div class="host-class" data-value="42">
@@ -496,11 +496,26 @@ export component App() {
 	</ark.div>
 }
 `;
+
+		expect(() => compile_to_volar_mappings(source, 'test.ripple')).toThrow(
+			/Component declarations cannot be used inside composite component children/,
+		);
+	});
+
+	it('preserves explicit component props in Volar mappings', () => {
+		const source = `
+export component App() {
+	component asChild({ children, href, ...rest }: { href: string; [key: string]: any }) {
+		<a id="aschild-anchor" {href} {...rest} data-extra="yes">{'Link'}</a>
+	}
+
+	<ark.div class="host-class" data-value="42" {asChild} />
+}
+`;
 		const result = compile_to_volar_mappings(source, 'test.ripple').code;
 
-		expect(result).toContain('<ark.div class="host-class" data-value="42" asChild={');
+		expect(result).toContain('<ark.div class="host-class" data-value="42" asChild={asChild}');
 		expect(result).not.toContain('children={() =>');
-		expect(result).not.toContain('function asChild');
 	});
 
 	it('should not error on `this` MemberExpression with a UpdateExpression', () => {

--- a/packages/ripple/tests/client/composite/composite.props.test.ripple
+++ b/packages/ripple/tests/client/composite/composite.props.test.ripple
@@ -107,9 +107,7 @@ describe('composite > props', () => {
 
 	it('correctly retains prop accessors and reactivity when using rest props', () => {
 		component Button(&{ children, ...rest }: Props) {
-			<button {...rest}>
-				<@children />
-			</button>
+			<button {...rest}>{children}</button>
 			<style>
 				.on {
 					color: blue;

--- a/packages/ripple/tests/client/composite/composite.render.test.ripple
+++ b/packages/ripple/tests/client/composite/composite.render.test.ripple
@@ -32,7 +32,7 @@ describe('composite > render', () => {
 		component Button({ A, B, children }: { A: () => void; B: () => void; children: () => void }) {
 			<div>
 				<A />
-				<children />
+				{children}
 				<B />
 			</div>
 		}
@@ -64,13 +64,43 @@ describe('composite > render', () => {
 		}
 
 		component Child({ children, ...rest }: { children: string; class: string }) {
-			<button {...rest}>
-				<children />
-			</button>
+			<button {...rest}>{children}</button>
 		}
 
 		render(App);
 		expect(container).toMatchSnapshot();
+	});
+
+	it('renders explicit text around children', () => {
+		component Frame({ children }) {
+			<div class="frame">
+				{text 'before'}
+				{children}
+				{text 'after'}
+			</div>
+		}
+
+		component App() {
+			<Frame>
+				<span class="middle">{'middle'}</span>
+			</Frame>
+		}
+
+		render(App);
+
+		const frame = /** @type {HTMLDivElement} */ (container.querySelector('.frame'));
+		const nodes = Array.from(frame.childNodes).filter(
+			(node) => node.nodeType !== Node.COMMENT_NODE,
+		);
+
+		expect(nodes).toHaveLength(3);
+		expect(nodes[0].nodeType).toBe(Node.TEXT_NODE);
+		expect(nodes[0].textContent).toBe('before');
+		expect((/** @type {HTMLElement} */ (nodes[1])).outerHTML).toBe(
+			'<span class="middle">middle</span>',
+		);
+		expect(nodes[2].nodeType).toBe(Node.TEXT_NODE);
+		expect(nodes[2].textContent).toBe('after');
 	});
 
 	it('preserves distinct scoped ripple hashes for wrapper and child content', () => {
@@ -78,7 +108,7 @@ describe('composite > render', () => {
 			component Wrapper({ children }) {
 				<div class="green">
 					{'Wrapper'}
-					<children />
+					{children}
 				</div>
 
 				<style>
@@ -143,7 +173,7 @@ describe('composite > render', () => {
 			[key: string]: any;
 		}) {
 			<div {...props}>
-				<children />
+				{children}
 				// @ts-expect-error - intentionally testing behavior when a component is undefined
 				<NonExistent />
 			</div>

--- a/packages/ripple/tests/client/composite/composite.render.test.ripple
+++ b/packages/ripple/tests/client/composite/composite.render.test.ripple
@@ -38,14 +38,16 @@ describe('composite > render', () => {
 		}
 
 		component App() {
-			<Button>
-				component A() {
-					<div>{'I am A'}</div>
-				}
+			component A() {
+				<div>{'I am A'}</div>
+			}
+
+			component B() {
+				<div>{'I am B'}</div>
+			}
+
+			<Button {A} {B}>
 				<div>{'other text'}</div>
-				component B() {
-					<div>{'I am B'}</div>
-				}
 			</Button>
 		}
 

--- a/packages/ripple/tests/client/css/global-additional-cases.test.ripple
+++ b/packages/ripple/tests/client/css/global-additional-cases.test.ripple
@@ -353,7 +353,7 @@ export component Test({ children }) {
 	<div>
 		<p class="before">{'before'}</p>
 
-		<children />
+		{children}
 
 		<p class="foo">
 			<span>{'foo'}</span>
@@ -379,8 +379,8 @@ export component Test({ children }) {
 		const { css } = compile(source, 'test.ripple');
 
 		expect(css).toMatch(/\.before\.ripple-[a-z0-9]+ \+ \.foo:where\(\.ripple-[a-z0-9]+\) {/);
-		expect((css.match(/\.x\ /g) || []).length).toBe(5);
-		expect((css.match(/\(unused\) :global\(\.x\) /g) || []).length).toBe(1);
+		expect((css.match(/\.x\ /g) || []).length).toBe(0);
+		expect((css.match(/\(unused\) :global\(\.x\) /g) || []).length).toBe(6);
 		expect(css).toContain('(unused) :global(.x) + .bar {');
 	});
 

--- a/packages/ripple/tests/client/svg.test.ripple
+++ b/packages/ripple/tests/client/svg.test.ripple
@@ -234,7 +234,7 @@ describe('SVG namespace handling', () => {
 	it('should render SVG with children as svg elements', () => {
 		component SVG({ children }: PropsWithChildren<{}>) {
 			<svg width={20} height={20} fill="blue" viewBox="0 0 30 10" preserveAspectRatio="none">
-				<children />
+				{children}
 			</svg>
 		}
 
@@ -285,7 +285,7 @@ describe('SVG namespace handling', () => {
 	it('should render SVG with children as dynamic elements', () => {
 		component SVG({ children }: PropsWithChildren<{}>) {
 			<svg width={20} height={20} fill="blue" viewBox="0 0 30 10" preserveAspectRatio="none">
-				<children />
+				{children}
 			</svg>
 		}
 
@@ -308,7 +308,7 @@ describe('SVG namespace handling', () => {
 	it('should render SVG with children as dynamic components', () => {
 		component SVG({ children }: PropsWithChildren<{}>) {
 			<svg width={20} height={20} fill="blue" viewBox="0 0 30 10" preserveAspectRatio="none">
-				<children />
+				{children}
 			</svg>
 		}
 
@@ -336,7 +336,7 @@ describe('SVG namespace handling', () => {
 		component SVG({ children }: PropsWithChildren<{}>) {
 			let &[tag] = track('svg');
 			<@tag width={100} height={50} fill="red" viewBox="0 0 30 10" preserveAspectRatio="none">
-				<children />
+				{children}
 			</@tag>
 		}
 

--- a/packages/ripple/tests/hydration/basic.test.js
+++ b/packages/ripple/tests/hydration/basic.test.js
@@ -72,6 +72,14 @@ describe('hydration > basic', () => {
 		flushSync();
 
 		expect(container.querySelector('.text-prop')?.textContent).toBe('hello');
+
+		// Verify text is placed between hydration markers, not before anchor
+		const innerHTML = container.querySelector('.text-prop')?.innerHTML ?? '';
+		const textIndex = innerHTML.indexOf('hello');
+		const startMarker = innerHTML.indexOf('<!--[-->');
+		const endMarker = innerHTML.indexOf('<!--]-->');
+		expect(textIndex).toBeGreaterThan(startMarker);
+		expect(textIndex).toBeLessThan(endMarker);
 	});
 
 	it('hydrates static child component followed by sibling content', async () => {

--- a/packages/ripple/tests/hydration/basic.test.js
+++ b/packages/ripple/tests/hydration/basic.test.js
@@ -62,13 +62,13 @@ describe('hydration > basic', () => {
 
 	it('restores text children after hydrating away initial server text', async () => {
 		await hydrateComponent(
-			ServerComponents.ServerTextPropWithContent,
-			ClientComponents.ClientTextPropRestoresAfterHydration,
+			ServerComponents.TextPropWithToggle,
+			ClientComponents.TextPropWithToggle,
 		);
 
 		expect(container.querySelector('.text-prop')?.textContent).toBe('');
 
-		/** @type {any} */ (container.querySelector('.show-text'))?.__click();
+		/** @type {any} */ (container.querySelector('.show-text'))?.click();
 		flushSync();
 
 		expect(container.querySelector('.text-prop')?.textContent).toBe('hello');

--- a/packages/ripple/tests/hydration/basic.test.js
+++ b/packages/ripple/tests/hydration/basic.test.js
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { flushSync } from 'ripple';
 import { hydrateComponent, container } from '../setup-hydration.js';
 
 // Import server-compiled components
@@ -57,6 +58,20 @@ describe('hydration > basic', () => {
 	it('hydrates expression content', async () => {
 		await hydrateComponent(ServerComponents.ExpressionContent, ClientComponents.ExpressionContent);
 		expect(container.innerHTML).toBeHtml('<div>42</div><span>COMPUTED</span>');
+	});
+
+	it('restores text children after hydrating away initial server text', async () => {
+		await hydrateComponent(
+			ServerComponents.ServerTextPropWithContent,
+			ClientComponents.ClientTextPropRestoresAfterHydration,
+		);
+
+		expect(container.querySelector('.text-prop')?.textContent).toBe('');
+
+		/** @type {any} */ (container.querySelector('.show-text'))?.__click();
+		flushSync();
+
+		expect(container.querySelector('.text-prop')?.textContent).toBe('hello');
 	});
 
 	it('hydrates static child component followed by sibling content', async () => {

--- a/packages/ripple/tests/hydration/compiled/client/basic.js
+++ b/packages/ripple/tests/hydration/compiled/client/basic.js
@@ -276,12 +276,15 @@ function Layout(__anchor, { children }, __block) {
 		var div_9 = _$_.child(main_1);
 
 		{
-			var node_6 = _$_.child(div_9);
+			var expression_5 = _$_.child(div_9);
 
-			children(node_6, {}, _$_.active_block);
 			_$_.pop(div_9);
 		}
 	}
+
+	_$_.render(() => {
+		_$_.expression(expression_5, () => children);
+	});
 
 	_$_.append(__anchor, main_1);
 	_$_.pop_component();
@@ -300,33 +303,33 @@ export function WebsiteIndex(__anchor, _, __block) {
 	_$_.push_component();
 
 	var fragment_8 = root_19();
-	var node_7 = _$_.first_child_frag(fragment_8);
+	var node_6 = _$_.first_child_frag(fragment_8);
 
 	Layout(
-		node_7,
+		node_6,
 		{
-			children(__anchor, _, __block) {
+			children: _$_.ripple_element(function render_children(__anchor, _, __block) {
 				_$_.push_component();
 
 				var fragment_9 = root_20();
-				var node_8 = _$_.first_child_frag(fragment_9);
+				var node_7 = _$_.first_child_frag(fragment_9);
 
-				Header(node_8, {}, _$_.active_block);
+				Header(node_7, {}, _$_.active_block);
+
+				var node_8 = _$_.sibling(node_7);
+
+				Actions(node_8, { playgroundVisible: true }, _$_.active_block);
 
 				var node_9 = _$_.sibling(node_8);
 
-				Actions(node_9, { playgroundVisible: true }, _$_.active_block);
+				Content(node_9, {}, _$_.active_block);
 
 				var node_10 = _$_.sibling(node_9);
 
-				Content(node_10, {}, _$_.active_block);
-
-				var node_11 = _$_.sibling(node_10);
-
-				Actions(node_11, { playgroundVisible: false }, _$_.active_block);
+				Actions(node_10, { playgroundVisible: false }, _$_.active_block);
 				_$_.append(__anchor, fragment_9);
 				_$_.pop_component();
-			}
+			})
 		},
 		_$_.active_block
 	);
@@ -352,9 +355,9 @@ export function ComponentAsLastSibling(__anchor, _, __block) {
 	{
 		var h1_1 = _$_.child(div_11);
 		var p_1 = _$_.sibling(h1_1);
-		var node_12 = _$_.sibling(p_1);
+		var node_11 = _$_.sibling(p_1);
 
-		LastChild(node_12, {}, _$_.active_block);
+		LastChild(node_11, {}, _$_.active_block);
 		_$_.pop(div_11);
 	}
 
@@ -369,9 +372,9 @@ function InnerContent(__anchor, _, __block) {
 
 	{
 		var span_5 = _$_.child(div_12);
-		var node_13 = _$_.sibling(span_5);
+		var node_12 = _$_.sibling(span_5);
 
-		LastChild(node_13, {}, _$_.active_block);
+		LastChild(node_12, {}, _$_.active_block);
 		_$_.pop(div_12);
 	}
 
@@ -386,9 +389,9 @@ export function NestedComponentAsLastSibling(__anchor, _, __block) {
 
 	{
 		var h2_1 = _$_.child(section_1);
-		var node_14 = _$_.sibling(h2_1);
+		var node_13 = _$_.sibling(h2_1);
 
-		InnerContent(node_14, {}, _$_.active_block);
+		InnerContent(node_13, {}, _$_.active_block);
 		_$_.pop(section_1);
 	}
 

--- a/packages/ripple/tests/hydration/compiled/client/basic.js
+++ b/packages/ripple/tests/hydration/compiled/client/basic.js
@@ -14,21 +14,20 @@ var root_9 = _$_.template(`<div> </div>`, 0);
 var root_10 = _$_.template(`<!>`, 1, 1);
 var root_11 = _$_.template(`<div> </div><span> </span>`, 1, 2);
 var root_12 = _$_.template(`<div class="text-prop"><!></div>`, 0);
-var root_13 = _$_.template(`<!>`, 1, 1);
-var root_14 = _$_.template(`<!><button class="show-text">Show</button>`, 1, 2);
-var root_15 = _$_.template(`<h1 class="sr-only">heading</h1><p class="subtitle">first paragraph</p><p class="subtitle">second paragraph</p>`, 1, 3);
-var root_16 = _$_.template(`<!><span class="sibling1"> </span><span class="sibling2"> </span>`, 1, 3);
-var root_17 = _$_.template(`<h1 class="sr-only">Ripple</h1><img src="/images/logo.png" alt="Logo" class="logo"><p class="subtitle">the elegant TypeScript UI framework</p>`, 1, 3);
-var root_19 = _$_.template(`<a href="/playground" class="playground-link">Playground</a>`, 0);
-var root_18 = _$_.template(`<div class="social-links"><a href="https://github.com" class="github-link">GitHub</a><a href="https://discord.com" class="discord-link">Discord</a><!></div>`, 0);
-var root_20 = _$_.template(`<main><div class="container"><!></div></main>`, 0);
-var root_21 = _$_.template(`<div class="content"><p>Some content here</p></div>`, 0);
-var root_23 = _$_.template(`<!><!><!><!>`, 1, 4);
-var root_22 = _$_.template(`<!>`, 1, 1);
-var root_24 = _$_.template(`<footer class="last-child">I am the last child</footer>`, 0);
-var root_25 = _$_.template(`<div class="wrapper"><h1>Header</h1><p>Some content</p><!></div>`, 0);
-var root_26 = _$_.template(`<div class="inner"><span>Inner text</span><!></div>`, 0);
-var root_27 = _$_.template(`<section class="outer"><h2>Section title</h2><!></section>`, 0);
+var root_13 = _$_.template(`<!><button class="show-text">Show</button>`, 1, 2);
+var root_14 = _$_.template(`<h1 class="sr-only">heading</h1><p class="subtitle">first paragraph</p><p class="subtitle">second paragraph</p>`, 1, 3);
+var root_15 = _$_.template(`<!><span class="sibling1"> </span><span class="sibling2"> </span>`, 1, 3);
+var root_16 = _$_.template(`<h1 class="sr-only">Ripple</h1><img src="/images/logo.png" alt="Logo" class="logo"><p class="subtitle">the elegant TypeScript UI framework</p>`, 1, 3);
+var root_18 = _$_.template(`<a href="/playground" class="playground-link">Playground</a>`, 0);
+var root_17 = _$_.template(`<div class="social-links"><a href="https://github.com" class="github-link">GitHub</a><a href="https://discord.com" class="discord-link">Discord</a><!></div>`, 0);
+var root_19 = _$_.template(`<main><div class="container"><!></div></main>`, 0);
+var root_20 = _$_.template(`<div class="content"><p>Some content here</p></div>`, 0);
+var root_22 = _$_.template(`<!><!><!><!>`, 1, 4);
+var root_21 = _$_.template(`<!>`, 1, 1);
+var root_23 = _$_.template(`<footer class="last-child">I am the last child</footer>`, 0);
+var root_24 = _$_.template(`<div class="wrapper"><h1>Header</h1><p>Some content</p><!></div>`, 0);
+var root_25 = _$_.template(`<div class="inner"><span>Inner text</span><!></div>`, 0);
+var root_26 = _$_.template(`<section class="outer"><h2>Section title</h2><!></section>`, 0);
 
 import { track } from 'ripple';
 
@@ -210,26 +209,15 @@ function TextProp(__anchor, __props, __block) {
 	_$_.pop_component();
 }
 
-export function ServerTextPropWithContent(__anchor, _, __block) {
-	_$_.push_component();
-
-	var fragment_5 = root_13();
-	var node_4 = _$_.first_child_frag(fragment_5);
-
-	TextProp(node_4, { children: _$_.normalize_children("hello") }, _$_.active_block);
-	_$_.append(__anchor, fragment_5);
-	_$_.pop_component();
-}
-
-export function ClientTextPropRestoresAfterHydration(__anchor, _, __block) {
+export function TextPropWithToggle(__anchor, _, __block) {
 	_$_.push_component();
 
 	let lazy = _$_.track(false, void 0, void 0, __block);
-	var fragment_6 = root_14();
-	var node_5 = _$_.first_child_frag(fragment_6);
+	var fragment_5 = root_13();
+	var node_4 = _$_.first_child_frag(fragment_5);
 
 	TextProp(
-		node_5,
+		node_4,
 		{
 			get children() {
 				return _$_.normalize_children(_$_.get(lazy) ? 'hello' : '');
@@ -238,20 +226,20 @@ export function ClientTextPropRestoresAfterHydration(__anchor, _, __block) {
 		_$_.active_block
 	);
 
-	var button_1 = _$_.sibling(node_5);
+	var button_1 = _$_.sibling(node_4);
 
 	button_1.__click = () => _$_.set(lazy, true);
-	_$_.append(__anchor, fragment_6);
+	_$_.append(__anchor, fragment_5);
 	_$_.pop_component();
 }
 
 function StaticHeader(__anchor, _, __block) {
 	_$_.push_component();
 
-	var fragment_7 = root_15();
+	var fragment_6 = root_14();
 
 	_$_.next(2);
-	_$_.append(__anchor, fragment_7, true);
+	_$_.append(__anchor, fragment_6, true);
 	_$_.pop_component();
 }
 
@@ -259,12 +247,12 @@ export function StaticChildWithSiblings(__anchor, _, __block) {
 	_$_.push_component();
 
 	const foo = 'bar';
-	var fragment_8 = root_16();
-	var node_6 = _$_.first_child_frag(fragment_8);
+	var fragment_7 = root_15();
+	var node_5 = _$_.first_child_frag(fragment_7);
 
-	StaticHeader(node_6, {}, _$_.active_block);
+	StaticHeader(node_5, {}, _$_.active_block);
 
-	var span_3 = _$_.sibling(node_6);
+	var span_3 = _$_.sibling(node_5);
 
 	{
 		var expression_4 = _$_.child(span_3, true);
@@ -283,38 +271,38 @@ export function StaticChildWithSiblings(__anchor, _, __block) {
 	}
 
 	_$_.next();
-	_$_.append(__anchor, fragment_8, true);
+	_$_.append(__anchor, fragment_7, true);
 	_$_.pop_component();
 }
 
 function Header(__anchor, _, __block) {
 	_$_.push_component();
 
-	var fragment_9 = root_17();
+	var fragment_8 = root_16();
 
 	_$_.next(2);
-	_$_.append(__anchor, fragment_9, true);
+	_$_.append(__anchor, fragment_8, true);
 	_$_.pop_component();
 }
 
 function Actions(__anchor, { playgroundVisible = false }, __block) {
 	_$_.push_component();
 
-	var div_9 = root_18();
+	var div_9 = root_17();
 
 	{
 		var a_2 = _$_.child(div_9);
 		var a_1 = _$_.sibling(a_2);
-		var node_7 = _$_.sibling(a_1);
+		var node_6 = _$_.sibling(a_1);
 
 		{
 			var consequent = (__anchor) => {
-				var a_3 = root_19();
+				var a_3 = root_18();
 
 				_$_.append(__anchor, a_3);
 			};
 
-			_$_.if(node_7, (__render) => {
+			_$_.if(node_6, (__render) => {
 				if (playgroundVisible) __render(consequent);
 			});
 		}
@@ -329,7 +317,7 @@ function Actions(__anchor, { playgroundVisible = false }, __block) {
 function Layout(__anchor, { children }, __block) {
 	_$_.push_component();
 
-	var main_1 = root_20();
+	var main_1 = root_19();
 
 	{
 		var div_10 = _$_.child(main_1);
@@ -352,7 +340,7 @@ function Layout(__anchor, { children }, __block) {
 function Content(__anchor, _, __block) {
 	_$_.push_component();
 
-	var div_11 = root_21();
+	var div_11 = root_20();
 
 	_$_.append(__anchor, div_11);
 	_$_.pop_component();
@@ -361,46 +349,46 @@ function Content(__anchor, _, __block) {
 export function WebsiteIndex(__anchor, _, __block) {
 	_$_.push_component();
 
-	var fragment_10 = root_22();
-	var node_8 = _$_.first_child_frag(fragment_10);
+	var fragment_9 = root_21();
+	var node_7 = _$_.first_child_frag(fragment_9);
 
 	Layout(
-		node_8,
+		node_7,
 		{
 			children: _$_.ripple_element(function render_children(__anchor, _, __block) {
 				_$_.push_component();
 
-				var fragment_11 = root_23();
-				var node_9 = _$_.first_child_frag(fragment_11);
+				var fragment_10 = root_22();
+				var node_8 = _$_.first_child_frag(fragment_10);
 
-				Header(node_9, {}, _$_.active_block);
+				Header(node_8, {}, _$_.active_block);
+
+				var node_9 = _$_.sibling(node_8);
+
+				Actions(node_9, { playgroundVisible: true }, _$_.active_block);
 
 				var node_10 = _$_.sibling(node_9);
 
-				Actions(node_10, { playgroundVisible: true }, _$_.active_block);
+				Content(node_10, {}, _$_.active_block);
 
 				var node_11 = _$_.sibling(node_10);
 
-				Content(node_11, {}, _$_.active_block);
-
-				var node_12 = _$_.sibling(node_11);
-
-				Actions(node_12, { playgroundVisible: false }, _$_.active_block);
-				_$_.append(__anchor, fragment_11);
+				Actions(node_11, { playgroundVisible: false }, _$_.active_block);
+				_$_.append(__anchor, fragment_10);
 				_$_.pop_component();
 			})
 		},
 		_$_.active_block
 	);
 
-	_$_.append(__anchor, fragment_10);
+	_$_.append(__anchor, fragment_9);
 	_$_.pop_component();
 }
 
 function LastChild(__anchor, _, __block) {
 	_$_.push_component();
 
-	var footer_1 = root_24();
+	var footer_1 = root_23();
 
 	_$_.append(__anchor, footer_1);
 	_$_.pop_component();
@@ -409,14 +397,14 @@ function LastChild(__anchor, _, __block) {
 export function ComponentAsLastSibling(__anchor, _, __block) {
 	_$_.push_component();
 
-	var div_12 = root_25();
+	var div_12 = root_24();
 
 	{
 		var h1_1 = _$_.child(div_12);
 		var p_1 = _$_.sibling(h1_1);
-		var node_13 = _$_.sibling(p_1);
+		var node_12 = _$_.sibling(p_1);
 
-		LastChild(node_13, {}, _$_.active_block);
+		LastChild(node_12, {}, _$_.active_block);
 		_$_.pop(div_12);
 	}
 
@@ -427,13 +415,13 @@ export function ComponentAsLastSibling(__anchor, _, __block) {
 function InnerContent(__anchor, _, __block) {
 	_$_.push_component();
 
-	var div_13 = root_26();
+	var div_13 = root_25();
 
 	{
 		var span_5 = _$_.child(div_13);
-		var node_14 = _$_.sibling(span_5);
+		var node_13 = _$_.sibling(span_5);
 
-		LastChild(node_14, {}, _$_.active_block);
+		LastChild(node_13, {}, _$_.active_block);
 		_$_.pop(div_13);
 	}
 
@@ -444,13 +432,13 @@ function InnerContent(__anchor, _, __block) {
 export function NestedComponentAsLastSibling(__anchor, _, __block) {
 	_$_.push_component();
 
-	var section_1 = root_27();
+	var section_1 = root_26();
 
 	{
 		var h2_1 = _$_.child(section_1);
-		var node_15 = _$_.sibling(h2_1);
+		var node_14 = _$_.sibling(h2_1);
 
-		InnerContent(node_15, {}, _$_.active_block);
+		InnerContent(node_14, {}, _$_.active_block);
 		_$_.pop(section_1);
 	}
 

--- a/packages/ripple/tests/hydration/compiled/client/basic.js
+++ b/packages/ripple/tests/hydration/compiled/client/basic.js
@@ -13,19 +13,24 @@ var root_8 = _$_.template(`<!><!>`, 1, 2);
 var root_9 = _$_.template(`<div> </div>`, 0);
 var root_10 = _$_.template(`<!>`, 1, 1);
 var root_11 = _$_.template(`<div> </div><span> </span>`, 1, 2);
-var root_12 = _$_.template(`<h1 class="sr-only">heading</h1><p class="subtitle">first paragraph</p><p class="subtitle">second paragraph</p>`, 1, 3);
-var root_13 = _$_.template(`<!><span class="sibling1"> </span><span class="sibling2"> </span>`, 1, 3);
-var root_14 = _$_.template(`<h1 class="sr-only">Ripple</h1><img src="/images/logo.png" alt="Logo" class="logo"><p class="subtitle">the elegant TypeScript UI framework</p>`, 1, 3);
-var root_16 = _$_.template(`<a href="/playground" class="playground-link">Playground</a>`, 0);
-var root_15 = _$_.template(`<div class="social-links"><a href="https://github.com" class="github-link">GitHub</a><a href="https://discord.com" class="discord-link">Discord</a><!></div>`, 0);
-var root_17 = _$_.template(`<main><div class="container"><!></div></main>`, 0);
-var root_18 = _$_.template(`<div class="content"><p>Some content here</p></div>`, 0);
-var root_20 = _$_.template(`<!><!><!><!>`, 1, 4);
-var root_19 = _$_.template(`<!>`, 1, 1);
-var root_21 = _$_.template(`<footer class="last-child">I am the last child</footer>`, 0);
-var root_22 = _$_.template(`<div class="wrapper"><h1>Header</h1><p>Some content</p><!></div>`, 0);
-var root_23 = _$_.template(`<div class="inner"><span>Inner text</span><!></div>`, 0);
-var root_24 = _$_.template(`<section class="outer"><h2>Section title</h2><!></section>`, 0);
+var root_12 = _$_.template(`<div class="text-prop"><!></div>`, 0);
+var root_13 = _$_.template(`<!>`, 1, 1);
+var root_14 = _$_.template(`<!><button class="show-text">Show</button>`, 1, 2);
+var root_15 = _$_.template(`<h1 class="sr-only">heading</h1><p class="subtitle">first paragraph</p><p class="subtitle">second paragraph</p>`, 1, 3);
+var root_16 = _$_.template(`<!><span class="sibling1"> </span><span class="sibling2"> </span>`, 1, 3);
+var root_17 = _$_.template(`<h1 class="sr-only">Ripple</h1><img src="/images/logo.png" alt="Logo" class="logo"><p class="subtitle">the elegant TypeScript UI framework</p>`, 1, 3);
+var root_19 = _$_.template(`<a href="/playground" class="playground-link">Playground</a>`, 0);
+var root_18 = _$_.template(`<div class="social-links"><a href="https://github.com" class="github-link">GitHub</a><a href="https://discord.com" class="discord-link">Discord</a><!></div>`, 0);
+var root_20 = _$_.template(`<main><div class="container"><!></div></main>`, 0);
+var root_21 = _$_.template(`<div class="content"><p>Some content here</p></div>`, 0);
+var root_23 = _$_.template(`<!><!><!><!>`, 1, 4);
+var root_22 = _$_.template(`<!>`, 1, 1);
+var root_24 = _$_.template(`<footer class="last-child">I am the last child</footer>`, 0);
+var root_25 = _$_.template(`<div class="wrapper"><h1>Header</h1><p>Some content</p><!></div>`, 0);
+var root_26 = _$_.template(`<div class="inner"><span>Inner text</span><!></div>`, 0);
+var root_27 = _$_.template(`<section class="outer"><h2>Section title</h2><!></section>`, 0);
+
+import { track } from 'ripple';
 
 export function StaticText(__anchor, _, __block) {
 	_$_.push_component();
@@ -186,13 +191,67 @@ export function ExpressionContent(__anchor, _, __block) {
 	_$_.pop_component();
 }
 
+function TextProp(__anchor, __props, __block) {
+	_$_.push_component();
+
+	var div_8 = root_12();
+
+	{
+		var expression_3 = _$_.child(div_8);
+
+		_$_.pop(div_8);
+	}
+
+	_$_.render(() => {
+		_$_.expression(expression_3, () => __props.children);
+	});
+
+	_$_.append(__anchor, div_8);
+	_$_.pop_component();
+}
+
+export function ServerTextPropWithContent(__anchor, _, __block) {
+	_$_.push_component();
+
+	var fragment_5 = root_13();
+	var node_4 = _$_.first_child_frag(fragment_5);
+
+	TextProp(node_4, { children: _$_.normalize_children("hello") }, _$_.active_block);
+	_$_.append(__anchor, fragment_5);
+	_$_.pop_component();
+}
+
+export function ClientTextPropRestoresAfterHydration(__anchor, _, __block) {
+	_$_.push_component();
+
+	let lazy = _$_.track(false, void 0, void 0, __block);
+	var fragment_6 = root_14();
+	var node_5 = _$_.first_child_frag(fragment_6);
+
+	TextProp(
+		node_5,
+		{
+			get children() {
+				return _$_.normalize_children(_$_.get(lazy) ? 'hello' : '');
+			}
+		},
+		_$_.active_block
+	);
+
+	var button_1 = _$_.sibling(node_5);
+
+	button_1.__click = () => _$_.set(lazy, true);
+	_$_.append(__anchor, fragment_6);
+	_$_.pop_component();
+}
+
 function StaticHeader(__anchor, _, __block) {
 	_$_.push_component();
 
-	var fragment_5 = root_12();
+	var fragment_7 = root_15();
 
 	_$_.next(2);
-	_$_.append(__anchor, fragment_5, true);
+	_$_.append(__anchor, fragment_7, true);
 	_$_.pop_component();
 }
 
@@ -200,90 +259,90 @@ export function StaticChildWithSiblings(__anchor, _, __block) {
 	_$_.push_component();
 
 	const foo = 'bar';
-	var fragment_6 = root_13();
-	var node_4 = _$_.first_child_frag(fragment_6);
+	var fragment_8 = root_16();
+	var node_6 = _$_.first_child_frag(fragment_8);
 
-	StaticHeader(node_4, {}, _$_.active_block);
+	StaticHeader(node_6, {}, _$_.active_block);
 
-	var span_3 = _$_.sibling(node_4);
+	var span_3 = _$_.sibling(node_6);
 
 	{
-		var expression_3 = _$_.child(span_3, true);
+		var expression_4 = _$_.child(span_3, true);
 
-		expression_3.nodeValue = foo;
+		expression_4.nodeValue = foo;
 		_$_.pop(span_3);
 	}
 
 	var span_4 = _$_.sibling(span_3);
 
 	{
-		var expression_4 = _$_.child(span_4, true);
+		var expression_5 = _$_.child(span_4, true);
 
-		expression_4.nodeValue = foo;
+		expression_5.nodeValue = foo;
 		_$_.pop(span_4);
 	}
 
 	_$_.next();
-	_$_.append(__anchor, fragment_6, true);
+	_$_.append(__anchor, fragment_8, true);
 	_$_.pop_component();
 }
 
 function Header(__anchor, _, __block) {
 	_$_.push_component();
 
-	var fragment_7 = root_14();
+	var fragment_9 = root_17();
 
 	_$_.next(2);
-	_$_.append(__anchor, fragment_7, true);
+	_$_.append(__anchor, fragment_9, true);
 	_$_.pop_component();
 }
 
 function Actions(__anchor, { playgroundVisible = false }, __block) {
 	_$_.push_component();
 
-	var div_8 = root_15();
+	var div_9 = root_18();
 
 	{
-		var a_2 = _$_.child(div_8);
+		var a_2 = _$_.child(div_9);
 		var a_1 = _$_.sibling(a_2);
-		var node_5 = _$_.sibling(a_1);
+		var node_7 = _$_.sibling(a_1);
 
 		{
 			var consequent = (__anchor) => {
-				var a_3 = root_16();
+				var a_3 = root_19();
 
 				_$_.append(__anchor, a_3);
 			};
 
-			_$_.if(node_5, (__render) => {
+			_$_.if(node_7, (__render) => {
 				if (playgroundVisible) __render(consequent);
 			});
 		}
 
-		_$_.pop(div_8);
+		_$_.pop(div_9);
 	}
 
-	_$_.append(__anchor, div_8);
+	_$_.append(__anchor, div_9);
 	_$_.pop_component();
 }
 
 function Layout(__anchor, { children }, __block) {
 	_$_.push_component();
 
-	var main_1 = root_17();
+	var main_1 = root_20();
 
 	{
-		var div_9 = _$_.child(main_1);
+		var div_10 = _$_.child(main_1);
 
 		{
-			var expression_5 = _$_.child(div_9);
+			var expression_6 = _$_.child(div_10);
 
-			_$_.pop(div_9);
+			_$_.pop(div_10);
 		}
 	}
 
 	_$_.render(() => {
-		_$_.expression(expression_5, () => children);
+		_$_.expression(expression_6, () => children);
 	});
 
 	_$_.append(__anchor, main_1);
@@ -293,55 +352,55 @@ function Layout(__anchor, { children }, __block) {
 function Content(__anchor, _, __block) {
 	_$_.push_component();
 
-	var div_10 = root_18();
+	var div_11 = root_21();
 
-	_$_.append(__anchor, div_10);
+	_$_.append(__anchor, div_11);
 	_$_.pop_component();
 }
 
 export function WebsiteIndex(__anchor, _, __block) {
 	_$_.push_component();
 
-	var fragment_8 = root_19();
-	var node_6 = _$_.first_child_frag(fragment_8);
+	var fragment_10 = root_22();
+	var node_8 = _$_.first_child_frag(fragment_10);
 
 	Layout(
-		node_6,
+		node_8,
 		{
 			children: _$_.ripple_element(function render_children(__anchor, _, __block) {
 				_$_.push_component();
 
-				var fragment_9 = root_20();
-				var node_7 = _$_.first_child_frag(fragment_9);
+				var fragment_11 = root_23();
+				var node_9 = _$_.first_child_frag(fragment_11);
 
-				Header(node_7, {}, _$_.active_block);
-
-				var node_8 = _$_.sibling(node_7);
-
-				Actions(node_8, { playgroundVisible: true }, _$_.active_block);
-
-				var node_9 = _$_.sibling(node_8);
-
-				Content(node_9, {}, _$_.active_block);
+				Header(node_9, {}, _$_.active_block);
 
 				var node_10 = _$_.sibling(node_9);
 
-				Actions(node_10, { playgroundVisible: false }, _$_.active_block);
-				_$_.append(__anchor, fragment_9);
+				Actions(node_10, { playgroundVisible: true }, _$_.active_block);
+
+				var node_11 = _$_.sibling(node_10);
+
+				Content(node_11, {}, _$_.active_block);
+
+				var node_12 = _$_.sibling(node_11);
+
+				Actions(node_12, { playgroundVisible: false }, _$_.active_block);
+				_$_.append(__anchor, fragment_11);
 				_$_.pop_component();
 			})
 		},
 		_$_.active_block
 	);
 
-	_$_.append(__anchor, fragment_8);
+	_$_.append(__anchor, fragment_10);
 	_$_.pop_component();
 }
 
 function LastChild(__anchor, _, __block) {
 	_$_.push_component();
 
-	var footer_1 = root_21();
+	var footer_1 = root_24();
 
 	_$_.append(__anchor, footer_1);
 	_$_.pop_component();
@@ -350,31 +409,14 @@ function LastChild(__anchor, _, __block) {
 export function ComponentAsLastSibling(__anchor, _, __block) {
 	_$_.push_component();
 
-	var div_11 = root_22();
+	var div_12 = root_25();
 
 	{
-		var h1_1 = _$_.child(div_11);
+		var h1_1 = _$_.child(div_12);
 		var p_1 = _$_.sibling(h1_1);
-		var node_11 = _$_.sibling(p_1);
+		var node_13 = _$_.sibling(p_1);
 
-		LastChild(node_11, {}, _$_.active_block);
-		_$_.pop(div_11);
-	}
-
-	_$_.append(__anchor, div_11);
-	_$_.pop_component();
-}
-
-function InnerContent(__anchor, _, __block) {
-	_$_.push_component();
-
-	var div_12 = root_23();
-
-	{
-		var span_5 = _$_.child(div_12);
-		var node_12 = _$_.sibling(span_5);
-
-		LastChild(node_12, {}, _$_.active_block);
+		LastChild(node_13, {}, _$_.active_block);
 		_$_.pop(div_12);
 	}
 
@@ -382,19 +424,38 @@ function InnerContent(__anchor, _, __block) {
 	_$_.pop_component();
 }
 
+function InnerContent(__anchor, _, __block) {
+	_$_.push_component();
+
+	var div_13 = root_26();
+
+	{
+		var span_5 = _$_.child(div_13);
+		var node_14 = _$_.sibling(span_5);
+
+		LastChild(node_14, {}, _$_.active_block);
+		_$_.pop(div_13);
+	}
+
+	_$_.append(__anchor, div_13);
+	_$_.pop_component();
+}
+
 export function NestedComponentAsLastSibling(__anchor, _, __block) {
 	_$_.push_component();
 
-	var section_1 = root_24();
+	var section_1 = root_27();
 
 	{
 		var h2_1 = _$_.child(section_1);
-		var node_13 = _$_.sibling(h2_1);
+		var node_15 = _$_.sibling(h2_1);
 
-		InnerContent(node_13, {}, _$_.active_block);
+		InnerContent(node_15, {}, _$_.active_block);
 		_$_.pop(section_1);
 	}
 
 	_$_.append(__anchor, section_1);
 	_$_.pop_component();
 }
+
+_$_.delegate(['click']);

--- a/packages/ripple/tests/hydration/compiled/client/composite.js
+++ b/packages/ripple/tests/hydration/compiled/client/composite.js
@@ -2,15 +2,18 @@
 import * as _$_ from 'ripple/internal/client';
 
 var root = _$_.template(`<div class="layout"><!></div>`, 0);
-var root_1 = _$_.template(`<div class="single">single</div>`, 0);
-var root_2 = _$_.template(`<h1>title</h1><p>description</p>`, 1, 2);
-var root_3 = _$_.template(`<!>`, 1, 1);
-var root_5 = _$_.template(`<!>`, 1, 1);
+var root_1 = _$_.template(`<div class="layout">before<!>after</div>`, 0);
+var root_2 = _$_.template(`<div class="single">single</div>`, 0);
+var root_3 = _$_.template(`<h1>title</h1><p>description</p>`, 1, 2);
 var root_4 = _$_.template(`<!>`, 1, 1);
-var root_7 = _$_.template(`<!><div class="extra">extra</div>`, 1, 2);
 var root_6 = _$_.template(`<!>`, 1, 1);
+var root_5 = _$_.template(`<!>`, 1, 1);
+var root_8 = _$_.template(`<!><div class="extra">extra</div>`, 1, 2);
+var root_7 = _$_.template(`<!>`, 1, 1);
+var root_10 = _$_.template(`<!>`, 1, 1);
 var root_9 = _$_.template(`<!>`, 1, 1);
-var root_8 = _$_.template(`<!>`, 1, 1);
+var root_12 = _$_.template(`<!>`, 1, 1);
+var root_11 = _$_.template(`<!>`, 1, 1);
 
 export function Layout(__anchor, __props, __block) {
 	_$_.push_component();
@@ -18,29 +21,52 @@ export function Layout(__anchor, __props, __block) {
 	var div_1 = root();
 
 	{
-		var node = _$_.child(div_1);
+		var expression = _$_.child(div_1);
 
-		_$_.composite(() => __props.children, node, {});
 		_$_.pop(div_1);
 	}
 
+	_$_.render(() => {
+		_$_.expression(expression, () => __props.children);
+	});
+
 	_$_.append(__anchor, div_1);
+	_$_.pop_component();
+}
+
+export function TextWrappedLayout(__anchor, __props, __block) {
+	_$_.push_component();
+
+	var div_2 = root_1();
+
+	{
+		var text = _$_.child(div_2);
+		var expression_1 = _$_.sibling(text);
+
+		_$_.pop(div_2);
+	}
+
+	_$_.render(() => {
+		_$_.expression(expression_1, () => __props.children);
+	});
+
+	_$_.append(__anchor, div_2);
 	_$_.pop_component();
 }
 
 export function SingleChild(__anchor, _, __block) {
 	_$_.push_component();
 
-	var div_2 = root_1();
+	var div_3 = root_2();
 
-	_$_.append(__anchor, div_2);
+	_$_.append(__anchor, div_3);
 	_$_.pop_component();
 }
 
 export function MultiRootChild(__anchor, _, __block) {
 	_$_.push_component();
 
-	var fragment = root_2();
+	var fragment = root_3();
 
 	_$_.next();
 	_$_.append(__anchor, fragment, true);
@@ -50,10 +76,10 @@ export function MultiRootChild(__anchor, _, __block) {
 export function EmptyLayout(__anchor, _, __block) {
 	_$_.push_component();
 
-	var fragment_1 = root_3();
-	var node_1 = _$_.first_child_frag(fragment_1);
+	var fragment_1 = root_4();
+	var node = _$_.first_child_frag(fragment_1);
 
-	Layout(node_1, {}, _$_.active_block);
+	Layout(node, {}, _$_.active_block);
 	_$_.append(__anchor, fragment_1);
 	_$_.pop_component();
 }
@@ -61,22 +87,22 @@ export function EmptyLayout(__anchor, _, __block) {
 export function LayoutWithSingleChild(__anchor, _, __block) {
 	_$_.push_component();
 
-	var fragment_2 = root_4();
-	var node_2 = _$_.first_child_frag(fragment_2);
+	var fragment_2 = root_5();
+	var node_1 = _$_.first_child_frag(fragment_2);
 
 	Layout(
-		node_2,
+		node_1,
 		{
-			children(__anchor, _, __block) {
+			children: _$_.ripple_element(function render_children(__anchor, _, __block) {
 				_$_.push_component();
 
-				var fragment_3 = root_5();
-				var node_3 = _$_.first_child_frag(fragment_3);
+				var fragment_3 = root_6();
+				var node_2 = _$_.first_child_frag(fragment_3);
 
-				SingleChild(node_3, {}, _$_.active_block);
+				SingleChild(node_2, {}, _$_.active_block);
 				_$_.append(__anchor, fragment_3);
 				_$_.pop_component();
-			}
+			})
 		},
 		_$_.active_block
 	);
@@ -88,22 +114,22 @@ export function LayoutWithSingleChild(__anchor, _, __block) {
 export function LayoutWithMultipleChildren(__anchor, _, __block) {
 	_$_.push_component();
 
-	var fragment_4 = root_6();
-	var node_4 = _$_.first_child_frag(fragment_4);
+	var fragment_4 = root_7();
+	var node_3 = _$_.first_child_frag(fragment_4);
 
 	Layout(
-		node_4,
+		node_3,
 		{
-			children(__anchor, _, __block) {
+			children: _$_.ripple_element(function render_children(__anchor, _, __block) {
 				_$_.push_component();
 
-				var fragment_5 = root_7();
-				var node_5 = _$_.first_child_frag(fragment_5);
+				var fragment_5 = root_8();
+				var node_4 = _$_.first_child_frag(fragment_5);
 
-				SingleChild(node_5, {}, _$_.active_block);
+				SingleChild(node_4, {}, _$_.active_block);
 				_$_.append(__anchor, fragment_5);
 				_$_.pop_component();
-			}
+			})
 		},
 		_$_.active_block
 	);
@@ -115,26 +141,53 @@ export function LayoutWithMultipleChildren(__anchor, _, __block) {
 export function LayoutWithMultiRootChild(__anchor, _, __block) {
 	_$_.push_component();
 
-	var fragment_6 = root_8();
-	var node_6 = _$_.first_child_frag(fragment_6);
+	var fragment_6 = root_9();
+	var node_5 = _$_.first_child_frag(fragment_6);
 
 	Layout(
-		node_6,
+		node_5,
 		{
-			children(__anchor, _, __block) {
+			children: _$_.ripple_element(function render_children(__anchor, _, __block) {
 				_$_.push_component();
 
-				var fragment_7 = root_9();
-				var node_7 = _$_.first_child_frag(fragment_7);
+				var fragment_7 = root_10();
+				var node_6 = _$_.first_child_frag(fragment_7);
 
-				MultiRootChild(node_7, {}, _$_.active_block);
+				MultiRootChild(node_6, {}, _$_.active_block);
 				_$_.append(__anchor, fragment_7);
 				_$_.pop_component();
-			}
+			})
 		},
 		_$_.active_block
 	);
 
 	_$_.append(__anchor, fragment_6);
+	_$_.pop_component();
+}
+
+export function LayoutWithTextAroundChildren(__anchor, _, __block) {
+	_$_.push_component();
+
+	var fragment_8 = root_11();
+	var node_7 = _$_.first_child_frag(fragment_8);
+
+	TextWrappedLayout(
+		node_7,
+		{
+			children: _$_.ripple_element(function render_children(__anchor, _, __block) {
+				_$_.push_component();
+
+				var fragment_9 = root_12();
+				var node_8 = _$_.first_child_frag(fragment_9);
+
+				SingleChild(node_8, {}, _$_.active_block);
+				_$_.append(__anchor, fragment_9);
+				_$_.pop_component();
+			})
+		},
+		_$_.active_block
+	);
+
+	_$_.append(__anchor, fragment_8);
 	_$_.pop_component();
 }

--- a/packages/ripple/tests/hydration/compiled/client/hmr.js
+++ b/packages/ripple/tests/hydration/compiled/client/hmr.js
@@ -19,12 +19,15 @@ export function Layout(__anchor, { children }, __block) {
 		var main_1 = _$_.sibling(nav_1);
 
 		{
-			var node = _$_.child(main_1);
+			var expression = _$_.child(main_1);
 
-			children(node, {}, _$_.active_block);
 			_$_.pop(main_1);
 		}
 	}
+
+	_$_.render(() => {
+		_$_.expression(expression, () => children);
+	});
 
 	_$_.append(__anchor, div_1);
 	_$_.pop_component();
@@ -37,7 +40,7 @@ export function Content(__anchor, _, __block) {
 	var div_2 = root_1();
 
 	{
-		var node_1 = _$_.child(div_2);
+		var node = _$_.child(div_2);
 
 		{
 			var consequent = (__anchor) => {
@@ -46,7 +49,7 @@ export function Content(__anchor, _, __block) {
 				_$_.append(__anchor, p_1);
 			};
 
-			_$_.if(node_1, (__render) => {
+			_$_.if(node, (__render) => {
 				if (_$_.get(lazy)) __render(consequent);
 			});
 		}
@@ -62,21 +65,21 @@ export function LayoutWithContent(__anchor, _, __block) {
 	_$_.push_component();
 
 	var fragment = root_3();
-	var node_2 = _$_.first_child_frag(fragment);
+	var node_1 = _$_.first_child_frag(fragment);
 
 	Layout(
-		node_2,
+		node_1,
 		{
-			children(__anchor, _, __block) {
+			children: _$_.ripple_element(function render_children(__anchor, _, __block) {
 				_$_.push_component();
 
 				var fragment_1 = root_4();
-				var node_3 = _$_.first_child_frag(fragment_1);
+				var node_2 = _$_.first_child_frag(fragment_1);
 
-				Content(node_3, {}, _$_.active_block);
+				Content(node_2, {}, _$_.active_block);
 				_$_.append(__anchor, fragment_1);
 				_$_.pop_component();
-			}
+			})
 		},
 		_$_.active_block
 	);

--- a/packages/ripple/tests/hydration/compiled/client/html.js
+++ b/packages/ripple/tests/hydration/compiled/client/html.js
@@ -224,12 +224,15 @@ export function HtmlWrapper(__anchor, { children }, __block) {
 		var div_7 = _$_.child(div_6);
 
 		{
-			var node_7 = _$_.child(div_7);
+			var expression = _$_.child(div_7);
 
-			children(node_7, {}, _$_.active_block);
 			_$_.pop(div_7);
 		}
 	}
+
+	_$_.render(() => {
+		_$_.expression(expression, () => children);
+	});
 
 	_$_.append(__anchor, div_6);
 	_$_.pop_component();
@@ -240,29 +243,29 @@ export function HtmlInChildren(__anchor, _, __block) {
 
 	const content = '<p><strong>Bold</strong> text</p>';
 	var fragment = root_7();
-	var node_8 = _$_.first_child_frag(fragment);
+	var node_7 = _$_.first_child_frag(fragment);
 
 	HtmlWrapper(
-		node_8,
+		node_7,
 		{
-			children(__anchor, _, __block) {
+			children: _$_.ripple_element(function render_children(__anchor, _, __block) {
 				_$_.push_component();
 
 				var div_8 = root_8();
 
 				{
-					var node_9 = _$_.child(div_8);
+					var node_8 = _$_.child(div_8);
 
 					_$_.pop(div_8);
 				}
 
 				_$_.render(() => {
-					_$_.html(node_9, () => content);
+					_$_.html(node_8, () => content);
 				});
 
 				_$_.append(__anchor, div_8);
 				_$_.pop_component();
-			}
+			})
 		},
 		_$_.active_block
 	);
@@ -276,12 +279,12 @@ export function HtmlInChildrenWithSiblings(__anchor, _, __block) {
 
 	const content = '<p>Dynamic content</p>';
 	var fragment_1 = root_9();
-	var node_10 = _$_.first_child_frag(fragment_1);
+	var node_9 = _$_.first_child_frag(fragment_1);
 
 	HtmlWrapper(
-		node_10,
+		node_9,
 		{
-			children(__anchor, _, __block) {
+			children: _$_.ripple_element(function render_children(__anchor, _, __block) {
 				_$_.push_component();
 
 				var fragment_2 = root_10();
@@ -289,7 +292,7 @@ export function HtmlInChildrenWithSiblings(__anchor, _, __block) {
 				var div_9 = _$_.sibling(h1_1);
 
 				{
-					var node_11 = _$_.child(div_9);
+					var node_10 = _$_.child(div_9);
 
 					_$_.pop(div_9);
 				}
@@ -297,12 +300,12 @@ export function HtmlInChildrenWithSiblings(__anchor, _, __block) {
 				_$_.next();
 
 				_$_.render(() => {
-					_$_.html(node_11, () => content);
+					_$_.html(node_10, () => content);
 				});
 
 				_$_.append(__anchor, fragment_2, true);
 				_$_.pop_component();
-			}
+			})
 		},
 		_$_.active_block
 	);
@@ -317,34 +320,34 @@ export function MultipleHtmlInChildren(__anchor, _, __block) {
 	const html1 = '<p>First</p>';
 	const html2 = '<p>Second</p>';
 	var fragment_3 = root_11();
-	var node_12 = _$_.first_child_frag(fragment_3);
+	var node_11 = _$_.first_child_frag(fragment_3);
 
 	HtmlWrapper(
-		node_12,
+		node_11,
 		{
-			children(__anchor, _, __block) {
+			children: _$_.ripple_element(function render_children(__anchor, _, __block) {
 				_$_.push_component();
 
 				var div_10 = root_12();
 
 				{
-					var node_13 = _$_.child(div_10);
-					var node_14 = _$_.sibling(node_13);
+					var node_12 = _$_.child(div_10);
+					var node_13 = _$_.sibling(node_12);
 
 					_$_.pop(div_10);
 				}
 
 				_$_.render(
 					(__prev) => {
-						_$_.html(node_13, () => html1);
-						_$_.html(node_14, () => html2);
+						_$_.html(node_12, () => html1);
+						_$_.html(node_13, () => html2);
 					},
 					{}
 				);
 
 				_$_.append(__anchor, div_10);
 				_$_.pop_component();
-			}
+			})
 		},
 		_$_.active_block
 	);
@@ -360,13 +363,13 @@ export function HtmlWithComments(__anchor, _, __block) {
 	var div_11 = root_13();
 
 	{
-		var node_15 = _$_.child(div_11);
+		var node_14 = _$_.child(div_11);
 
 		_$_.pop(div_11);
 	}
 
 	_$_.render(() => {
-		_$_.html(node_15, () => content);
+		_$_.html(node_14, () => content);
 	});
 
 	_$_.append(__anchor, div_11);
@@ -380,13 +383,13 @@ export function HtmlWithEmptyComment(__anchor, _, __block) {
 	var div_12 = root_14();
 
 	{
-		var node_16 = _$_.child(div_12);
+		var node_15 = _$_.child(div_12);
 
 		_$_.pop(div_12);
 	}
 
 	_$_.render(() => {
-		_$_.html(node_16, () => content);
+		_$_.html(node_15, () => content);
 	});
 
 	_$_.append(__anchor, div_12);
@@ -398,29 +401,29 @@ export function HtmlWithCommentsInChildren(__anchor, _, __block) {
 
 	const content = '<h2 id="intro">Introduction</h2><p>Some text</p><!-- TODO --><p>More text</p>';
 	var fragment_4 = root_15();
-	var node_17 = _$_.first_child_frag(fragment_4);
+	var node_16 = _$_.first_child_frag(fragment_4);
 
 	HtmlWrapper(
-		node_17,
+		node_16,
 		{
-			children(__anchor, _, __block) {
+			children: _$_.ripple_element(function render_children(__anchor, _, __block) {
 				_$_.push_component();
 
 				var div_13 = root_16();
 
 				{
-					var node_18 = _$_.child(div_13);
+					var node_17 = _$_.child(div_13);
 
 					_$_.pop(div_13);
 				}
 
 				_$_.render(() => {
-					_$_.html(node_18, () => content);
+					_$_.html(node_17, () => content);
 				});
 
 				_$_.append(__anchor, div_13);
 				_$_.pop_component();
-			}
+			})
 		},
 		_$_.active_block
 	);
@@ -457,16 +460,15 @@ export function DocLayout(
 				var div_15 = _$_.child(article_1);
 
 				{
-					var node_19 = _$_.child(div_15);
+					var expression_1 = _$_.child(div_15);
 
-					children(node_19, {}, _$_.active_block);
 					_$_.pop(div_15);
 				}
 			}
 
 			_$_.pop(article_1);
 
-			var node_20 = _$_.sibling(article_1);
+			var node_18 = _$_.sibling(article_1);
 
 			{
 				var consequent = (__anchor) => {
@@ -481,12 +483,12 @@ export function DocLayout(
 					_$_.append(__anchor, div_17);
 				};
 
-				_$_.if(node_20, (__render) => {
+				_$_.if(node_18, (__render) => {
 					if (editPath) __render(consequent);
 				});
 			}
 
-			var node_21 = _$_.sibling(node_20);
+			var node_19 = _$_.sibling(node_18);
 
 			{
 				var consequent_1 = (__anchor) => {
@@ -496,7 +498,7 @@ export function DocLayout(
 						var a_2 = _$_.child(nav_1);
 
 						{
-							var expression = _$_.child(a_2, true);
+							var expression_2 = _$_.child(a_2, true);
 
 							_$_.pop(a_2);
 						}
@@ -507,7 +509,7 @@ export function DocLayout(
 							var __a = nextLink.text;
 
 							if (__prev.a !== __a) {
-								_$_.set_text(expression, __prev.a = __a);
+								_$_.set_text(expression_2, __prev.a = __a);
 							}
 
 							var __b = nextLink.href;
@@ -522,21 +524,21 @@ export function DocLayout(
 					_$_.append(__anchor, nav_1);
 				};
 
-				_$_.if(node_21, (__render) => {
+				_$_.if(node_19, (__render) => {
 					if (nextLink) __render(consequent_1);
 				});
 			}
 
-			var node_22 = _$_.sibling(node_21);
+			var node_20 = _$_.sibling(node_19);
 
-			DocFooter(node_22, {}, _$_.active_block);
+			DocFooter(node_20, {}, _$_.active_block);
 			_$_.pop(div_16);
 		}
 
 		var aside_1 = _$_.sibling(div_16);
 
 		{
-			var node_23 = _$_.child(aside_1);
+			var node_21 = _$_.child(aside_1);
 
 			{
 				var consequent_2 = (__anchor) => {
@@ -556,7 +558,7 @@ export function DocLayout(
 										var a_3 = _$_.child(li_1);
 
 										{
-											var expression_1 = _$_.child(a_3, true);
+											var expression_3 = _$_.child(a_3, true);
 
 											_$_.pop(a_3);
 										}
@@ -567,7 +569,7 @@ export function DocLayout(
 											var __a = item.text;
 
 											if (__prev.a !== __a) {
-												_$_.set_text(expression_1, __prev.a = __a);
+												_$_.set_text(expression_3, __prev.a = __a);
 											}
 
 											var __b = item.href;
@@ -591,7 +593,7 @@ export function DocLayout(
 					_$_.append(__anchor, div_18);
 				};
 
-				_$_.if(node_23, (__render) => {
+				_$_.if(node_21, (__render) => {
 					if (toc.length > 0) __render(consequent_2);
 				});
 			}
@@ -599,6 +601,10 @@ export function DocLayout(
 			_$_.pop(aside_1);
 		}
 	}
+
+	_$_.render(() => {
+		_$_.expression(expression_1, () => children);
+	});
 
 	_$_.append(__anchor, div_14);
 	_$_.pop_component();
@@ -609,10 +615,10 @@ export function HtmlWithServerData(__anchor, _, __block) {
 
 	const content = '<h1 id="intro" class="doc-h1">Introduction</h1><p>Ripple is a framework.</p>';
 	var fragment_5 = root_23();
-	var node_24 = _$_.first_child_frag(fragment_5);
+	var node_22 = _$_.first_child_frag(fragment_5);
 
 	DocLayout(
-		node_24,
+		node_22,
 		{
 			editPath: "docs/introduction.md",
 			nextLink: { href: '/docs/quick-start', text: 'Quick Start' },
@@ -621,24 +627,24 @@ export function HtmlWithServerData(__anchor, _, __block) {
 				{ href: '#features', text: 'Features' }
 			],
 
-			children(__anchor, _, __block) {
+			children: _$_.ripple_element(function render_children(__anchor, _, __block) {
 				_$_.push_component();
 
 				var div_19 = root_24();
 
 				{
-					var node_25 = _$_.child(div_19);
+					var node_23 = _$_.child(div_19);
 
 					_$_.pop(div_19);
 				}
 
 				_$_.render(() => {
-					_$_.html(node_25, () => content);
+					_$_.html(node_23, () => content);
 				});
 
 				_$_.append(__anchor, div_19);
 				_$_.pop_component();
-			}
+			})
 		},
 		_$_.active_block
 	);
@@ -652,29 +658,29 @@ export function HtmlWithClientDefaults(__anchor, _, __block) {
 
 	const content = '<h1 id="intro" class="doc-h1">Introduction</h1><p>Ripple is a framework.</p>';
 	var fragment_6 = root_25();
-	var node_26 = _$_.first_child_frag(fragment_6);
+	var node_24 = _$_.first_child_frag(fragment_6);
 
 	DocLayout(
-		node_26,
+		node_24,
 		{
-			children(__anchor, _, __block) {
+			children: _$_.ripple_element(function render_children(__anchor, _, __block) {
 				_$_.push_component();
 
 				var div_20 = root_26();
 
 				{
-					var node_27 = _$_.child(div_20);
+					var node_25 = _$_.child(div_20);
 
 					_$_.pop(div_20);
 				}
 
 				_$_.render(() => {
-					_$_.html(node_27, () => content);
+					_$_.html(node_25, () => content);
 				});
 
 				_$_.append(__anchor, div_20);
 				_$_.pop_component();
-			}
+			})
 		},
 		_$_.active_block
 	);
@@ -688,29 +694,29 @@ export function HtmlWithUndefinedContent(__anchor, _, __block) {
 
 	const content = undefined;
 	var fragment_7 = root_27();
-	var node_28 = _$_.first_child_frag(fragment_7);
+	var node_26 = _$_.first_child_frag(fragment_7);
 
 	DocLayout(
-		node_28,
+		node_26,
 		{
-			children(__anchor, _, __block) {
+			children: _$_.ripple_element(function render_children(__anchor, _, __block) {
 				_$_.push_component();
 
 				var div_21 = root_28();
 
 				{
-					var node_29 = _$_.child(div_21);
+					var node_27 = _$_.child(div_21);
 
 					_$_.pop(div_21);
 				}
 
 				_$_.render(() => {
-					_$_.html(node_29, () => content);
+					_$_.html(node_27, () => content);
 				});
 
 				_$_.append(__anchor, div_21);
 				_$_.pop_component();
-			}
+			})
 		},
 		_$_.active_block
 	);
@@ -723,18 +729,21 @@ function DynamicHeading(__anchor, { level, children }, __block) {
 	_$_.push_component();
 
 	var fragment_8 = root_29();
-	var node_30 = _$_.first_child_frag(fragment_8);
+	var node_28 = _$_.first_child_frag(fragment_8);
 
 	{
 		var switch_case_0 = (__anchor) => {
 			var h1_2 = root_30();
 
 			{
-				var node_31 = _$_.child(h1_2);
+				var expression_4 = _$_.child(h1_2);
 
-				children(node_31, {}, _$_.active_block);
 				_$_.pop(h1_2);
 			}
+
+			_$_.render(() => {
+				_$_.expression(expression_4, () => children);
+			});
 
 			_$_.append(__anchor, h1_2);
 		};
@@ -743,16 +752,19 @@ function DynamicHeading(__anchor, { level, children }, __block) {
 			var h2_1 = root_31();
 
 			{
-				var node_32 = _$_.child(h2_1);
+				var expression_5 = _$_.child(h2_1);
 
-				children(node_32, {}, _$_.active_block);
 				_$_.pop(h2_1);
 			}
+
+			_$_.render(() => {
+				_$_.expression(expression_5, () => children);
+			});
 
 			_$_.append(__anchor, h2_1);
 		};
 
-		_$_.switch(node_30, () => {
+		_$_.switch(node_28, () => {
 			var result = [];
 
 			switch (level) {
@@ -784,14 +796,14 @@ function CodeBlock(__anchor, { code }, __block) {
 		var div_24 = _$_.sibling(div_23);
 
 		{
-			var node_33 = _$_.child(div_24);
+			var node_29 = _$_.child(div_24);
 
 			_$_.pop(div_24);
 		}
 	}
 
 	_$_.render(() => {
-		_$_.html(node_33, () => highlighted);
+		_$_.html(node_29, () => highlighted);
 	});
 
 	_$_.append(__anchor, div_22);
@@ -807,12 +819,15 @@ function ContentWrapper(__anchor, { children }, __block) {
 		var div_26 = _$_.child(div_25);
 
 		{
-			var node_34 = _$_.child(div_26);
+			var expression_6 = _$_.child(div_26);
 
-			children(node_34, {}, _$_.active_block);
 			_$_.pop(div_26);
 		}
 	}
+
+	_$_.render(() => {
+		_$_.expression(expression_6, () => children);
+	});
 
 	_$_.append(__anchor, div_25);
 	_$_.pop_component();
@@ -822,41 +837,41 @@ export function HtmlAfterSwitchInChildren(__anchor, _, __block) {
 	_$_.push_component();
 
 	var fragment_9 = root_34();
-	var node_35 = _$_.first_child_frag(fragment_9);
+	var node_30 = _$_.first_child_frag(fragment_9);
 
 	ContentWrapper(
-		node_35,
+		node_30,
 		{
-			children(__anchor, _, __block) {
+			children: _$_.ripple_element(function render_children(__anchor, _, __block) {
 				_$_.push_component();
 
 				var fragment_10 = root_35();
-				var node_36 = _$_.first_child_frag(fragment_10);
+				var node_31 = _$_.first_child_frag(fragment_10);
 
 				DynamicHeading(
-					node_36,
+					node_31,
 					{
 						level: 1,
-						children(__anchor, _, __block) {
+						children: _$_.ripple_element(function render_children(__anchor, _, __block) {
 							_$_.push_component();
 
-							var expression_2 = _$_.text('Title');
+							var expression_7 = _$_.text('Title');
 
-							_$_.append(__anchor, expression_2);
+							_$_.append(__anchor, expression_7);
 							_$_.pop_component();
-						}
+						})
 					},
 					_$_.active_block
 				);
 
-				var p_2 = _$_.sibling(node_36);
+				var p_2 = _$_.sibling(node_31);
 				var p_1 = _$_.sibling(p_2);
-				var node_37 = _$_.sibling(p_1);
+				var node_32 = _$_.sibling(p_1);
 
-				CodeBlock(node_37, { code: "const x = 1;" }, _$_.active_block);
+				CodeBlock(node_32, { code: "const x = 1;" }, _$_.active_block);
 				_$_.append(__anchor, fragment_10);
 				_$_.pop_component();
-			}
+			})
 		},
 		_$_.active_block
 	);
@@ -873,7 +888,7 @@ function NavItem(__anchor, { href, text: label, active = false }, __block) {
 	_$_.set_class(div_27, `nav-item${active ? ' active' : ''}`, void 0, true);
 
 	{
-		var node_38 = _$_.child(div_27);
+		var node_33 = _$_.child(div_27);
 
 		{
 			var consequent_3 = (__anchor) => {
@@ -882,12 +897,12 @@ function NavItem(__anchor, { href, text: label, active = false }, __block) {
 				_$_.append(__anchor, div_28);
 			};
 
-			_$_.if(node_38, (__render) => {
+			_$_.if(node_33, (__render) => {
 				if (active) __render(consequent_3);
 			});
 		}
 
-		var a_4 = _$_.sibling(node_38);
+		var a_4 = _$_.sibling(node_33);
 
 		_$_.set_attribute(a_4, 'href', href);
 
@@ -895,9 +910,9 @@ function NavItem(__anchor, { href, text: label, active = false }, __block) {
 			var span_1 = _$_.child(a_4);
 
 			{
-				var expression_3 = _$_.child(span_1, true);
+				var expression_8 = _$_.child(span_1, true);
 
-				expression_3.nodeValue = label;
+				expression_8.nodeValue = label;
 				_$_.pop(span_1);
 			}
 		}
@@ -922,9 +937,9 @@ function SidebarSection(__anchor, { title, children }, __block) {
 			var h2_2 = _$_.child(div_29);
 
 			{
-				var expression_4 = _$_.child(h2_2, true);
+				var expression_9 = _$_.child(h2_2, true);
 
-				expression_4.nodeValue = title;
+				expression_9.nodeValue = title;
 				_$_.pop(h2_2);
 			}
 
@@ -935,23 +950,26 @@ function SidebarSection(__anchor, { title, children }, __block) {
 
 		_$_.pop(div_29);
 
-		var node_39 = _$_.sibling(div_29);
+		var node_34 = _$_.sibling(div_29);
 
 		{
 			var consequent_4 = (__anchor) => {
 				var div_30 = root_39();
 
 				{
-					var node_40 = _$_.child(div_30);
+					var expression_10 = _$_.child(div_30);
 
-					children(node_40, {}, _$_.active_block);
 					_$_.pop(div_30);
 				}
+
+				_$_.render(() => {
+					_$_.expression(expression_10, () => children);
+				});
 
 				_$_.append(__anchor, div_30);
 			};
 
-			_$_.if(node_39, (__render) => {
+			_$_.if(node_34, (__render) => {
 				if (_$_.get(lazy)) __render(consequent_4);
 			});
 		}
@@ -975,20 +993,20 @@ function SideNav(__anchor, { currentPath }, __block) {
 			var div_31 = _$_.child(nav_2);
 
 			{
-				var node_41 = _$_.child(div_31);
+				var node_35 = _$_.child(div_31);
 
 				SidebarSection(
-					node_41,
+					node_35,
 					{
 						title: "Getting Started",
-						children(__anchor, _, __block) {
+						children: _$_.ripple_element(function render_children(__anchor, _, __block) {
 							_$_.push_component();
 
 							var fragment_11 = root_41();
-							var node_42 = _$_.first_child_frag(fragment_11);
+							var node_36 = _$_.first_child_frag(fragment_11);
 
 							NavItem(
-								node_42,
+								node_36,
 								{
 									href: "/intro",
 									text: "Introduction",
@@ -997,10 +1015,10 @@ function SideNav(__anchor, { currentPath }, __block) {
 								_$_.active_block
 							);
 
-							var node_43 = _$_.sibling(node_42);
+							var node_37 = _$_.sibling(node_36);
 
 							NavItem(
-								node_43,
+								node_37,
 								{
 									href: "/start",
 									text: "Quick Start",
@@ -1011,7 +1029,7 @@ function SideNav(__anchor, { currentPath }, __block) {
 
 							_$_.append(__anchor, fragment_11);
 							_$_.pop_component();
-						}
+						})
 					},
 					_$_.active_block
 				);
@@ -1022,20 +1040,20 @@ function SideNav(__anchor, { currentPath }, __block) {
 			var div_32 = _$_.sibling(div_31);
 
 			{
-				var node_44 = _$_.child(div_32);
+				var node_38 = _$_.child(div_32);
 
 				SidebarSection(
-					node_44,
+					node_38,
 					{
 						title: "Guide",
-						children(__anchor, _, __block) {
+						children: _$_.ripple_element(function render_children(__anchor, _, __block) {
 							_$_.push_component();
 
 							var fragment_12 = root_42();
-							var node_45 = _$_.first_child_frag(fragment_12);
+							var node_39 = _$_.first_child_frag(fragment_12);
 
 							NavItem(
-								node_45,
+								node_39,
 								{
 									href: "/guide/app",
 									text: "Application",
@@ -1044,10 +1062,10 @@ function SideNav(__anchor, { currentPath }, __block) {
 								_$_.active_block
 							);
 
-							var node_46 = _$_.sibling(node_45);
+							var node_40 = _$_.sibling(node_39);
 
 							NavItem(
-								node_46,
+								node_40,
 								{
 									href: "/guide/syntax",
 									text: "Syntax",
@@ -1058,7 +1076,7 @@ function SideNav(__anchor, { currentPath }, __block) {
 
 							_$_.append(__anchor, fragment_12);
 							_$_.pop_component();
-						}
+						})
 					},
 					_$_.active_block
 				);
@@ -1087,25 +1105,25 @@ export function LayoutWithSidebarAndMain(__anchor, _, __block) {
 	var div_33 = root_44();
 
 	{
-		var node_47 = _$_.child(div_33);
+		var node_41 = _$_.child(div_33);
 
-		PageHeader(node_47, {}, _$_.active_block);
+		PageHeader(node_41, {}, _$_.active_block);
 
-		var div_34 = _$_.sibling(node_47);
+		var div_34 = _$_.sibling(node_41);
 
 		{
-			var node_48 = _$_.child(div_34);
+			var node_42 = _$_.child(div_34);
 
-			SideNav(node_48, { currentPath: "/intro" }, _$_.active_block);
+			SideNav(node_42, { currentPath: "/intro" }, _$_.active_block);
 
-			var main_1 = _$_.sibling(node_48);
+			var main_1 = _$_.sibling(node_42);
 
 			{
 				var div_35 = _$_.child(main_1);
 
 				_$_.pop(div_35);
 
-				var node_49 = _$_.sibling(div_35);
+				var node_43 = _$_.sibling(div_35);
 
 				{
 					var consequent_5 = (__anchor) => {
@@ -1114,14 +1132,14 @@ export function LayoutWithSidebarAndMain(__anchor, _, __block) {
 						_$_.append(__anchor, div_36);
 					};
 
-					_$_.if(node_49, (__render) => {
+					_$_.if(node_43, (__render) => {
 						if (true) __render(consequent_5);
 					});
 				}
 
-				var node_50 = _$_.sibling(node_49);
+				var node_44 = _$_.sibling(node_43);
 
-				PageHeader(node_50, {}, _$_.active_block);
+				PageHeader(node_44, {}, _$_.active_block);
 				_$_.pop(main_1);
 			}
 
@@ -1144,12 +1162,15 @@ function ArticleWrapper(__anchor, { children }, __block) {
 		var div_37 = _$_.child(article_2);
 
 		{
-			var node_51 = _$_.child(div_37);
+			var expression_11 = _$_.child(div_37);
 
-			children(node_51, {}, _$_.active_block);
 			_$_.pop(div_37);
 		}
 	}
+
+	_$_.render(() => {
+		_$_.expression(expression_11, () => children);
+	});
 
 	_$_.append(__anchor, article_2);
 	_$_.pop_component();
@@ -1170,24 +1191,24 @@ export function ArticleWithChildrenThenSibling(__anchor, _, __block) {
 	var div_38 = root_48();
 
 	{
-		var node_52 = _$_.child(div_38);
+		var node_45 = _$_.child(div_38);
 
 		ArticleWrapper(
-			node_52,
+			node_45,
 			{
-				children(__anchor, _, __block) {
+				children: _$_.ripple_element(function render_children(__anchor, _, __block) {
 					_$_.push_component();
 
 					var fragment_13 = root_49();
 
 					_$_.append(__anchor, fragment_13);
 					_$_.pop_component();
-				}
+				})
 			},
 			_$_.active_block
 		);
 
-		var node_53 = _$_.sibling(node_52);
+		var node_46 = _$_.sibling(node_45);
 
 		{
 			var consequent_6 = (__anchor) => {
@@ -1196,12 +1217,12 @@ export function ArticleWithChildrenThenSibling(__anchor, _, __block) {
 				_$_.append(__anchor, div_39);
 			};
 
-			_$_.if(node_53, (__render) => {
+			_$_.if(node_46, (__render) => {
 				if (true) __render(consequent_6);
 			});
 		}
 
-		var node_54 = _$_.sibling(node_53);
+		var node_47 = _$_.sibling(node_46);
 
 		{
 			var consequent_7 = (__anchor) => {
@@ -1210,14 +1231,14 @@ export function ArticleWithChildrenThenSibling(__anchor, _, __block) {
 				_$_.append(__anchor, nav_3);
 			};
 
-			_$_.if(node_54, (__render) => {
+			_$_.if(node_47, (__render) => {
 				if (true) __render(consequent_7);
 			});
 		}
 
-		var node_55 = _$_.sibling(node_54);
+		var node_48 = _$_.sibling(node_47);
 
-		SimpleFooter(node_55, {}, _$_.active_block);
+		SimpleFooter(node_48, {}, _$_.active_block);
 		_$_.pop(div_38);
 	}
 
@@ -1232,34 +1253,34 @@ export function ArticleWithHtmlChildThenSibling(__anchor, _, __block) {
 	var div_40 = root_52();
 
 	{
-		var node_56 = _$_.child(div_40);
+		var node_49 = _$_.child(div_40);
 
 		ArticleWrapper(
-			node_56,
+			node_49,
 			{
-				children(__anchor, _, __block) {
+				children: _$_.ripple_element(function render_children(__anchor, _, __block) {
 					_$_.push_component();
 
 					var div_41 = root_53();
 
 					{
-						var node_57 = _$_.child(div_41);
+						var node_50 = _$_.child(div_41);
 
 						_$_.pop(div_41);
 					}
 
 					_$_.render(() => {
-						_$_.html(node_57, () => htmlContent);
+						_$_.html(node_50, () => htmlContent);
 					});
 
 					_$_.append(__anchor, div_41);
 					_$_.pop_component();
-				}
+				})
 			},
 			_$_.active_block
 		);
 
-		var node_58 = _$_.sibling(node_56);
+		var node_51 = _$_.sibling(node_49);
 
 		{
 			var consequent_8 = (__anchor) => {
@@ -1268,14 +1289,14 @@ export function ArticleWithHtmlChildThenSibling(__anchor, _, __block) {
 				_$_.append(__anchor, div_42);
 			};
 
-			_$_.if(node_58, (__render) => {
+			_$_.if(node_51, (__render) => {
 				if (true) __render(consequent_8);
 			});
 		}
 
-		var node_59 = _$_.sibling(node_58);
+		var node_52 = _$_.sibling(node_51);
 
-		SimpleFooter(node_59, {}, _$_.active_block);
+		SimpleFooter(node_52, {}, _$_.active_block);
 		_$_.pop(div_40);
 	}
 
@@ -1295,16 +1316,15 @@ function InlineArticleLayout(__anchor, { children }, __block) {
 			var div_44 = _$_.child(article_3);
 
 			{
-				var node_60 = _$_.child(div_44);
+				var expression_12 = _$_.child(div_44);
 
-				children(node_60, {}, _$_.active_block);
 				_$_.pop(div_44);
 			}
 		}
 
 		_$_.pop(article_3);
 
-		var node_61 = _$_.sibling(article_3);
+		var node_53 = _$_.sibling(article_3);
 
 		{
 			var consequent_9 = (__anchor) => {
@@ -1313,16 +1333,20 @@ function InlineArticleLayout(__anchor, { children }, __block) {
 				_$_.append(__anchor, div_45);
 			};
 
-			_$_.if(node_61, (__render) => {
+			_$_.if(node_53, (__render) => {
 				if (true) __render(consequent_9);
 			});
 		}
 
-		var node_62 = _$_.sibling(node_61);
+		var node_54 = _$_.sibling(node_53);
 
-		SimpleFooter(node_62, {}, _$_.active_block);
+		SimpleFooter(node_54, {}, _$_.active_block);
 		_$_.pop(div_43);
 	}
+
+	_$_.render(() => {
+		_$_.expression(expression_12, () => children);
+	});
 
 	_$_.append(__anchor, div_43);
 	_$_.pop_component();
@@ -1333,29 +1357,29 @@ export function InlineArticleWithHtmlChild(__anchor, _, __block) {
 
 	const htmlContent = '<pre><code>const x = 1;</code></pre>';
 	var fragment_14 = root_57();
-	var node_63 = _$_.first_child_frag(fragment_14);
+	var node_55 = _$_.first_child_frag(fragment_14);
 
 	InlineArticleLayout(
-		node_63,
+		node_55,
 		{
-			children(__anchor, _, __block) {
+			children: _$_.ripple_element(function render_children(__anchor, _, __block) {
 				_$_.push_component();
 
 				var div_46 = root_58();
 
 				{
-					var node_64 = _$_.child(div_46);
+					var node_56 = _$_.child(div_46);
 
 					_$_.pop(div_46);
 				}
 
 				_$_.render(() => {
-					_$_.html(node_64, () => htmlContent);
+					_$_.html(node_56, () => htmlContent);
 				});
 
 				_$_.append(__anchor, div_46);
 				_$_.pop_component();
-			}
+			})
 		},
 		_$_.active_block
 	);
@@ -1401,18 +1425,18 @@ function DocsLayoutInner(
 	var div_47 = root_62();
 
 	{
-		var node_65 = _$_.child(div_47);
+		var node_57 = _$_.child(div_47);
 
-		HeaderStub(node_65, {}, _$_.active_block);
+		HeaderStub(node_57, {}, _$_.active_block);
 
-		var div_48 = _$_.sibling(node_65);
+		var div_48 = _$_.sibling(node_57);
 
 		{
-			var node_66 = _$_.child(div_48);
+			var node_58 = _$_.child(div_48);
 
-			SidebarStub(node_66, {}, _$_.active_block);
+			SidebarStub(node_58, {}, _$_.active_block);
 
-			var main_2 = _$_.sibling(node_66);
+			var main_2 = _$_.sibling(node_58);
 
 			{
 				var div_52 = _$_.child(main_2);
@@ -1430,16 +1454,15 @@ function DocsLayoutInner(
 								var div_49 = _$_.child(article_4);
 
 								{
-									var node_67 = _$_.child(div_49);
+									var expression_13 = _$_.child(div_49);
 
-									children(node_67, {}, _$_.active_block);
 									_$_.pop(div_49);
 								}
 							}
 
 							_$_.pop(article_4);
 
-							var node_68 = _$_.sibling(article_4);
+							var node_59 = _$_.sibling(article_4);
 
 							{
 								var consequent_10 = (__anchor) => {
@@ -1448,12 +1471,12 @@ function DocsLayoutInner(
 									_$_.append(__anchor, div_53);
 								};
 
-								_$_.if(node_68, (__render) => {
+								_$_.if(node_59, (__render) => {
 									if (editPath) __render(consequent_10);
 								});
 							}
 
-							var node_69 = _$_.sibling(node_68);
+							var node_60 = _$_.sibling(node_59);
 
 							{
 								var consequent_11 = (__anchor) => {
@@ -1463,7 +1486,7 @@ function DocsLayoutInner(
 										var a_5 = _$_.child(nav_4);
 
 										{
-											var expression_5 = _$_.child(a_5, true);
+											var expression_14 = _$_.child(a_5, true);
 
 											_$_.pop(a_5);
 										}
@@ -1474,7 +1497,7 @@ function DocsLayoutInner(
 											var __a = nextLink.text;
 
 											if (__prev.a !== __a) {
-												_$_.set_text(expression_5, __prev.a = __a);
+												_$_.set_text(expression_14, __prev.a = __a);
 											}
 
 											var __b = nextLink.href;
@@ -1489,14 +1512,14 @@ function DocsLayoutInner(
 									_$_.append(__anchor, nav_4);
 								};
 
-								_$_.if(node_69, (__render) => {
+								_$_.if(node_60, (__render) => {
 									if (nextLink) __render(consequent_11);
 								});
 							}
 
-							var node_70 = _$_.sibling(node_69);
+							var node_61 = _$_.sibling(node_60);
 
-							FooterStub(node_70, {}, _$_.active_block);
+							FooterStub(node_61, {}, _$_.active_block);
 							_$_.pop(div_50);
 						}
 					}
@@ -1509,6 +1532,10 @@ function DocsLayoutInner(
 		_$_.pop(div_47);
 	}
 
+	_$_.render(() => {
+		_$_.expression(expression_13, () => children);
+	});
+
 	_$_.append(__anchor, div_47);
 	_$_.pop_component();
 }
@@ -1518,31 +1545,31 @@ export function DocsLayoutWithData(__anchor, _, __block) {
 
 	const htmlContent = '<h1>Title</h1><p>Content</p>';
 	var fragment_15 = root_65();
-	var node_71 = _$_.first_child_frag(fragment_15);
+	var node_62 = _$_.first_child_frag(fragment_15);
 
 	DocsLayoutInner(
-		node_71,
+		node_62,
 		{
 			editPath: "docs/styling.md",
 			nextLink: { href: '/next', text: 'Next' },
-			children(__anchor, _, __block) {
+			children: _$_.ripple_element(function render_children(__anchor, _, __block) {
 				_$_.push_component();
 
 				var div_54 = root_66();
 
 				{
-					var node_72 = _$_.child(div_54);
+					var node_63 = _$_.child(div_54);
 
 					_$_.pop(div_54);
 				}
 
 				_$_.render(() => {
-					_$_.html(node_72, () => htmlContent);
+					_$_.html(node_63, () => htmlContent);
 				});
 
 				_$_.append(__anchor, div_54);
 				_$_.pop_component();
-			}
+			})
 		},
 		_$_.active_block
 	);
@@ -1556,29 +1583,29 @@ export function DocsLayoutWithoutData(__anchor, _, __block) {
 
 	const htmlContent = undefined;
 	var fragment_16 = root_67();
-	var node_73 = _$_.first_child_frag(fragment_16);
+	var node_64 = _$_.first_child_frag(fragment_16);
 
 	DocsLayoutInner(
-		node_73,
+		node_64,
 		{
-			children(__anchor, _, __block) {
+			children: _$_.ripple_element(function render_children(__anchor, _, __block) {
 				_$_.push_component();
 
 				var div_55 = root_68();
 
 				{
-					var node_74 = _$_.child(div_55);
+					var node_65 = _$_.child(div_55);
 
 					_$_.pop(div_55);
 				}
 
 				_$_.render(() => {
-					_$_.html(node_74, () => htmlContent);
+					_$_.html(node_65, () => htmlContent);
 				});
 
 				_$_.append(__anchor, div_55);
 				_$_.pop_component();
-			}
+			})
 		},
 		_$_.active_block
 	);
@@ -1603,18 +1630,18 @@ function DocsLayoutExact(
 	var div_56 = root_69();
 
 	{
-		var node_75 = _$_.child(div_56);
+		var node_66 = _$_.child(div_56);
 
-		HeaderStub(node_75, {}, _$_.active_block);
+		HeaderStub(node_66, {}, _$_.active_block);
 
-		var div_57 = _$_.sibling(node_75);
+		var div_57 = _$_.sibling(node_66);
 
 		{
-			var node_76 = _$_.child(div_57);
+			var node_67 = _$_.child(div_57);
 
-			SidebarStub(node_76, {}, _$_.active_block);
+			SidebarStub(node_67, {}, _$_.active_block);
 
-			var main_3 = _$_.sibling(node_76);
+			var main_3 = _$_.sibling(node_67);
 
 			{
 				var div_61 = _$_.child(main_3);
@@ -1632,16 +1659,15 @@ function DocsLayoutExact(
 								var div_58 = _$_.child(article_5);
 
 								{
-									var node_77 = _$_.child(div_58);
+									var expression_15 = _$_.child(div_58);
 
-									children(node_77, {}, _$_.active_block);
 									_$_.pop(div_58);
 								}
 							}
 
 							_$_.pop(article_5);
 
-							var node_78 = _$_.sibling(article_5);
+							var node_68 = _$_.sibling(article_5);
 
 							{
 								var consequent_12 = (__anchor) => {
@@ -1656,19 +1682,19 @@ function DocsLayoutExact(
 									_$_.append(__anchor, div_62);
 								};
 
-								_$_.if(node_78, (__render) => {
+								_$_.if(node_68, (__render) => {
 									if (editPath) __render(consequent_12);
 								});
 							}
 
-							var node_79 = _$_.sibling(node_78);
+							var node_69 = _$_.sibling(node_68);
 
 							{
 								var consequent_15 = (__anchor) => {
 									var nav_5 = root_71();
 
 									{
-										var node_80 = _$_.child(nav_5);
+										var node_70 = _$_.child(nav_5);
 
 										{
 											var consequent_13 = (__anchor) => {
@@ -1678,7 +1704,7 @@ function DocsLayoutExact(
 													var span_2 = _$_.child(a_7);
 
 													{
-														var expression_6 = _$_.child(span_2, true);
+														var expression_16 = _$_.child(span_2, true);
 
 														_$_.pop(span_2);
 													}
@@ -1689,7 +1715,7 @@ function DocsLayoutExact(
 														var __a = prevLink.text;
 
 														if (__prev.a !== __a) {
-															_$_.set_text(expression_6, __prev.a = __a);
+															_$_.set_text(expression_16, __prev.a = __a);
 														}
 
 														var __b = prevLink.href;
@@ -1710,12 +1736,12 @@ function DocsLayoutExact(
 												_$_.append(__anchor, span_3);
 											};
 
-											_$_.if(node_80, (__render) => {
+											_$_.if(node_70, (__render) => {
 												if (prevLink) __render(consequent_13); else __render(alternate, false);
 											});
 										}
 
-										var node_81 = _$_.sibling(node_80);
+										var node_71 = _$_.sibling(node_70);
 
 										{
 											var consequent_14 = (__anchor) => {
@@ -1725,7 +1751,7 @@ function DocsLayoutExact(
 													var span_4 = _$_.child(a_8);
 
 													{
-														var expression_7 = _$_.child(span_4, true);
+														var expression_17 = _$_.child(span_4, true);
 
 														_$_.pop(span_4);
 													}
@@ -1736,7 +1762,7 @@ function DocsLayoutExact(
 														var __a = nextLink.text;
 
 														if (__prev.a !== __a) {
-															_$_.set_text(expression_7, __prev.a = __a);
+															_$_.set_text(expression_17, __prev.a = __a);
 														}
 
 														var __b = nextLink.href;
@@ -1751,7 +1777,7 @@ function DocsLayoutExact(
 												_$_.append(__anchor, a_8);
 											};
 
-											_$_.if(node_81, (__render) => {
+											_$_.if(node_71, (__render) => {
 												if (nextLink) __render(consequent_14);
 											});
 										}
@@ -1762,14 +1788,14 @@ function DocsLayoutExact(
 									_$_.append(__anchor, nav_5);
 								};
 
-								_$_.if(node_79, (__render) => {
+								_$_.if(node_69, (__render) => {
 									if (prevLink || nextLink) __render(consequent_15);
 								});
 							}
 
-							var node_82 = _$_.sibling(node_79);
+							var node_72 = _$_.sibling(node_69);
 
-							FooterStub(node_82, {}, _$_.active_block);
+							FooterStub(node_72, {}, _$_.active_block);
 							_$_.pop(div_59);
 						}
 					}
@@ -1779,7 +1805,7 @@ function DocsLayoutExact(
 					var aside_4 = _$_.sibling(div_60);
 
 					{
-						var node_83 = _$_.child(aside_4);
+						var node_73 = _$_.child(aside_4);
 
 						{
 							var consequent_16 = (__anchor) => {
@@ -1796,7 +1822,7 @@ function DocsLayoutExact(
 												var a_9 = root_76();
 
 												{
-													var expression_8 = _$_.child(a_9, true);
+													var expression_18 = _$_.child(a_9, true);
 
 													_$_.pop(a_9);
 												}
@@ -1806,7 +1832,7 @@ function DocsLayoutExact(
 														var __a = item.text;
 
 														if (__prev.a !== __a) {
-															_$_.set_text(expression_8, __prev.a = __a);
+															_$_.set_text(expression_18, __prev.a = __a);
 														}
 
 														var __b = item.href;
@@ -1830,7 +1856,7 @@ function DocsLayoutExact(
 								_$_.append(__anchor, div_63);
 							};
 
-							_$_.if(node_83, (__render) => {
+							_$_.if(node_73, (__render) => {
 								if (toc.length > 0) __render(consequent_16);
 							});
 						}
@@ -1846,6 +1872,10 @@ function DocsLayoutExact(
 		_$_.pop(div_56);
 	}
 
+	_$_.render(() => {
+		_$_.expression(expression_15, () => children);
+	});
+
 	_$_.append(__anchor, div_56);
 	_$_.pop_component();
 }
@@ -1855,10 +1885,10 @@ export function DocsLayoutExactWithData(__anchor, _, __block) {
 
 	const htmlContent = '<h1>Styling Guide</h1><p>Content</p>';
 	var fragment_17 = root_77();
-	var node_84 = _$_.first_child_frag(fragment_17);
+	var node_74 = _$_.first_child_frag(fragment_17);
 
 	DocsLayoutExact(
-		node_84,
+		node_74,
 		{
 			editPath: "docs/guide/styling.md",
 			prevLink: { href: '/prev', text: 'Previous' },
@@ -1868,24 +1898,24 @@ export function DocsLayoutExactWithData(__anchor, _, __block) {
 				{ href: '#usage', text: 'Usage' }
 			],
 
-			children(__anchor, _, __block) {
+			children: _$_.ripple_element(function render_children(__anchor, _, __block) {
 				_$_.push_component();
 
 				var div_64 = root_78();
 
 				{
-					var node_85 = _$_.child(div_64);
+					var node_75 = _$_.child(div_64);
 
 					_$_.pop(div_64);
 				}
 
 				_$_.render(() => {
-					_$_.html(node_85, () => htmlContent);
+					_$_.html(node_75, () => htmlContent);
 				});
 
 				_$_.append(__anchor, div_64);
 				_$_.pop_component();
-			}
+			})
 		},
 		_$_.active_block
 	);
@@ -1903,33 +1933,33 @@ export function DocsLayoutExactWithoutData(__anchor, _, __block) {
 	const nextLink = undefined;
 	const toc = undefined;
 	var fragment_18 = root_79();
-	var node_86 = _$_.first_child_frag(fragment_18);
+	var node_76 = _$_.first_child_frag(fragment_18);
 
 	DocsLayoutExact(
-		node_86,
+		node_76,
 		{
 			editPath,
 			prevLink,
 			nextLink,
 			toc,
-			children(__anchor, _, __block) {
+			children: _$_.ripple_element(function render_children(__anchor, _, __block) {
 				_$_.push_component();
 
 				var div_65 = root_80();
 
 				{
-					var node_87 = _$_.child(div_65);
+					var node_77 = _$_.child(div_65);
 
 					_$_.pop(div_65);
 				}
 
 				_$_.render(() => {
-					_$_.html(node_87, () => htmlContent);
+					_$_.html(node_77, () => htmlContent);
 				});
 
 				_$_.append(__anchor, div_65);
 				_$_.pop_component();
-			}
+			})
 		},
 		_$_.active_block
 	);
@@ -1985,16 +2015,24 @@ function LayoutWithTemplate(__anchor, { children, data }, __block) {
 		var main_4 = _$_.sibling(template_3);
 
 		{
-			var node_88 = _$_.child(main_4);
+			var expression_19 = _$_.child(main_4);
 
-			children(node_88, {}, _$_.active_block);
 			_$_.pop(main_4);
 		}
 	}
 
-	_$_.render(() => {
-		template_3.innerHTML = _$_.with_scope(__block, () => JSON.stringify(data));
-	});
+	_$_.render(
+		(__prev) => {
+			var __a = _$_.with_scope(__block, () => JSON.stringify(data));
+
+			if (__prev.a !== __a) {
+				template_3.innerHTML = __prev.a = __a;
+			}
+
+			_$_.expression(expression_19, () => children);
+		},
+		{ a: '' }
+	);
 
 	_$_.append(__anchor, div_68);
 	_$_.pop_component();
@@ -2005,30 +2043,30 @@ export function NestedTemplateInLayout(__anchor, _, __block) {
 
 	const doc = { title: 'Comparison', html: '<p>Content</p>' };
 	var fragment_19 = root_84();
-	var node_89 = _$_.first_child_frag(fragment_19);
+	var node_78 = _$_.first_child_frag(fragment_19);
 
 	LayoutWithTemplate(
-		node_89,
+		node_78,
 		{
 			data: doc,
-			children(__anchor, _, __block) {
+			children: _$_.ripple_element(function render_children(__anchor, _, __block) {
 				_$_.push_component();
 
 				var div_69 = root_85();
 
 				{
-					var node_90 = _$_.child(div_69);
+					var node_79 = _$_.child(div_69);
 
 					_$_.pop(div_69);
 				}
 
 				_$_.render(() => {
-					_$_.html(node_90, () => doc.html);
+					_$_.html(node_79, () => doc.html);
 				});
 
 				_$_.append(__anchor, div_69);
 				_$_.pop_component();
-			}
+			})
 		},
 		_$_.active_block
 	);

--- a/packages/ripple/tests/hydration/compiled/client/if-children.js
+++ b/packages/ripple/tests/hydration/compiled/client/if-children.js
@@ -42,11 +42,14 @@ export function IfWithChildren(__anchor, { children }, __block) {
 				var div_3 = root_1();
 
 				{
-					var node_1 = _$_.child(div_3);
+					var expression = _$_.child(div_3);
 
-					children(node_1, {}, _$_.active_block);
 					_$_.pop(div_3);
 				}
+
+				_$_.render(() => {
+					_$_.expression(expression, () => children);
+				});
 
 				_$_.append(__anchor, div_3);
 			};
@@ -69,9 +72,9 @@ export function ChildItem(__anchor, { text: label }, __block) {
 	var div_4 = root_2();
 
 	{
-		var expression = _$_.child(div_4, true);
+		var expression_1 = _$_.child(div_4, true);
 
-		expression.nodeValue = label;
+		expression_1.nodeValue = label;
 		_$_.pop(div_4);
 	}
 
@@ -83,25 +86,25 @@ export function TestIfWithChildren(__anchor, _, __block) {
 	_$_.push_component();
 
 	var fragment = root_3();
-	var node_2 = _$_.first_child_frag(fragment);
+	var node_1 = _$_.first_child_frag(fragment);
 
 	IfWithChildren(
-		node_2,
+		node_1,
 		{
-			children(__anchor, _, __block) {
+			children: _$_.ripple_element(function render_children(__anchor, _, __block) {
 				_$_.push_component();
 
 				var fragment_1 = root_4();
-				var node_3 = _$_.first_child_frag(fragment_1);
+				var node_2 = _$_.first_child_frag(fragment_1);
 
-				ChildItem(node_3, { text: "Item 1" }, _$_.active_block);
+				ChildItem(node_2, { text: "Item 1" }, _$_.active_block);
 
-				var node_4 = _$_.sibling(node_3);
+				var node_3 = _$_.sibling(node_2);
 
-				ChildItem(node_4, { text: "Item 2" }, _$_.active_block);
+				ChildItem(node_3, { text: "Item 2" }, _$_.active_block);
 				_$_.append(__anchor, fragment_1);
 				_$_.pop_component();
-			}
+			})
 		},
 		_$_.active_block
 	);
@@ -121,7 +124,7 @@ export function IfWithStaticChildren(__anchor, _, __block) {
 
 		div_6.__click = () => _$_.set(lazy_1, !_$_.get(lazy_1));
 
-		var node_5 = _$_.sibling(div_6);
+		var node_4 = _$_.sibling(div_6);
 
 		{
 			var consequent_1 = (__anchor) => {
@@ -130,7 +133,7 @@ export function IfWithStaticChildren(__anchor, _, __block) {
 				_$_.append(__anchor, div_7);
 			};
 
-			_$_.if(node_5, (__render) => {
+			_$_.if(node_4, (__render) => {
 				if (_$_.get(lazy_1)) __render(consequent_1);
 			});
 		}
@@ -154,23 +157,26 @@ export function IfWithSiblingsAndChildren(__anchor, { children }, __block) {
 		div_8.__click = () => _$_.set(lazy_2, !_$_.get(lazy_2));
 		_$_.pop(div_8);
 
-		var node_6 = _$_.sibling(div_8);
+		var node_5 = _$_.sibling(div_8);
 
 		{
 			var consequent_2 = (__anchor) => {
 				var div_9 = root_8();
 
 				{
-					var node_7 = _$_.child(div_9);
+					var expression_2 = _$_.child(div_9);
 
-					children(node_7, {}, _$_.active_block);
 					_$_.pop(div_9);
 				}
+
+				_$_.render(() => {
+					_$_.expression(expression_2, () => children);
+				});
 
 				_$_.append(__anchor, div_9);
 			};
 
-			_$_.if(node_6, (__render) => {
+			_$_.if(node_5, (__render) => {
 				if (_$_.get(lazy_2)) __render(consequent_2);
 			});
 		}
@@ -186,25 +192,25 @@ export function TestIfWithSiblingsAndChildren(__anchor, _, __block) {
 	_$_.push_component();
 
 	var fragment_2 = root_9();
-	var node_8 = _$_.first_child_frag(fragment_2);
+	var node_6 = _$_.first_child_frag(fragment_2);
 
 	IfWithSiblingsAndChildren(
-		node_8,
+		node_6,
 		{
-			children(__anchor, _, __block) {
+			children: _$_.ripple_element(function render_children(__anchor, _, __block) {
 				_$_.push_component();
 
 				var fragment_3 = root_10();
-				var node_9 = _$_.first_child_frag(fragment_3);
+				var node_7 = _$_.first_child_frag(fragment_3);
 
-				ChildItem(node_9, { text: "Item A" }, _$_.active_block);
+				ChildItem(node_7, { text: "Item A" }, _$_.active_block);
 
-				var node_10 = _$_.sibling(node_9);
+				var node_8 = _$_.sibling(node_7);
 
-				ChildItem(node_10, { text: "Item B" }, _$_.active_block);
+				ChildItem(node_8, { text: "Item B" }, _$_.active_block);
 				_$_.append(__anchor, fragment_3);
 				_$_.pop_component();
-			}
+			})
 		},
 		_$_.active_block
 	);
@@ -225,7 +231,7 @@ export function ElementWithChildrenThenIf(__anchor, _, __block) {
 
 		_$_.pop(div_10);
 
-		var node_11 = _$_.sibling(div_10);
+		var node_9 = _$_.sibling(div_10);
 
 		{
 			var consequent_3 = (__anchor) => {
@@ -234,7 +240,7 @@ export function ElementWithChildrenThenIf(__anchor, _, __block) {
 				_$_.append(__anchor, div_12);
 			};
 
-			_$_.if(node_11, (__render) => {
+			_$_.if(node_9, (__render) => {
 				if (_$_.get(lazy_3)) __render(consequent_3);
 			});
 		}
@@ -262,7 +268,7 @@ export function DeepNestingThenIf(__anchor, _, __block) {
 
 		_$_.pop(article_1);
 
-		var node_12 = _$_.sibling(article_1);
+		var node_10 = _$_.sibling(article_1);
 
 		{
 			var consequent_4 = (__anchor) => {
@@ -271,7 +277,7 @@ export function DeepNestingThenIf(__anchor, _, __block) {
 				_$_.append(__anchor, footer_1);
 			};
 
-			_$_.if(node_12, (__render) => {
+			_$_.if(node_10, (__render) => {
 				if (_$_.get(lazy_4)) __render(consequent_4);
 			});
 		}
@@ -311,7 +317,7 @@ export function DomElementChildrenThenSibling(__anchor, _, __block) {
 		var div_15 = _$_.sibling(div_14);
 
 		{
-			var node_13 = _$_.child(div_15);
+			var node_11 = _$_.child(div_15);
 
 			{
 				var consequent_5 = (__anchor) => {
@@ -326,7 +332,7 @@ export function DomElementChildrenThenSibling(__anchor, _, __block) {
 					_$_.append(__anchor, div_16);
 				};
 
-				_$_.if(node_13, (__render) => {
+				_$_.if(node_11, (__render) => {
 					if (_$_.get(lazy_5) === 'code') __render(consequent_5); else __render(alternate, false);
 				});
 			}
@@ -370,7 +376,7 @@ export function DomChildrenThenStaticSiblings(__anchor, _, __block) {
 			var li_1 = _$_.child(ul_1);
 
 			{
-				var expression_1 = _$_.child(li_1, true);
+				var expression_3 = _$_.child(li_1, true);
 
 				_$_.pop(li_1);
 			}
@@ -385,7 +391,7 @@ export function DomChildrenThenStaticSiblings(__anchor, _, __block) {
 	_$_.next();
 
 	_$_.render(() => {
-		_$_.set_text(expression_1, 'Item count: ' + _$_.with_scope(__block, () => String(_$_.get(lazy_6))));
+		_$_.set_text(expression_3, 'Item count: ' + _$_.with_scope(__block, () => String(_$_.get(lazy_6))));
 	});
 
 	_$_.append(__anchor, fragment_6, true);

--- a/packages/ripple/tests/hydration/compiled/client/portal.js
+++ b/packages/ripple/tests/hydration/compiled/client/portal.js
@@ -29,14 +29,14 @@ export function SimplePortal(__anchor, _, __block) {
 					return typeof document !== 'undefined' ? document.body : null;
 				},
 
-				children(__anchor, _, __block) {
+				children: _$_.ripple_element(function render_children(__anchor, _, __block) {
 					_$_.push_component();
 
 					var div_2 = root_1();
 
 					_$_.append(__anchor, div_2);
 					_$_.pop_component();
-				}
+				})
 			},
 			_$_.active_block
 		);
@@ -73,14 +73,14 @@ export function ConditionalPortal(__anchor, _, __block) {
 							return typeof document !== 'undefined' ? document.body : null;
 						},
 
-						children(__anchor, _, __block) {
+						children: _$_.ripple_element(function render_children(__anchor, _, __block) {
 							_$_.push_component();
 
 							var div_4 = root_4();
 
 							_$_.append(__anchor, div_4);
 							_$_.pop_component();
-						}
+						})
 					},
 					_$_.active_block
 				);
@@ -116,14 +116,14 @@ export function PortalWithMainContent(__anchor, _, __block) {
 					return typeof document !== 'undefined' ? document.body : null;
 				},
 
-				children(__anchor, _, __block) {
+				children: _$_.ripple_element(function render_children(__anchor, _, __block) {
 					_$_.push_component();
 
 					var div_7 = root_6();
 
 					_$_.append(__anchor, div_7);
 					_$_.pop_component();
-				}
+				})
 			},
 			_$_.active_block
 		);
@@ -154,14 +154,14 @@ export function NestedContentWithPortal(__anchor, _, __block) {
 					return typeof document !== 'undefined' ? document.body : null;
 				},
 
-				children(__anchor, _, __block) {
+				children: _$_.ripple_element(function render_children(__anchor, _, __block) {
 					_$_.push_component();
 
 					var div_10 = root_8();
 
 					_$_.append(__anchor, div_10);
 					_$_.pop_component();
-				}
+				})
 			},
 			_$_.active_block
 		);

--- a/packages/ripple/tests/hydration/compiled/server/basic.js
+++ b/packages/ripple/tests/hydration/compiled/server/basic.js
@@ -366,39 +366,26 @@ function Actions(__output, { playgroundVisible = false }) {
 	_$_.pop_component();
 }
 
-async function Layout(__output, { children }) {
-	return _$_.async(async () => {
-		_$_.push_component();
-		__output.push('<main');
+function Layout(__output, { children }) {
+	_$_.push_component();
+	__output.push('<main');
+	__output.push('>');
+
+	{
+		__output.push('<div');
+		__output.push(' class="container"');
 		__output.push('>');
 
 		{
-			__output.push('<div');
-			__output.push(' class="container"');
-			__output.push('>');
-
-			{
-				{
-					const comp = children;
-					const args = [__output, {}];
-
-					if (comp?.async) {
-						await comp(...args);
-					} else if (comp) {
-						comp(...args);
-					}
-				}
-			}
-
-			__output.push('</div>');
+			_$_.render_expression(__output, children);
 		}
 
-		__output.push('</main>');
-		_$_.pop_component();
-	});
-}
+		__output.push('</div>');
+	}
 
-Layout.async = true;
+	__output.push('</main>');
+	_$_.pop_component();
+}
 
 function Content(__output) {
 	_$_.push_component();
@@ -430,7 +417,7 @@ export function WebsiteIndex(__output) {
 		const args = [
 			__output,
 			{
-				children: function children(__output) {
+				children: _$_.ripple_element(function render_children(__output) {
 					_$_.push_component();
 
 					{
@@ -462,7 +449,7 @@ export function WebsiteIndex(__output) {
 					}
 
 					_$_.pop_component();
-				}
+				})
 			}
 		];
 

--- a/packages/ripple/tests/hydration/compiled/server/basic.js
+++ b/packages/ripple/tests/hydration/compiled/server/basic.js
@@ -240,20 +240,7 @@ function TextProp(__output, __props) {
 	_$_.pop_component();
 }
 
-export function ServerTextPropWithContent(__output) {
-	_$_.push_component();
-
-	{
-		const comp = TextProp;
-		const args = [__output, { children: _$_.normalize_children("hello") }];
-
-		comp(...args);
-	}
-
-	_$_.pop_component();
-}
-
-export function ClientTextPropRestoresAfterHydration(__output) {
+export function TextPropWithToggle(__output) {
 	_$_.push_component();
 
 	let lazy = _$_.track(false);

--- a/packages/ripple/tests/hydration/compiled/server/basic.js
+++ b/packages/ripple/tests/hydration/compiled/server/basic.js
@@ -1,6 +1,8 @@
 // @ts-nocheck
 import * as _$_ from 'ripple/internal/server';
 
+import { track } from 'ripple/server';
+
 export function StaticText(__output) {
 	_$_.push_component();
 	__output.push('<div');
@@ -221,6 +223,63 @@ export function ExpressionContent(__output) {
 	}
 
 	__output.push('</span>');
+	_$_.pop_component();
+}
+
+function TextProp(__output, __props) {
+	_$_.push_component();
+	__output.push('<div');
+	__output.push(' class="text-prop"');
+	__output.push('>');
+
+	{
+		_$_.render_expression(__output, __props.children);
+	}
+
+	__output.push('</div>');
+	_$_.pop_component();
+}
+
+export function ServerTextPropWithContent(__output) {
+	_$_.push_component();
+
+	{
+		const comp = TextProp;
+		const args = [__output, { children: _$_.normalize_children("hello") }];
+
+		comp(...args);
+	}
+
+	_$_.pop_component();
+}
+
+export function ClientTextPropRestoresAfterHydration(__output) {
+	_$_.push_component();
+
+	let lazy = _$_.track(false);
+
+	{
+		const comp = TextProp;
+
+		const args = [
+			__output,
+			{
+				children: _$_.normalize_children(_$_.get(lazy) ? 'hello' : '')
+			}
+		];
+
+		comp(...args);
+	}
+
+	__output.push('<button');
+	__output.push(' class="show-text"');
+	__output.push('>');
+
+	{
+		__output.push('Show');
+	}
+
+	__output.push('</button>');
 	_$_.pop_component();
 }
 

--- a/packages/ripple/tests/hydration/compiled/server/composite.js
+++ b/packages/ripple/tests/hydration/compiled/server/composite.js
@@ -1,32 +1,35 @@
 // @ts-nocheck
 import * as _$_ from 'ripple/internal/server';
 
-export async function Layout(__output, __props) {
-	return _$_.async(async () => {
-		_$_.push_component();
-		__output.push('<div');
-		__output.push(' class="layout"');
-		__output.push('>');
+export function Layout(__output, __props) {
+	_$_.push_component();
+	__output.push('<div');
+	__output.push(' class="layout"');
+	__output.push('>');
 
-		{
-			{
-				const comp = __props.children;
-				const args = [__output, {}];
+	{
+		_$_.render_expression(__output, __props.children);
+	}
 
-				if (comp?.async) {
-					await comp(...args);
-				} else if (comp) {
-					comp(...args);
-				}
-			}
-		}
-
-		__output.push('</div>');
-		_$_.pop_component();
-	});
+	__output.push('</div>');
+	_$_.pop_component();
 }
 
-Layout.async = true;
+export function TextWrappedLayout(__output, __props) {
+	_$_.push_component();
+	__output.push('<div');
+	__output.push(' class="layout"');
+	__output.push('>');
+
+	{
+		__output.push('before');
+		_$_.render_expression(__output, __props.children);
+		__output.push('after');
+	}
+
+	__output.push('</div>');
+	_$_.pop_component();
+}
 
 export function SingleChild(__output) {
 	_$_.push_component();
@@ -85,7 +88,7 @@ export function LayoutWithSingleChild(__output) {
 		const args = [
 			__output,
 			{
-				children: function children(__output) {
+				children: _$_.ripple_element(function render_children(__output) {
 					_$_.push_component();
 
 					{
@@ -96,7 +99,7 @@ export function LayoutWithSingleChild(__output) {
 					}
 
 					_$_.pop_component();
-				}
+				})
 			}
 		];
 
@@ -115,7 +118,7 @@ export function LayoutWithMultipleChildren(__output) {
 		const args = [
 			__output,
 			{
-				children: function children(__output) {
+				children: _$_.ripple_element(function render_children(__output) {
 					_$_.push_component();
 
 					{
@@ -135,7 +138,7 @@ export function LayoutWithMultipleChildren(__output) {
 
 					__output.push('</div>');
 					_$_.pop_component();
-				}
+				})
 			}
 		];
 
@@ -154,7 +157,7 @@ export function LayoutWithMultiRootChild(__output) {
 		const args = [
 			__output,
 			{
-				children: function children(__output) {
+				children: _$_.ripple_element(function render_children(__output) {
 					_$_.push_component();
 
 					{
@@ -165,7 +168,37 @@ export function LayoutWithMultiRootChild(__output) {
 					}
 
 					_$_.pop_component();
-				}
+				})
+			}
+		];
+
+		comp(...args);
+	}
+
+	_$_.pop_component();
+}
+
+export function LayoutWithTextAroundChildren(__output) {
+	_$_.push_component();
+
+	{
+		const comp = TextWrappedLayout;
+
+		const args = [
+			__output,
+			{
+				children: _$_.ripple_element(function render_children(__output) {
+					_$_.push_component();
+
+					{
+						const comp = SingleChild;
+						const args = [__output, {}];
+
+						comp(...args);
+					}
+
+					_$_.pop_component();
+				})
 			}
 		];
 

--- a/packages/ripple/tests/hydration/compiled/server/hmr.js
+++ b/packages/ripple/tests/hydration/compiled/server/hmr.js
@@ -3,49 +3,36 @@ import * as _$_ from 'ripple/internal/server';
 
 import { track } from 'ripple/server';
 
-export async function Layout(__output, { children }) {
-	return _$_.async(async () => {
-		_$_.push_component();
-		__output.push('<div');
-		__output.push(' class="layout"');
+export function Layout(__output, { children }) {
+	_$_.push_component();
+	__output.push('<div');
+	__output.push(' class="layout"');
+	__output.push('>');
+
+	{
+		__output.push('<nav');
+		__output.push(' class="nav"');
 		__output.push('>');
 
 		{
-			__output.push('<nav');
-			__output.push(' class="nav"');
-			__output.push('>');
-
-			{
-				__output.push('Navigation');
-			}
-
-			__output.push('</nav>');
-			__output.push('<main');
-			__output.push(' class="main"');
-			__output.push('>');
-
-			{
-				{
-					const comp = children;
-					const args = [__output, {}];
-
-					if (comp?.async) {
-						await comp(...args);
-					} else if (comp) {
-						comp(...args);
-					}
-				}
-			}
-
-			__output.push('</main>');
+			__output.push('Navigation');
 		}
 
-		__output.push('</div>');
-		_$_.pop_component();
-	});
-}
+		__output.push('</nav>');
+		__output.push('<main');
+		__output.push(' class="main"');
+		__output.push('>');
 
-Layout.async = true;
+		{
+			_$_.render_expression(__output, children);
+		}
+
+		__output.push('</main>');
+	}
+
+	__output.push('</div>');
+	_$_.pop_component();
+}
 
 export function Content(__output) {
 	_$_.push_component();
@@ -87,7 +74,7 @@ export function LayoutWithContent(__output) {
 		const args = [
 			__output,
 			{
-				children: function children(__output) {
+				children: _$_.ripple_element(function render_children(__output) {
 					_$_.push_component();
 
 					{
@@ -98,7 +85,7 @@ export function LayoutWithContent(__output) {
 					}
 
 					_$_.pop_component();
-				}
+				})
 			}
 		];
 

--- a/packages/ripple/tests/hydration/compiled/server/html.js
+++ b/packages/ripple/tests/hydration/compiled/server/html.js
@@ -133,40 +133,27 @@ export function HtmlWithReactivity(__output) {
 	_$_.pop_component();
 }
 
-export async function HtmlWrapper(__output, { children }) {
-	return _$_.async(async () => {
-		_$_.push_component();
+export function HtmlWrapper(__output, { children }) {
+	_$_.push_component();
+	__output.push('<div');
+	__output.push(' class="wrapper"');
+	__output.push('>');
+
+	{
 		__output.push('<div');
-		__output.push(' class="wrapper"');
+		__output.push(' class="inner"');
 		__output.push('>');
 
 		{
-			__output.push('<div');
-			__output.push(' class="inner"');
-			__output.push('>');
-
-			{
-				{
-					const comp = children;
-					const args = [__output, {}];
-
-					if (comp?.async) {
-						await comp(...args);
-					} else if (comp) {
-						comp(...args);
-					}
-				}
-			}
-
-			__output.push('</div>');
+			_$_.render_expression(__output, children);
 		}
 
 		__output.push('</div>');
-		_$_.pop_component();
-	});
-}
+	}
 
-HtmlWrapper.async = true;
+	__output.push('</div>');
+	_$_.pop_component();
+}
 
 export function HtmlInChildren(__output) {
 	_$_.push_component();
@@ -179,7 +166,7 @@ export function HtmlInChildren(__output) {
 		const args = [
 			__output,
 			{
-				children: function children(__output) {
+				children: _$_.ripple_element(function render_children(__output) {
 					_$_.push_component();
 					__output.push('<div');
 					__output.push(' class="vp-doc"');
@@ -195,7 +182,7 @@ export function HtmlInChildren(__output) {
 
 					__output.push('</div>');
 					_$_.pop_component();
-				}
+				})
 			}
 		];
 
@@ -216,7 +203,7 @@ export function HtmlInChildrenWithSiblings(__output) {
 		const args = [
 			__output,
 			{
-				children: function children(__output) {
+				children: _$_.ripple_element(function render_children(__output) {
 					_$_.push_component();
 					__output.push('<h1');
 					__output.push('>');
@@ -240,7 +227,7 @@ export function HtmlInChildrenWithSiblings(__output) {
 
 					__output.push('</div>');
 					_$_.pop_component();
-				}
+				})
 			}
 		];
 
@@ -262,7 +249,7 @@ export function MultipleHtmlInChildren(__output) {
 		const args = [
 			__output,
 			{
-				children: function children(__output) {
+				children: _$_.ripple_element(function render_children(__output) {
 					_$_.push_component();
 					__output.push('<div');
 					__output.push(' class="doc"');
@@ -284,7 +271,7 @@ export function MultipleHtmlInChildren(__output) {
 
 					__output.push('</div>');
 					_$_.pop_component();
-				}
+				})
 			}
 		];
 
@@ -345,7 +332,7 @@ export function HtmlWithCommentsInChildren(__output) {
 		const args = [
 			__output,
 			{
-				children: function children(__output) {
+				children: _$_.ripple_element(function render_children(__output) {
 					_$_.push_component();
 					__output.push('<div');
 					__output.push(' class="vp-doc"');
@@ -361,7 +348,7 @@ export function HtmlWithCommentsInChildren(__output) {
 
 					__output.push('</div>');
 					_$_.pop_component();
-				}
+				})
 			}
 		];
 
@@ -385,160 +372,147 @@ function DocFooter(__output) {
 	_$_.pop_component();
 }
 
-export async function DocLayout(
+export function DocLayout(
 	__output,
 	{ children, editPath = '', nextLink = null, toc = [] }
 ) {
-	return _$_.async(async () => {
-		_$_.push_component();
+	_$_.push_component();
+	__output.push('<div');
+	__output.push(' class="layout"');
+	__output.push('>');
+
+	{
 		__output.push('<div');
-		__output.push(' class="layout"');
+		__output.push(' class="content-container"');
 		__output.push('>');
 
 		{
-			__output.push('<div');
-			__output.push(' class="content-container"');
+			__output.push('<article');
 			__output.push('>');
 
 			{
-				__output.push('<article');
+				__output.push('<div');
 				__output.push('>');
 
 				{
-					__output.push('<div');
-					__output.push('>');
-
-					{
-						{
-							const comp = children;
-							const args = [__output, {}];
-
-							if (comp?.async) {
-								await comp(...args);
-							} else if (comp) {
-								comp(...args);
-							}
-						}
-					}
-
-					__output.push('</div>');
+					_$_.render_expression(__output, children);
 				}
 
-				__output.push('</article>');
-				__output.push('<!--[-->');
+				__output.push('</div>');
+			}
 
-				if (editPath) {
-					__output.push('<div');
-					__output.push(' class="edit-link"');
-					__output.push('>');
+			__output.push('</article>');
+			__output.push('<!--[-->');
 
-					{
-						__output.push('<a');
-						__output.push(_$_.attr('href', `https://github.com/edit/${editPath}`, false));
-						__output.push('>');
-
-						{
-							__output.push('Edit');
-						}
-
-						__output.push('</a>');
-					}
-
-					__output.push('</div>');
-				}
-
-				__output.push('<!--]-->');
-				__output.push('<!--[-->');
-
-				if (nextLink) {
-					__output.push('<nav');
-					__output.push(' class="prev-next"');
-					__output.push('>');
-
-					{
-						__output.push('<a');
-						__output.push(_$_.attr('href', nextLink.href, false));
-						__output.push('>');
-
-						{
-							__output.push(_$_.escape(nextLink.text));
-						}
-
-						__output.push('</a>');
-					}
-
-					__output.push('</nav>');
-				}
-
-				__output.push('<!--]-->');
+			if (editPath) {
+				__output.push('<div');
+				__output.push(' class="edit-link"');
+				__output.push('>');
 
 				{
-					const comp = DocFooter;
-					const args = [__output, {}];
-
-					comp(...args);
-				}
-			}
-
-			__output.push('</div>');
-			__output.push('<aside');
-			__output.push('>');
-
-			{
-				__output.push('<!--[-->');
-
-				if (toc.length > 0) {
-					__output.push('<div');
-					__output.push(' class="toc"');
+					__output.push('<a');
+					__output.push(_$_.attr('href', `https://github.com/edit/${editPath}`, false));
 					__output.push('>');
 
 					{
-						__output.push('<ul');
-						__output.push('>');
-
-						{
-							__output.push('<!--[-->');
-
-							for (const item of toc) {
-								__output.push('<li');
-								__output.push('>');
-
-								{
-									__output.push('<a');
-									__output.push(_$_.attr('href', item.href, false));
-									__output.push('>');
-
-									{
-										__output.push(_$_.escape(item.text));
-									}
-
-									__output.push('</a>');
-								}
-
-								__output.push('</li>');
-							}
-
-							__output.push('<!--]-->');
-						}
-
-						__output.push('</ul>');
+						__output.push('Edit');
 					}
 
-					__output.push('</div>');
+					__output.push('</a>');
 				}
 
-				__output.push('<!--]-->');
+				__output.push('</div>');
 			}
 
-			__output.push('</aside>');
+			__output.push('<!--]-->');
+			__output.push('<!--[-->');
+
+			if (nextLink) {
+				__output.push('<nav');
+				__output.push(' class="prev-next"');
+				__output.push('>');
+
+				{
+					__output.push('<a');
+					__output.push(_$_.attr('href', nextLink.href, false));
+					__output.push('>');
+
+					{
+						__output.push(_$_.escape(nextLink.text));
+					}
+
+					__output.push('</a>');
+				}
+
+				__output.push('</nav>');
+			}
+
+			__output.push('<!--]-->');
+
+			{
+				const comp = DocFooter;
+				const args = [__output, {}];
+
+				comp(...args);
+			}
 		}
 
 		__output.push('</div>');
-		_$_.pop_component();
-	});
-}
+		__output.push('<aside');
+		__output.push('>');
 
-DocLayout.async = true;
+		{
+			__output.push('<!--[-->');
+
+			if (toc.length > 0) {
+				__output.push('<div');
+				__output.push(' class="toc"');
+				__output.push('>');
+
+				{
+					__output.push('<ul');
+					__output.push('>');
+
+					{
+						__output.push('<!--[-->');
+
+						for (const item of toc) {
+							__output.push('<li');
+							__output.push('>');
+
+							{
+								__output.push('<a');
+								__output.push(_$_.attr('href', item.href, false));
+								__output.push('>');
+
+								{
+									__output.push(_$_.escape(item.text));
+								}
+
+								__output.push('</a>');
+							}
+
+							__output.push('</li>');
+						}
+
+						__output.push('<!--]-->');
+					}
+
+					__output.push('</ul>');
+				}
+
+				__output.push('</div>');
+			}
+
+			__output.push('<!--]-->');
+		}
+
+		__output.push('</aside>');
+	}
+
+	__output.push('</div>');
+	_$_.pop_component();
+}
 
 export function HtmlWithServerData(__output) {
 	_$_.push_component();
@@ -558,7 +532,7 @@ export function HtmlWithServerData(__output) {
 					{ href: '#features', text: 'Features' }
 				],
 
-				children: function children(__output) {
+				children: _$_.ripple_element(function render_children(__output) {
 					_$_.push_component();
 					__output.push('<div');
 					__output.push(' class="vp-doc"');
@@ -574,7 +548,7 @@ export function HtmlWithServerData(__output) {
 
 					__output.push('</div>');
 					_$_.pop_component();
-				}
+				})
 			}
 		];
 
@@ -595,7 +569,7 @@ export function HtmlWithClientDefaults(__output) {
 		const args = [
 			__output,
 			{
-				children: function children(__output) {
+				children: _$_.ripple_element(function render_children(__output) {
 					_$_.push_component();
 					__output.push('<div');
 					__output.push(' class="vp-doc"');
@@ -611,7 +585,7 @@ export function HtmlWithClientDefaults(__output) {
 
 					__output.push('</div>');
 					_$_.pop_component();
-				}
+				})
 			}
 		];
 
@@ -632,7 +606,7 @@ export function HtmlWithUndefinedContent(__output) {
 		const args = [
 			__output,
 			{
-				children: function children(__output) {
+				children: _$_.ripple_element(function render_children(__output) {
 					_$_.push_component();
 					__output.push('<div');
 					__output.push(' class="vp-doc"');
@@ -648,7 +622,7 @@ export function HtmlWithUndefinedContent(__output) {
 
 					__output.push('</div>');
 					_$_.pop_component();
-				}
+				})
 			}
 		];
 
@@ -658,55 +632,33 @@ export function HtmlWithUndefinedContent(__output) {
 	_$_.pop_component();
 }
 
-async function DynamicHeading(__output, { level, children }) {
-	return _$_.async(async () => {
-		_$_.push_component();
-		__output.push('<!--[-->');
+function DynamicHeading(__output, { level, children }) {
+	_$_.push_component();
+	__output.push('<!--[-->');
 
-		switch (level) {
-			case 1:
-				__output.push('<h1');
-				__output.push(' class="heading"');
-				__output.push('>');
-				{
-					{
-						const comp = children;
-						const args = [__output, {}];
+	switch (level) {
+		case 1:
+			__output.push('<h1');
+			__output.push(' class="heading"');
+			__output.push('>');
+			{
+				_$_.render_expression(__output, children);
+			}
+			__output.push('</h1>');
 
-						if (comp?.async) {
-							await comp(...args);
-						} else if (comp) {
-							comp(...args);
-						}
-					}
-				}
-				__output.push('</h1>');
+		case 2:
+			__output.push('<h2');
+			__output.push(' class="heading"');
+			__output.push('>');
+			{
+				_$_.render_expression(__output, children);
+			}
+			__output.push('</h2>');
+	}
 
-			case 2:
-				__output.push('<h2');
-				__output.push(' class="heading"');
-				__output.push('>');
-				{
-					{
-						const comp = children;
-						const args = [__output, {}];
-
-						if (comp?.async) {
-							await comp(...args);
-						} else if (comp) {
-							comp(...args);
-						}
-					}
-				}
-				__output.push('</h2>');
-		}
-
-		__output.push('<!--]-->');
-		_$_.pop_component();
-	});
+	__output.push('<!--]-->');
+	_$_.pop_component();
 }
-
-DynamicHeading.async = true;
 
 function CodeBlock(__output, { code }) {
 	_$_.push_component();
@@ -762,40 +714,27 @@ function CodeBlock(__output, { code }) {
 	_$_.pop_component();
 }
 
-async function ContentWrapper(__output, { children }) {
-	return _$_.async(async () => {
-		_$_.push_component();
+function ContentWrapper(__output, { children }) {
+	_$_.push_component();
+	__output.push('<div');
+	__output.push(' class="wrapper"');
+	__output.push('>');
+
+	{
 		__output.push('<div');
-		__output.push(' class="wrapper"');
+		__output.push(' class="inner"');
 		__output.push('>');
 
 		{
-			__output.push('<div');
-			__output.push(' class="inner"');
-			__output.push('>');
-
-			{
-				{
-					const comp = children;
-					const args = [__output, {}];
-
-					if (comp?.async) {
-						await comp(...args);
-					} else if (comp) {
-						comp(...args);
-					}
-				}
-			}
-
-			__output.push('</div>');
+			_$_.render_expression(__output, children);
 		}
 
 		__output.push('</div>');
-		_$_.pop_component();
-	});
-}
+	}
 
-ContentWrapper.async = true;
+	__output.push('</div>');
+	_$_.pop_component();
+}
 
 export function HtmlAfterSwitchInChildren(__output) {
 	_$_.push_component();
@@ -806,7 +745,7 @@ export function HtmlAfterSwitchInChildren(__output) {
 		const args = [
 			__output,
 			{
-				children: function children(__output) {
+				children: _$_.ripple_element(function render_children(__output) {
 					_$_.push_component();
 
 					{
@@ -816,11 +755,11 @@ export function HtmlAfterSwitchInChildren(__output) {
 							__output,
 							{
 								level: 1,
-								children: function children(__output) {
+								children: _$_.ripple_element(function render_children(__output) {
 									_$_.push_component();
 									__output.push('Title');
 									_$_.pop_component();
-								}
+								})
 							}
 						];
 
@@ -860,7 +799,7 @@ export function HtmlAfterSwitchInChildren(__output) {
 
 					__output.push('</p>');
 					_$_.pop_component();
-				}
+				})
 			}
 		];
 
@@ -909,73 +848,60 @@ function NavItem(__output, { href, text: label, active = false }) {
 	_$_.pop_component();
 }
 
-async function SidebarSection(__output, { title, children }) {
-	return _$_.async(async () => {
-		_$_.push_component();
+function SidebarSection(__output, { title, children }) {
+	_$_.push_component();
 
-		let lazy = _$_.track(true);
+	let lazy = _$_.track(true);
 
-		__output.push('<section');
-		__output.push(' class="sidebar-section"');
+	__output.push('<section');
+	__output.push(' class="sidebar-section"');
+	__output.push('>');
+
+	{
+		__output.push('<div');
+		__output.push(' class="section-header"');
 		__output.push('>');
 
 		{
-			__output.push('<div');
-			__output.push(' class="section-header"');
+			__output.push('<h2');
 			__output.push('>');
 
 			{
-				__output.push('<h2');
-				__output.push('>');
+				__output.push(_$_.escape(title));
+			}
 
-				{
-					__output.push(_$_.escape(title));
-				}
+			__output.push('</h2>');
+			__output.push('<button');
+			__output.push('>');
 
-				__output.push('</h2>');
-				__output.push('<button');
-				__output.push('>');
+			{
+				__output.push('Toggle');
+			}
 
-				{
-					__output.push('Toggle');
-				}
+			__output.push('</button>');
+		}
 
-				__output.push('</button>');
+		__output.push('</div>');
+		__output.push('<!--[-->');
+
+		if (_$_.get(lazy)) {
+			__output.push('<div');
+			__output.push(' class="section-items"');
+			__output.push('>');
+
+			{
+				_$_.render_expression(__output, children);
 			}
 
 			__output.push('</div>');
-			__output.push('<!--[-->');
-
-			if (_$_.get(lazy)) {
-				__output.push('<div');
-				__output.push(' class="section-items"');
-				__output.push('>');
-
-				{
-					{
-						const comp = children;
-						const args = [__output, {}];
-
-						if (comp?.async) {
-							await comp(...args);
-						} else if (comp) {
-							comp(...args);
-						}
-					}
-				}
-
-				__output.push('</div>');
-			}
-
-			__output.push('<!--]-->');
 		}
 
-		__output.push('</section>');
-		_$_.pop_component();
-	});
-}
+		__output.push('<!--]-->');
+	}
 
-SidebarSection.async = true;
+	__output.push('</section>');
+	_$_.pop_component();
+}
 
 function SideNav(__output, { currentPath }) {
 	_$_.push_component();
@@ -1000,7 +926,7 @@ function SideNav(__output, { currentPath }) {
 						__output,
 						{
 							title: "Getting Started",
-							children: function children(__output) {
+							children: _$_.ripple_element(function render_children(__output) {
 								_$_.push_component();
 
 								{
@@ -1034,7 +960,7 @@ function SideNav(__output, { currentPath }) {
 								}
 
 								_$_.pop_component();
-							}
+							})
 						}
 					];
 
@@ -1055,7 +981,7 @@ function SideNav(__output, { currentPath }) {
 						__output,
 						{
 							title: "Guide",
-							children: function children(__output) {
+							children: _$_.ripple_element(function render_children(__output) {
 								_$_.push_component();
 
 								{
@@ -1089,7 +1015,7 @@ function SideNav(__output, { currentPath }) {
 								}
 
 								_$_.pop_component();
-							}
+							})
 						}
 					];
 
@@ -1233,39 +1159,26 @@ export function LayoutWithSidebarAndMain(__output) {
 	_$_.pop_component();
 }
 
-async function ArticleWrapper(__output, { children }) {
-	return _$_.async(async () => {
-		_$_.push_component();
-		__output.push('<article');
-		__output.push(' class="doc-content"');
+function ArticleWrapper(__output, { children }) {
+	_$_.push_component();
+	__output.push('<article');
+	__output.push(' class="doc-content"');
+	__output.push('>');
+
+	{
+		__output.push('<div');
 		__output.push('>');
 
 		{
-			__output.push('<div');
-			__output.push('>');
-
-			{
-				{
-					const comp = children;
-					const args = [__output, {}];
-
-					if (comp?.async) {
-						await comp(...args);
-					} else if (comp) {
-						comp(...args);
-					}
-				}
-			}
-
-			__output.push('</div>');
+			_$_.render_expression(__output, children);
 		}
 
-		__output.push('</article>');
-		_$_.pop_component();
-	});
-}
+		__output.push('</div>');
+	}
 
-ArticleWrapper.async = true;
+	__output.push('</article>');
+	_$_.pop_component();
+}
 
 function SimpleFooter(__output) {
 	_$_.push_component();
@@ -1294,7 +1207,7 @@ export function ArticleWithChildrenThenSibling(__output) {
 			const args = [
 				__output,
 				{
-					children: function children(__output) {
+					children: _$_.ripple_element(function render_children(__output) {
 						_$_.push_component();
 						__output.push('<h1');
 						__output.push('>');
@@ -1313,7 +1226,7 @@ export function ArticleWithChildrenThenSibling(__output) {
 
 						__output.push('</p>');
 						_$_.pop_component();
-					}
+					})
 				}
 			];
 
@@ -1395,7 +1308,7 @@ export function ArticleWithHtmlChildThenSibling(__output) {
 			const args = [
 				__output,
 				{
-					children: function children(__output) {
+					children: _$_.ripple_element(function render_children(__output) {
 						_$_.push_component();
 						__output.push('<div');
 						__output.push(' class="doc-content"');
@@ -1411,7 +1324,7 @@ export function ArticleWithHtmlChildThenSibling(__output) {
 
 						__output.push('</div>');
 						_$_.pop_component();
-					}
+					})
 				}
 			];
 
@@ -1454,77 +1367,64 @@ export function ArticleWithHtmlChildThenSibling(__output) {
 	_$_.pop_component();
 }
 
-async function InlineArticleLayout(__output, { children }) {
-	return _$_.async(async () => {
-		_$_.push_component();
-		__output.push('<div');
-		__output.push(' class="content-container"');
+function InlineArticleLayout(__output, { children }) {
+	_$_.push_component();
+	__output.push('<div');
+	__output.push(' class="content-container"');
+	__output.push('>');
+
+	{
+		__output.push('<article');
+		__output.push(' class="doc-content"');
 		__output.push('>');
 
 		{
-			__output.push('<article');
-			__output.push(' class="doc-content"');
+			__output.push('<div');
 			__output.push('>');
 
 			{
-				__output.push('<div');
-				__output.push('>');
-
-				{
-					{
-						const comp = children;
-						const args = [__output, {}];
-
-						if (comp?.async) {
-							await comp(...args);
-						} else if (comp) {
-							comp(...args);
-						}
-					}
-				}
-
-				__output.push('</div>');
+				_$_.render_expression(__output, children);
 			}
 
-			__output.push('</article>');
-			__output.push('<!--[-->');
-
-			if (true) {
-				__output.push('<div');
-				__output.push(' class="edit-link"');
-				__output.push('>');
-
-				{
-					__output.push('<a');
-					__output.push(' href="/edit"');
-					__output.push('>');
-
-					{
-						__output.push('Edit');
-					}
-
-					__output.push('</a>');
-				}
-
-				__output.push('</div>');
-			}
-
-			__output.push('<!--]-->');
-
-			{
-				const comp = SimpleFooter;
-				const args = [__output, {}];
-
-				comp(...args);
-			}
+			__output.push('</div>');
 		}
 
-		__output.push('</div>');
-		_$_.pop_component();
-	});
-}
+		__output.push('</article>');
+		__output.push('<!--[-->');
 
-InlineArticleLayout.async = true;
+		if (true) {
+			__output.push('<div');
+			__output.push(' class="edit-link"');
+			__output.push('>');
+
+			{
+				__output.push('<a');
+				__output.push(' href="/edit"');
+				__output.push('>');
+
+				{
+					__output.push('Edit');
+				}
+
+				__output.push('</a>');
+			}
+
+			__output.push('</div>');
+		}
+
+		__output.push('<!--]-->');
+
+		{
+			const comp = SimpleFooter;
+			const args = [__output, {}];
+
+			comp(...args);
+		}
+	}
+
+	__output.push('</div>');
+	_$_.pop_component();
+}
 
 export function InlineArticleWithHtmlChild(__output) {
 	_$_.push_component();
@@ -1537,7 +1437,7 @@ export function InlineArticleWithHtmlChild(__output) {
 		const args = [
 			__output,
 			{
-				children: function children(__output) {
+				children: _$_.ripple_element(function render_children(__output) {
 					_$_.push_component();
 					__output.push('<div');
 					__output.push(' class="doc-content"');
@@ -1553,7 +1453,7 @@ export function InlineArticleWithHtmlChild(__output) {
 
 					__output.push('</div>');
 					_$_.pop_component();
-				}
+				})
 			}
 		];
 
@@ -1605,134 +1505,121 @@ function FooterStub(__output) {
 	_$_.pop_component();
 }
 
-async function DocsLayoutInner(__output, { children, editPath = '', nextLink = null }) {
-	return _$_.async(async () => {
-		_$_.push_component();
+function DocsLayoutInner(__output, { children, editPath = '', nextLink = null }) {
+	_$_.push_component();
+	__output.push('<div');
+	__output.push(' class="layout"');
+	__output.push('>');
+
+	{
+		{
+			const comp = HeaderStub;
+			const args = [__output, {}];
+
+			comp(...args);
+		}
+
 		__output.push('<div');
-		__output.push(' class="layout"');
+		__output.push(' class="docs-wrapper"');
 		__output.push('>');
 
 		{
 			{
-				const comp = HeaderStub;
+				const comp = SidebarStub;
 				const args = [__output, {}];
 
 				comp(...args);
 			}
 
-			__output.push('<div');
-			__output.push(' class="docs-wrapper"');
+			__output.push('<main');
+			__output.push(' class="docs-main"');
 			__output.push('>');
 
 			{
-				{
-					const comp = SidebarStub;
-					const args = [__output, {}];
-
-					comp(...args);
-				}
-
-				__output.push('<main');
-				__output.push(' class="docs-main"');
+				__output.push('<div');
+				__output.push(' class="docs-container"');
 				__output.push('>');
 
 				{
 					__output.push('<div');
-					__output.push(' class="docs-container"');
+					__output.push(' class="content"');
 					__output.push('>');
 
 					{
 						__output.push('<div');
-						__output.push(' class="content"');
+						__output.push(' class="content-container"');
 						__output.push('>');
 
 						{
-							__output.push('<div');
-							__output.push(' class="content-container"');
+							__output.push('<article');
+							__output.push(' class="doc-content"');
 							__output.push('>');
 
 							{
-								__output.push('<article');
-								__output.push(' class="doc-content"');
+								__output.push('<div');
 								__output.push('>');
 
 								{
-									__output.push('<div');
-									__output.push('>');
-
-									{
-										{
-											const comp = children;
-											const args = [__output, {}];
-
-											if (comp?.async) {
-												await comp(...args);
-											} else if (comp) {
-												comp(...args);
-											}
-										}
-									}
-
-									__output.push('</div>');
+									_$_.render_expression(__output, children);
 								}
 
-								__output.push('</article>');
-								__output.push('<!--[-->');
-
-								if (editPath) {
-									__output.push('<div');
-									__output.push(' class="edit-link"');
-									__output.push('>');
-
-									{
-										__output.push('<a');
-										__output.push(' href="/edit"');
-										__output.push('>');
-
-										{
-											__output.push('Edit on GitHub');
-										}
-
-										__output.push('</a>');
-									}
-
-									__output.push('</div>');
-								}
-
-								__output.push('<!--]-->');
-								__output.push('<!--[-->');
-
-								if (nextLink) {
-									__output.push('<nav');
-									__output.push(' class="prev-next"');
-									__output.push('>');
-
-									{
-										__output.push('<a');
-										__output.push(_$_.attr('href', nextLink.href, false));
-										__output.push('>');
-
-										{
-											__output.push(_$_.escape(nextLink.text));
-										}
-
-										__output.push('</a>');
-									}
-
-									__output.push('</nav>');
-								}
-
-								__output.push('<!--]-->');
-
-								{
-									const comp = FooterStub;
-									const args = [__output, {}];
-
-									comp(...args);
-								}
+								__output.push('</div>');
 							}
 
-							__output.push('</div>');
+							__output.push('</article>');
+							__output.push('<!--[-->');
+
+							if (editPath) {
+								__output.push('<div');
+								__output.push(' class="edit-link"');
+								__output.push('>');
+
+								{
+									__output.push('<a');
+									__output.push(' href="/edit"');
+									__output.push('>');
+
+									{
+										__output.push('Edit on GitHub');
+									}
+
+									__output.push('</a>');
+								}
+
+								__output.push('</div>');
+							}
+
+							__output.push('<!--]-->');
+							__output.push('<!--[-->');
+
+							if (nextLink) {
+								__output.push('<nav');
+								__output.push(' class="prev-next"');
+								__output.push('>');
+
+								{
+									__output.push('<a');
+									__output.push(_$_.attr('href', nextLink.href, false));
+									__output.push('>');
+
+									{
+										__output.push(_$_.escape(nextLink.text));
+									}
+
+									__output.push('</a>');
+								}
+
+								__output.push('</nav>');
+							}
+
+							__output.push('<!--]-->');
+
+							{
+								const comp = FooterStub;
+								const args = [__output, {}];
+
+								comp(...args);
+							}
 						}
 
 						__output.push('</div>');
@@ -1741,18 +1628,18 @@ async function DocsLayoutInner(__output, { children, editPath = '', nextLink = n
 					__output.push('</div>');
 				}
 
-				__output.push('</main>');
+				__output.push('</div>');
 			}
 
-			__output.push('</div>');
+			__output.push('</main>');
 		}
 
 		__output.push('</div>');
-		_$_.pop_component();
-	});
-}
+	}
 
-DocsLayoutInner.async = true;
+	__output.push('</div>');
+	_$_.pop_component();
+}
 
 export function DocsLayoutWithData(__output) {
 	_$_.push_component();
@@ -1767,7 +1654,7 @@ export function DocsLayoutWithData(__output) {
 			{
 				editPath: "docs/styling.md",
 				nextLink: { href: '/next', text: 'Next' },
-				children: function children(__output) {
+				children: _$_.ripple_element(function render_children(__output) {
 					_$_.push_component();
 					__output.push('<div');
 					__output.push(' class="doc-content"');
@@ -1783,7 +1670,7 @@ export function DocsLayoutWithData(__output) {
 
 					__output.push('</div>');
 					_$_.pop_component();
-				}
+				})
 			}
 		];
 
@@ -1804,7 +1691,7 @@ export function DocsLayoutWithoutData(__output) {
 		const args = [
 			__output,
 			{
-				children: function children(__output) {
+				children: _$_.ripple_element(function render_children(__output) {
 					_$_.push_component();
 					__output.push('<div');
 					__output.push(' class="doc-content"');
@@ -1820,7 +1707,7 @@ export function DocsLayoutWithoutData(__output) {
 
 					__output.push('</div>');
 					_$_.pop_component();
-				}
+				})
 			}
 		];
 
@@ -1830,7 +1717,7 @@ export function DocsLayoutWithoutData(__output) {
 	_$_.pop_component();
 }
 
-async function DocsLayoutExact(
+function DocsLayoutExact(
 	__output,
 	{
 		children,
@@ -1840,241 +1727,228 @@ async function DocsLayoutExact(
 		toc = []
 	}
 ) {
-	return _$_.async(async () => {
-		_$_.push_component();
+	_$_.push_component();
+	__output.push('<div');
+	__output.push(' class="layout"');
+	__output.push('>');
+
+	{
+		{
+			const comp = HeaderStub;
+			const args = [__output, {}];
+
+			comp(...args);
+		}
+
 		__output.push('<div');
-		__output.push(' class="layout"');
+		__output.push(' class="docs-wrapper"');
 		__output.push('>');
 
 		{
 			{
-				const comp = HeaderStub;
+				const comp = SidebarStub;
 				const args = [__output, {}];
 
 				comp(...args);
 			}
 
-			__output.push('<div');
-			__output.push(' class="docs-wrapper"');
+			__output.push('<main');
+			__output.push(' class="docs-main"');
 			__output.push('>');
 
 			{
-				{
-					const comp = SidebarStub;
-					const args = [__output, {}];
-
-					comp(...args);
-				}
-
-				__output.push('<main');
-				__output.push(' class="docs-main"');
+				__output.push('<div');
+				__output.push(' class="docs-container"');
 				__output.push('>');
 
 				{
 					__output.push('<div');
-					__output.push(' class="docs-container"');
+					__output.push(' class="content"');
 					__output.push('>');
 
 					{
 						__output.push('<div');
-						__output.push(' class="content"');
+						__output.push(' class="content-container"');
 						__output.push('>');
 
 						{
-							__output.push('<div');
-							__output.push(' class="content-container"');
+							__output.push('<article');
+							__output.push(' class="doc-content"');
 							__output.push('>');
 
 							{
-								__output.push('<article');
-								__output.push(' class="doc-content"');
+								__output.push('<div');
 								__output.push('>');
 
 								{
-									__output.push('<div');
-									__output.push('>');
-
-									{
-										{
-											const comp = children;
-											const args = [__output, {}];
-
-											if (comp?.async) {
-												await comp(...args);
-											} else if (comp) {
-												comp(...args);
-											}
-										}
-									}
-
-									__output.push('</div>');
+									_$_.render_expression(__output, children);
 								}
 
-								__output.push('</article>');
-								__output.push('<!--[-->');
-
-								if (editPath) {
-									__output.push('<div');
-									__output.push(' class="edit-link"');
-									__output.push('>');
-
-									{
-										__output.push('<a');
-										__output.push(_$_.attr('href', `/edit/${editPath}`, false));
-										__output.push('>');
-
-										{
-											__output.push('Edit on GitHub');
-										}
-
-										__output.push('</a>');
-									}
-
-									__output.push('</div>');
-								}
-
-								__output.push('<!--]-->');
-								__output.push('<!--[-->');
-
-								if (prevLink || nextLink) {
-									__output.push('<nav');
-									__output.push(' class="prev-next"');
-									__output.push('>');
-
-									{
-										__output.push('<!--[-->');
-
-										if (prevLink) {
-											__output.push('<a');
-											__output.push(_$_.attr('href', prevLink.href, false));
-											__output.push(' class="pager prev"');
-											__output.push('>');
-
-											{
-												__output.push('<span');
-												__output.push(' class="title"');
-												__output.push('>');
-
-												{
-													__output.push(_$_.escape(prevLink.text));
-												}
-
-												__output.push('</span>');
-											}
-
-											__output.push('</a>');
-										} else {
-											__output.push('<span');
-											__output.push('>');
-											__output.push('</span>');
-										}
-
-										__output.push('<!--]-->');
-										__output.push('<!--[-->');
-
-										if (nextLink) {
-											__output.push('<a');
-											__output.push(_$_.attr('href', nextLink.href, false));
-											__output.push(' class="pager next"');
-											__output.push('>');
-
-											{
-												__output.push('<span');
-												__output.push(' class="title"');
-												__output.push('>');
-
-												{
-													__output.push(_$_.escape(nextLink.text));
-												}
-
-												__output.push('</span>');
-											}
-
-											__output.push('</a>');
-										}
-
-										__output.push('<!--]-->');
-									}
-
-									__output.push('</nav>');
-								}
-
-								__output.push('<!--]-->');
-
-								{
-									const comp = FooterStub;
-									const args = [__output, {}];
-
-									comp(...args);
-								}
+								__output.push('</div>');
 							}
 
-							__output.push('</div>');
-						}
-
-						__output.push('</div>');
-						__output.push('<aside');
-						__output.push(' class="aside"');
-						__output.push('>');
-
-						{
+							__output.push('</article>');
 							__output.push('<!--[-->');
 
-							if (toc.length > 0) {
+							if (editPath) {
 								__output.push('<div');
-								__output.push(' class="aside-content"');
+								__output.push(' class="edit-link"');
 								__output.push('>');
 
 								{
-									__output.push('<nav');
-									__output.push(' class="outline"');
+									__output.push('<a');
+									__output.push(_$_.attr('href', `/edit/${editPath}`, false));
 									__output.push('>');
 
 									{
-										__output.push('<!--[-->');
-
-										for (const item of toc) {
-											__output.push('<a');
-											__output.push(_$_.attr('href', item.href, false));
-											__output.push('>');
-
-											{
-												__output.push(_$_.escape(item.text));
-											}
-
-											__output.push('</a>');
-										}
-
-										__output.push('<!--]-->');
+										__output.push('Edit on GitHub');
 									}
 
-									__output.push('</nav>');
+									__output.push('</a>');
 								}
 
 								__output.push('</div>');
 							}
 
 							__output.push('<!--]-->');
+							__output.push('<!--[-->');
+
+							if (prevLink || nextLink) {
+								__output.push('<nav');
+								__output.push(' class="prev-next"');
+								__output.push('>');
+
+								{
+									__output.push('<!--[-->');
+
+									if (prevLink) {
+										__output.push('<a');
+										__output.push(_$_.attr('href', prevLink.href, false));
+										__output.push(' class="pager prev"');
+										__output.push('>');
+
+										{
+											__output.push('<span');
+											__output.push(' class="title"');
+											__output.push('>');
+
+											{
+												__output.push(_$_.escape(prevLink.text));
+											}
+
+											__output.push('</span>');
+										}
+
+										__output.push('</a>');
+									} else {
+										__output.push('<span');
+										__output.push('>');
+										__output.push('</span>');
+									}
+
+									__output.push('<!--]-->');
+									__output.push('<!--[-->');
+
+									if (nextLink) {
+										__output.push('<a');
+										__output.push(_$_.attr('href', nextLink.href, false));
+										__output.push(' class="pager next"');
+										__output.push('>');
+
+										{
+											__output.push('<span');
+											__output.push(' class="title"');
+											__output.push('>');
+
+											{
+												__output.push(_$_.escape(nextLink.text));
+											}
+
+											__output.push('</span>');
+										}
+
+										__output.push('</a>');
+									}
+
+									__output.push('<!--]-->');
+								}
+
+								__output.push('</nav>');
+							}
+
+							__output.push('<!--]-->');
+
+							{
+								const comp = FooterStub;
+								const args = [__output, {}];
+
+								comp(...args);
+							}
 						}
 
-						__output.push('</aside>');
+						__output.push('</div>');
 					}
 
 					__output.push('</div>');
+					__output.push('<aside');
+					__output.push(' class="aside"');
+					__output.push('>');
+
+					{
+						__output.push('<!--[-->');
+
+						if (toc.length > 0) {
+							__output.push('<div');
+							__output.push(' class="aside-content"');
+							__output.push('>');
+
+							{
+								__output.push('<nav');
+								__output.push(' class="outline"');
+								__output.push('>');
+
+								{
+									__output.push('<!--[-->');
+
+									for (const item of toc) {
+										__output.push('<a');
+										__output.push(_$_.attr('href', item.href, false));
+										__output.push('>');
+
+										{
+											__output.push(_$_.escape(item.text));
+										}
+
+										__output.push('</a>');
+									}
+
+									__output.push('<!--]-->');
+								}
+
+								__output.push('</nav>');
+							}
+
+							__output.push('</div>');
+						}
+
+						__output.push('<!--]-->');
+					}
+
+					__output.push('</aside>');
 				}
 
-				__output.push('</main>');
+				__output.push('</div>');
 			}
 
-			__output.push('</div>');
+			__output.push('</main>');
 		}
 
 		__output.push('</div>');
-		_$_.pop_component();
-	});
-}
+	}
 
-DocsLayoutExact.async = true;
+	__output.push('</div>');
+	_$_.pop_component();
+}
 
 export function DocsLayoutExactWithData(__output) {
 	_$_.push_component();
@@ -2095,7 +1969,7 @@ export function DocsLayoutExactWithData(__output) {
 					{ href: '#usage', text: 'Usage' }
 				],
 
-				children: function children(__output) {
+				children: _$_.ripple_element(function render_children(__output) {
 					_$_.push_component();
 					__output.push('<div');
 					__output.push(' class="doc-content"');
@@ -2111,7 +1985,7 @@ export function DocsLayoutExactWithData(__output) {
 
 					__output.push('</div>');
 					_$_.pop_component();
-				}
+				})
 			}
 		];
 
@@ -2140,7 +2014,7 @@ export function DocsLayoutExactWithoutData(__output) {
 				prevLink,
 				nextLink,
 				toc,
-				children: function children(__output) {
+				children: _$_.ripple_element(function render_children(__output) {
 					_$_.push_component();
 					__output.push('<div');
 					__output.push(' class="doc-content"');
@@ -2156,7 +2030,7 @@ export function DocsLayoutExactWithoutData(__output) {
 
 					__output.push('</div>');
 					_$_.pop_component();
-				}
+				})
 			}
 		];
 
@@ -2249,52 +2123,39 @@ export function TemplateWithHtmlAndSiblings(__output) {
 	_$_.pop_component();
 }
 
-async function LayoutWithTemplate(__output, { children, data }) {
-	return _$_.async(async () => {
-		_$_.push_component();
-		__output.push('<div');
-		__output.push(' class="layout"');
+function LayoutWithTemplate(__output, { children, data }) {
+	_$_.push_component();
+	__output.push('<div');
+	__output.push(' class="layout"');
+	__output.push('>');
+
+	{
+		__output.push('<template');
+		__output.push(' id="page-data"');
 		__output.push('>');
 
 		{
-			__output.push('<template');
-			__output.push(' id="page-data"');
-			__output.push('>');
+			const html_value_25 = String(JSON.stringify(data) ?? '');
 
-			{
-				const html_value_25 = String(JSON.stringify(data) ?? '');
-
-				__output.push('<!--' + _$_.hash(html_value_25) + '-->');
-				__output.push(html_value_25);
-				__output.push('<!---->');
-			}
-
-			__output.push('</template>');
-			__output.push('<main');
-			__output.push('>');
-
-			{
-				{
-					const comp = children;
-					const args = [__output, {}];
-
-					if (comp?.async) {
-						await comp(...args);
-					} else if (comp) {
-						comp(...args);
-					}
-				}
-			}
-
-			__output.push('</main>');
+			__output.push('<!--' + _$_.hash(html_value_25) + '-->');
+			__output.push(html_value_25);
+			__output.push('<!---->');
 		}
 
-		__output.push('</div>');
-		_$_.pop_component();
-	});
-}
+		__output.push('</template>');
+		__output.push('<main');
+		__output.push('>');
 
-LayoutWithTemplate.async = true;
+		{
+			_$_.render_expression(__output, children);
+		}
+
+		__output.push('</main>');
+	}
+
+	__output.push('</div>');
+	_$_.pop_component();
+}
 
 export function NestedTemplateInLayout(__output) {
 	_$_.push_component();
@@ -2308,7 +2169,7 @@ export function NestedTemplateInLayout(__output) {
 			__output,
 			{
 				data: doc,
-				children: function children(__output) {
+				children: _$_.ripple_element(function render_children(__output) {
 					_$_.push_component();
 					__output.push('<div');
 					__output.push(' class="doc-content"');
@@ -2324,7 +2185,7 @@ export function NestedTemplateInLayout(__output) {
 
 					__output.push('</div>');
 					_$_.pop_component();
-				}
+				})
 			}
 		];
 

--- a/packages/ripple/tests/hydration/compiled/server/if-children.js
+++ b/packages/ripple/tests/hydration/compiled/server/if-children.js
@@ -3,59 +3,46 @@ import * as _$_ from 'ripple/internal/server';
 
 import { track } from 'ripple/server';
 
-export async function IfWithChildren(__output, { children }) {
-	return _$_.async(async () => {
-		_$_.push_component();
+export function IfWithChildren(__output, { children }) {
+	_$_.push_component();
 
-		let lazy = _$_.track(true);
+	let lazy = _$_.track(true);
 
+	__output.push('<div');
+	__output.push(' class="container"');
+	__output.push('>');
+
+	{
 		__output.push('<div');
-		__output.push(' class="container"');
+		__output.push(' role="button"');
+		__output.push(' class="header"');
 		__output.push('>');
 
 		{
-			__output.push('<div');
-			__output.push(' role="button"');
-			__output.push(' class="header"');
-			__output.push('>');
-
-			{
-				__output.push('Toggle');
-			}
-
-			__output.push('</div>');
-			__output.push('<!--[-->');
-
-			if (_$_.get(lazy)) {
-				__output.push('<div');
-				__output.push(' class="content"');
-				__output.push('>');
-
-				{
-					{
-						const comp = children;
-						const args = [__output, {}];
-
-						if (comp?.async) {
-							await comp(...args);
-						} else if (comp) {
-							comp(...args);
-						}
-					}
-				}
-
-				__output.push('</div>');
-			}
-
-			__output.push('<!--]-->');
+			__output.push('Toggle');
 		}
 
 		__output.push('</div>');
-		_$_.pop_component();
-	});
-}
+		__output.push('<!--[-->');
 
-IfWithChildren.async = true;
+		if (_$_.get(lazy)) {
+			__output.push('<div');
+			__output.push(' class="content"');
+			__output.push('>');
+
+			{
+				_$_.render_expression(__output, children);
+			}
+
+			__output.push('</div>');
+		}
+
+		__output.push('<!--]-->');
+	}
+
+	__output.push('</div>');
+	_$_.pop_component();
+}
 
 export function ChildItem(__output, { text: label }) {
 	_$_.push_component();
@@ -80,7 +67,7 @@ export function TestIfWithChildren(__output) {
 		const args = [
 			__output,
 			{
-				children: function children(__output) {
+				children: _$_.ripple_element(function render_children(__output) {
 					_$_.push_component();
 
 					{
@@ -98,7 +85,7 @@ export function TestIfWithChildren(__output) {
 					}
 
 					_$_.pop_component();
-				}
+				})
 			}
 		];
 
@@ -164,94 +151,81 @@ export function IfWithStaticChildren(__output) {
 	_$_.pop_component();
 }
 
-export async function IfWithSiblingsAndChildren(__output, { children }) {
-	return _$_.async(async () => {
-		_$_.push_component();
+export function IfWithSiblingsAndChildren(__output, { children }) {
+	_$_.push_component();
 
-		let lazy_2 = _$_.track(true);
+	let lazy_2 = _$_.track(true);
 
-		__output.push('<section');
-		__output.push(' class="group"');
+	__output.push('<section');
+	__output.push(' class="group"');
+	__output.push('>');
+
+	{
+		__output.push('<div');
+		__output.push(' role="button"');
+		__output.push(' class="item"');
 		__output.push('>');
 
 		{
 			__output.push('<div');
-			__output.push(' role="button"');
-			__output.push(' class="item"');
+			__output.push(' class="indicator"');
+			__output.push('>');
+			__output.push('</div>');
+			__output.push('<h2');
+			__output.push(' class="text"');
 			__output.push('>');
 
 			{
-				__output.push('<div');
-				__output.push(' class="indicator"');
-				__output.push('>');
-				__output.push('</div>');
-				__output.push('<h2');
-				__output.push(' class="text"');
+				__output.push('Title');
+			}
+
+			__output.push('</h2>');
+			__output.push('<div');
+			__output.push(' class="caret"');
+			__output.push('>');
+
+			{
+				__output.push('<svg');
+				__output.push(' xmlns="http://www.w3.org/2000/svg"');
+				__output.push(' width="18"');
+				__output.push(' height="18"');
+				__output.push(' viewBox="0 0 24 24"');
 				__output.push('>');
 
 				{
-					__output.push('Title');
-				}
-
-				__output.push('</h2>');
-				__output.push('<div');
-				__output.push(' class="caret"');
-				__output.push('>');
-
-				{
-					__output.push('<svg');
-					__output.push(' xmlns="http://www.w3.org/2000/svg"');
-					__output.push(' width="18"');
-					__output.push(' height="18"');
-					__output.push(' viewBox="0 0 24 24"');
+					__output.push('<path');
+					__output.push(' d="m9 18 6-6-6-6"');
 					__output.push('>');
-
-					{
-						__output.push('<path');
-						__output.push(' d="m9 18 6-6-6-6"');
-						__output.push('>');
-						__output.push('</path>');
-					}
-
-					__output.push('</svg>');
+					__output.push('</path>');
 				}
 
-				__output.push('</div>');
+				__output.push('</svg>');
 			}
 
 			__output.push('</div>');
-			__output.push('<!--[-->');
-
-			if (_$_.get(lazy_2)) {
-				__output.push('<div');
-				__output.push(' class="items"');
-				__output.push('>');
-
-				{
-					{
-						const comp = children;
-						const args = [__output, {}];
-
-						if (comp?.async) {
-							await comp(...args);
-						} else if (comp) {
-							comp(...args);
-						}
-					}
-				}
-
-				__output.push('</div>');
-			}
-
-			__output.push('<!--]-->');
 		}
 
-		__output.push('</section>');
-		_$_.pop_component();
-	});
-}
+		__output.push('</div>');
+		__output.push('<!--[-->');
 
-IfWithSiblingsAndChildren.async = true;
+		if (_$_.get(lazy_2)) {
+			__output.push('<div');
+			__output.push(' class="items"');
+			__output.push('>');
+
+			{
+				_$_.render_expression(__output, children);
+			}
+
+			__output.push('</div>');
+		}
+
+		__output.push('<!--]-->');
+	}
+
+	__output.push('</section>');
+	_$_.pop_component();
+}
 
 export function TestIfWithSiblingsAndChildren(__output) {
 	_$_.push_component();
@@ -262,7 +236,7 @@ export function TestIfWithSiblingsAndChildren(__output) {
 		const args = [
 			__output,
 			{
-				children: function children(__output) {
+				children: _$_.ripple_element(function render_children(__output) {
 					_$_.push_component();
 
 					{
@@ -280,7 +254,7 @@ export function TestIfWithSiblingsAndChildren(__output) {
 					}
 
 					_$_.pop_component();
-				}
+				})
 			}
 		];
 

--- a/packages/ripple/tests/hydration/compiled/server/portal.js
+++ b/packages/ripple/tests/hydration/compiled/server/portal.js
@@ -27,7 +27,7 @@ export async function SimplePortal(__output) {
 					__output,
 					{
 						target: typeof document !== 'undefined' ? document.body : null,
-						children: function children(__output) {
+						children: _$_.ripple_element(function render_children(__output) {
 							_$_.push_component();
 							__output.push('<div');
 							__output.push(' class="portal-content"');
@@ -39,7 +39,7 @@ export async function SimplePortal(__output) {
 
 							__output.push('</div>');
 							_$_.pop_component();
-						}
+						})
 					}
 				];
 
@@ -88,7 +88,7 @@ export async function ConditionalPortal(__output) {
 						__output,
 						{
 							target: typeof document !== 'undefined' ? document.body : null,
-							children: function children(__output) {
+							children: _$_.ripple_element(function render_children(__output) {
 								_$_.push_component();
 								__output.push('<div');
 								__output.push(' class="portal-content"');
@@ -100,7 +100,7 @@ export async function ConditionalPortal(__output) {
 
 								__output.push('</div>');
 								_$_.pop_component();
-							}
+							})
 						}
 					];
 
@@ -146,7 +146,7 @@ export async function PortalWithMainContent(__output) {
 					__output,
 					{
 						target: typeof document !== 'undefined' ? document.body : null,
-						children: function children(__output) {
+						children: _$_.ripple_element(function render_children(__output) {
 							_$_.push_component();
 							__output.push('<div');
 							__output.push(' class="portal-content"');
@@ -158,7 +158,7 @@ export async function PortalWithMainContent(__output) {
 
 							__output.push('</div>');
 							_$_.pop_component();
-						}
+						})
 					}
 				];
 
@@ -219,7 +219,7 @@ export async function NestedContentWithPortal(__output) {
 					__output,
 					{
 						target: typeof document !== 'undefined' ? document.body : null,
-						children: function children(__output) {
+						children: _$_.ripple_element(function render_children(__output) {
 							_$_.push_component();
 							__output.push('<div');
 							__output.push(' class="portal-content"');
@@ -231,7 +231,7 @@ export async function NestedContentWithPortal(__output) {
 
 							__output.push('</div>');
 							_$_.pop_component();
-						}
+						})
 					}
 				];
 

--- a/packages/ripple/tests/hydration/components/basic.ripple
+++ b/packages/ripple/tests/hydration/components/basic.ripple
@@ -70,11 +70,7 @@ component TextProp(&{ children }: { children: string }) {
 	<div class="text-prop">{children}</div>
 }
 
-export component ServerTextPropWithContent() {
-	<TextProp children="hello" />
-}
-
-export component ClientTextPropRestoresAfterHydration() {
+export component TextPropWithToggle() {
 	let &[show] = track(false);
 
 	<TextProp children={show ? 'hello' : ''} />

--- a/packages/ripple/tests/hydration/components/basic.ripple
+++ b/packages/ripple/tests/hydration/components/basic.ripple
@@ -99,9 +99,7 @@ component Actions({ playgroundVisible = false }: { playgroundVisible: boolean })
 
 component Layout({ children }: { children: Children }) {
 	<main>
-		<div class="container">
-			<children />
-		</div>
+		<div class="container">{children}</div>
 	</main>
 }
 

--- a/packages/ripple/tests/hydration/components/basic.ripple
+++ b/packages/ripple/tests/hydration/components/basic.ripple
@@ -1,4 +1,5 @@
 // Basic static components for hydration testing
+import { track } from 'ripple';
 import type { Children } from 'ripple';
 
 export component StaticText() {
@@ -63,6 +64,21 @@ export component ExpressionContent() {
 	const label = 'computed';
 	<div>{value}</div>
 	<span>{label.toUpperCase()}</span>
+}
+
+component TextProp(&{ children }: { children: string }) {
+	<div class="text-prop">{children}</div>
+}
+
+export component ServerTextPropWithContent() {
+	<TextProp children="hello" />
+}
+
+export component ClientTextPropRestoresAfterHydration() {
+	let &[show] = track(false);
+
+	<TextProp children={show ? 'hello' : ''} />
+	<button class="show-text" onClick={() => (show = true)}>{'Show'}</button>
 }
 
 // Test for static content in child component followed by sibling content

--- a/packages/ripple/tests/hydration/components/composite.ripple
+++ b/packages/ripple/tests/hydration/components/composite.ripple
@@ -1,8 +1,14 @@
 import type { Children } from 'ripple';
 
 export component Layout(&{ children }: { children?: Children }) {
+	<div class="layout">{children}</div>
+}
+
+export component TextWrappedLayout(&{ children }: { children?: Children }) {
 	<div class="layout">
-		<children />
+		{text 'before'}
+		{children}
+		{text 'after'}
 	</div>
 }
 
@@ -36,4 +42,10 @@ export component LayoutWithMultiRootChild() {
 	<Layout>
 		<MultiRootChild />
 	</Layout>
+}
+
+export component LayoutWithTextAroundChildren() {
+	<TextWrappedLayout>
+		<SingleChild />
+	</TextWrappedLayout>
 }

--- a/packages/ripple/tests/hydration/components/hmr.ripple
+++ b/packages/ripple/tests/hydration/components/hmr.ripple
@@ -11,9 +11,7 @@ import { track } from 'ripple';
 export component Layout({ children }: { children: any }) {
 	<div class="layout">
 		<nav class="nav">{'Navigation'}</nav>
-		<main class="main">
-			<children />
-		</main>
+		<main class="main">{children}</main>
 	</div>
 }
 

--- a/packages/ripple/tests/hydration/components/html.ripple
+++ b/packages/ripple/tests/hydration/components/html.ripple
@@ -38,9 +38,7 @@ export component HtmlWithReactivity() {
 
 export component HtmlWrapper({ children }: { children: any }) {
 	<div class="wrapper">
-		<div class="inner">
-			<children />
-		</div>
+		<div class="inner">{children}</div>
 	</div>
 }
 
@@ -105,9 +103,7 @@ export component DocLayout({
 	<div class="layout">
 		<div class="content-container">
 			<article>
-				<div>
-					<children />
-				</div>
+				<div>{children}</div>
 			</article>
 			if (editPath) {
 				<div class="edit-link">
@@ -168,14 +164,10 @@ export component HtmlWithUndefinedContent() {
 component DynamicHeading({ level, children }: { level: number; children: any }) {
 	switch (level) {
 		case 1: {
-			<h1 class="heading">
-				<children />
-			</h1>
+			<h1 class="heading">{children}</h1>
 		}
 		case 2: {
-			<h2 class="heading">
-				<children />
-			</h2>
+			<h2 class="heading">{children}</h2>
 		}
 	}
 }
@@ -193,9 +185,7 @@ component CodeBlock({ code }: { code: string }) {
 
 component ContentWrapper({ children }: { children: any }) {
 	<div class="wrapper">
-		<div class="inner">
-			<children />
-		</div>
+		<div class="inner">{children}</div>
 	</div>
 }
 
@@ -236,9 +226,7 @@ component SidebarSection({ title, children }: { title: string; children: any }) 
 			<button onClick={() => (expanded = !expanded)}>{'Toggle'}</button>
 		</div>
 		if (expanded) {
-			<div class="section-items">
-				<children />
-			</div>
+			<div class="section-items">{children}</div>
 		}
 	</section>
 }
@@ -293,9 +281,7 @@ export component LayoutWithSidebarAndMain() {
 
 component ArticleWrapper({ children }: { children: any }) {
 	<article class="doc-content">
-		<div>
-			<children />
-		</div>
+		<div>{children}</div>
 	</article>
 }
 
@@ -341,9 +327,7 @@ export component ArticleWithHtmlChildThenSibling() {
 component InlineArticleLayout({ children }: { children: any }) {
 	<div class="content-container">
 		<article class="doc-content">
-			<div>
-				<children />
-			</div>
+			<div>{children}</div>
 		</article>
 		if (true) {
 			<div class="edit-link">
@@ -391,9 +375,7 @@ component DocsLayoutInner({
 					<div class="content">
 						<div class="content-container">
 							<article class="doc-content">
-								<div>
-									<children />
-								</div>
+								<div>{children}</div>
 							</article>
 							if (editPath) {
 								<div class="edit-link">
@@ -450,9 +432,7 @@ component DocsLayoutExact({
 					<div class="content">
 						<div class="content-container">
 							<article class="doc-content">
-								<div>
-									<children />
-								</div>
+								<div>{children}</div>
 							</article>
 							if (editPath) {
 								<div class="edit-link">
@@ -542,9 +522,7 @@ export component TemplateWithHtmlAndSiblings() {
 component LayoutWithTemplate({ children, data }: { children: any; data: object }) {
 	<div class="layout">
 		<template id="page-data">{html JSON.stringify(data)}</template>
-		<main>
-			<children />
-		</main>
+		<main>{children}</main>
 	</div>
 }
 

--- a/packages/ripple/tests/hydration/components/if-children.ripple
+++ b/packages/ripple/tests/hydration/components/if-children.ripple
@@ -9,9 +9,7 @@ export component IfWithChildren({ children }: { children: any }) {
 	<div class="container">
 		<div class="header" role="button" onClick={() => (expanded = !expanded)}>{'Toggle'}</div>
 		if (expanded) {
-			<div class="content">
-				<children />
-			</div>
+			<div class="content">{children}</div>
 		}
 	</div>
 }
@@ -57,9 +55,7 @@ export component IfWithSiblingsAndChildren({ children }: { children: any }) {
 			</div>
 		</div>
 		if (expanded) {
-			<div class="items">
-				<children />
-			</div>
+			<div class="items">{children}</div>
 		}
 	</section>
 }

--- a/packages/ripple/tests/hydration/composite.test.js
+++ b/packages/ripple/tests/hydration/composite.test.js
@@ -39,4 +39,15 @@ describe('hydration > composite', () => {
 			'<div class=\"layout\"><h1>title</h1><p>description</p></div>',
 		);
 	});
+
+	it('hydrates explicit text around children', async () => {
+		await hydrateComponent(
+			ServerComponents.LayoutWithTextAroundChildren,
+			ClientComponents.LayoutWithTextAroundChildren,
+		);
+		expect(container.innerHTML).toBeHtml(
+			'<div class="layout">before<div class="single">single</div>after</div>',
+		);
+		expect(container.querySelector('.layout')?.textContent).toBe('beforesingleafter');
+	});
 });

--- a/packages/ripple/tests/server/basic.attributes.test.ripple
+++ b/packages/ripple/tests/server/basic.attributes.test.ripple
@@ -345,6 +345,56 @@ describe('basic server > attribute rendering', () => {
 		expect(body).toBeHtml('<input type="checkbox" disabled checked />');
 	});
 
+	it('renders formnovalidate as a boolean attribute', async () => {
+		component Basic() {
+			let &[formnovalidate] = track(true);
+
+			<button {formnovalidate}>{'Submit'}</button>
+		}
+
+		const { body } = await render(Basic);
+		const { document } = parseHtml(body);
+
+		const button = document.querySelector('button');
+
+		expect(button.hasAttribute('formnovalidate')).toBe(true);
+		expect(button.getAttribute('formnovalidate')).toBe('');
+		expect(body).toBeHtml('<button formnovalidate>Submit</button>');
+	});
+
+	it('renders hidden as a boolean attribute when true', async () => {
+		component Basic() {
+			let &[hidden] = track(true);
+
+			<div {hidden}>{'Hidden content'}</div>
+		}
+
+		const { body } = await render(Basic);
+		const { document } = parseHtml(body);
+
+		const div = document.querySelector('div');
+
+		expect(div.hasAttribute('hidden')).toBe(true);
+		expect(div.getAttribute('hidden')).toBe('');
+		expect(body).toBeHtml('<div hidden>Hidden content</div>');
+	});
+
+	it('does not render hidden when false', async () => {
+		component Basic() {
+			let &[hidden] = track(false);
+
+			<div {hidden}>{'Visible content'}</div>
+		}
+
+		const { body } = await render(Basic);
+		const { document } = parseHtml(body);
+
+		const div = document.querySelector('div');
+
+		expect(div.hasAttribute('hidden')).toBe(false);
+		expect(body).toBeHtml('<div>Visible content</div>');
+	});
+
 	it('render multiple dynamic attributes', async () => {
 		component Basic() {
 			let &[theme] = track('light');

--- a/packages/ripple/tests/server/basic.components.test.ripple
+++ b/packages/ripple/tests/server/basic.components.test.ripple
@@ -16,11 +16,11 @@ describe('basic server > components & composition', () => {
 		}
 
 		component Basic() {
-			<Card>
-				component children() {
-					<p>{'Card content here'}</p>
-				}
-			</Card>
+			component children() {
+				<p>{'Card content here'}</p>
+			}
+
+			<Card {children} />
 		}
 
 		const { body } = await render(Basic);
@@ -42,11 +42,11 @@ describe('basic server > components & composition', () => {
 		}
 
 		component Basic() {
-			<Card>
-				component test() {
-					<p>{'Card content here'}</p>
-				}
-			</Card>
+			component test() {
+				<p>{'Card content here'}</p>
+			}
+
+			<Card {test} />
 		}
 
 		const { body } = await render(Basic);
@@ -181,14 +181,14 @@ describe('basic server > components & composition', () => {
 		};
 
 		component App() {
+			component children() {
+				<span>{'Click me!'}</span>
+			}
+
 			<div>
 				<h1>{'Component as Property Test'}</h1>
 				<UI.span />
-				<UI.button>
-					component children() {
-						<span>{'Click me!'}</span>
-					}
-				</UI.button>
+				<UI.button {children} />
 			</div>
 		}
 

--- a/packages/ripple/tests/server/basic.components.test.ripple
+++ b/packages/ripple/tests/server/basic.components.test.ripple
@@ -10,9 +10,7 @@ import type {
 describe('basic server > components & composition', () => {
 	it('renders with component composition and children', async () => {
 		component Card(props: PropsWithChildren<{}>) {
-			<div class="card">
-				<props.children />
-			</div>
+			<div class="card">{props.children}</div>
 		}
 
 		component Basic() {
@@ -37,7 +35,7 @@ describe('basic server > components & composition', () => {
 		component Card(props: PropsWithChildrenOptional<{ test: Component }>) {
 			<div class="card">
 				// @ts-expect-error - ripple automatically handles falsy children
-				<props.children />
+				{props.children}
 			</div>
 		}
 
@@ -62,9 +60,7 @@ describe('basic server > components & composition', () => {
 
 	it('renders a component when children is set a component prop', async () => {
 		component Card(props: PropsWithChildren<{}>) {
-			<div class="card">
-				<props.children />
-			</div>
+			<div class="card">{props.children}</div>
 		}
 
 		component Basic() {
@@ -174,9 +170,7 @@ describe('basic server > components & composition', () => {
 				<span>{'Hello from Span'}</span>
 			},
 			button: component({ children }: PropsWithChildren<{}>) {
-				<button>
-					<children />
-				</button>
+				<button>{children}</button>
 			},
 		};
 
@@ -207,7 +201,7 @@ describe('basic server > components & composition', () => {
 
 	it('handles empty string children', async () => {
 		component Button({ children }: PropsWithChildren<{}>) {
-			<children />
+			{children}
 		}
 
 		component App() {

--- a/packages/ripple/tests/server/compiler.test.ripple
+++ b/packages/ripple/tests/server/compiler.test.ripple
@@ -78,9 +78,7 @@ export component Layout({ children }) {
 		<div>{children}</div>
 }`;
 
-		expect(() => compile(source, 'test.ripple', { mode: 'server' })).toThrow(
-			'`children` cannot be rendered using text interpolation. Use `<children />` instead.',
-		);
+		expect(() => compile(source, 'test.ripple', { mode: 'server' })).not.toThrow();
 	});
 
 	it('throws error for interpolating props.children as text in SSR mode', () => {
@@ -89,9 +87,7 @@ export component Layout(props) {
 	<div>{props.children}</div>
 }`;
 
-		expect(() => compile(source, 'test.ripple', { mode: 'server' })).toThrow(
-			'`children` cannot be rendered using text interpolation. Use `<children />` instead.',
-		);
+		expect(() => compile(source, 'test.ripple', { mode: 'server' })).not.toThrow();
 	});
 
 	it('throws error for calling children as a function in SSR mode', () => {
@@ -101,7 +97,7 @@ export component Layout({ children }) {
 }`;
 
 		expect(() => compile(source, 'test.ripple', { mode: 'server' })).toThrow(
-			'`children` cannot be called like a regular function. Use element syntax instead, e.g. `<children />` or `<props.children />`.',
+			'`children` cannot be called like a regular function. Render it with `{children}` or `{props.children}` instead.',
 		);
 	});
 
@@ -112,7 +108,7 @@ export component Layout(props) {
 }`;
 
 		expect(() => compile(source, 'test.ripple', { mode: 'server' })).toThrow(
-			'`children` cannot be called like a regular function. Use element syntax instead, e.g. `<children />` or `<props.children />`.',
+			'`children` cannot be called like a regular function. Render it with `{children}` or `{props.children}` instead.',
 		);
 	});
 });

--- a/packages/ripple/tests/server/compiler.test.ripple
+++ b/packages/ripple/tests/server/compiler.test.ripple
@@ -111,6 +111,27 @@ export component Layout(props) {
 			'`children` cannot be called like a regular function. Render it with `{children}` or `{props.children}` instead.',
 		);
 	});
+
+	it('merges explicit children prop with implicit children in SSR output', () => {
+		const source = `
+component Card(props) {
+	<div>{props.children}</div>
+}
+
+export component App() {
+	const fallback = 'fallback';
+
+	<Card children={fallback}>
+		<span>{'content'}</span>
+	</Card>
+}
+`;
+
+		const result = compile(source, 'test.ripple', { mode: 'server' }).js.code;
+
+		expect((result.match(/children:/g) || []).length).toBe(1);
+		expect(result).toContain('children: _$_.normalize_children(fallback) ?? _$_.ripple_element(');
+	});
 });
 
 describe('compiler server block tests', () => {

--- a/packages/ripple/tests/server/composite.props.test.ripple
+++ b/packages/ripple/tests/server/composite.props.test.ripple
@@ -80,9 +80,7 @@ describe('composite > props', () => {
 
 	it('correctly retains prop accessors and reactivity when using rest props', async () => {
 		component Button(&{ children, ...rest }: Props) {
-			<button {...rest}>
-				<@children />
-			</button>
+			<button {...rest}>{children}</button>
 			<style>
 				.on {
 					color: blue;

--- a/packages/ripple/tests/server/style-identifier.test.ripple
+++ b/packages/ripple/tests/server/style-identifier.test.ripple
@@ -190,7 +190,7 @@ describe('#style identifier (server)', () => {
 		component Wrapper({ children }) {
 			<div class="green">
 				{'Wrapper'}
-				<children />
+				{children}
 			</div>
 
 			<style>
@@ -235,9 +235,7 @@ describe('#style identifier (server)', () => {
 
 	it('applies caller scoped hash to slotted children through dynamic components', async () => {
 		component Wrapper({ children }) {
-			<section>
-				<children />
-			</section>
+			<section>{children}</section>
 		}
 
 		component App() {

--- a/packages/ripple/types/index.d.ts
+++ b/packages/ripple/types/index.d.ts
@@ -1,7 +1,14 @@
 export type Component<T = Record<string, any>> = (props: T) => void;
 
-/** Type for JSX children - accepts single child, multiple children, or no children */
-export type Children = Component | readonly Component[];
+declare const RIPPLE_ELEMENT: unique symbol;
+
+export type RippleElement = {
+	readonly render: Function;
+	readonly [RIPPLE_ELEMENT]: true;
+};
+
+/** Type for implicit children fragments rendered with `{children}`. */
+export type Children = RippleElement;
 
 export type CompatApi = {
 	createRoot: () => void;

--- a/website-new/docs/examples.ts
+++ b/website-new/docs/examples.ts
@@ -139,7 +139,7 @@ component Card(props: { message: string, className?: string, onClick?: () => voi
 
 component Card(props: { children: Children }) {
   <div class="card">
-    <props.children />
+    {props.children}
   </div>
 }
 
@@ -177,7 +177,7 @@ export default component App() {
 	<fieldset>
 		<Header />
 		<hr />
-		<children />
+		{children}
 		<hr />
 		<Footer />
 	</fieldset>
@@ -631,16 +631,16 @@ export default component App() {
 }
 
 component Child({ Button, children }) {
-  <@Button><children /></@Button>
+  <@Button>{children}</@Button>
 }
 
 component AnotherChild(props) {
-  <props.@Button><props.children /></props.@Button>
+  <props.@Button>{props.children}</props.@Button>
 }
 
 component SomeButton({ children }) {
   <button onClick={() => alert('Clicked')}>
-		<children />
+		{children}
 	</button>
 }
 

--- a/website-new/docs/examples.ts
+++ b/website-new/docs/examples.ts
@@ -163,11 +163,11 @@ component Separate() {
 }
 
 export default component App() {
-	<Composite PropComp={Separate}>
-		component InlineComp() {
-			<p>{\`I'm an inline component.\`}</p>
-		}
-	</Composite>
+	component InlineComp() {
+		<p>{\`I'm an inline component.\`}</p>
+	}
+
+	<Composite PropComp={Separate} {InlineComp} />
 }
 `,
 	},
@@ -188,11 +188,12 @@ component CustomHeader() {
 }
 
 export default component App() {
-	<Card Header={CustomHeader}> // <- Header passed in as a prop
+	component Footer() {
+		<p>{'Card footer'}</p>
+	}
+
+	<Card Header={CustomHeader} {Footer}> // <- Header and Footer passed in as props
 		<p>{'Card content here'}</p>
-		component Footer() {     // <- Footer passed in as a inline component
-			<p>{'Card footer'}</p>
-		}
 	</Card>
 }
 `,

--- a/website-new/docs/guide/components.md
+++ b/website-new/docs/guide/components.md
@@ -40,20 +40,19 @@ export component App() {
     <p>{'Card content here'}</p>
   </Card>
 
-  // or explicitly!
-  <Card>
-    component children() {
-      <p>{'Card content here'}</p>
-    }
-  </Card>
+  // or pass children explicitly as a prop.
+  component children() {
+    <p>{'Card content here'}</p>
+  }
+
+  <Card {children} />
 }
 ```
 
 ### Named Children
 
-If you need to pass more than one child to a component, you can either pass the
-child as a prop or define a component with the same name as the prop within the
-scope of the parent.
+If you need to pass more than one child to a component, pass each child as an
+explicit prop on the component element.
 
 ::: warning Note The child you pass in MUST be a component, not just templates!
 :::
@@ -71,11 +70,11 @@ component Separate() {
 }
 
 export component App() {
-  <Composite PropComp={Separate}>
-    component InlineComp() {
-      <p>{`I'm an inline component.`}</p>
-    }
-  </Composite>
+  component InlineComp() {
+    <p>{`I'm an inline component.`}</p>
+  }
+
+  <Composite PropComp={Separate} {InlineComp} />
 }
 ```
 
@@ -107,14 +106,14 @@ component CustomHeader() {
 }
 
 export component App() {
-  <Card Header={CustomHeader}>
+  component Footer() {
+    <button>{'Cancel'}</button>
+    <button>{'OK'}</button>
+  }
+
+  <Card Header={CustomHeader} {Footer}>
     // <- Header passed in as a prop
     <p>{'Card content here'}</p>
-    component Footer() {
-      // <- Footer passed in as a inline component
-      <button>{'Cancel'}</button>
-      <button>{'OK'}</button>
-    }
   </Card>
 }
 ```

--- a/website-new/docs/guide/components.md
+++ b/website-new/docs/guide/components.md
@@ -22,16 +22,14 @@ within `effect()` to ensure they only run when intended.
 
 To pass elements to be nested within a component, simply nest them as you would
 write HTML. By default, Ripple will make the content available as the `children`
-prop, which you can then render using `<props.children />` (or simply
-`<children />` if you destructured your props).
+prop, which you can then render using `{props.children}` (or simply `{children}`
+if you destructured your props).
 
 ```ripple
 import type { Children } from 'ripple';
 
 component Card(props: { children: Children }) {
-  <div class="card">
-    <props.children />
-  </div>
+  <div class="card">{props.children}</div>
 }
 
 export component App() {
@@ -48,77 +46,6 @@ export component App() {
   <Card {children} />
 }
 ```
-
-### Named Children
-
-If you need to pass more than one child to a component, pass each child as an
-explicit prop on the component element.
-
-::: warning Note The child you pass in MUST be a component, not just templates!
-:::
-
-<Code>
-
-```ripple
-component Composite({ PropComp, InlineComp }) {
-  <PropComp />
-  <InlineComp />
-}
-
-component Separate() {
-  <p>{`I'm a separate component.`}</p>
-}
-
-export component App() {
-  component InlineComp() {
-    <p>{`I'm an inline component.`}</p>
-  }
-
-  <Composite PropComp={Separate} {InlineComp} />
-}
-```
-
-</Code>
-
-## Example: Card Component Using Child Composition
-
-Using what we've learnt, let's make a versatile card component that can display an
-optional header and footer.
-
-This pattern is commonly achieved with "slots" from Vue/Web Components, "render
-props" from React, and "snippets" from Svelte.
-
-<Code>
-
-```ripple
-component Card({ children, Header, Footer }) {
-  <fieldset>
-    <Header />
-    <hr />
-    <children />
-    <hr />
-    <Footer />
-  </fieldset>
-}
-
-component CustomHeader() {
-  <h1>{'Card Title'}</h1>
-}
-
-export component App() {
-  component Footer() {
-    <button>{'Cancel'}</button>
-    <button>{'OK'}</button>
-  }
-
-  <Card Header={CustomHeader} {Footer}>
-    // <- Header passed in as a prop
-    <p>{'Card content here'}</p>
-  </Card>
-}
-```
-
-</Code>
 
 ## Reactive Props
 

--- a/website-new/docs/guide/reactivity.md
+++ b/website-new/docs/guide/reactivity.md
@@ -191,7 +191,7 @@ reactivity:
 component Child(&{ count, className, children }: Props) {
   // count, className, children are lazily read from the props object
   <button class={className}>
-    <@children />
+    {children}
   </button>
   <pre>{`Count is: ${count}`}</pre>
 }

--- a/website-new/docs/guide/reactivity.md
+++ b/website-new/docs/guide/reactivity.md
@@ -190,9 +190,7 @@ reactivity:
 ```ripple
 component Child(&{ count, className, children }: Props) {
   // count, className, children are lazily read from the props object
-  <button class={className}>
-    {children}
-  </button>
+  <button class={className}>{children}</button>
   <pre>{`Count is: ${count}`}</pre>
 }
 ```

--- a/website-new/public/llms.txt
+++ b/website-new/public/llms.txt
@@ -505,7 +505,7 @@ import type { Children } from 'ripple';
 
 component Card(props: { children: Children }) {
   <div class="card">
-    <children />
+    {children}
   </div>
 }
 

--- a/website-new/src/components/doc-callout.ripple
+++ b/website-new/src/components/doc-callout.ripple
@@ -11,6 +11,6 @@ export component DocCallout({
 		if (title) {
 			<p class="custom-block-title">{title}</p>
 		}
-		<children />
+		{children}
 	</div>
 }

--- a/website-new/src/components/doc-heading.ripple
+++ b/website-new/src/components/doc-heading.ripple
@@ -12,25 +12,25 @@ export component DocHeading({
 	switch (level) {
 		case 1: {
 			<h1 {id} class="doc-h1">
-				<children />
+				{children}
 				<a class="header-anchor" href={`#${id}`} aria-label={`Permalink`} />
 			</h1>
 		}
 		case 2: {
 			<h2 {id} class="doc-h2">
-				<children />
+				{children}
 				<a class="header-anchor" href={`#${id}`} aria-label={`Permalink`} />
 			</h2>
 		}
 		case 3: {
 			<h3 {id} class="doc-h3">
-				<children />
+				{children}
 				<a class="header-anchor" href={`#${id}`} aria-label={`Permalink`} />
 			</h3>
 		}
 		case 4: {
 			<h4 {id} class="doc-h4">
-				<children />
+				{children}
 				<a class="header-anchor" href={`#${id}`} aria-label={`Permalink`} />
 			</h4>
 		}

--- a/website-new/src/components/docs-layout.ripple
+++ b/website-new/src/components/docs-layout.ripple
@@ -40,9 +40,7 @@ export component DocsLayout({
 					<div class="content">
 						<div class="content-container">
 							<article class="doc-content">
-								<div>
-									<children />
-								</div>
+								<div>{children}</div>
 							</article>
 							if (editPath) {
 								<div class="edit-link">

--- a/website-new/src/components/layout.ripple
+++ b/website-new/src/components/layout.ripple
@@ -1,8 +1,6 @@
 export component Layout({ children }) {
 	<main>
-		<div class="container">
-			<children />
-		</div>
+		<div class="container">{children}</div>
 
 		<div class="vercel-footer">
 			<p>

--- a/website-new/src/components/sidebar.ripple
+++ b/website-new/src/components/sidebar.ripple
@@ -250,9 +250,7 @@ component SidebarGroup({
 			</div>
 		</div>
 		if (expanded) {
-			<div class="items">
-				<children />
-			</div>
+			<div class="items">{children}</div>
 		}
 	</section>
 

--- a/website/docs/examples.ts
+++ b/website/docs/examples.ts
@@ -139,7 +139,7 @@ component Card(props: { message: string, className?: string, onClick?: () => voi
 
 component Card(props: { children: Children }) {
   <div class="card">
-    <props.children />
+    {props.children}
   </div>
 }
 
@@ -177,7 +177,7 @@ export default component App() {
 	<fieldset>
 		<Header />
 		<hr />
-		<children />
+		{children}
 		<hr />
 		<Footer />
 	</fieldset>
@@ -630,16 +630,16 @@ export default component App() {
 }
 
 component Child({ Button, children }) {
-  <@Button><children /></@Button>
+  <@Button>{children}</@Button>
 }
 
 component AnotherChild(&{ Button, children }) {
-  <@Button><children /></@Button>
+  <@Button>{children}</@Button>
 }
 
 component SomeButton({ children }) {
   <button onClick={() => alert('Clicked')}>
-		<children />
+		{children}
 	</button>
 }
 

--- a/website/docs/guide/components.md
+++ b/website/docs/guide/components.md
@@ -23,15 +23,15 @@ within `effect()` to ensure they only run when intended.
 
 To pass elements to be nested within a component, simply nest them as you would
 write HTML. By default, Ripple will make the content available as the
-`children` prop, which you can then render using `<props.children />` (or simply
-`<children />` if you destructured your props).
+`children` prop, which you can then render using `{props.children}` (or simply
+`{children}` if you destructured your props).
 
 ```ripple
 import type { Children } from 'ripple';
 
 component Card(props: { children: Children }) {
 	<div class="card">
-		<props.children />
+		{props.children}
 	</div>
 }
 
@@ -98,7 +98,7 @@ component Card({ children, Header, Footer }) {
 	<fieldset>
 		<Header />
 		<hr />
-		<children />
+		{children}
 		<hr />
 		<Footer />
 	</fieldset>

--- a/website/docs/guide/components.md
+++ b/website/docs/guide/components.md
@@ -41,12 +41,12 @@ export component App() {
 		<p>{"Card content here"}</p>
 	</Card>
 
-	// or explicitly!
-	<Card>
-		component children() {
-			<p>{"Card content here"}</p>
-		}
-	</Card>
+	// or pass children explicitly as a prop.
+	component children() {
+		<p>{"Card content here"}</p>
+	}
+
+	<Card {children} />
 }
 ```
 

--- a/website/docs/guide/reactivity.md
+++ b/website/docs/guide/reactivity.md
@@ -194,7 +194,7 @@ reactivity:
 ```ripple
 component Child(&{ count, className, children }: Props) {
   // count, className, children are lazily read from the props object
-  <button class={className}><@children /></button>
+  <button class={className}>{children}</button>
   <pre>{`Count is: ${count}`}</pre>
 }
 ```

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -354,7 +354,7 @@ const &{ a, ...rest } = props;
 ```ripple
 component Child(&{ count, className, children }: Props) {
   // count, className, children are lazily read from __props
-  <button class={className}><children /></button>
+  <button class={className}>{children}</button>
   <pre>{`Count is: ${count}`}</pre>
 }
 ```
@@ -591,7 +591,7 @@ import type { Children, Component } from 'ripple';
 
 component Card(props: { children: Children; Footer?: Component }) {
   <div class="card">
-    <props.children />
+    {props.children}
     if (props.Footer) {
       <props.Footer />
     }

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -17,11 +17,11 @@ Ripple is a TypeScript UI framework that combines the best parts of React, Solid
 # Create new project from template
 npx degit Ripple-TS/ripple/templates/basic my-app
 cd my-app
-npm i && npm run dev
+pnpm install && pnpm dev
 
 # Or install in existing project
-npm install ripple
-npm install --save-dev '@ripple-ts/vite-plugin'  # For Vite integration
+pnpm add ripple
+pnpm add -D '@ripple-ts/vite-plugin'  # For Vite integration
 ```
 
 ## Core Syntax & Concepts
@@ -584,19 +584,26 @@ component ErrorBoundary() {
 
 ### Children Components
 
-Use `children` prop for component composition. Use `Children` type to accept one or more children:
+Use the `children` prop for component composition. Use the `Children` type to accept one or more children. If you need to pass additional child components such as `Header`, `Footer`, or `InlineComp`, define them in scope and pass them as explicit props on the component element. Do not declare `component Foo() {}` directly inside another component's child content.
 
 ```ripple
-import type { Children } from 'ripple';
+import type { Children, Component } from 'ripple';
 
-component Card(props: { children: Children }) {
+component Card(props: { children: Children; Footer?: Component }) {
   <div class="card">
-    <children />
+    <props.children />
+    if (props.Footer) {
+      <props.Footer />
+    }
   </div>
 }
 
+component Footer() {
+  <button>{'OK'}</button>
+}
+
 // Usage
-<Card>
+<Card Footer={Footer}>
   <p>{"Card content here"}</p>
 </Card>
 ```
@@ -1159,7 +1166,7 @@ Ripple provides a compatibility layer for integrating with React applications. T
 #### Installation
 
 ```bash
-npm install @ripple-ts/compat-react
+pnpm add @ripple-ts/compat-react
 ```
 
 #### Using React Components in Ripple (tsx:react)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Touches core compiler transforms and both client/SSR runtime rendering/hydration paths for `children`, introducing a new `RippleElement` wrapper and new expression rendering behavior; regressions could affect composition, hydration markers, and namespace handling.
> 
> **Overview**
> **Removes “magical” component-children support**: nested `component children()` declarations inside composite children are now rejected, and `children` is intended to be rendered via `{children}`/`{props.children}` rather than `<children />`-style component syntax.
> 
> **Introduces `RippleElement` wrappers for renderable children** (`ripple_element`, `normalize_children`, `is_ripple_element`) and updates client/server transforms to always normalize `children` props, merge explicit `children` props with implicit template children via `??`, and stop auto-converting nested child component declarations into props.
> 
> **Adds expression rendering for element-valued interpolations**: client runtime gains `expression()` to render either text or `RippleElement` ranges (with hydration markers), SSR adds `render_expression()`, and composite/portal rendering paths are updated to consume `RippleElement` children and preserve namespaces. Tests and generated fixtures are updated accordingly, including new coverage for reactive text `children` updates during hydration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0b187d34fce4ac2f897a29bae705398fad313fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->