### PR TITLE
fix: remove invalid StringLiteral/NumericLiteral type comparisons in prettier plugin

### DIFF
--- a/packages/prettier-plugin/src/index.js
+++ b/packages/prettier-plugin/src/index.js
@@ -5466,10 +5466,7 @@ function shouldInlineSingleChild(parentNode, firstChild, childDoc) {
 		const expr = firstChild.expression;
 		if (
 			expr &&
-			(expr.type === 'Literal' ||
-				expr.type === 'StringLiteral' ||
-				expr.type === 'NumericLiteral' ||
-				expr.type === 'TemplateLiteral')
+			(expr.type === 'Literal' || expr.type === 'TemplateLiteral')
 		) {
 			return true;
 		}

--- a/packages/prettier-plugin/src/index.js
+++ b/packages/prettier-plugin/src/index.js
@@ -5464,10 +5464,7 @@ function shouldInlineSingleChild(parentNode, firstChild, childDoc) {
 		}
 		// For multi-line parents, only inline if the expression is a simple literal
 		const expr = firstChild.expression;
-		if (
-			expr &&
-			(expr.type === 'Literal' || expr.type === 'TemplateLiteral')
-		) {
+		if (expr && (expr.type === 'Literal' || expr.type === 'TemplateLiteral')) {
 			return true;
 		}
 		return false;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The CI typecheck was failing with two TS2367 errors in `packages/prettier-plugin/src/index.js` at lines 5470-5471:

```
error TS2367: This comparison appears to be unintentional because the types '...' and '"StringLiteral"' have no overlap.
error TS2367: This comparison appears to be unintentional because the types '...' and '"NumericLiteral"' have no overlap.
```

## Root Cause

The code was comparing `expr.type` against `'StringLiteral'` and `'NumericLiteral'`, which are **Babel AST** node types. Ripple uses **ESTree**-compatible AST where both string and numeric literals are represented as `'Literal'` nodes. The `'Literal'` check was already present, making the `'StringLiteral'` and `'NumericLiteral'` comparisons both redundant and type-incorrect.

## Fix

Removed the two invalid comparisons. The existing `expr.type === 'Literal'` check already covers both string and numeric literals in the ESTree AST.

## Validation

- `pnpm typecheck` passes
- `pnpm test --project prettier-plugin` passes (270/270 tests)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-714ede7c-76c3-4abd-94e8-12a64370290b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-714ede7c-76c3-4abd-94e8-12a64370290b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

