### PR TITLE
Adds native support to Ripple for JSX/TSX

### DIFF
--- a/packages/prettier-plugin/src/index.js
+++ b/packages/prettier-plugin/src/index.js
@@ -2194,6 +2194,10 @@ function printRippleNode(node, path, options, print, args) {
 			nodeContent = printTsxCompat(node, path, options, print);
 			break;
 
+		case 'Tsx':
+			nodeContent = printTsx(node, path, options, print);
+			break;
+
 		case 'JSXElement':
 			nodeContent = printJSXElement(node, path, options, print);
 			break;
@@ -5546,6 +5550,53 @@ function createElementLevelCommentPartsTrimmed(comments) {
 		parts.pop();
 	}
 	return parts;
+}
+
+/**
+ * Print a Tsx node - renders Ripple template children inside <tsx>...</tsx>
+ * @param {AST.Tsx} node - The Tsx node
+ * @param {AstPath<AST.Tsx>} path - The AST path
+ * @param {RippleFormatOptions} options - Prettier options
+ * @param {PrintFn} print - Print callback
+ * @returns {Doc}
+ */
+function printTsx(node, path, options, print) {
+	const tagName = '<tsx>';
+	const closingTagName = '</tsx>';
+
+	const hasChildren = Array.isArray(node.children) && node.children.length > 0;
+
+	if (!hasChildren) {
+		return [tagName, closingTagName];
+	}
+
+	// Print children - these are Ripple template children (Element, Text, etc.)
+	const printedChildren = [];
+
+	for (let i = 0; i < node.children.length; i++) {
+		const child = node.children[i];
+
+		if (child.type === 'JSXText') {
+			const text = child.value.trim();
+			if (!text) continue;
+			printedChildren.push(text);
+		} else {
+			const printedChild = path.call(print, 'children', i);
+			printedChildren.push(printedChild);
+		}
+	}
+
+	if (printedChildren.length === 0) {
+		return [tagName, closingTagName];
+	}
+
+	// Use softline to allow single-line when content fits
+	return group([
+		tagName,
+		indent([softline, join(softline, printedChildren)]),
+		softline,
+		closingTagName,
+	]);
 }
 
 /**

--- a/packages/ripple/src/compiler/errors.js
+++ b/packages/ripple/src/compiler/errors.js
@@ -59,7 +59,7 @@ function is_ripple_error_suppress_comment(comment) {
 }
 
 /**
- * @param {AST.Node} node
+ * @param {AST.Node | AST.NodeWithLocation} node
  * @param {AST.CommentWithLocation[]} comments
  */
 function is_ripple_error_suppressed(node, comments) {

--- a/packages/ripple/src/compiler/phases/1-parse/index.js
+++ b/packages/ripple/src/compiler/phases/1-parse/index.js
@@ -1358,7 +1358,9 @@ function RipplePlugin(config) {
 
 			/** @type {Parse.Parser['jsx_readToken']} */
 			jsx_readToken() {
-				const inside_tsx_compat = this.#path.findLast((n) => n.type === 'TsxCompat');
+				const inside_tsx_compat = this.#path.findLast(
+					(n) => n.type === 'TsxCompat' || n.type === 'Tsx',
+				);
 				if (inside_tsx_compat) {
 					return super.jsx_readToken();
 				}
@@ -1510,6 +1512,44 @@ function RipplePlugin(config) {
 			}
 
 			/**
+			 * Override jsx_parseElement to intercept expression-level JSX.
+			 * This is called by acorn-jsx's parseExprAtom when it encounters <
+			 * in expression position. Only <tsx> and <tsx:*> are allowed.
+			 * @type {Parse.Parser['jsx_parseElement']}
+			 */
+			jsx_parseElement() {
+				const inside_tsx = this.#path.findLast((n) => n.type === 'TsxCompat' || n.type === 'Tsx');
+				if (inside_tsx) {
+					// Inside tsx/tsx:*, let acorn-jsx handle it normally
+					return super.jsx_parseElement();
+				}
+
+				// Check if the element being parsed IS a <tsx> or <tsx:*> tag
+				// Current token is jsxTagStart, this.end is position after '<'
+				const tag_name_start = this.end;
+				const is_tsx_tag =
+					this.input.startsWith('tsx', tag_name_start) &&
+					(tag_name_start + 3 >= this.input.length ||
+						this.input.charCodeAt(tag_name_start + 3) === 62 || // >
+						this.input.charCodeAt(tag_name_start + 3) === 32 || // space
+						this.input.charCodeAt(tag_name_start + 3) === 9 || // tab
+						this.input.charCodeAt(tag_name_start + 3) === 58); // : (tsx:react)
+
+				if (is_tsx_tag) {
+					// Use Ripple's parseElement to create a Tsx/TsxCompat node
+					this.next();
+					return /** @type {import('estree-jsx').JSXElement} */ (
+						/** @type {unknown} */ (this.parseElement())
+					);
+				}
+
+				this.raise(
+					this.start,
+					'JSX elements cannot be used as expressions. Wrap with `<tsx>...</tsx>` or use elements as statements within a component.',
+				);
+			}
+
+			/**
 			 * @type {Parse.Parser['parseElement']}
 			 */
 			parseElement() {
@@ -1520,7 +1560,7 @@ function RipplePlugin(config) {
 				const start = this.start - 1;
 				const position = new acorn.Position(this.curLine, start - this.lineStart);
 
-				const element = /** @type {AST.Element | AST.TsxCompat} */ (this.startNode());
+				const element = /** @type {AST.Element | AST.Tsx | AST.TsxCompat} */ (this.startNode());
 				element.start = start;
 				/** @type {AST.NodeWithLocation} */ (element).loc.start = position;
 				element.metadata = { path: [] };
@@ -1535,6 +1575,8 @@ function RipplePlugin(config) {
 
 				// Check if this is a namespaced element (tsx:react)
 				const is_tsx_compat = open.name.type === 'JSXNamespacedName';
+				const is_tsx =
+					!is_tsx_compat && open.name.type === 'JSXIdentifier' && open.name.name === 'tsx';
 
 				if (is_tsx_compat) {
 					const namespace_node = /** @type {ESTreeJSX.JSXNamespacedName} */ (open.name);
@@ -1546,6 +1588,15 @@ function RipplePlugin(config) {
 						this.raise(
 							open.start,
 							`TSX compatibility elements cannot be self-closing. '<${tagName} />' must have a closing tag '</${tagName}>'.`,
+						);
+					}
+				} else if (is_tsx) {
+					/** @type {AST.Tsx} */ (element).type = 'Tsx';
+
+					if (open.selfClosing) {
+						this.raise(
+							open.start,
+							`TSX elements cannot be self-closing. '<tsx />' must have a closing tag '</tsx>'.`,
 						);
 					}
 				} else {
@@ -1575,7 +1626,7 @@ function RipplePlugin(config) {
 					}
 				}
 
-				if (!is_tsx_compat) {
+				if (!is_tsx_compat && !is_tsx) {
 					/** @type {AST.Element} */ (element).id = /** @type {AST.Identifier} */ (
 						convert_from_jsx(/** @type {ESTreeJSX.JSXIdentifier} */ (open.name))
 					);
@@ -1745,6 +1796,7 @@ function RipplePlugin(config) {
 						const insideTemplate =
 							parent?.type === 'Component' ||
 							parent?.type === 'Element' ||
+							parent?.type === 'Tsx' ||
 							parent?.type === 'TsxCompat';
 
 						if (curContext === tstc.tc_expr && !insideTemplate) {
@@ -1757,7 +1809,30 @@ function RipplePlugin(config) {
 						this.parseTemplateBody(/** @type {AST.Element} */ (element).children);
 						this.exitScope();
 
-						if (element.type === 'TsxCompat') {
+						if (element.type === 'Tsx') {
+							this.#path.pop();
+
+							if (!element.unclosed) {
+								const raise_error = () => {
+									this.raise(this.start, `Expected closing tag '</tsx>'`);
+								};
+
+								this.next();
+								// we should expect to see </tsx>
+								if (this.value !== '/') {
+									raise_error();
+								}
+								this.next();
+								if (this.value !== 'tsx') {
+									raise_error();
+								}
+								this.next();
+								if (this.type !== tstt.jsxTagEnd) {
+									raise_error();
+								}
+								this.next();
+							}
+						} else if (element.type === 'TsxCompat') {
 							this.#path.pop();
 
 							if (!element.unclosed) {
@@ -1813,6 +1888,7 @@ function RipplePlugin(config) {
 					const insideTemplate =
 						parent?.type === 'Component' ||
 						parent?.type === 'Element' ||
+						parent?.type === 'Tsx' ||
 						parent?.type === 'TsxCompat';
 
 					if (curContext === tstc.tc_expr && !insideTemplate) {
@@ -1820,7 +1896,7 @@ function RipplePlugin(config) {
 					}
 				}
 
-				if (element.closingElement && !is_tsx_compat) {
+				if (element.closingElement && !is_tsx_compat && !is_tsx) {
 					/** @type {unknown} */ (element.closingElement.name) = convert_from_jsx(
 						element.closingElement.name,
 					);
@@ -1836,6 +1912,7 @@ function RipplePlugin(config) {
 			parseTemplateBody(body) {
 				const inside_func =
 					this.context.some((n) => n.token === 'function') || this.scopeStack.length > 1;
+				const inside_tsx = this.#path.findLast((n) => n.type === 'Tsx');
 				const inside_tsx_compat = this.#path.findLast((n) => n.type === 'TsxCompat');
 
 				if (!inside_func) {
@@ -1847,6 +1924,74 @@ function RipplePlugin(config) {
 					}
 				}
 
+				if (inside_tsx) {
+					this.exprAllowed = true;
+
+					while (true) {
+						if (this.type === tt.eof || this.pos >= this.input.length || this.type === tt.braceR) {
+							if (!this.#loose) {
+								this.raise(
+									this.start,
+									`Unclosed tag '<tsx>'. Expected '</tsx>' before end of component.`,
+								);
+							} else {
+								inside_tsx.unclosed = true;
+								/** @type {AST.NodeWithLocation} */ (inside_tsx).loc.end = {
+									.../** @type {AST.SourceLocation} */ (inside_tsx.openingElement.loc).end,
+								};
+								inside_tsx.end = inside_tsx.openingElement.end;
+							}
+							return;
+						}
+
+						if (this.input.slice(this.pos, this.pos + 4) === '/tsx') {
+							const after = this.input.charCodeAt(this.pos + 4);
+							// Make sure it's </tsx> and not </tsx:...>
+							if (after === 62 /* > */) {
+								return;
+							}
+						}
+
+						if (this.type === tt.braceL) {
+							const node = this.jsx_parseExpressionContainer();
+							body.push(node);
+						} else if (this.type === tstt.jsxTagStart) {
+							// Parse JSX element
+							const node = super.parseExpression();
+							body.push(node);
+						} else {
+							const start = this.start;
+							this.pos = start;
+							let text = '';
+
+							while (this.pos < this.input.length) {
+								const ch = this.input.charCodeAt(this.pos);
+
+								// Stop at opening tag, expression, or the component-closing brace
+								if (ch === 60 || ch === 123 || ch === 125) {
+									// < or { or }
+									break;
+								}
+
+								text += this.input[this.pos];
+								this.pos++;
+							}
+
+							if (text) {
+								const node = /** @type {ESTreeJSX.JSXText} */ ({
+									type: 'JSXText',
+									value: text,
+									raw: text,
+									start,
+									end: this.pos,
+								});
+								body.push(node);
+							}
+
+							this.next();
+						}
+					}
+				}
 				if (inside_tsx_compat) {
 					this.exprAllowed = true;
 
@@ -1950,7 +2095,9 @@ function RipplePlugin(config) {
 						const currentElement = this.#path[this.#path.length - 1];
 						if (
 							!currentElement ||
-							(currentElement.type !== 'Element' && currentElement.type !== 'TsxCompat')
+							(currentElement.type !== 'Element' &&
+								currentElement.type !== 'Tsx' &&
+								currentElement.type !== 'TsxCompat')
 						) {
 							this.raise(this.start, 'Unexpected closing tag');
 						}
@@ -1962,6 +2109,12 @@ function RipplePlugin(config) {
 
 						if (currentElement.type === 'TsxCompat') {
 							openingTagName = 'tsx:' + currentElement.kind;
+							closingTagName =
+								closingElement.name?.type === 'JSXNamespacedName'
+									? closingElement.name.namespace.name + ':' + closingElement.name.name.name
+									: this.getElementName(closingElement.name);
+						} else if (currentElement.type === 'Tsx') {
+							openingTagName = 'tsx';
 							closingTagName =
 								closingElement.name?.type === 'JSXNamespacedName'
 									? closingElement.name.namespace.name + ':' + closingElement.name.name.name
@@ -1987,12 +2140,16 @@ function RipplePlugin(config) {
 									const elem = this.#path[this.#path.length - 1];
 
 									// Stop at non-Element boundaries (Component, etc.)
-									if (elem.type !== 'Element' && elem.type !== 'TsxCompat') {
+									if (elem.type !== 'Element' && elem.type !== 'Tsx' && elem.type !== 'TsxCompat') {
 										break;
 									}
 
 									const elemName =
-										elem.type === 'TsxCompat' ? 'tsx:' + elem.kind : this.getElementName(elem.id);
+										elem.type === 'TsxCompat'
+											? 'tsx:' + elem.kind
+											: elem.type === 'Tsx'
+												? 'tsx'
+												: this.getElementName(elem.id);
 
 									// Found matching opening tag
 									if (elemName === closingTagName) {

--- a/packages/ripple/src/compiler/phases/1-parse/index.js
+++ b/packages/ripple/src/compiler/phases/1-parse/index.js
@@ -1990,9 +1990,10 @@ function RipplePlugin(config) {
 									end: this.pos,
 								});
 								body.push(node);
-
-								this.next();
 							}
+
+							// Always call next() to ensure parser makes progress
+							this.next();
 						}
 					}
 				}
@@ -2054,9 +2055,9 @@ function RipplePlugin(config) {
 									end: this.pos,
 								});
 								body.push(node);
-
-								this.next();
 							}
+
+							this.next();
 						}
 					}
 				}

--- a/packages/ripple/src/compiler/phases/1-parse/index.js
+++ b/packages/ripple/src/compiler/phases/1-parse/index.js
@@ -1990,9 +1990,9 @@ function RipplePlugin(config) {
 									end: this.pos,
 								});
 								body.push(node);
-							}
 
-							this.next();
+								this.next();
+							}
 						}
 					}
 				}
@@ -2054,9 +2054,9 @@ function RipplePlugin(config) {
 									end: this.pos,
 								});
 								body.push(node);
-							}
 
-							this.next();
+								this.next();
+							}
 						}
 					}
 				}

--- a/packages/ripple/src/compiler/phases/1-parse/index.js
+++ b/packages/ripple/src/compiler/phases/1-parse/index.js
@@ -1527,13 +1527,17 @@ function RipplePlugin(config) {
 				// Check if the element being parsed IS a <tsx> or <tsx:*> tag
 				// Current token is jsxTagStart, this.end is position after '<'
 				const tag_name_start = this.end;
+				const char_after_tsx = this.input.charCodeAt(tag_name_start + 3);
 				const is_tsx_tag =
 					this.input.startsWith('tsx', tag_name_start) &&
 					(tag_name_start + 3 >= this.input.length ||
-						this.input.charCodeAt(tag_name_start + 3) === 62 || // >
-						this.input.charCodeAt(tag_name_start + 3) === 32 || // space
-						this.input.charCodeAt(tag_name_start + 3) === 9 || // tab
-						this.input.charCodeAt(tag_name_start + 3) === 58); // : (tsx:react)
+						char_after_tsx === 62 || // >
+						char_after_tsx === 47 || // / (self-closing)
+						char_after_tsx === 32 || // space
+						char_after_tsx === 9 || // tab
+						char_after_tsx === 10 || // newline
+						char_after_tsx === 13 || // carriage return
+						char_after_tsx === 58); // : (tsx:react)
 
 				if (is_tsx_tag) {
 					// Use Ripple's parseElement to create a Tsx/TsxCompat node

--- a/packages/ripple/src/compiler/phases/2-analyze/index.js
+++ b/packages/ripple/src/compiler/phases/2-analyze/index.js
@@ -68,6 +68,10 @@ function expression_has_side_effects(node) {
 			);
 		case 'UnaryExpression':
 			return expression_has_side_effects(node.argument);
+		case 'AwaitExpression':
+			return expression_has_side_effects(node.argument);
+		case 'ChainExpression':
+			return expression_has_side_effects(node.expression);
 		case 'MemberExpression':
 			return (
 				expression_has_side_effects(node.object) ||

--- a/packages/ripple/src/compiler/phases/2-analyze/index.js
+++ b/packages/ripple/src/compiler/phases/2-analyze/index.js
@@ -41,9 +41,53 @@ import { validate_nesting } from './validation.js';
 
 const valid_in_head = new Set(['title', 'base', 'link', 'meta', 'style', 'script', 'noscript']);
 
+const mutating_method_names = new Set([
+	'add',
+	'append',
+	'clear',
+	'copyWithin',
+	'delete',
+	'fill',
+	'pop',
+	'push',
+	'reverse',
+	'set',
+	'shift',
+	'sort',
+	'splice',
+	'unshift',
+]);
+
 /**
- * Check if an expression contains side effects (assignments or updates).
- * Template expressions should be pure reads — writes belong outside the template.
+ * @param {AST.MemberExpression} node
+ * @returns {string | null}
+ */
+function get_member_name(node) {
+	if (!node.computed && node.property.type === 'Identifier') {
+		return node.property.name;
+	}
+
+	if (node.computed && node.property.type === 'Literal') {
+		return typeof node.property.value === 'string' ? node.property.value : null;
+	}
+
+	return null;
+}
+
+/**
+ * @param {AST.CallExpression} node
+ * @returns {boolean}
+ */
+function is_mutating_call_expression(node) {
+	return (
+		node.callee.type === 'MemberExpression' &&
+		mutating_method_names.has(get_member_name(node.callee) ?? '')
+	);
+}
+
+/**
+ * Check if an expression contains side effects or other impure operations.
+ * Template expressions should be pure reads.
  * @param {AST.Expression | AST.SpreadElement | AST.Super | AST.Pattern} node
  * @returns {boolean}
  */
@@ -81,6 +125,11 @@ function expression_has_side_effects(node) {
 					expression_has_side_effects(/** @type {AST.Expression} */ (node.property)))
 			);
 		case 'CallExpression':
+			return (
+				is_mutating_call_expression(node) ||
+				expression_has_side_effects(node.callee) ||
+				node.arguments.some(expression_has_side_effects)
+			);
 		case 'NewExpression':
 			return (
 				expression_has_side_effects(node.callee) || node.arguments.some(expression_has_side_effects)
@@ -2050,7 +2099,7 @@ const visitors = {
 
 		if (expression_has_side_effects(node.expression)) {
 			error(
-				'Template expressions must not contain assignments or updates..',
+				'Template expressions must not contain side effects.',
 				context.state.analysis.module.filename,
 				node.expression,
 				context.state.loose ? context.state.analysis.errors : undefined,

--- a/packages/ripple/src/compiler/phases/2-analyze/index.js
+++ b/packages/ripple/src/compiler/phases/2-analyze/index.js
@@ -88,7 +88,9 @@ function expression_has_side_effects(node) {
 			return node.properties.some((prop) =>
 				prop.type === 'SpreadElement'
 					? expression_has_side_effects(prop.argument)
-					: expression_has_side_effects(prop.value),
+					: expression_has_side_effects(prop.value) ||
+						(prop.computed &&
+							expression_has_side_effects(/** @type {AST.Expression} */ (prop.key))),
 			);
 		case 'SpreadElement':
 			return expression_has_side_effects(node.argument);

--- a/packages/ripple/src/compiler/phases/2-analyze/index.js
+++ b/packages/ripple/src/compiler/phases/2-analyze/index.js
@@ -62,13 +62,17 @@ function expression_has_side_effects(node) {
 			);
 		case 'LogicalExpression':
 		case 'BinaryExpression':
-			return expression_has_side_effects(node.left) || expression_has_side_effects(node.right);
+			return (
+				expression_has_side_effects(/** @type {AST.Expression} */ (node.left)) ||
+				expression_has_side_effects(node.right)
+			);
 		case 'UnaryExpression':
 			return expression_has_side_effects(node.argument);
 		case 'MemberExpression':
 			return (
 				expression_has_side_effects(node.object) ||
-				(node.computed && expression_has_side_effects(node.property))
+				(node.computed &&
+					expression_has_side_effects(/** @type {AST.Expression} */ (node.property)))
 			);
 		case 'CallExpression':
 		case 'NewExpression':
@@ -184,7 +188,11 @@ function setup_lazy_transforms(pattern, source_id, state, writable, is_track_cal
 
 						if (node.prefix) {
 							// ++count: return new value
-							return b.assignment('=', member, b.binary('+', fallback_read, delta));
+							return b.assignment(
+								'=',
+								/** @type {AST.Pattern} */ (member),
+								b.binary('+', fallback_read, delta),
+							);
 						} else {
 							// count++: return old value, write new value
 							// Use IIFE to declare temp variable
@@ -194,7 +202,13 @@ function setup_lazy_transforms(pattern, source_id, state, writable, is_track_cal
 									[],
 									b.block([
 										b.var(temp, fallback_read),
-										b.stmt(b.assignment('=', member, b.binary('+', temp, delta))),
+										b.stmt(
+											b.assignment(
+												'=',
+												/** @type {AST.Pattern} */ (member),
+												b.binary('+', temp, delta),
+											),
+										),
 										b.return(temp),
 									]),
 								),
@@ -257,7 +271,12 @@ function setup_lazy_array_transforms(pattern, source_id, state, writable) {
 			if (i === 0) {
 				// Fast path for index 0: use _$_.get(source) instead of source[0]
 				const read_expr = has_fallback
-					? () => b.call('_$_.fallback', b.call('_$_.get', source_id), fallback_value)
+					? () =>
+							b.call(
+								'_$_.fallback',
+								b.call('_$_.get', source_id),
+								/** @type {AST.Expression} */ (fallback_value),
+							)
 					: () => b.call('_$_.get', source_id);
 
 				// Signal that read already produces an unwrapped value (calls _$_.get internally)
@@ -306,6 +325,7 @@ function setup_lazy_array_transforms(pattern, source_id, state, writable) {
 					} else {
 						binding.transform.update = (node) => {
 							const fn_name = node.prefix ? '_$_.update_pre' : '_$_.update';
+							/** @type {AST.Expression[]} */
 							const args = [source_id];
 							if (node.operator === '--') {
 								args.push(b.literal(-1));
@@ -339,7 +359,10 @@ function setup_lazy_array_transforms(pattern, source_id, state, writable) {
 				binding.kind = path.has_default_value ? 'lazy_fallback' : 'lazy';
 
 				binding.transform = {
-					read: (_) => path.expression(base_expression(source_id)),
+					read: (_) =>
+						path.expression(
+							/** @type {AST.Identifier | AST.CallExpression} */ (base_expression(source_id)),
+						),
 				};
 
 				if (writable) {
@@ -347,7 +370,7 @@ function setup_lazy_array_transforms(pattern, source_id, state, writable) {
 						return b.assignment(
 							'=',
 							/** @type {AST.MemberExpression} */ (
-								path.update_expression(base_expression(source_id))
+								path.update_expression(/** @type {AST.Identifier} */ (base_expression(source_id)))
 							),
 							value,
 						);
@@ -355,12 +378,20 @@ function setup_lazy_array_transforms(pattern, source_id, state, writable) {
 
 					if (path.has_default_value) {
 						binding.transform.update = (node) => {
-							const member = path.update_expression(base_expression(source_id));
-							const fallback_read = path.expression(base_expression(source_id));
+							const member = path.update_expression(
+								/** @type {AST.Identifier} */ (base_expression(source_id)),
+							);
+							const fallback_read = path.expression(
+								/** @type {AST.Identifier | AST.CallExpression} */ (base_expression(source_id)),
+							);
 							const delta = node.operator === '++' ? b.literal(1) : b.literal(-1);
 
 							if (node.prefix) {
-								return b.assignment('=', member, b.binary('+', fallback_read, delta));
+								return b.assignment(
+									'=',
+									/** @type {AST.Pattern} */ (member),
+									b.binary('+', fallback_read, delta),
+								);
 							} else {
 								const temp = b.id('_v');
 								return b.call(
@@ -368,7 +399,13 @@ function setup_lazy_array_transforms(pattern, source_id, state, writable) {
 										[],
 										b.block([
 											b.var(temp, fallback_read),
-											b.stmt(b.assignment('=', member, b.binary('+', temp, delta))),
+											b.stmt(
+												b.assignment(
+													'=',
+													/** @type {AST.Pattern} */ (member),
+													b.binary('+', temp, delta),
+												),
+											),
 											b.return(temp),
 										]),
 									),
@@ -379,7 +416,7 @@ function setup_lazy_array_transforms(pattern, source_id, state, writable) {
 						binding.transform.update = (node) =>
 							b.update(
 								node.operator,
-								path.update_expression(base_expression(source_id)),
+								path.update_expression(/** @type {AST.Identifier} */ (base_expression(source_id))),
 								node.prefix,
 							);
 					}
@@ -407,11 +444,11 @@ function unwrap_type_annotation(type_annotation) {
 
 	while (annotation) {
 		if (annotation.type === 'TSParenthesizedType') {
-			annotation = annotation.typeAnnotation;
+			annotation = /** @type {AST.TypeNode | undefined} */ (annotation.typeAnnotation);
 			continue;
 		}
 		if (annotation.type === 'TSOptionalType') {
-			annotation = annotation.typeAnnotation;
+			annotation = /** @type {AST.TypeNode | undefined} */ (annotation.typeAnnotation);
 			continue;
 		}
 		break;
@@ -434,11 +471,11 @@ function normalize_tuple_element_type(type_annotation) {
 			continue;
 		}
 		if (annotation.type === 'TSParenthesizedType') {
-			annotation = annotation.typeAnnotation;
+			annotation = /** @type {AST.TypeNode} */ (annotation.typeAnnotation);
 			continue;
 		}
 		if (annotation.type === 'TSOptionalType') {
-			annotation = annotation.typeAnnotation;
+			annotation = /** @type {AST.TypeNode} */ (annotation.typeAnnotation);
 			continue;
 		}
 		break;
@@ -490,7 +527,7 @@ function get_object_property_type_annotation(type_annotation, property) {
 		return undefined;
 	}
 
-	const key_name = get_object_pattern_key_name(property.key);
+	const key_name = get_object_pattern_key_name(/** @type {AST.Expression} */ (property.key));
 	if (key_name === null) {
 		return undefined;
 	}

--- a/packages/ripple/src/compiler/phases/2-analyze/index.js
+++ b/packages/ripple/src/compiler/phases/2-analyze/index.js
@@ -67,6 +67,8 @@ function expression_has_side_effects(node) {
 				expression_has_side_effects(node.right)
 			);
 		case 'UnaryExpression':
+			// delete operator has side effects (removes object properties)
+			if (node.operator === 'delete') return true;
 			return expression_has_side_effects(node.argument);
 		case 'AwaitExpression':
 			return expression_has_side_effects(node.argument);

--- a/packages/ripple/src/compiler/phases/2-analyze/index.js
+++ b/packages/ripple/src/compiler/phases/2-analyze/index.js
@@ -42,6 +42,62 @@ import { validate_nesting } from './validation.js';
 const valid_in_head = new Set(['title', 'base', 'link', 'meta', 'style', 'script', 'noscript']);
 
 /**
+ * Check if an expression contains side effects (assignments or updates).
+ * Template expressions should be pure reads — writes belong outside the template.
+ * @param {AST.Expression | AST.SpreadElement | AST.Super | AST.Pattern} node
+ * @returns {boolean}
+ */
+function expression_has_side_effects(node) {
+	switch (node.type) {
+		case 'AssignmentExpression':
+		case 'UpdateExpression':
+			return true;
+		case 'SequenceExpression':
+			return node.expressions.some(expression_has_side_effects);
+		case 'ConditionalExpression':
+			return (
+				expression_has_side_effects(node.test) ||
+				expression_has_side_effects(node.consequent) ||
+				expression_has_side_effects(node.alternate)
+			);
+		case 'LogicalExpression':
+		case 'BinaryExpression':
+			return expression_has_side_effects(node.left) || expression_has_side_effects(node.right);
+		case 'UnaryExpression':
+			return expression_has_side_effects(node.argument);
+		case 'MemberExpression':
+			return (
+				expression_has_side_effects(node.object) ||
+				(node.computed && expression_has_side_effects(node.property))
+			);
+		case 'CallExpression':
+		case 'NewExpression':
+			return (
+				expression_has_side_effects(node.callee) || node.arguments.some(expression_has_side_effects)
+			);
+		case 'TemplateLiteral':
+			return node.expressions.some(expression_has_side_effects);
+		case 'TaggedTemplateExpression':
+			return (
+				expression_has_side_effects(node.tag) ||
+				node.quasi.expressions.some(expression_has_side_effects)
+			);
+		case 'ArrayExpression':
+			return node.elements.some((el) => el !== null && expression_has_side_effects(el));
+		case 'ObjectExpression':
+			return node.properties.some((prop) =>
+				prop.type === 'SpreadElement'
+					? expression_has_side_effects(prop.argument)
+					: expression_has_side_effects(prop.value),
+			);
+		case 'SpreadElement':
+			return expression_has_side_effects(node.argument);
+		default:
+			return false;
+	}
+}
+
+/**
  * @param {AnalysisContext['path']} path
  */
 function mark_control_flow_has_template(path) {
@@ -63,6 +119,7 @@ function mark_control_flow_has_template(path) {
 			node.type === 'TryStatement' ||
 			node.type === 'IfStatement' ||
 			node.type === 'SwitchStatement' ||
+			node.type === 'Tsx' ||
 			node.type === 'TsxCompat'
 		) {
 			node.metadata.has_template = true;
@@ -928,7 +985,9 @@ const visitors = {
 		const callee = node.callee;
 
 		if (
-			!context.path.some((path_node) => path_node.type === 'TsxCompat') &&
+			!context.path.some(
+				(path_node) => path_node.type === 'TsxCompat' || path_node.type === 'Tsx',
+			) &&
 			is_children_template_expression(/** @type {AST.Expression} */ (callee), context)
 		) {
 			error(
@@ -1646,7 +1705,7 @@ const visitors = {
 	},
 
 	JSXElement(node, context) {
-		const inside_tsx_compat = context.path.some((n) => n.type === 'TsxCompat');
+		const inside_tsx_compat = context.path.some((n) => n.type === 'TsxCompat' || n.type === 'Tsx');
 
 		if (inside_tsx_compat) {
 			return context.next();
@@ -1657,6 +1716,11 @@ const visitors = {
 			context.state.analysis.module.filename,
 			node,
 		);
+	},
+
+	Tsx(_, context) {
+		mark_control_flow_has_template(context.path);
+		return context.next();
 	},
 
 	TsxCompat(_, context) {
@@ -1938,6 +2002,16 @@ const visitors = {
 
 	RippleExpression(node, context) {
 		mark_control_flow_has_template(context.path);
+
+		if (expression_has_side_effects(node.expression)) {
+			error(
+				'Template expressions must not contain assignments or updates..',
+				context.state.analysis.module.filename,
+				node.expression,
+				context.state.loose ? context.state.analysis.errors : undefined,
+				context.state.analysis.comments,
+			);
+		}
 
 		context.next();
 	},

--- a/packages/ripple/src/compiler/phases/3-transform/client/index.js
+++ b/packages/ripple/src/compiler/phases/3-transform/client/index.js
@@ -1220,20 +1220,18 @@ const visitors = {
 			),
 		);
 
-		// Template body context: push to template and schedule update
+		// Template body context: push to template and schedule init
 		if (state.flush_node) {
 			state.template?.push('<!>');
 
 			const id = state.flush_node(false);
 
-			state.update?.push({
-				operation: () => {
-					const call = b.call('_$_.expression', id, b.thunk(element));
-					return state.namespace !== DEFAULT_NAMESPACE
-						? b.stmt(b.call('_$_.with_ns', b.literal(state.namespace), b.thunk(call)))
-						: b.stmt(call);
-				},
-			});
+			const call = b.call('_$_.expression', id, b.thunk(element));
+			state.init?.push(
+				state.namespace !== DEFAULT_NAMESPACE
+					? b.stmt(b.call('_$_.with_ns', b.literal(state.namespace), b.thunk(call)))
+					: b.stmt(call),
+			);
 			return;
 		}
 
@@ -3463,6 +3461,15 @@ function transform_children(children, context) {
 				(node) =>
 					node.type === 'RippleExpression' &&
 					is_children_template_expression(node.expression, state.scope),
+			)) ||
+		// At root level, non-literal expressions need a fragment template so the
+		// anchor has a parent node. Without a parent, expression()'s .before() call
+		// is a no-op when the value is a RippleElement.
+		(root &&
+			normalized.some(
+				(node) =>
+					node.type === 'RippleExpression' &&
+					/** @type {AST.RippleExpression} */ (node).expression.type !== 'Literal',
 			)) ||
 		normalized.filter(
 			(node) => node.type !== 'VariableDeclaration' && node.type !== 'EmptyStatement',

--- a/packages/ripple/src/compiler/phases/3-transform/client/index.js
+++ b/packages/ripple/src/compiler/phases/3-transform/client/index.js
@@ -1689,7 +1689,9 @@ const visitors = {
 						let property =
 							attr.value === null
 								? b.literal(true)
-								: /** @type {AST.Expression} */ (visit(attr.value, { ...state, metadata }));
+								: /** @type {AST.Expression} */ (
+										visit(attr.value, { ...state, flush_node: null, metadata })
+									);
 
 						if (attr.name.name === 'class' && node.metadata.scoped && state.component?.css) {
 							if (property.type === 'Literal') {
@@ -1737,7 +1739,9 @@ const visitors = {
 							b.prop(
 								'init',
 								b.key(attr.name.name),
-								/** @type {AST.Expression} */ (visit(/** @type {AST.Node} */ (attr.value), state)),
+								/** @type {AST.Expression} */ (
+									visit(/** @type {AST.Node} */ (attr.value), { ...state, flush_node: null })
+								),
 							),
 						);
 					}
@@ -1745,7 +1749,13 @@ const visitors = {
 					props.push(
 						b.spread(
 							/** @type {AST.Expression} */
-							(visit(attr.argument, { ...state, metadata: { ...state.metadata } })),
+							(
+								visit(attr.argument, {
+									...state,
+									flush_node: null,
+									metadata: { ...state.metadata },
+								})
+							),
 						),
 					);
 				} else if (attr.type === 'RefAttribute') {
@@ -1756,7 +1766,9 @@ const visitors = {
 						b.prop(
 							'init',
 							b.id(ref_id),
-							/** @type {AST.Expression} */ (visit(attr.argument, { ...state, metadata })),
+							/** @type {AST.Expression} */ (
+								visit(attr.argument, { ...state, flush_node: null, metadata })
+							),
 							true,
 						),
 					);

--- a/packages/ripple/src/compiler/phases/3-transform/client/index.js
+++ b/packages/ripple/src/compiler/phases/3-transform/client/index.js
@@ -3821,7 +3821,10 @@ function transform_children(children, context) {
 						skipped++;
 						state.template?.push(escape_html(expr.value));
 					}
-				} else if (normalized.length === 1) {
+				} else if (
+					normalized.length === 1 &&
+					!is_children_template_expression(node.expression, state.scope)
+				) {
 					skipped++;
 					state.template?.push(' ');
 					const id = flush_node(true);

--- a/packages/ripple/src/compiler/phases/3-transform/client/index.js
+++ b/packages/ripple/src/compiler/phases/3-transform/client/index.js
@@ -859,6 +859,8 @@ const visitors = {
 		// Handle standalone lazy destructuring: &[data] = track(0); → const lazy0 = track(0);
 		if (
 			node.expression.type === 'AssignmentExpression' &&
+			(node.expression.left.type === 'ObjectPattern' ||
+				node.expression.left.type === 'ArrayPattern') &&
 			node.expression.left.lazy &&
 			node.expression.left.metadata?.lazy_id
 		) {
@@ -4469,7 +4471,10 @@ function create_tsx_with_typescript_support(comments) {
 					// Shorthand object properties require an Identifier value. When the
 					// transformed value is a tracked MemberExpression (for example
 					// @value), emit longhand to keep valid output.
-					if (node.value.type === 'MemberExpression' && node.value.tracked) {
+					if (
+						node.value.type === 'MemberExpression' &&
+						/** @type {AST.MemberExpression & { tracked?: boolean }} */ (node.value).tracked
+					) {
 						context.visit(node.key);
 						context.write(': ');
 						context.visit(node.value);

--- a/packages/ripple/src/compiler/phases/3-transform/client/index.js
+++ b/packages/ripple/src/compiler/phases/3-transform/client/index.js
@@ -1216,6 +1216,7 @@ const visitors = {
 				visit(children_component, {
 					...state,
 					namespace: state.namespace,
+					is_ripple_element: true,
 				})
 			),
 		);
@@ -1799,6 +1800,7 @@ const visitors = {
 								: {}),
 							scope: /** @type {ScopeInterface} */ (component_scope),
 							namespace: child_namespace,
+							is_ripple_element: true,
 						})
 					),
 				);
@@ -2016,30 +2018,44 @@ const visitors = {
 		}
 
 		const component_scope = context.state.scopes.get(node) || context.state.scope;
-		const body_statements = [
-			b.stmt(b.call('_$_.push_component')),
-			...transform_body(node.body, {
-				...context,
-				state: {
-					...context.state,
-					flush_node: null,
-					component: node,
-					metadata,
-					scope: component_scope,
-				},
-			}),
-			b.stmt(b.call('_$_.pop_component')),
-		];
+		const is_ripple_element = context.state.is_ripple_element;
+		const transformed_body = transform_body(node.body, {
+			...context,
+			state: {
+				...context.state,
+				flush_node: null,
+				component: node,
+				metadata,
+				scope: component_scope,
+				is_ripple_element: false,
+			},
+		});
+
+		// RippleElement render functions don't need push/pop component context
+		// since they inherit context from where they're used
+		const body_statements = is_ripple_element
+			? transformed_body
+			: [
+					b.stmt(b.call('_$_.push_component')),
+					...transformed_body,
+					b.stmt(b.call('_$_.pop_component')),
+				];
 
 		if (node.css !== null && node.css) {
 			context.state.stylesheets.push(node.css);
 		}
 
+		// RippleElement render functions use simpler params: [__anchor, __block]
+		// Regular components use: [__anchor, props, __block] or [__anchor, _, __block]
+		const params = is_ripple_element
+			? [b.id('__anchor'), b.id('__block')]
+			: node.params.length > 0
+				? [b.id('__anchor'), props, b.id('__block')]
+				: [b.id('__anchor'), b.id('_'), b.id('__block')];
+
 		const func = b.function(
 			node.id,
-			node.params.length > 0
-				? [b.id('__anchor'), props, b.id('__block')]
-				: [b.id('__anchor'), b.id('_'), b.id('__block')],
+			params,
 			b.block([
 				...style_statements,
 				...(prop_statements ?? []),

--- a/packages/ripple/src/compiler/phases/3-transform/client/index.js
+++ b/packages/ripple/src/compiler/phases/3-transform/client/index.js
@@ -2902,7 +2902,10 @@ function transform_ts_child(node, context) {
 			}
 		}
 
-		if (/** @type {AST.Node} */ (node.id).type !== 'MemberExpression' && node.id.tracked) {
+		if (
+			/** @type {AST.Node} */ (node.id).type !== 'MemberExpression' &&
+			/** @type {AST.Identifier} */ (node.id).tracked
+		) {
 			// This is just temporary until we remove capitalization
 			// The `is_capitalized` was never handled for MemberExpression
 			// but it should've been for the `object` part because it starts the tag

--- a/packages/ripple/src/compiler/phases/3-transform/client/index.js
+++ b/packages/ripple/src/compiler/phases/3-transform/client/index.js
@@ -61,6 +61,7 @@ import {
 	is_ripple_import,
 	replace_lazy_param_pattern,
 	ripple_import_requires_block,
+	jsx_to_ripple_node,
 } from '../../../utils.js';
 import {
 	CSS_HASH_IDENTIFIER,
@@ -1140,6 +1141,16 @@ const visitors = {
 	TsxCompat(node, context) {
 		const { state, visit } = context;
 
+		// to_ts mode: produce a JSX fragment
+		if (state.to_ts) {
+			const children = /** @type {AST.TsxCompat['children']} */ (
+				node.children
+					.map((child) => visit(/** @type {AST.Node} */ (child), state))
+					.filter((child) => child.type !== 'JSXText' || child.value.trim() !== '')
+			);
+			return b.jsx_fragment(children);
+		}
+
 		state.template?.push('<!>');
 
 		const normalized_children = node.children.filter((child) => {
@@ -1175,6 +1186,59 @@ const visitors = {
 		context.state.init?.push(
 			b.stmt(b.call('_$_.tsx_compat', b.literal(node.kind), id, children_fn)),
 		);
+	},
+
+	Tsx(node, context) {
+		const { state, visit } = context;
+
+		// to_ts mode: produce a JSX fragment
+		if (state.to_ts) {
+			const children = /** @type {AST.Tsx['children']} */ (
+				node.children
+					.map((child) => visit(/** @type {AST.Node} */ (child), state))
+					.filter((child) => child.type !== 'JSXText' || child.value.trim() !== '')
+			);
+			return b.jsx_fragment(children);
+		}
+
+		const children_filtered = node.children
+			.map((child) => jsx_to_ripple_node(/** @type {AST.Node} */ (child)))
+			.flat()
+			.filter(
+				(child) => child != null && child.type !== 'EmptyStatement' && child.type !== 'Component',
+			);
+
+		const children_component = b.component(b.id('render_children'), [], children_filtered);
+
+		const element = b.call(
+			'_$_.ripple_element',
+			/** @type {AST.Expression} */ (
+				visit(children_component, {
+					...state,
+					namespace: state.namespace,
+				})
+			),
+		);
+
+		// Template body context: push to template and schedule update
+		if (state.flush_node) {
+			state.template?.push('<!>');
+
+			const id = state.flush_node(false);
+
+			state.update?.push({
+				operation: () => {
+					const call = b.call('_$_.expression', id, b.thunk(element));
+					return state.namespace !== DEFAULT_NAMESPACE
+						? b.stmt(b.call('_$_.with_ns', b.literal(state.namespace), b.thunk(call)))
+						: b.stmt(call);
+				},
+			});
+			return;
+		}
+
+		// Expression context: return the ripple_element directly as an expression value
+		return element;
 	},
 
 	Element(node, context) {
@@ -1574,6 +1638,7 @@ const visitors = {
 							child.type === 'TryStatement' ||
 							child.type === 'ForOfStatement' ||
 							child.type === 'SwitchStatement' ||
+							child.type === 'Tsx' ||
 							child.type === 'TsxCompat' ||
 							child.type === 'Html' ||
 							(child.type === 'Element' &&
@@ -3064,6 +3129,18 @@ function transform_ts_child(node, context) {
 		);
 
 		state.init?.push(b.stmt(b.jsx_fragment(children)));
+	} else if (node.type === 'Tsx') {
+		const children = /** @type {AST.Tsx['children']} */ (
+			node.children
+				.map((child) => visit(/** @type {AST.Node} */ (child), state))
+				.filter((child) => child.type !== 'JSXText' || child.value.trim() !== '')
+		);
+
+		const result = b.jsx_fragment(children);
+		if (!state.init) {
+			return result;
+		}
+		state.init.push(b.stmt(result));
 	} else if (node.type === 'JSXExpressionContainer') {
 		// JSX comments {/* ... */} are JSXExpressionContainer with JSXEmptyExpression
 		// These should be preserved in the output as-is for prettier to handle
@@ -3105,6 +3182,7 @@ function is_template_or_control_flow(node) {
 		node.type === 'RippleExpression' ||
 		node.type === 'Text' ||
 		node.type === 'Html' ||
+		node.type === 'Tsx' ||
 		node.type === 'TsxCompat' ||
 		node.type === 'IfStatement' ||
 		node.type === 'ForOfStatement' ||
@@ -3196,6 +3274,7 @@ function element_has_dynamic_content(element) {
 			child.type === 'TryStatement' ||
 			child.type === 'ForOfStatement' ||
 			child.type === 'SwitchStatement' ||
+			child.type === 'Tsx' ||
 			child.type === 'TsxCompat' ||
 			child.type === 'Html'
 		) {
@@ -3371,6 +3450,7 @@ function transform_children(children, context) {
 				node.type === 'TryStatement' ||
 				node.type === 'ForOfStatement' ||
 				node.type === 'SwitchStatement' ||
+				node.type === 'Tsx' ||
 				node.type === 'TsxCompat' ||
 				node.type === 'Html' ||
 				(node.type === 'Element' &&
@@ -3652,6 +3732,7 @@ function transform_children(children, context) {
 							child.type === 'TryStatement' ||
 							child.type === 'ForOfStatement' ||
 							child.type === 'SwitchStatement' ||
+							child.type === 'Tsx' ||
 							child.type === 'TsxCompat' ||
 							child.type === 'Html' ||
 							(child.type === 'Element' &&
@@ -3682,6 +3763,7 @@ function transform_children(children, context) {
 							next_node.type === 'TryStatement' ||
 							next_node.type === 'ForOfStatement' ||
 							next_node.type === 'SwitchStatement' ||
+							next_node.type === 'Tsx' ||
 							next_node.type === 'TsxCompat'
 						) {
 							needs_sibling_call = true;
@@ -3693,7 +3775,7 @@ function transform_children(children, context) {
 						}
 					}
 				}
-			} else if (node.type === 'TsxCompat') {
+			} else if (node.type === 'TsxCompat' || node.type === 'Tsx') {
 				skipped = 0;
 
 				visit(node, {
@@ -3721,10 +3803,6 @@ function transform_children(children, context) {
 				});
 			} else if (node.type === 'RippleExpression') {
 				const expr = /** @type {AST.Expression} */ (expression);
-				const is_children_expression = is_children_template_expression(
-					node.expression,
-					state.scope,
-				);
 
 				if (expr.type === 'Literal') {
 					if (normalized.length === 1) {
@@ -3743,60 +3821,26 @@ function transform_children(children, context) {
 						skipped++;
 						state.template?.push(escape_html(expr.value));
 					}
-				} else if (is_children_expression) {
+				} else if (normalized.length === 1) {
+					skipped++;
+					state.template?.push(' ');
+					const id = flush_node(true);
+					const call = b.call('_$_.expression', id, b.thunk(expr));
+					state.init?.push(
+						state.namespace !== DEFAULT_NAMESPACE
+							? b.stmt(b.call('_$_.with_ns', b.literal(state.namespace), b.thunk(call)))
+							: b.stmt(call),
+					);
+				} else {
 					skipped = 0;
 					state.template?.push('<!>');
 					const id = flush_node(false);
-					state.update?.push({
-						operation: () => {
-							const call = b.call('_$_.expression', id, b.thunk(expr));
-							return state.namespace !== DEFAULT_NAMESPACE
-								? b.stmt(b.call('_$_.with_ns', b.literal(state.namespace), b.thunk(call)))
-								: b.stmt(call);
-						},
-					});
-					if (metadata?.await) {
-						/** @type {NonNullable<TransformClientState['update']>} */ (state.update).async = true;
-					}
-				} else if (metadata?.tracking) {
-					skipped = 0;
-					state.template?.push(' ');
-					const id = flush_node(true);
-					state.update?.push({
-						operation: (key) => b.stmt(b.call('_$_.set_text', id, key)),
-						expression: expr,
-						identity: node.expression,
-						initial: b.literal(' '),
-					});
-					if (metadata.await) {
-						/** @type {NonNullable<TransformClientState['update']>} */ (state.update).async = true;
-					}
-				} else if (normalized.length === 1) {
-					skipped++;
-					const id = flush_node(true);
-					state.template?.push(' ');
+					const call = b.call('_$_.expression', id, b.thunk(expr));
 					state.init?.push(
-						b.stmt(
-							b.assignment(
-								'=',
-								b.member(/** @type {AST.Identifier} */ (id), b.id('nodeValue')),
-								expr,
-							),
-						),
+						state.namespace !== DEFAULT_NAMESPACE
+							? b.stmt(b.call('_$_.with_ns', b.literal(state.namespace), b.thunk(call)))
+							: b.stmt(call),
 					);
-				} else {
-					skipped++;
-					state.template?.push(' ');
-					const id = flush_node(true);
-					state.update?.push({
-						operation: (key) => b.stmt(b.call('_$_.set_text', id, key)),
-						expression: expr,
-						identity: node.expression,
-						initial: b.literal(' '),
-					});
-					if (metadata?.await) {
-						/** @type {NonNullable<TransformClientState['update']>} */ (state.update).async = true;
-					}
 				}
 			} else if (node.type === 'Text') {
 				if (metadata?.tracking) {

--- a/packages/ripple/src/compiler/phases/3-transform/server/index.js
+++ b/packages/ripple/src/compiler/phases/3-transform/server/index.js
@@ -411,7 +411,9 @@ const visitors = {
 
 		let component_fn = b.function(
 			node.id,
-			node.params.length > 0 ? [b.id('__output'), props_param_output] : [b.id('__output')],
+			node.params.length > 0
+				? [b.id('__output'), /** @type {AST.Pattern} */ (props_param_output)]
+				: [b.id('__output')],
 			b.block([
 				...(metadata.await
 					? [b.return(b.call('_$_.async', b.thunk(b.block(body_statements), true)))]
@@ -809,6 +811,8 @@ const visitors = {
 		// Handle standalone lazy destructuring: &[data] = track(0); → const lazy0 = track(0);
 		if (
 			node.expression.type === 'AssignmentExpression' &&
+			(node.expression.left.type === 'ObjectPattern' ||
+				node.expression.left.type === 'ArrayPattern') &&
 			node.expression.left.lazy &&
 			node.expression.left.metadata?.lazy_id
 		) {

--- a/packages/ripple/src/compiler/phases/3-transform/server/index.js
+++ b/packages/ripple/src/compiler/phases/3-transform/server/index.js
@@ -32,6 +32,7 @@ import {
 	hash,
 	flatten_switch_consequent,
 	get_ripple_namespace_call_name,
+	jsx_to_ripple_node,
 } from '../../../utils.js';
 import { escape } from '../../../../utils/escaping.js';
 import { is_event_attribute } from '../../../../utils/events.js';
@@ -55,6 +56,7 @@ function is_template_or_control_flow(node) {
 		node.type === 'RippleExpression' ||
 		node.type === 'Text' ||
 		node.type === 'Html' ||
+		node.type === 'Tsx' ||
 		node.type === 'TsxCompat' ||
 		node.type === 'IfStatement' ||
 		node.type === 'ForOfStatement' ||
@@ -199,7 +201,7 @@ function transform_children(children, context) {
 				}
 			}
 		} else {
-			visit(node, { ...state, return_flags });
+			visit(node, { ...state, return_flags, template_child: true });
 		}
 	};
 
@@ -1651,6 +1653,37 @@ const visitors = {
 			context.state.init?.push(
 				b.stmt(b.call(b.member(b.id('__output'), b.id('push')), b.call('_$_.escape', expression))),
 			);
+		}
+	},
+
+	Tsx(node, { visit, state }) {
+		const converted_children = node.children
+			.map((child) => jsx_to_ripple_node(/** @type {AST.Node} */ (child)))
+			.flat()
+			.filter((child) => child != null);
+
+		/** @type {AST.Statement[]} */
+		const init = [];
+		transform_children(
+			converted_children,
+			/** @type {TransformServerContext} */ ({
+				visit,
+				state: {
+					...state,
+					init,
+				},
+			}),
+		);
+
+		if (state.template_child) {
+			// Template body: push children statements inline
+			if (init.length > 0) {
+				state.init?.push(b.block(init));
+			}
+		} else {
+			// Expression context: return ripple_element(render_fn)
+			const render_fn = b.function(b.id('render_children'), [b.id('__output')], b.block(init));
+			return b.call('_$_.ripple_element', render_fn);
 		}
 	},
 

--- a/packages/ripple/src/compiler/types/index.d.ts
+++ b/packages/ripple/src/compiler/types/index.d.ts
@@ -1335,6 +1335,7 @@ export interface TransformClientState extends BaseState {
 	applyParentCssScope?: AST.CSS.StyleSheet['hash'];
 	skip_children_traversal: boolean;
 	return_flags?: Map<AST.ReturnStatement, { name: string; tracked: boolean }>;
+	is_ripple_element?: boolean;
 }
 
 /** Override zimmerframe types and provide our own */

--- a/packages/ripple/src/compiler/types/index.d.ts
+++ b/packages/ripple/src/compiler/types/index.d.ts
@@ -134,6 +134,7 @@ declare module 'estree' {
 	// Include TypeScript node types and Ripple-specific nodes in NodeMap
 	interface NodeMap {
 		Component: Component;
+		Tsx: Tsx;
 		TsxCompat: TsxCompat;
 		RippleExpression: RippleExpression;
 		Html: Html;
@@ -269,6 +270,16 @@ declare module 'estree' {
 		};
 		default: boolean;
 		typeParameters?: AST.TSTypeParameterDeclaration;
+	}
+
+	interface Tsx extends AST.BaseNode {
+		type: 'Tsx';
+		attributes: Array<any>;
+		children: ESTreeJSX.JSXElement['children'];
+		selfClosing?: boolean;
+		unclosed?: boolean;
+		openingElement: ESTreeJSX.JSXOpeningElement;
+		closingElement: ESTreeJSX.JSXClosingElement;
 	}
 
 	interface TsxCompat extends AST.BaseNode {
@@ -407,7 +418,7 @@ declare module 'estree' {
 
 	export type RippleStatement = AST.Statement | TSESTree.Statement;
 
-	export type NodeWithChildren = AST.Element | AST.TsxCompat;
+	export type NodeWithChildren = AST.Element | AST.Tsx | AST.TsxCompat;
 
 	export namespace CSS {
 		export interface BaseNode extends AST.NodeWithMaybeComments {

--- a/packages/ripple/src/compiler/types/index.d.ts
+++ b/packages/ripple/src/compiler/types/index.d.ts
@@ -1302,6 +1302,7 @@ export interface TransformServerState extends BaseState {
 	applyParentCssScope?: AST.CSS.StyleSheet['hash'];
 	dev?: boolean;
 	return_flags?: Map<AST.ReturnStatement, { name: string; tracked: boolean }>;
+	template_child?: boolean;
 }
 
 type UpdateList = Array<

--- a/packages/ripple/src/compiler/types/index.d.ts
+++ b/packages/ripple/src/compiler/types/index.d.ts
@@ -117,7 +117,9 @@ declare module 'estree' {
 
 	// We mark the whole node as marked when member is @[expression]
 	// Otherwise, we only mark Identifier nodes
-	interface MemberExpression {}
+	interface MemberExpression {
+		tracked?: boolean;
+	}
 
 	interface SimpleLiteral extends AST.LiteralNode {}
 	interface RegExpLiteral extends AST.LiteralNode {}

--- a/packages/ripple/src/compiler/types/parse.d.ts
+++ b/packages/ripple/src/compiler/types/parse.d.ts
@@ -1166,7 +1166,7 @@ export namespace Parse {
 
 		parseServerBlock(): AST.ServerBlock;
 
-		parseElement(): AST.Element | AST.TsxCompat;
+		parseElement(): AST.Element | AST.Tsx | AST.TsxCompat;
 
 		parseTemplateBody(
 			body: (AST.Statement | AST.Node | ESTreeJSX.JSXText | ESTreeJSX.JSXElement['children'])[],

--- a/packages/ripple/src/compiler/utils.js
+++ b/packages/ripple/src/compiler/utils.js
@@ -1236,6 +1236,7 @@ export function jsx_to_ripple_node(node) {
 				start: node.start,
 				end: node.end,
 			},
+			metadata: {},
 			start: node.start,
 			end: node.end,
 		});
@@ -1246,6 +1247,7 @@ export function jsx_to_ripple_node(node) {
 		return /** @type {AST.Node} */ ({
 			type: 'RippleExpression',
 			expression: node.expression,
+			metadata: {},
 			start: node.start,
 			end: node.end,
 		});

--- a/packages/ripple/src/compiler/utils.js
+++ b/packages/ripple/src/compiler/utils.js
@@ -1122,7 +1122,10 @@ export function jsx_to_ripple_node(node) {
 						type: 'Attribute',
 						name: {
 							type: 'Identifier',
-							name: attr.name.type === 'JSXIdentifier' ? attr.name.name : attr.name.name,
+							name:
+								attr.name.type === 'JSXIdentifier'
+									? attr.name.name
+									: attr.name.namespace.name + ':' + attr.name.name.name,
 							tracked: is_dynamic,
 							start: attr.name.start,
 							end: attr.name.end,
@@ -1148,7 +1151,9 @@ export function jsx_to_ripple_node(node) {
 			})
 			.filter(Boolean);
 
-		const children = node.children.map(jsx_to_ripple_node).flat().filter(Boolean);
+		const children = /** @type {AST.Node[]} */ (
+			/** @type {AST.Node[]} */ (node.children).map(jsx_to_ripple_node).flat().filter(Boolean)
+		);
 
 		return /** @type {AST.Node} */ ({
 			type: 'Element',
@@ -1189,7 +1194,9 @@ export function jsx_to_ripple_node(node) {
 	}
 
 	if (node.type === 'JSXFragment') {
-		return node.children.map(jsx_to_ripple_node).flat().filter(Boolean);
+		return /** @type {AST.Node[]} */ (
+			/** @type {AST.Node[]} */ (node.children).map(jsx_to_ripple_node).flat().filter(Boolean)
+		);
 	}
 
 	return node;

--- a/packages/ripple/src/compiler/utils.js
+++ b/packages/ripple/src/compiler/utils.js
@@ -1211,16 +1211,18 @@ export function jsx_to_ripple_node(node) {
 			/** @type {AST.Node[]} */ (node.children).map(jsx_to_ripple_node).flat().filter(Boolean)
 		);
 
-		return /** @type {AST.Node} */ ({
-			type: 'Element',
-			id,
-			attributes,
-			children,
-			selfClosing: opening.selfClosing,
-			metadata: { scoped: false, path: [] },
-			start: node.start,
-			end: node.end,
-		});
+		return /** @type {AST.Element} */ (
+			/** @type {unknown} */ ({
+				type: 'Element',
+				id,
+				attributes,
+				children,
+				selfClosing: opening.selfClosing,
+				metadata: { scoped: false, path: /** @type {string[]} */ ([]) },
+				start: node.start,
+				end: node.end,
+			})
+		);
 	}
 
 	if (node.type === 'JSXText') {

--- a/packages/ripple/src/compiler/utils.js
+++ b/packages/ripple/src/compiler/utils.js
@@ -1089,6 +1089,45 @@ export function ripple_import_requires_block(name) {
 }
 
 /**
+ * Converts a JSXMemberExpression to an AST MemberExpression.
+ * e.g., <Foo.Bar.Baz> → MemberExpression(MemberExpression(Foo, Bar), Baz)
+ * @param {import('estree-jsx').JSXMemberExpression} jsx_member
+ * @returns {AST.MemberExpression}
+ */
+function jsx_member_expression_to_member_expression(jsx_member) {
+	/** @type {AST.Expression} */
+	let object;
+
+	if (jsx_member.object.type === 'JSXMemberExpression') {
+		// Recursively convert nested member expressions
+		object = jsx_member_expression_to_member_expression(jsx_member.object);
+	} else {
+		// Base case: JSXIdentifier
+		object = /** @type {AST.Identifier} */ ({
+			type: 'Identifier',
+			name: jsx_member.object.name,
+			start: jsx_member.object.start,
+			end: jsx_member.object.end,
+		});
+	}
+
+	return /** @type {AST.MemberExpression} */ ({
+		type: 'MemberExpression',
+		object,
+		property: /** @type {AST.Identifier} */ ({
+			type: 'Identifier',
+			name: jsx_member.property.name,
+			start: jsx_member.property.start,
+			end: jsx_member.property.end,
+		}),
+		computed: false,
+		optional: false,
+		start: jsx_member.start,
+		end: jsx_member.end,
+	});
+}
+
+/**
  * Converts a JSX AST node (JSXElement, JSXText, etc.) to a Ripple AST node
  * (Element, Text, RippleExpression) for processing inside `<tsx>` blocks.
  * @param {AST.Node} node
@@ -1099,20 +1138,37 @@ export function jsx_to_ripple_node(node) {
 		const opening = node.openingElement;
 		const name = opening.name;
 
-		const id =
-			name.type === 'JSXIdentifier'
-				? /** @type {AST.Identifier} */ ({
-						type: 'Identifier',
-						name: name.name,
-						start: name.start,
-						end: name.end,
-					})
-				: /** @type {AST.Identifier} */ ({
-						type: 'Identifier',
-						name: 'unknown',
-						start: name.start,
-						end: name.end,
-					});
+		/** @type {AST.Identifier | AST.MemberExpression} */
+		let id;
+
+		if (name.type === 'JSXIdentifier') {
+			id = /** @type {AST.Identifier} */ ({
+				type: 'Identifier',
+				name: name.name,
+				start: name.start,
+				end: name.end,
+			});
+		} else if (name.type === 'JSXMemberExpression') {
+			// Convert JSXMemberExpression to MemberExpression
+			// e.g., <Foo.Bar.Baz> → MemberExpression(MemberExpression(Foo, Bar), Baz)
+			id = jsx_member_expression_to_member_expression(name);
+		} else if (name.type === 'JSXNamespacedName') {
+			// For JSXNamespacedName like <namespace:element>, create an identifier with the full name
+			id = /** @type {AST.Identifier} */ ({
+				type: 'Identifier',
+				name: name.namespace.name + ':' + name.name.name,
+				start: name.start,
+				end: name.end,
+			});
+		} else {
+			// Fallback - should not reach here
+			id = /** @type {AST.Identifier} */ ({
+				type: 'Identifier',
+				name: 'unknown',
+				start: /** @type {any} */ (name).start,
+				end: /** @type {any} */ (name).end,
+			});
+		}
 
 		const attributes = opening.attributes
 			.map((attr) => {

--- a/packages/ripple/src/compiler/utils.js
+++ b/packages/ripple/src/compiler/utils.js
@@ -1087,3 +1087,110 @@ export function get_ripple_namespace_call_name(name) {
 export function ripple_import_requires_block(name) {
 	return name !== 'effect' && name !== 'untrack' && name !== 'Context';
 }
+
+/**
+ * Converts a JSX AST node (JSXElement, JSXText, etc.) to a Ripple AST node
+ * (Element, Text, RippleExpression) for processing inside `<tsx>` blocks.
+ * @param {AST.Node} node
+ * @returns {AST.Node | AST.Node[] | null}
+ */
+export function jsx_to_ripple_node(node) {
+	if (node.type === 'JSXElement') {
+		const opening = node.openingElement;
+		const name = opening.name;
+
+		const id =
+			name.type === 'JSXIdentifier'
+				? /** @type {AST.Identifier} */ ({
+						type: 'Identifier',
+						name: name.name,
+						start: name.start,
+						end: name.end,
+					})
+				: /** @type {AST.Identifier} */ ({
+						type: 'Identifier',
+						name: 'unknown',
+						start: name.start,
+						end: name.end,
+					});
+
+		const attributes = opening.attributes
+			.map((attr) => {
+				if (attr.type === 'JSXAttribute') {
+					const is_dynamic = attr.value && attr.value.type === 'JSXExpressionContainer';
+					return /** @type {AST.Node} */ ({
+						type: 'Attribute',
+						name: {
+							type: 'Identifier',
+							name: attr.name.type === 'JSXIdentifier' ? attr.name.name : attr.name.name,
+							tracked: is_dynamic,
+							start: attr.name.start,
+							end: attr.name.end,
+						},
+						value: attr.value
+							? attr.value.type === 'JSXExpressionContainer'
+								? attr.value.expression
+								: attr.value
+							: null,
+						shorthand: false,
+						start: attr.start,
+						end: attr.end,
+					});
+				} else if (attr.type === 'JSXSpreadAttribute') {
+					return /** @type {AST.Node} */ ({
+						type: 'SpreadAttribute',
+						argument: attr.argument,
+						start: attr.start,
+						end: attr.end,
+					});
+				}
+				return null;
+			})
+			.filter(Boolean);
+
+		const children = node.children.map(jsx_to_ripple_node).flat().filter(Boolean);
+
+		return /** @type {AST.Node} */ ({
+			type: 'Element',
+			id,
+			attributes,
+			children,
+			selfClosing: opening.selfClosing,
+			metadata: { scoped: false },
+			start: node.start,
+			end: node.end,
+		});
+	}
+
+	if (node.type === 'JSXText') {
+		if (node.value.trim() === '') return null;
+		return /** @type {AST.Node} */ ({
+			type: 'Text',
+			expression: {
+				type: 'Literal',
+				value: node.value,
+				raw: JSON.stringify(node.value),
+				start: node.start,
+				end: node.end,
+			},
+			start: node.start,
+			end: node.end,
+		});
+	}
+
+	if (node.type === 'JSXExpressionContainer') {
+		if (node.expression.type === 'JSXEmptyExpression') return null;
+		return /** @type {AST.Node} */ ({
+			type: 'RippleExpression',
+			expression: node.expression,
+			start: node.start,
+			end: node.end,
+		});
+	}
+
+	if (node.type === 'JSXFragment') {
+		return node.children.map(jsx_to_ripple_node).flat().filter(Boolean);
+	}
+
+	return node;
+}

--- a/packages/ripple/src/compiler/utils.js
+++ b/packages/ripple/src/compiler/utils.js
@@ -1217,7 +1217,7 @@ export function jsx_to_ripple_node(node) {
 			attributes,
 			children,
 			selfClosing: opening.selfClosing,
-			metadata: { scoped: false },
+			metadata: { scoped: false, path: [] },
 			start: node.start,
 			end: node.end,
 		});

--- a/packages/ripple/src/runtime/internal/client/composite.js
+++ b/packages/ripple/src/runtime/internal/client/composite.js
@@ -74,9 +74,9 @@ export function composite(get_component, node, props) {
 						element.appendChild(child_anchor);
 
 						if (ns !== DEFAULT_NAMESPACE) {
-							with_ns(ns, () => props.children.render(child_anchor, {}, block));
+							with_ns(ns, () => props.children.render(child_anchor, block));
 						} else {
-							props.children.render(child_anchor, {}, block);
+							props.children.render(child_anchor, block);
 						}
 					}
 				};

--- a/packages/ripple/src/runtime/internal/client/expression.js
+++ b/packages/ripple/src/runtime/internal/client/expression.js
@@ -1,12 +1,27 @@
 /** @import { Block } from '#client' */
 
 import { branch, destroy_block, render } from './blocks.js';
-import { UNINITIALIZED } from './constants.js';
+import { BRANCH_BLOCK, UNINITIALIZED } from './constants.js';
 import { create_text, get_next_sibling } from './operations.js';
 import { active_block } from './runtime.js';
 import { hydrating, set_hydrate_node } from './hydration.js';
 import { COMMENT_NODE, HYDRATION_END, HYDRATION_START, TEXT_NODE } from '../../../constants.js';
 import { is_ripple_element } from '../../element.js';
+
+/**
+ * Finds the nearest enclosing BRANCH_BLOCK in the block hierarchy.
+ * @param {Block | null} block
+ * @returns {Block | null}
+ */
+function find_enclosing_branch(block) {
+	while (block !== null) {
+		if ((block.f & BRANCH_BLOCK) !== 0) {
+			return block;
+		}
+		block = block.p;
+	}
+	return null;
+}
 
 /**
  * @param {Node} node
@@ -63,10 +78,35 @@ export function expression(node, get_value) {
 				set_hydrate_node(get_next_sibling(anchor) ?? end);
 			}
 
+			// Find the enclosing branch block BEFORE creating child_block
+			// so we can update its s.start to include content inserted before anchor
+			var parent_branch = find_enclosing_branch(active_block);
+
 			child_block = branch(() => {
 				var block = active_block;
 				next_value.render(end ?? anchor, {}, block);
 			});
+
+			// Update parent branch's s.start to include content inserted before anchor.
+			// This ensures that when the parent branch is destroyed, the full DOM range
+			// (including RippleElement content) is removed.
+			if (
+				parent_branch !== null &&
+				parent_branch.s !== null &&
+				child_block.s !== null &&
+				child_block.s.start !== null
+			) {
+				// The child inserted content before the anchor. Update parent's start
+				// to encompass this content.
+				var child_start = child_block.s.start;
+				var parent_start = parent_branch.s.start;
+
+				// If parent's start is the anchor (or comes after child's start),
+				// update it to include the child's content
+				if (parent_start === anchor || parent_start === end) {
+					parent_branch.s.start = child_start;
+				}
+			}
 
 			value = next_value;
 			is_element = true;

--- a/packages/ripple/src/runtime/internal/client/expression.js
+++ b/packages/ripple/src/runtime/internal/client/expression.js
@@ -84,7 +84,7 @@ export function expression(node, get_value) {
 
 			child_block = branch(() => {
 				var block = active_block;
-				next_value.render(end ?? anchor, {}, block);
+				next_value.render(end ?? anchor, block);
 			});
 
 			// Update parent branch's s.start to include content inserted before anchor.

--- a/packages/ripple/src/runtime/internal/client/expression.js
+++ b/packages/ripple/src/runtime/internal/client/expression.js
@@ -40,6 +40,10 @@ export function expression(node, get_value) {
 	var value = UNINITIALIZED;
 	var is_element = false;
 	var initialized = false;
+	/** @type {Block | null} */
+	var modified_parent_branch = null;
+	/** @type {Node | null} */
+	var original_parent_start = null;
 
 	render(() => {
 		var next_value = get_value();
@@ -68,6 +72,12 @@ export function expression(node, get_value) {
 			if (child_block !== null) {
 				destroy_block(child_block);
 				child_block = null;
+				// Restore parent branch's start since we may update it again below
+				if (modified_parent_branch !== null && modified_parent_branch.s !== null) {
+					modified_parent_branch.s.start = original_parent_start;
+					modified_parent_branch = null;
+					original_parent_start = null;
+				}
 			}
 
 			if (end !== null && (initialized || !hydrating)) {
@@ -104,6 +114,11 @@ export function expression(node, get_value) {
 				// If parent's start is the anchor (or comes after child's start),
 				// update it to include the child's content
 				if (parent_start === anchor || parent_start === end) {
+					// Save original so we can restore it when switching to non-RippleElement
+					if (modified_parent_branch === null) {
+						modified_parent_branch = parent_branch;
+						original_parent_start = parent_start;
+					}
 					parent_branch.s.start = child_start;
 				}
 			}
@@ -129,6 +144,13 @@ export function expression(node, get_value) {
 		if (child_block !== null) {
 			destroy_block(child_block);
 			child_block = null;
+			// Restore parent branch's start to original value since the child's DOM nodes
+			// have been removed and the old start reference would be stale
+			if (modified_parent_branch !== null && modified_parent_branch.s !== null) {
+				modified_parent_branch.s.start = original_parent_start;
+				modified_parent_branch = null;
+				original_parent_start = null;
+			}
 		}
 
 		if (is_hydration_marker) {

--- a/packages/ripple/src/runtime/internal/client/portal.js
+++ b/packages/ripple/src/runtime/internal/client/portal.js
@@ -72,7 +72,7 @@ export function Portal(_, props) {
 
 			b = branch(() => {
 				if (is_ripple_element(children)) {
-					children.render(/** @type {Text} */ (anchor), {}, block);
+					children.render(/** @type {Text} */ (anchor), block);
 				}
 			});
 

--- a/packages/ripple/src/utils/builders.js
+++ b/packages/ripple/src/utils/builders.js
@@ -514,6 +514,36 @@ export function ts_intersection_type(types, loc_info) {
 }
 
 /**
+ * @param {'string' | 'number' | 'boolean' | 'any' | 'void' | 'null' | 'undefined' | 'never' | 'unknown' | 'bigint' | 'symbol' | 'object'} keyword
+ * @param {AST.NodeWithLocation} [loc_info]
+ * @returns {AST.TypeNode}
+ */
+export function ts_keyword_type(keyword, loc_info) {
+	/** @type {Record<string, string>} */
+	const keyword_to_type = {
+		string: 'TSStringKeyword',
+		number: 'TSNumberKeyword',
+		boolean: 'TSBooleanKeyword',
+		any: 'TSAnyKeyword',
+		void: 'TSVoidKeyword',
+		null: 'TSNullKeyword',
+		undefined: 'TSUndefinedKeyword',
+		never: 'TSNeverKeyword',
+		unknown: 'TSUnknownKeyword',
+		bigint: 'TSBigIntKeyword',
+		symbol: 'TSSymbolKeyword',
+		object: 'TSObjectKeyword',
+	};
+
+	const node = /** @type {AST.TypeNode} */ ({
+		type: keyword_to_type[keyword],
+		metadata: { path: [] },
+	});
+
+	return set_location(node, loc_info);
+}
+
+/**
  * @param {AST.Node} type_annotation
  * @param {AST.NodeWithLocation} [loc_info]
  * @returns {AST.TSTypeAnnotation}

--- a/packages/ripple/tests/client/basic/__snapshots__/basic.rendering.test.ripple.snap
+++ b/packages/ripple/tests/client/basic/__snapshots__/basic.rendering.test.ripple.snap
@@ -52,6 +52,7 @@ exports[`basic client > rendering & text > should handle lexical scopes correctl
 <div>
   <section>
     Nested scope variable
+    <!---->
   </section>
   
 </div>

--- a/packages/ripple/tests/client/basic/basic.rendering.test.ripple
+++ b/packages/ripple/tests/client/basic/basic.rendering.test.ripple
@@ -167,8 +167,10 @@ describe('basic client > rendering & text', () => {
 	it('basic operations', () => {
 		component App() {
 			let &[count] = track(0);
-			<div>{count++}</div>
-			<div>{++count}</div>
+			const a = count++;
+			const b = ++count;
+			<div>{a}</div>
+			<div>{b}</div>
 			<div>{5}</div>
 			<div>{count}</div>
 		}

--- a/packages/ripple/tests/client/composite/__snapshots__/composite.render.test.ripple.snap
+++ b/packages/ripple/tests/client/composite/__snapshots__/composite.render.test.ripple.snap
@@ -29,7 +29,7 @@ exports[`composite > render > render simple text as children 1`] = `
     class="my-button"
   >
     Click Me
-    <!---->
+    
   </button>
   <!---->
   

--- a/packages/ripple/tests/client/composite/__snapshots__/composite.render.test.ripple.snap
+++ b/packages/ripple/tests/client/composite/__snapshots__/composite.render.test.ripple.snap
@@ -29,7 +29,7 @@ exports[`composite > render > render simple text as children 1`] = `
     class="my-button"
   >
     Click Me
-    
+    <!---->
   </button>
   <!---->
   

--- a/packages/ripple/tests/client/tsx.test.ripple
+++ b/packages/ripple/tests/client/tsx.test.ripple
@@ -241,4 +241,246 @@ describe('tsx expression', () => {
 		expect(div.getAttribute('data-index')).toBe('1');
 		expect(div.title).toBe('Item 1');
 	});
+
+	it('renders tsx passed directly as component prop', () => {
+		component Wrapper(&{ content }: { content: any }) {
+			<div class="wrapper">{content}</div>
+		}
+
+		component App() {
+			<Wrapper content={<tsx><span class="inner">direct prop</span></tsx>} />
+		}
+		render(App);
+		const wrapper = container.querySelector('.wrapper');
+		expect(wrapper).toBeTruthy();
+		expect(wrapper.querySelector('.inner')).toBeTruthy();
+		expect(wrapper.textContent).toBe('direct prop');
+	});
+
+	it('renders tsx passed directly as children prop', () => {
+		component Card(&{ title, children }: { title: any; children: any }) {
+			<div class="card">
+				<h2 class="card-title">{title}</h2>
+				<div class="card-body">{children}</div>
+			</div>
+		}
+
+		component App() {
+			<Card
+				title={<tsx><span class="bold">Title</span></tsx>}
+				children={<tsx><p>Card content here</p></tsx>}
+			/>
+		}
+		render(App);
+		const card = container.querySelector('.card');
+		expect(card.querySelector('.card-title .bold').textContent).toBe('Title');
+		expect(card.querySelector('.card-body p').textContent).toBe('Card content here');
+	});
+
+	it('renders tsx from function defined outside component', () => {
+		function createBadge(label: string) {
+			return <tsx>
+				<span class="badge">
+					{label}
+				</span>
+			</tsx>;
+		}
+
+		component App() {
+			const badge = createBadge('New');
+			{badge}
+		}
+		render(App);
+		expect(container.querySelector('.badge')).toBeTruthy();
+		expect(container.querySelector('.badge').textContent).toBe('New');
+	});
+
+	it('renders tsx from function with multiple elements', () => {
+		function createListItem(item: string) {
+			return <tsx>
+				<li class="list-item">
+					{item}
+				</li>
+			</tsx>;
+		}
+
+		component App() {
+			const items = ['Apple', 'Banana', 'Cherry'];
+			<ul>
+				for (const item of items) {
+					{createListItem(item)}
+				}
+			</ul>
+		}
+		render(App);
+		const listItems = container.querySelectorAll('.list-item');
+		expect(listItems.length).toBe(3);
+		expect(listItems[0].textContent).toBe('Apple');
+		expect(listItems[1].textContent).toBe('Banana');
+		expect(listItems[2].textContent).toBe('Cherry');
+	});
+
+	it('renders tsx from factory function passed to component', () => {
+		component List(&{ renderItem, items }: { renderItem: (item: string) => any; items: string[] }) {
+			<ul class="list">
+				for (const item of items) {
+					{renderItem(item)}
+				}
+			</ul>
+		}
+
+		function itemRenderer(item: string) {
+			return <tsx>
+				<li>
+					<span class="item-content">
+						{item}
+					</span>
+				</li>
+			</tsx>;
+		}
+
+		component App() {
+			<List items={['One', 'Two', 'Three']} renderItem={itemRenderer} />
+		}
+		render(App);
+		const items = container.querySelectorAll('.item-content');
+		expect(items.length).toBe(3);
+		expect(items[0].textContent).toBe('One');
+		expect(items[1].textContent).toBe('Two');
+		expect(items[2].textContent).toBe('Three');
+	});
+
+	it('renders tsx from function with reactive state', () => {
+		function createCounter(label: string, getCount: () => number) {
+			return <tsx>
+				<div class="counter-display">
+					<span class="label">
+						{label}
+					</span>
+					<span class="count">
+						{getCount()}
+					</span>
+				</div>
+			</tsx>;
+		}
+
+		component App() {
+			let &[count] = track(0);
+			const counterElement = createCounter('Count:', () => count);
+			{counterElement}
+			<button onClick={() => count++}>{'increment'}</button>
+		}
+		render(App);
+		expect(container.querySelector('.label').textContent).toBe('Count:');
+		expect(container.querySelector('.count').textContent).toBe('0');
+
+		container.querySelector('button').click();
+		flushSync();
+		expect(container.querySelector('.count').textContent).toBe('1');
+	});
+
+	it('renders nested tsx from multiple functions', () => {
+		function createIcon(name: string) {
+			return <tsx><i class={'icon icon-' + name}></i></tsx>;
+		}
+
+		function createButton(icon: string, label: string) {
+			return <tsx>
+				<button class="icon-button">
+					{createIcon(icon)}
+					<span class="btn-label">
+						{label}
+					</span>
+				</button>
+			</tsx>;
+		}
+
+		component App() {
+			const btn = createButton('save', 'Save');
+			{btn}
+		}
+		render(App);
+		const button = container.querySelector('.icon-button');
+		expect(button).toBeTruthy();
+		expect(button.querySelector('.icon-save')).toBeTruthy();
+		expect(button.querySelector('.btn-label').textContent).toBe('Save');
+	});
+
+	it('renders tsx as prop with fallback in component', () => {
+		component Alert(&{ icon, message }: { icon?: any; message: string }) {
+			<div class="alert">
+				{icon}
+				<span class="message">{message}</span>
+			</div>
+		}
+
+		component App() {
+			<Alert message="No icon" />
+			<Alert icon={<tsx><span class="custom-icon">✓</span></tsx>} message="Custom icon" />
+		}
+		render(App);
+		const alerts = container.querySelectorAll('.alert');
+		expect(alerts[0].querySelector('.message').textContent).toBe('No icon');
+		expect(alerts[1].querySelector('.custom-icon')).toBeTruthy();
+		expect(alerts[1].querySelector('.message').textContent).toBe('Custom icon');
+	});
+
+	it('renders tsx stored in array via function', () => {
+		function createItem(className: string, content: string) {
+			return <tsx>
+				<div class={className}>
+					{content}
+				</div>
+			</tsx>;
+		}
+
+		component App() {
+			const items = [
+				{ className: 'item-a', content: 'A' },
+				{ className: 'item-b', content: 'B' },
+				{ className: 'item-c', content: 'C' },
+			];
+
+			<div class="container">
+				for (const item of items) {
+					{createItem(item.className, item.content)}
+				}
+			</div>
+		}
+		render(App);
+		const container_el = container.querySelector('.container');
+		expect(container_el.querySelector('.item-a').textContent).toBe('A');
+		expect(container_el.querySelector('.item-b').textContent).toBe('B');
+		expect(container_el.querySelector('.item-c').textContent).toBe('C');
+	});
+
+	it('renders tsx conditionally from function', () => {
+		function createContent(type: string) {
+			if (type === 'success') {
+				return <tsx><div class="success">Success!</div></tsx>;
+			} else if (type === 'error') {
+				return <tsx><div class="error">Error!</div></tsx>;
+			}
+			return <tsx><div class="default">Default</div></tsx>;
+		}
+
+		component App() {
+			let &[status] = track('default');
+			{createContent(status)}
+			<button class="set-success" onClick={() => (status = 'success')}>{'Success'}</button>
+			<button class="set-error" onClick={() => (status = 'error')}>{'Error'}</button>
+		}
+		render(App);
+		expect(container.querySelector('.default')).toBeTruthy();
+
+		container.querySelector('.set-success').click();
+		flushSync();
+		expect(container.querySelector('.success')).toBeTruthy();
+		expect(container.querySelector('.default')).toBeFalsy();
+
+		container.querySelector('.set-error').click();
+		flushSync();
+		expect(container.querySelector('.error')).toBeTruthy();
+		expect(container.querySelector('.success')).toBeFalsy();
+	});
 });

--- a/packages/ripple/tests/client/tsx.test.ripple
+++ b/packages/ripple/tests/client/tsx.test.ripple
@@ -128,4 +128,117 @@ describe('tsx expression', () => {
 		render(App);
 		expect(container.textContent).toBe('just text');
 	});
+
+	it('renders tsx element with static attributes', () => {
+		component App() {
+			const el = <tsx>
+				<div id="my-id" class="my-class" data-testid="test" aria-label="label">content</div>
+			</tsx>;
+			{el}
+		}
+		render(App);
+		const div = container.querySelector('div');
+		expect(div.id).toBe('my-id');
+		expect(div.className).toBe('my-class');
+		expect(div.getAttribute('data-testid')).toBe('test');
+		expect(div.getAttribute('aria-label')).toBe('label');
+	});
+
+	it('renders tsx element with dynamic attribute values', () => {
+		component App() {
+			let &[name] = track('initial');
+			const el = <tsx><div id={name} class={'cls-' + name}>content</div></tsx>;
+			{el}
+			<button onClick={() => (name = 'updated')}>{'update'}</button>
+		}
+		render(App);
+		const div = container.querySelector('div');
+		expect(div.id).toBe('initial');
+		expect(div.className).toBe('cls-initial');
+
+		container.querySelector('button').click();
+		flushSync();
+		expect(div.id).toBe('updated');
+		expect(div.className).toBe('cls-updated');
+	});
+
+	it('renders tsx element with event handlers', () => {
+		component App() {
+			let &[clicked] = track(false);
+			const el = <tsx>
+				<button onClick={() => (clicked = true)}>
+					{'click me'}
+				</button>
+			</tsx>;
+			{el}
+			<div class="status">{clicked ? 'clicked' : 'not clicked'}</div>
+		}
+		render(App);
+		expect(container.querySelector('.status').textContent).toBe('not clicked');
+
+		container.querySelector('button').click();
+		flushSync();
+		expect(container.querySelector('.status').textContent).toBe('clicked');
+	});
+
+	it('renders tsx element with boolean attributes', () => {
+		component App() {
+			let &[isDisabled] = track(true);
+			const el = <tsx>
+				<button disabled={isDisabled}>
+					{'btn'}
+				</button>
+			</tsx>;
+			{el}
+			<button class="toggle" onClick={() => (isDisabled = !isDisabled)}>{'toggle'}</button>
+		}
+		render(App);
+		expect(container.querySelector('button:not(.toggle)').disabled).toBe(true);
+
+		container.querySelector('.toggle').click();
+		flushSync();
+		expect(container.querySelector('button:not(.toggle)').disabled).toBe(false);
+	});
+
+	it('renders tsx element with style attribute', () => {
+		component App() {
+			let &[color] = track('red');
+			const el = <tsx><div style={'color: ' + color}>styled</div></tsx>;
+			{el}
+			<button onClick={() => (color = 'blue')}>{'change color'}</button>
+		}
+		render(App);
+		expect(container.querySelector('div').style.color).toBe('red');
+
+		container.querySelector('button').click();
+		flushSync();
+		expect(container.querySelector('div').style.color).toBe('blue');
+	});
+
+	it('renders tsx element with multiple dynamic attributes', () => {
+		component App() {
+			let &[index] = track(0);
+			const el = <tsx>
+				<div id={'item-' + index} class={'item pos-' + index} data-index={index} title={'Item ' +
+					index}>
+					{'Item ' + index}
+				</div>
+			</tsx>;
+			{el}
+			<button onClick={() => index++}>{'next'}</button>
+		}
+		render(App);
+		const div = container.querySelector('div');
+		expect(div.id).toBe('item-0');
+		expect(div.className).toBe('item pos-0');
+		expect(div.getAttribute('data-index')).toBe('0');
+		expect(div.title).toBe('Item 0');
+
+		container.querySelector('button').click();
+		flushSync();
+		expect(div.id).toBe('item-1');
+		expect(div.className).toBe('item pos-1');
+		expect(div.getAttribute('data-index')).toBe('1');
+		expect(div.title).toBe('Item 1');
+	});
 });

--- a/packages/ripple/tests/client/tsx.test.ripple
+++ b/packages/ripple/tests/client/tsx.test.ripple
@@ -1,0 +1,131 @@
+import { flushSync, track } from 'ripple';
+
+describe('tsx expression', () => {
+	it('renders a basic tsx element', () => {
+		component App() {
+			const el = <tsx><div>hello world</div></tsx>;
+			{el}
+		}
+		render(App);
+		expect(container.textContent).toBe('hello world');
+		expect(container.querySelector('div')).toBeTruthy();
+	});
+
+	it('renders a tsx element assigned to a variable', () => {
+		component App() {
+			const el = <tsx><span class="test">content</span></tsx>;
+			{el}
+		}
+		render(App);
+		const span = container.querySelector('span.test');
+		expect(span).toBeTruthy();
+		expect(span.textContent).toBe('content');
+	});
+
+	it('renders a tsx element with multiple children', () => {
+		component App() {
+			const el = <tsx><div>first</div><div>second</div></tsx>;
+			{el}
+		}
+		render(App);
+		const divs = container.querySelectorAll('div');
+		expect(divs.length).toBe(2);
+		expect(divs[0].textContent).toBe('first');
+		expect(divs[1].textContent).toBe('second');
+	});
+
+	it('renders a tsx element with nested elements', () => {
+		component App() {
+			const el = <tsx>
+				<div class="outer">
+					<span class="inner">nested</span>
+				</div>
+			</tsx>;
+			{el}
+		}
+		render(App);
+		const outer = container.querySelector('div.outer');
+		expect(outer).toBeTruthy();
+		const inner = outer.querySelector('span.inner');
+		expect(inner).toBeTruthy();
+		expect(inner.textContent).toBe('nested');
+	});
+
+	it('renders a tsx element inline in a parent element', () => {
+		component App() {
+			const el = <tsx><span>inline</span></tsx>;
+			<div class="parent">{el}</div>
+		}
+		render(App);
+		const parent = container.querySelector('div.parent');
+		expect(parent).toBeTruthy();
+		expect(parent.querySelector('span')).toBeTruthy();
+		expect(parent.textContent).toBe('inline');
+	});
+
+	it('renders a tsx element with reactive expressions', () => {
+		component App() {
+			let &[count] = track(0);
+			const el = <tsx>
+				<div>
+					{'count: ' + count}
+				</div>
+			</tsx>;
+			{el}
+			<button onClick={() => count++}>{'increment'}</button>
+		}
+		render(App);
+		expect(container.querySelector('div').textContent).toBe('count: 0');
+
+		container.querySelector('button').click();
+		flushSync();
+		expect(container.querySelector('div').textContent).toBe('count: 1');
+	});
+
+	it('conditionally renders tsx elements', () => {
+		component App() {
+			let &[show] = track(true);
+			const el = <tsx><div class="tsx-content">visible</div></tsx>;
+
+			if (show) {
+				{el}
+			}
+			<button onClick={() => (show = !show)}>{'toggle'}</button>
+		}
+		render(App);
+		expect(container.querySelector('.tsx-content')).toBeTruthy();
+
+		container.querySelector('button').click();
+		flushSync();
+		expect(container.querySelector('.tsx-content')).toBeFalsy();
+
+		container.querySelector('button').click();
+		flushSync();
+		expect(container.querySelector('.tsx-content')).toBeTruthy();
+	});
+
+	it('renders tsx element passed as children prop', () => {
+		component Child(&{ children }: { children: any }) {
+			<div class="wrapper">{children}</div>
+		}
+
+		component App() {
+			const el = <tsx><span>from tsx</span></tsx>;
+			<Child children={el} />
+		}
+		render(App);
+		const wrapper = container.querySelector('.wrapper');
+		expect(wrapper).toBeTruthy();
+		expect(wrapper.querySelector('span')).toBeTruthy();
+		expect(wrapper.textContent).toBe('from tsx');
+	});
+
+	it('renders tsx element with text content only', () => {
+		component App() {
+			const el = <tsx>just text</tsx>;
+			{el}
+		}
+		render(App);
+		expect(container.textContent).toBe('just text');
+	});
+});

--- a/packages/ripple/tests/hydration/compiled/client/basic.js
+++ b/packages/ripple/tests/hydration/compiled/client/basic.js
@@ -13,14 +13,14 @@ var root_8 = _$_.template(`<!><!>`, 1, 2);
 var root_9 = _$_.template(`<div> </div>`, 0);
 var root_10 = _$_.template(`<!>`, 1, 1);
 var root_11 = _$_.template(`<div> </div><span> </span>`, 1, 2);
-var root_12 = _$_.template(`<div class="text-prop"> </div>`, 0);
+var root_12 = _$_.template(`<div class="text-prop"><!></div>`, 0);
 var root_13 = _$_.template(`<!><button class="show-text">Show</button>`, 1, 2);
 var root_14 = _$_.template(`<h1 class="sr-only">heading</h1><p class="subtitle">first paragraph</p><p class="subtitle">second paragraph</p>`, 1, 3);
 var root_15 = _$_.template(`<!><span class="sibling1"> </span><span class="sibling2"> </span>`, 1, 3);
 var root_16 = _$_.template(`<h1 class="sr-only">Ripple</h1><img src="/images/logo.png" alt="Logo" class="logo"><p class="subtitle">the elegant TypeScript UI framework</p>`, 1, 3);
 var root_18 = _$_.template(`<a href="/playground" class="playground-link">Playground</a>`, 0);
 var root_17 = _$_.template(`<div class="social-links"><a href="https://github.com" class="github-link">GitHub</a><a href="https://discord.com" class="discord-link">Discord</a><!></div>`, 0);
-var root_19 = _$_.template(`<main><div class="container"> </div></main>`, 0);
+var root_19 = _$_.template(`<main><div class="container"><!></div></main>`, 0);
 var root_20 = _$_.template(`<div class="content"><p>Some content here</p></div>`, 0);
 var root_22 = _$_.template(`<!><!><!><!>`, 1, 4);
 var root_21 = _$_.template(`<!>`, 1, 1);
@@ -189,7 +189,7 @@ function TextProp(__anchor, __props, __block) {
 	var div_8 = root_12();
 
 	{
-		var expression_3 = _$_.child(div_8, true);
+		var expression_3 = _$_.child(div_8);
 
 		_$_.expression(expression_3, () => __props.children);
 		_$_.pop(div_8);
@@ -313,7 +313,7 @@ function Layout(__anchor, { children }, __block) {
 		var div_10 = _$_.child(main_1);
 
 		{
-			var expression_6 = _$_.child(div_10, true);
+			var expression_6 = _$_.child(div_10);
 
 			_$_.expression(expression_6, () => children);
 			_$_.pop(div_10);

--- a/packages/ripple/tests/hydration/compiled/client/basic.js
+++ b/packages/ripple/tests/hydration/compiled/client/basic.js
@@ -13,14 +13,14 @@ var root_8 = _$_.template(`<!><!>`, 1, 2);
 var root_9 = _$_.template(`<div> </div>`, 0);
 var root_10 = _$_.template(`<!>`, 1, 1);
 var root_11 = _$_.template(`<div> </div><span> </span>`, 1, 2);
-var root_12 = _$_.template(`<div class="text-prop"><!></div>`, 0);
+var root_12 = _$_.template(`<div class="text-prop"> </div>`, 0);
 var root_13 = _$_.template(`<!><button class="show-text">Show</button>`, 1, 2);
 var root_14 = _$_.template(`<h1 class="sr-only">heading</h1><p class="subtitle">first paragraph</p><p class="subtitle">second paragraph</p>`, 1, 3);
 var root_15 = _$_.template(`<!><span class="sibling1"> </span><span class="sibling2"> </span>`, 1, 3);
 var root_16 = _$_.template(`<h1 class="sr-only">Ripple</h1><img src="/images/logo.png" alt="Logo" class="logo"><p class="subtitle">the elegant TypeScript UI framework</p>`, 1, 3);
 var root_18 = _$_.template(`<a href="/playground" class="playground-link">Playground</a>`, 0);
 var root_17 = _$_.template(`<div class="social-links"><a href="https://github.com" class="github-link">GitHub</a><a href="https://discord.com" class="discord-link">Discord</a><!></div>`, 0);
-var root_19 = _$_.template(`<main><div class="container"><!></div></main>`, 0);
+var root_19 = _$_.template(`<main><div class="container"> </div></main>`, 0);
 var root_20 = _$_.template(`<div class="content"><p>Some content here</p></div>`, 0);
 var root_22 = _$_.template(`<!><!><!><!>`, 1, 4);
 var root_21 = _$_.template(`<!>`, 1, 1);
@@ -135,12 +135,9 @@ export function Greeting(__anchor, props, __block) {
 	{
 		var expression = _$_.child(div_6, true);
 
+		_$_.expression(expression, () => 'Hello ' + _$_.with_scope(__block, () => String(props.name)));
 		_$_.pop(div_6);
 	}
-
-	_$_.render(() => {
-		_$_.set_text(expression, 'Hello ' + _$_.with_scope(__block, () => String(props.name)));
-	});
 
 	_$_.append(__anchor, div_6);
 	_$_.pop_component();
@@ -168,7 +165,7 @@ export function ExpressionContent(__anchor, _, __block) {
 	{
 		var expression_1 = _$_.child(div_7, true);
 
-		expression_1.nodeValue = value;
+		_$_.expression(expression_1, () => value);
 		_$_.pop(div_7);
 	}
 
@@ -177,15 +174,11 @@ export function ExpressionContent(__anchor, _, __block) {
 	{
 		var expression_2 = _$_.child(span_2, true);
 
+		_$_.expression(expression_2, () => _$_.with_scope(__block, () => label.toUpperCase()));
 		_$_.pop(span_2);
 	}
 
 	_$_.next();
-
-	_$_.render(() => {
-		_$_.set_text(expression_2, _$_.with_scope(__block, () => label.toUpperCase()));
-	});
-
 	_$_.append(__anchor, fragment_4, true);
 	_$_.pop_component();
 }
@@ -196,14 +189,11 @@ function TextProp(__anchor, __props, __block) {
 	var div_8 = root_12();
 
 	{
-		var expression_3 = _$_.child(div_8);
+		var expression_3 = _$_.child(div_8, true);
 
+		_$_.expression(expression_3, () => __props.children);
 		_$_.pop(div_8);
 	}
-
-	_$_.render(() => {
-		_$_.expression(expression_3, () => __props.children);
-	});
 
 	_$_.append(__anchor, div_8);
 	_$_.pop_component();
@@ -257,7 +247,7 @@ export function StaticChildWithSiblings(__anchor, _, __block) {
 	{
 		var expression_4 = _$_.child(span_3, true);
 
-		expression_4.nodeValue = foo;
+		_$_.expression(expression_4, () => foo);
 		_$_.pop(span_3);
 	}
 
@@ -266,7 +256,7 @@ export function StaticChildWithSiblings(__anchor, _, __block) {
 	{
 		var expression_5 = _$_.child(span_4, true);
 
-		expression_5.nodeValue = foo;
+		_$_.expression(expression_5, () => foo);
 		_$_.pop(span_4);
 	}
 
@@ -323,15 +313,12 @@ function Layout(__anchor, { children }, __block) {
 		var div_10 = _$_.child(main_1);
 
 		{
-			var expression_6 = _$_.child(div_10);
+			var expression_6 = _$_.child(div_10, true);
 
+			_$_.expression(expression_6, () => children);
 			_$_.pop(div_10);
 		}
 	}
-
-	_$_.render(() => {
-		_$_.expression(expression_6, () => children);
-	});
 
 	_$_.append(__anchor, main_1);
 	_$_.pop_component();

--- a/packages/ripple/tests/hydration/compiled/client/basic.js
+++ b/packages/ripple/tests/hydration/compiled/client/basic.js
@@ -342,9 +342,7 @@ export function WebsiteIndex(__anchor, _, __block) {
 	Layout(
 		node_7,
 		{
-			children: _$_.ripple_element(function render_children(__anchor, _, __block) {
-				_$_.push_component();
-
+			children: _$_.ripple_element(function render_children(__anchor, __block) {
 				var fragment_10 = root_22();
 				var node_8 = _$_.first_child_frag(fragment_10);
 
@@ -362,7 +360,6 @@ export function WebsiteIndex(__anchor, _, __block) {
 
 				Actions(node_11, { playgroundVisible: false }, _$_.active_block);
 				_$_.append(__anchor, fragment_10);
-				_$_.pop_component();
 			})
 		},
 		_$_.active_block

--- a/packages/ripple/tests/hydration/compiled/client/composite.js
+++ b/packages/ripple/tests/hydration/compiled/client/composite.js
@@ -87,15 +87,12 @@ export function LayoutWithSingleChild(__anchor, _, __block) {
 	Layout(
 		node_1,
 		{
-			children: _$_.ripple_element(function render_children(__anchor, _, __block) {
-				_$_.push_component();
-
+			children: _$_.ripple_element(function render_children(__anchor, __block) {
 				var fragment_3 = root_6();
 				var node_2 = _$_.first_child_frag(fragment_3);
 
 				SingleChild(node_2, {}, _$_.active_block);
 				_$_.append(__anchor, fragment_3);
-				_$_.pop_component();
 			})
 		},
 		_$_.active_block
@@ -114,15 +111,12 @@ export function LayoutWithMultipleChildren(__anchor, _, __block) {
 	Layout(
 		node_3,
 		{
-			children: _$_.ripple_element(function render_children(__anchor, _, __block) {
-				_$_.push_component();
-
+			children: _$_.ripple_element(function render_children(__anchor, __block) {
 				var fragment_5 = root_8();
 				var node_4 = _$_.first_child_frag(fragment_5);
 
 				SingleChild(node_4, {}, _$_.active_block);
 				_$_.append(__anchor, fragment_5);
-				_$_.pop_component();
 			})
 		},
 		_$_.active_block
@@ -141,15 +135,12 @@ export function LayoutWithMultiRootChild(__anchor, _, __block) {
 	Layout(
 		node_5,
 		{
-			children: _$_.ripple_element(function render_children(__anchor, _, __block) {
-				_$_.push_component();
-
+			children: _$_.ripple_element(function render_children(__anchor, __block) {
 				var fragment_7 = root_10();
 				var node_6 = _$_.first_child_frag(fragment_7);
 
 				MultiRootChild(node_6, {}, _$_.active_block);
 				_$_.append(__anchor, fragment_7);
-				_$_.pop_component();
 			})
 		},
 		_$_.active_block
@@ -168,15 +159,12 @@ export function LayoutWithTextAroundChildren(__anchor, _, __block) {
 	TextWrappedLayout(
 		node_7,
 		{
-			children: _$_.ripple_element(function render_children(__anchor, _, __block) {
-				_$_.push_component();
-
+			children: _$_.ripple_element(function render_children(__anchor, __block) {
 				var fragment_9 = root_12();
 				var node_8 = _$_.first_child_frag(fragment_9);
 
 				SingleChild(node_8, {}, _$_.active_block);
 				_$_.append(__anchor, fragment_9);
-				_$_.pop_component();
 			})
 		},
 		_$_.active_block

--- a/packages/ripple/tests/hydration/compiled/client/composite.js
+++ b/packages/ripple/tests/hydration/compiled/client/composite.js
@@ -1,7 +1,7 @@
 // @ts-nocheck
 import * as _$_ from 'ripple/internal/client';
 
-var root = _$_.template(`<div class="layout"> </div>`, 0);
+var root = _$_.template(`<div class="layout"><!></div>`, 0);
 var root_1 = _$_.template(`<div class="layout">before<!>after</div>`, 0);
 var root_2 = _$_.template(`<div class="single">single</div>`, 0);
 var root_3 = _$_.template(`<h1>title</h1><p>description</p>`, 1, 2);
@@ -21,7 +21,7 @@ export function Layout(__anchor, __props, __block) {
 	var div_1 = root();
 
 	{
-		var expression = _$_.child(div_1, true);
+		var expression = _$_.child(div_1);
 
 		_$_.expression(expression, () => __props.children);
 		_$_.pop(div_1);

--- a/packages/ripple/tests/hydration/compiled/client/composite.js
+++ b/packages/ripple/tests/hydration/compiled/client/composite.js
@@ -1,7 +1,7 @@
 // @ts-nocheck
 import * as _$_ from 'ripple/internal/client';
 
-var root = _$_.template(`<div class="layout"><!></div>`, 0);
+var root = _$_.template(`<div class="layout"> </div>`, 0);
 var root_1 = _$_.template(`<div class="layout">before<!>after</div>`, 0);
 var root_2 = _$_.template(`<div class="single">single</div>`, 0);
 var root_3 = _$_.template(`<h1>title</h1><p>description</p>`, 1, 2);
@@ -21,14 +21,11 @@ export function Layout(__anchor, __props, __block) {
 	var div_1 = root();
 
 	{
-		var expression = _$_.child(div_1);
+		var expression = _$_.child(div_1, true);
 
+		_$_.expression(expression, () => __props.children);
 		_$_.pop(div_1);
 	}
-
-	_$_.render(() => {
-		_$_.expression(expression, () => __props.children);
-	});
 
 	_$_.append(__anchor, div_1);
 	_$_.pop_component();
@@ -43,12 +40,9 @@ export function TextWrappedLayout(__anchor, __props, __block) {
 		var text = _$_.child(div_2);
 		var expression_1 = _$_.sibling(text);
 
+		_$_.expression(expression_1, () => __props.children);
 		_$_.pop(div_2);
 	}
-
-	_$_.render(() => {
-		_$_.expression(expression_1, () => __props.children);
-	});
 
 	_$_.append(__anchor, div_2);
 	_$_.pop_component();

--- a/packages/ripple/tests/hydration/compiled/client/events.js
+++ b/packages/ripple/tests/hydration/compiled/client/events.js
@@ -29,13 +29,10 @@ export function ClickCounter(__anchor, _, __block) {
 		{
 			var expression = _$_.child(span_1, true);
 
+			_$_.expression(expression, () => _$_.get(lazy));
 			_$_.pop(span_1);
 		}
 	}
-
-	_$_.render(() => {
-		_$_.set_text(expression, _$_.get(lazy));
-	});
 
 	_$_.append(__anchor, div_1);
 	_$_.pop_component();
@@ -59,6 +56,7 @@ export function IncrementDecrement(__anchor, _, __block) {
 		{
 			var expression_1 = _$_.child(span_2, true);
 
+			_$_.expression(expression_1, () => _$_.get(lazy_1));
 			_$_.pop(span_2);
 		}
 
@@ -68,10 +66,6 @@ export function IncrementDecrement(__anchor, _, __block) {
 			_$_.update(lazy_1);
 		};
 	}
-
-	_$_.render(() => {
-		_$_.set_text(expression_1, _$_.get(lazy_1));
-	});
 
 	_$_.append(__anchor, div_2);
 	_$_.pop_component();
@@ -100,6 +94,7 @@ export function MultipleEvents(__anchor, _, __block) {
 		{
 			var expression_2 = _$_.child(span_3, true);
 
+			_$_.expression(expression_2, () => _$_.get(lazy_2));
 			_$_.pop(span_3);
 		}
 
@@ -108,26 +103,10 @@ export function MultipleEvents(__anchor, _, __block) {
 		{
 			var expression_3 = _$_.child(span_4, true);
 
+			_$_.expression(expression_3, () => _$_.get(lazy_3));
 			_$_.pop(span_4);
 		}
 	}
-
-	_$_.render(
-		(__prev) => {
-			var __a = _$_.get(lazy_2);
-
-			if (__prev.a !== __a) {
-				_$_.set_text(expression_2, __prev.a = __a);
-			}
-
-			var __b = _$_.get(lazy_3);
-
-			if (__prev.b !== __b) {
-				_$_.set_text(expression_3, __prev.b = __b);
-			}
-		},
-		{ a: ' ', b: ' ' }
-	);
 
 	_$_.append(__anchor, div_3);
 	_$_.pop_component();
@@ -156,6 +135,7 @@ export function MultiStateUpdate(__anchor, _, __block) {
 		{
 			var expression_4 = _$_.child(span_5, true);
 
+			_$_.expression(expression_4, () => _$_.get(lazy_4));
 			_$_.pop(span_5);
 		}
 
@@ -164,26 +144,10 @@ export function MultiStateUpdate(__anchor, _, __block) {
 		{
 			var expression_5 = _$_.child(span_6, true);
 
+			_$_.expression(expression_5, () => _$_.get(lazy_5));
 			_$_.pop(span_6);
 		}
 	}
-
-	_$_.render(
-		(__prev) => {
-			var __a = _$_.get(lazy_4);
-
-			if (__prev.a !== __a) {
-				_$_.set_text(expression_4, __prev.a = __a);
-			}
-
-			var __b = _$_.get(lazy_5);
-
-			if (__prev.b !== __b) {
-				_$_.set_text(expression_5, __prev.b = __b);
-			}
-		},
-		{ a: ' ', b: ' ' }
-	);
 
 	_$_.append(__anchor, div_4);
 	_$_.pop_component();
@@ -205,13 +169,10 @@ export function ToggleButton(__anchor, _, __block) {
 		{
 			var expression_6 = _$_.child(button_6, true);
 
+			_$_.expression(expression_6, () => _$_.get(lazy_6) ? 'ON' : 'OFF');
 			_$_.pop(button_6);
 		}
 	}
-
-	_$_.render(() => {
-		_$_.set_text(expression_6, _$_.get(lazy_6) ? 'ON' : 'OFF');
-	});
 
 	_$_.append(__anchor, div_5);
 	_$_.pop_component();
@@ -227,12 +188,9 @@ export function ChildButton(__anchor, props, __block) {
 	{
 		var expression_7 = _$_.child(button_7, true);
 
+		_$_.expression(expression_7, () => props.label);
 		_$_.pop(button_7);
 	}
-
-	_$_.render(() => {
-		_$_.set_text(expression_7, props.label);
-	});
 
 	_$_.append(__anchor, button_7);
 	_$_.pop_component();
@@ -263,15 +221,12 @@ export function ParentWithChildButton(__anchor, _, __block) {
 		{
 			var expression_8 = _$_.child(span_7, true);
 
+			_$_.expression(expression_8, () => _$_.get(lazy_7));
 			_$_.pop(span_7);
 		}
 
 		_$_.pop(div_6);
 	}
-
-	_$_.render(() => {
-		_$_.set_text(expression_8, _$_.get(lazy_7));
-	});
 
 	_$_.append(__anchor, div_6);
 	_$_.pop_component();

--- a/packages/ripple/tests/hydration/compiled/client/for.js
+++ b/packages/ripple/tests/hydration/compiled/client/for.js
@@ -82,7 +82,7 @@ export function StaticForLoop(__anchor, _, __block) {
 				{
 					var expression = _$_.child(li_1, true);
 
-					expression.nodeValue = item;
+					_$_.expression(expression, () => item);
 					_$_.pop(li_1);
 				}
 
@@ -114,12 +114,9 @@ export function ForLoopWithIndex(__anchor, _, __block) {
 				{
 					var expression_1 = _$_.child(li_2, true);
 
+					_$_.expression(expression_1, () => `${_$_.get(i)}: ${item}`);
 					_$_.pop(li_2);
 				}
-
-				_$_.render(() => {
-					_$_.set_text(expression_1, `${_$_.get(i)}: ${item}`);
-				});
 
 				_$_.append(__anchor, li_2);
 			},
@@ -154,12 +151,9 @@ export function KeyedForLoop(__anchor, _, __block) {
 				{
 					var expression_2 = _$_.child(li_3, true);
 
+					_$_.expression(expression_2, () => _$_.get(pattern).name);
 					_$_.pop(li_3);
 				}
-
-				_$_.render(() => {
-					_$_.set_text(expression_2, _$_.get(pattern).name);
-				});
 
 				_$_.append(__anchor, li_3);
 			},
@@ -197,7 +191,7 @@ export function ReactiveForLoopAdd(__anchor, _, __block) {
 				{
 					var expression_3 = _$_.child(li_4, true);
 
-					expression_3.nodeValue = item;
+					_$_.expression(expression_3, () => item);
 					_$_.pop(li_4);
 				}
 
@@ -237,7 +231,7 @@ export function ReactiveForLoopRemove(__anchor, _, __block) {
 				{
 					var expression_4 = _$_.child(li_5, true);
 
-					expression_4.nodeValue = item;
+					_$_.expression(expression_4, () => item);
 					_$_.pop(li_5);
 				}
 
@@ -273,7 +267,7 @@ export function ForLoopInteractive(__anchor, _, __block) {
 					{
 						var expression_5 = _$_.child(span_1, true);
 
-						expression_5.nodeValue = count;
+						_$_.expression(expression_5, () => count);
 						_$_.pop(span_1);
 					}
 
@@ -326,7 +320,7 @@ export function NestedForLoop(__anchor, _, __block) {
 							{
 								var expression_6 = _$_.child(span_2, true);
 
-								expression_6.nodeValue = cell;
+								_$_.expression(expression_6, () => cell);
 								_$_.pop(span_2);
 							}
 
@@ -374,7 +368,7 @@ export function EmptyForLoop(__anchor, _, __block) {
 				{
 					var expression_7 = _$_.child(span_3, true);
 
-					expression_7.nodeValue = item;
+					_$_.expression(expression_7, () => item);
 					_$_.pop(span_3);
 				}
 
@@ -413,6 +407,7 @@ export function ForLoopComplexObjects(__anchor, _, __block) {
 					{
 						var expression_8 = _$_.child(span_4, true);
 
+						_$_.expression(expression_8, () => _$_.get(pattern_1).name);
 						_$_.pop(span_4);
 					}
 
@@ -421,32 +416,14 @@ export function ForLoopComplexObjects(__anchor, _, __block) {
 					{
 						var expression_9 = _$_.child(span_5, true);
 
+						_$_.expression(expression_9, () => _$_.get(pattern_1).role);
 						_$_.pop(span_5);
 					}
 				}
 
-				_$_.render(
-					(__prev) => {
-						var __a = _$_.get(pattern_1).name;
-
-						if (__prev.a !== __a) {
-							_$_.set_text(expression_8, __prev.a = __a);
-						}
-
-						var __b = _$_.get(pattern_1).role;
-
-						if (__prev.b !== __b) {
-							_$_.set_text(expression_9, __prev.b = __b);
-						}
-
-						var __c = `user-${_$_.get(pattern_1).id}`;
-
-						if (__prev.c !== __c) {
-							_$_.set_class(div_7, __prev.c = __c, void 0, true);
-						}
-					},
-					{ a: ' ', b: ' ', c: Symbol() }
-				);
+				_$_.render(() => {
+					_$_.set_class(div_7, `user-${_$_.get(pattern_1).id}`, void 0, true);
+				});
 
 				_$_.append(__anchor, div_7);
 			},
@@ -494,25 +471,13 @@ export function KeyedForLoopReorder(__anchor, _, __block) {
 				{
 					var expression_10 = _$_.child(li_6, true);
 
+					_$_.expression(expression_10, () => _$_.get(pattern_2).name);
 					_$_.pop(li_6);
 				}
 
-				_$_.render(
-					(__prev) => {
-						var __a = _$_.get(pattern_2).name;
-
-						if (__prev.a !== __a) {
-							_$_.set_text(expression_10, __prev.a = __a);
-						}
-
-						var __b = `item-${_$_.get(pattern_2).id}`;
-
-						if (__prev.b !== __b) {
-							_$_.set_class(li_6, __prev.b = __b, void 0, true);
-						}
-					},
-					{ a: ' ', b: Symbol() }
-				);
+				_$_.render(() => {
+					_$_.set_class(li_6, `item-${_$_.get(pattern_2).id}`, void 0, true);
+				});
 
 				_$_.append(__anchor, li_6);
 			},
@@ -551,25 +516,13 @@ export function KeyedForLoopUpdate(__anchor, _, __block) {
 				{
 					var expression_11 = _$_.child(li_7, true);
 
+					_$_.expression(expression_11, () => _$_.get(pattern_3).name);
 					_$_.pop(li_7);
 				}
 
-				_$_.render(
-					(__prev) => {
-						var __a = _$_.get(pattern_3).name;
-
-						if (__prev.a !== __a) {
-							_$_.set_text(expression_11, __prev.a = __a);
-						}
-
-						var __b = `item-${_$_.get(pattern_3).id}`;
-
-						if (__prev.b !== __b) {
-							_$_.set_class(li_7, __prev.b = __b, void 0, true);
-						}
-					},
-					{ a: ' ', b: Symbol() }
-				);
+				_$_.render(() => {
+					_$_.set_class(li_7, `item-${_$_.get(pattern_3).id}`, void 0, true);
+				});
 
 				_$_.append(__anchor, li_7);
 			},
@@ -610,7 +563,7 @@ export function ForLoopMixedOperations(__anchor, _, __block) {
 				{
 					var expression_12 = _$_.child(li_8, true);
 
-					expression_12.nodeValue = item;
+					_$_.expression(expression_12, () => item);
 					_$_.pop(li_8);
 				}
 
@@ -661,7 +614,7 @@ export function ForLoopInsideIf(__anchor, _, __block) {
 						{
 							var expression_13 = _$_.child(li_9, true);
 
-							expression_13.nodeValue = item;
+							_$_.expression(expression_13, () => item);
 							_$_.pop(li_9);
 						}
 
@@ -708,7 +661,7 @@ export function ForLoopEmptyToPopulated(__anchor, _, __block) {
 				{
 					var expression_14 = _$_.child(li_10, true);
 
-					expression_14.nodeValue = item;
+					_$_.expression(expression_14, () => item);
 					_$_.pop(li_10);
 				}
 
@@ -748,7 +701,7 @@ export function ForLoopPopulatedToEmpty(__anchor, _, __block) {
 				{
 					var expression_15 = _$_.child(li_11, true);
 
-					expression_15.nodeValue = item;
+					_$_.expression(expression_15, () => item);
 					_$_.pop(li_11);
 				}
 
@@ -804,7 +757,7 @@ export function NestedForLoopReactive(__anchor, _, __block) {
 							{
 								var expression_16 = _$_.child(span_6, true);
 
-								expression_16.nodeValue = cell;
+								_$_.expression(expression_16, () => cell);
 								_$_.pop(span_6);
 							}
 
@@ -872,6 +825,7 @@ export function ForLoopDeeplyNested(__anchor, _, __block) {
 					{
 						var expression_17 = _$_.child(h2_1, true);
 
+						_$_.expression(expression_17, () => _$_.get(pattern_4).name);
 						_$_.pop(h2_1);
 					}
 
@@ -889,6 +843,7 @@ export function ForLoopDeeplyNested(__anchor, _, __block) {
 								{
 									var expression_18 = _$_.child(h3_1, true);
 
+									_$_.expression(expression_18, () => _$_.get(pattern_5).name);
 									_$_.pop(h3_1);
 								}
 
@@ -904,7 +859,7 @@ export function ForLoopDeeplyNested(__anchor, _, __block) {
 											{
 												var expression_19 = _$_.child(li_12, true);
 
-												expression_19.nodeValue = member;
+												_$_.expression(expression_19, () => member);
 												_$_.pop(li_12);
 											}
 
@@ -917,22 +872,9 @@ export function ForLoopDeeplyNested(__anchor, _, __block) {
 								}
 							}
 
-							_$_.render(
-								(__prev) => {
-									var __a = _$_.get(pattern_5).name;
-
-									if (__prev.a !== __a) {
-										_$_.set_text(expression_18, __prev.a = __a);
-									}
-
-									var __b = `team-${_$_.get(pattern_5).id}`;
-
-									if (__prev.b !== __b) {
-										_$_.set_class(div_12, __prev.b = __b, void 0, true);
-									}
-								},
-								{ a: ' ', b: Symbol() }
-							);
+							_$_.render(() => {
+								_$_.set_class(div_12, `team-${_$_.get(pattern_5).id}`, void 0, true);
+							});
 
 							_$_.append(__anchor, div_12);
 						},
@@ -943,22 +885,9 @@ export function ForLoopDeeplyNested(__anchor, _, __block) {
 					_$_.pop(div_11);
 				}
 
-				_$_.render(
-					(__prev) => {
-						var __a = _$_.get(pattern_4).name;
-
-						if (__prev.a !== __a) {
-							_$_.set_text(expression_17, __prev.a = __a);
-						}
-
-						var __b = `dept-${_$_.get(pattern_4).id}`;
-
-						if (__prev.b !== __b) {
-							_$_.set_class(div_11, __prev.b = __b, void 0, true);
-						}
-					},
-					{ a: ' ', b: Symbol() }
-				);
+				_$_.render(() => {
+					_$_.set_class(div_11, `dept-${_$_.get(pattern_4).id}`, void 0, true);
+				});
 
 				_$_.append(__anchor, div_11);
 			},
@@ -996,25 +925,13 @@ export function ForLoopIndexUpdate(__anchor, _, __block) {
 				{
 					var expression_20 = _$_.child(li_13, true);
 
+					_$_.expression(expression_20, () => `[${_$_.get(i)}] ${item}`);
 					_$_.pop(li_13);
 				}
 
-				_$_.render(
-					(__prev) => {
-						var __a = `[${_$_.get(i)}] ${item}`;
-
-						if (__prev.a !== __a) {
-							_$_.set_text(expression_20, __prev.a = __a);
-						}
-
-						var __b = `item-${_$_.get(i)}`;
-
-						if (__prev.b !== __b) {
-							_$_.set_class(li_13, __prev.b = __b, void 0, true);
-						}
-					},
-					{ a: ' ', b: Symbol() }
-				);
+				_$_.render(() => {
+					_$_.set_class(li_13, `item-${_$_.get(i)}`, void 0, true);
+				});
 
 				_$_.append(__anchor, li_13);
 			},
@@ -1066,30 +983,25 @@ export function KeyedForLoopWithIndex(__anchor, _, __block) {
 				{
 					var expression_21 = _$_.child(li_14, true);
 
+					_$_.expression(expression_21, () => `[${_$_.get(i)}] ${_$_.get(pattern_6).id}: ${_$_.get(pattern_6).value}`);
 					_$_.pop(li_14);
 				}
 
 				_$_.render(
 					(__prev) => {
-						var __a = `[${_$_.get(i)}] ${_$_.get(pattern_6).id}: ${_$_.get(pattern_6).value}`;
+						var __a = _$_.get(i);
 
 						if (__prev.a !== __a) {
-							_$_.set_text(expression_21, __prev.a = __a);
+							_$_.set_attribute(li_14, 'data-index', __prev.a = __a);
 						}
 
-						var __b = _$_.get(i);
+						var __b = `item-${_$_.get(pattern_6).id}`;
 
 						if (__prev.b !== __b) {
-							_$_.set_attribute(li_14, 'data-index', __prev.b = __b);
-						}
-
-						var __c = `item-${_$_.get(pattern_6).id}`;
-
-						if (__prev.c !== __c) {
-							_$_.set_class(li_14, __prev.c = __c, void 0, true);
+							_$_.set_class(li_14, __prev.b = __b, void 0, true);
 						}
 					},
-					{ a: ' ', b: void 0, c: Symbol() }
+					{ a: void 0, b: Symbol() }
 				);
 
 				_$_.append(__anchor, li_14);
@@ -1128,7 +1040,7 @@ export function ForLoopWithSiblings(__anchor, _, __block) {
 				{
 					var expression_22 = _$_.child(div_14, true);
 
-					expression_22.nodeValue = item;
+					_$_.expression(expression_22, () => item);
 					_$_.pop(div_14);
 				}
 
@@ -1215,6 +1127,7 @@ function TodoItem(__anchor, props, __block) {
 		{
 			var expression_23 = _$_.child(span_7, true);
 
+			_$_.expression(expression_23, () => props.text);
 			_$_.pop(span_7);
 		}
 	}
@@ -1227,25 +1140,19 @@ function TodoItem(__anchor, props, __block) {
 				_$_.set_checked(input_1, __prev.a = __a);
 			}
 
-			var __b = props.text;
+			var __b = _$_.get(lazy_14) ? 'completed' : 'pending';
 
 			if (__prev.b !== __b) {
-				_$_.set_text(expression_23, __prev.b = __b);
+				_$_.set_class(span_7, __prev.b = __b, void 0, true);
 			}
 
-			var __c = _$_.get(lazy_14) ? 'completed' : 'pending';
+			var __c = `todo-${props.id}`;
 
 			if (__prev.c !== __c) {
-				_$_.set_class(span_7, __prev.c = __c, void 0, true);
-			}
-
-			var __d = `todo-${props.id}`;
-
-			if (__prev.d !== __d) {
-				_$_.set_class(div_16, __prev.d = __d, void 0, true);
+				_$_.set_class(div_16, __prev.c = __c, void 0, true);
 			}
 		},
-		{ a: void 0, b: ' ', c: Symbol(), d: Symbol() }
+		{ a: void 0, b: Symbol(), c: Symbol() }
 	);
 
 	_$_.append(__anchor, div_16);
@@ -1268,7 +1175,7 @@ export function ForLoopSingleItem(__anchor, _, __block) {
 				{
 					var expression_24 = _$_.child(li_15, true);
 
-					expression_24.nodeValue = item;
+					_$_.expression(expression_24, () => item);
 					_$_.pop(li_15);
 				}
 
@@ -1309,7 +1216,7 @@ export function ForLoopAddAtBeginning(__anchor, _, __block) {
 				{
 					var expression_25 = _$_.child(li_16, true);
 
-					expression_25.nodeValue = item;
+					_$_.expression(expression_25, () => item);
 					_$_.pop(li_16);
 				}
 
@@ -1354,7 +1261,7 @@ export function ForLoopAddInMiddle(__anchor, _, __block) {
 				{
 					var expression_26 = _$_.child(li_17, true);
 
-					expression_26.nodeValue = item;
+					_$_.expression(expression_26, () => item);
 					_$_.pop(li_17);
 				}
 
@@ -1396,7 +1303,7 @@ export function ForLoopRemoveFromMiddle(__anchor, _, __block) {
 				{
 					var expression_27 = _$_.child(li_18, true);
 
-					expression_27.nodeValue = item;
+					_$_.expression(expression_27, () => item);
 					_$_.pop(li_18);
 				}
 
@@ -1429,7 +1336,7 @@ export function ForLoopLargeList(__anchor, _, __block) {
 				{
 					var expression_28 = _$_.child(li_19, true);
 
-					expression_28.nodeValue = item;
+					_$_.expression(expression_28, () => item);
 					_$_.pop(li_19);
 				}
 
@@ -1477,7 +1384,7 @@ export function ForLoopSwap(__anchor, _, __block) {
 				{
 					var expression_29 = _$_.child(li_20, true);
 
-					expression_29.nodeValue = item;
+					_$_.expression(expression_29, () => item);
 					_$_.pop(li_20);
 				}
 
@@ -1519,7 +1426,7 @@ export function ForLoopReverse(__anchor, _, __block) {
 				{
 					var expression_30 = _$_.child(li_21, true);
 
-					expression_30.nodeValue = item;
+					_$_.expression(expression_30, () => item);
 					_$_.pop(li_21);
 				}
 

--- a/packages/ripple/tests/hydration/compiled/client/head.js
+++ b/packages/ripple/tests/hydration/compiled/client/head.js
@@ -42,6 +42,7 @@ export function ReactiveTitle(__anchor, _, __block) {
 		{
 			var expression = _$_.child(span_1, true);
 
+			_$_.expression(expression, () => _$_.get(lazy));
 			_$_.pop(span_1);
 		}
 	}
@@ -50,10 +51,6 @@ export function ReactiveTitle(__anchor, _, __block) {
 		_$_.render(() => {
 			_$_.document.title = _$_.get(lazy);
 		});
-	});
-
-	_$_.render(() => {
-		_$_.set_text(expression, _$_.get(lazy));
 	});
 
 	_$_.append(__anchor, div_2);
@@ -86,6 +83,7 @@ export function ReactiveMetaTags(__anchor, _, __block) {
 	{
 		var expression_1 = _$_.child(div_4, true);
 
+		_$_.expression(expression_1, () => _$_.get(lazy_1));
 		_$_.pop(div_4);
 	}
 
@@ -95,10 +93,6 @@ export function ReactiveMetaTags(__anchor, _, __block) {
 		_$_.document.title = 'My Page';
 		_$_.set_attribute(meta_1, 'content');
 		_$_.append(__anchor, meta_1);
-	});
-
-	_$_.render(() => {
-		_$_.set_text(expression_1, _$_.get(lazy_1));
 	});
 
 	_$_.append(__anchor, div_4);
@@ -114,6 +108,7 @@ export function TitleWithTemplate(__anchor, _, __block) {
 	{
 		var expression_2 = _$_.child(div_5, true);
 
+		_$_.expression(expression_2, () => _$_.get(lazy_2));
 		_$_.pop(div_5);
 	}
 
@@ -121,10 +116,6 @@ export function TitleWithTemplate(__anchor, _, __block) {
 		_$_.render(() => {
 			_$_.document.title = `Hello ${_$_.get(lazy_2)}!`;
 		});
-	});
-
-	_$_.render(() => {
-		_$_.set_text(expression_2, _$_.get(lazy_2));
 	});
 
 	_$_.append(__anchor, div_5);
@@ -154,6 +145,7 @@ export function ConditionalTitle(__anchor, _, __block) {
 	{
 		var expression_3 = _$_.child(div_7, true);
 
+		_$_.expression(expression_3, () => _$_.get(lazy_4));
 		_$_.pop(div_7);
 	}
 
@@ -161,10 +153,6 @@ export function ConditionalTitle(__anchor, _, __block) {
 		_$_.render(() => {
 			_$_.document.title = _$_.get(lazy_3) ? 'App - ' + _$_.get(lazy_4) : _$_.get(lazy_4);
 		});
-	});
-
-	_$_.render(() => {
-		_$_.set_text(expression_3, _$_.get(lazy_4));
 	});
 
 	_$_.append(__anchor, div_7);
@@ -184,6 +172,7 @@ export function ComputedTitle(__anchor, _, __block) {
 		{
 			var expression_4 = _$_.child(span_2, true);
 
+			_$_.expression(expression_4, () => _$_.get(lazy_5));
 			_$_.pop(span_2);
 		}
 	}
@@ -192,10 +181,6 @@ export function ComputedTitle(__anchor, _, __block) {
 		_$_.render(() => {
 			_$_.document.title = prefix + _$_.get(lazy_5);
 		});
-	});
-
-	_$_.render(() => {
-		_$_.set_text(expression_4, _$_.get(lazy_5));
 	});
 
 	_$_.append(__anchor, div_8);

--- a/packages/ripple/tests/hydration/compiled/client/hmr.js
+++ b/packages/ripple/tests/hydration/compiled/client/hmr.js
@@ -67,15 +67,12 @@ export function LayoutWithContent(__anchor, _, __block) {
 	Layout(
 		node_1,
 		{
-			children: _$_.ripple_element(function render_children(__anchor, _, __block) {
-				_$_.push_component();
-
+			children: _$_.ripple_element(function render_children(__anchor, __block) {
 				var fragment_1 = root_4();
 				var node_2 = _$_.first_child_frag(fragment_1);
 
 				Content(node_2, {}, _$_.active_block);
 				_$_.append(__anchor, fragment_1);
-				_$_.pop_component();
 			})
 		},
 		_$_.active_block

--- a/packages/ripple/tests/hydration/compiled/client/hmr.js
+++ b/packages/ripple/tests/hydration/compiled/client/hmr.js
@@ -1,7 +1,7 @@
 // @ts-nocheck
 import * as _$_ from 'ripple/internal/client';
 
-var root = _$_.template(`<div class="layout"><nav class="nav">Navigation</nav><main class="main"><!></main></div>`, 0);
+var root = _$_.template(`<div class="layout"><nav class="nav">Navigation</nav><main class="main"> </main></div>`, 0);
 var root_2 = _$_.template(`<p class="text">Hello world</p>`, 0);
 var root_1 = _$_.template(`<div class="content"><!></div>`, 0);
 var root_4 = _$_.template(`<!>`, 1, 1);
@@ -19,15 +19,12 @@ export function Layout(__anchor, { children }, __block) {
 		var main_1 = _$_.sibling(nav_1);
 
 		{
-			var expression = _$_.child(main_1);
+			var expression = _$_.child(main_1, true);
 
+			_$_.expression(expression, () => children);
 			_$_.pop(main_1);
 		}
 	}
-
-	_$_.render(() => {
-		_$_.expression(expression, () => children);
-	});
 
 	_$_.append(__anchor, div_1);
 	_$_.pop_component();

--- a/packages/ripple/tests/hydration/compiled/client/hmr.js
+++ b/packages/ripple/tests/hydration/compiled/client/hmr.js
@@ -1,7 +1,7 @@
 // @ts-nocheck
 import * as _$_ from 'ripple/internal/client';
 
-var root = _$_.template(`<div class="layout"><nav class="nav">Navigation</nav><main class="main"> </main></div>`, 0);
+var root = _$_.template(`<div class="layout"><nav class="nav">Navigation</nav><main class="main"><!></main></div>`, 0);
 var root_2 = _$_.template(`<p class="text">Hello world</p>`, 0);
 var root_1 = _$_.template(`<div class="content"><!></div>`, 0);
 var root_4 = _$_.template(`<!>`, 1, 1);
@@ -19,7 +19,7 @@ export function Layout(__anchor, { children }, __block) {
 		var main_1 = _$_.sibling(nav_1);
 
 		{
-			var expression = _$_.child(main_1, true);
+			var expression = _$_.child(main_1);
 
 			_$_.expression(expression, () => children);
 			_$_.pop(main_1);

--- a/packages/ripple/tests/hydration/compiled/client/html.js
+++ b/packages/ripple/tests/hydration/compiled/client/html.js
@@ -245,9 +245,7 @@ export function HtmlInChildren(__anchor, _, __block) {
 	HtmlWrapper(
 		node_7,
 		{
-			children: _$_.ripple_element(function render_children(__anchor, _, __block) {
-				_$_.push_component();
-
+			children: _$_.ripple_element(function render_children(__anchor, __block) {
 				var div_8 = root_8();
 
 				{
@@ -261,7 +259,6 @@ export function HtmlInChildren(__anchor, _, __block) {
 				});
 
 				_$_.append(__anchor, div_8);
-				_$_.pop_component();
 			})
 		},
 		_$_.active_block
@@ -281,9 +278,7 @@ export function HtmlInChildrenWithSiblings(__anchor, _, __block) {
 	HtmlWrapper(
 		node_9,
 		{
-			children: _$_.ripple_element(function render_children(__anchor, _, __block) {
-				_$_.push_component();
-
+			children: _$_.ripple_element(function render_children(__anchor, __block) {
 				var fragment_2 = root_10();
 				var h1_1 = _$_.first_child_frag(fragment_2);
 				var div_9 = _$_.sibling(h1_1);
@@ -301,7 +296,6 @@ export function HtmlInChildrenWithSiblings(__anchor, _, __block) {
 				});
 
 				_$_.append(__anchor, fragment_2, true);
-				_$_.pop_component();
 			})
 		},
 		_$_.active_block
@@ -322,9 +316,7 @@ export function MultipleHtmlInChildren(__anchor, _, __block) {
 	HtmlWrapper(
 		node_11,
 		{
-			children: _$_.ripple_element(function render_children(__anchor, _, __block) {
-				_$_.push_component();
-
+			children: _$_.ripple_element(function render_children(__anchor, __block) {
 				var div_10 = root_12();
 
 				{
@@ -343,7 +335,6 @@ export function MultipleHtmlInChildren(__anchor, _, __block) {
 				);
 
 				_$_.append(__anchor, div_10);
-				_$_.pop_component();
 			})
 		},
 		_$_.active_block
@@ -403,9 +394,7 @@ export function HtmlWithCommentsInChildren(__anchor, _, __block) {
 	HtmlWrapper(
 		node_16,
 		{
-			children: _$_.ripple_element(function render_children(__anchor, _, __block) {
-				_$_.push_component();
-
+			children: _$_.ripple_element(function render_children(__anchor, __block) {
 				var div_13 = root_16();
 
 				{
@@ -419,7 +408,6 @@ export function HtmlWithCommentsInChildren(__anchor, _, __block) {
 				});
 
 				_$_.append(__anchor, div_13);
-				_$_.pop_component();
 			})
 		},
 		_$_.active_block
@@ -597,9 +585,7 @@ export function HtmlWithServerData(__anchor, _, __block) {
 				{ href: '#features', text: 'Features' }
 			],
 
-			children: _$_.ripple_element(function render_children(__anchor, _, __block) {
-				_$_.push_component();
-
+			children: _$_.ripple_element(function render_children(__anchor, __block) {
 				var div_19 = root_24();
 
 				{
@@ -613,7 +599,6 @@ export function HtmlWithServerData(__anchor, _, __block) {
 				});
 
 				_$_.append(__anchor, div_19);
-				_$_.pop_component();
 			})
 		},
 		_$_.active_block
@@ -633,9 +618,7 @@ export function HtmlWithClientDefaults(__anchor, _, __block) {
 	DocLayout(
 		node_24,
 		{
-			children: _$_.ripple_element(function render_children(__anchor, _, __block) {
-				_$_.push_component();
-
+			children: _$_.ripple_element(function render_children(__anchor, __block) {
 				var div_20 = root_26();
 
 				{
@@ -649,7 +632,6 @@ export function HtmlWithClientDefaults(__anchor, _, __block) {
 				});
 
 				_$_.append(__anchor, div_20);
-				_$_.pop_component();
 			})
 		},
 		_$_.active_block
@@ -669,9 +651,7 @@ export function HtmlWithUndefinedContent(__anchor, _, __block) {
 	DocLayout(
 		node_26,
 		{
-			children: _$_.ripple_element(function render_children(__anchor, _, __block) {
-				_$_.push_component();
-
+			children: _$_.ripple_element(function render_children(__anchor, __block) {
 				var div_21 = root_28();
 
 				{
@@ -685,7 +665,6 @@ export function HtmlWithUndefinedContent(__anchor, _, __block) {
 				});
 
 				_$_.append(__anchor, div_21);
-				_$_.pop_component();
 			})
 		},
 		_$_.active_block
@@ -803,9 +782,7 @@ export function HtmlAfterSwitchInChildren(__anchor, _, __block) {
 	ContentWrapper(
 		node_30,
 		{
-			children: _$_.ripple_element(function render_children(__anchor, _, __block) {
-				_$_.push_component();
-
+			children: _$_.ripple_element(function render_children(__anchor, __block) {
 				var fragment_10 = root_35();
 				var node_31 = _$_.first_child_frag(fragment_10);
 
@@ -813,13 +790,10 @@ export function HtmlAfterSwitchInChildren(__anchor, _, __block) {
 					node_31,
 					{
 						level: 1,
-						children: _$_.ripple_element(function render_children(__anchor, _, __block) {
-							_$_.push_component();
-
+						children: _$_.ripple_element(function render_children(__anchor, __block) {
 							var expression_7 = _$_.text('Title');
 
 							_$_.append(__anchor, expression_7);
-							_$_.pop_component();
 						})
 					},
 					_$_.active_block
@@ -831,7 +805,6 @@ export function HtmlAfterSwitchInChildren(__anchor, _, __block) {
 
 				CodeBlock(node_32, { code: "const x = 1;" }, _$_.active_block);
 				_$_.append(__anchor, fragment_10);
-				_$_.pop_component();
 			})
 		},
 		_$_.active_block
@@ -957,9 +930,7 @@ function SideNav(__anchor, { currentPath }, __block) {
 					node_35,
 					{
 						title: "Getting Started",
-						children: _$_.ripple_element(function render_children(__anchor, _, __block) {
-							_$_.push_component();
-
+						children: _$_.ripple_element(function render_children(__anchor, __block) {
 							var fragment_11 = root_41();
 							var node_36 = _$_.first_child_frag(fragment_11);
 
@@ -986,7 +957,6 @@ function SideNav(__anchor, { currentPath }, __block) {
 							);
 
 							_$_.append(__anchor, fragment_11);
-							_$_.pop_component();
 						})
 					},
 					_$_.active_block
@@ -1004,9 +974,7 @@ function SideNav(__anchor, { currentPath }, __block) {
 					node_38,
 					{
 						title: "Guide",
-						children: _$_.ripple_element(function render_children(__anchor, _, __block) {
-							_$_.push_component();
-
+						children: _$_.ripple_element(function render_children(__anchor, __block) {
 							var fragment_12 = root_42();
 							var node_39 = _$_.first_child_frag(fragment_12);
 
@@ -1033,7 +1001,6 @@ function SideNav(__anchor, { currentPath }, __block) {
 							);
 
 							_$_.append(__anchor, fragment_12);
-							_$_.pop_component();
 						})
 					},
 					_$_.active_block
@@ -1151,13 +1118,10 @@ export function ArticleWithChildrenThenSibling(__anchor, _, __block) {
 		ArticleWrapper(
 			node_45,
 			{
-				children: _$_.ripple_element(function render_children(__anchor, _, __block) {
-					_$_.push_component();
-
+				children: _$_.ripple_element(function render_children(__anchor, __block) {
 					var fragment_13 = root_49();
 
 					_$_.append(__anchor, fragment_13);
-					_$_.pop_component();
 				})
 			},
 			_$_.active_block
@@ -1213,9 +1177,7 @@ export function ArticleWithHtmlChildThenSibling(__anchor, _, __block) {
 		ArticleWrapper(
 			node_49,
 			{
-				children: _$_.ripple_element(function render_children(__anchor, _, __block) {
-					_$_.push_component();
-
+				children: _$_.ripple_element(function render_children(__anchor, __block) {
 					var div_41 = root_53();
 
 					{
@@ -1229,7 +1191,6 @@ export function ArticleWithHtmlChildThenSibling(__anchor, _, __block) {
 					});
 
 					_$_.append(__anchor, div_41);
-					_$_.pop_component();
 				})
 			},
 			_$_.active_block
@@ -1314,9 +1275,7 @@ export function InlineArticleWithHtmlChild(__anchor, _, __block) {
 	InlineArticleLayout(
 		node_55,
 		{
-			children: _$_.ripple_element(function render_children(__anchor, _, __block) {
-				_$_.push_component();
-
+			children: _$_.ripple_element(function render_children(__anchor, __block) {
 				var div_46 = root_58();
 
 				{
@@ -1330,7 +1289,6 @@ export function InlineArticleWithHtmlChild(__anchor, _, __block) {
 				});
 
 				_$_.append(__anchor, div_46);
-				_$_.pop_component();
 			})
 		},
 		_$_.active_block
@@ -1489,9 +1447,7 @@ export function DocsLayoutWithData(__anchor, _, __block) {
 		{
 			editPath: "docs/styling.md",
 			nextLink: { href: '/next', text: 'Next' },
-			children: _$_.ripple_element(function render_children(__anchor, _, __block) {
-				_$_.push_component();
-
+			children: _$_.ripple_element(function render_children(__anchor, __block) {
 				var div_54 = root_66();
 
 				{
@@ -1505,7 +1461,6 @@ export function DocsLayoutWithData(__anchor, _, __block) {
 				});
 
 				_$_.append(__anchor, div_54);
-				_$_.pop_component();
 			})
 		},
 		_$_.active_block
@@ -1525,9 +1480,7 @@ export function DocsLayoutWithoutData(__anchor, _, __block) {
 	DocsLayoutInner(
 		node_64,
 		{
-			children: _$_.ripple_element(function render_children(__anchor, _, __block) {
-				_$_.push_component();
-
+			children: _$_.ripple_element(function render_children(__anchor, __block) {
 				var div_55 = root_68();
 
 				{
@@ -1541,7 +1494,6 @@ export function DocsLayoutWithoutData(__anchor, _, __block) {
 				});
 
 				_$_.append(__anchor, div_55);
-				_$_.pop_component();
 			})
 		},
 		_$_.active_block
@@ -1796,9 +1748,7 @@ export function DocsLayoutExactWithData(__anchor, _, __block) {
 				{ href: '#usage', text: 'Usage' }
 			],
 
-			children: _$_.ripple_element(function render_children(__anchor, _, __block) {
-				_$_.push_component();
-
+			children: _$_.ripple_element(function render_children(__anchor, __block) {
 				var div_64 = root_78();
 
 				{
@@ -1812,7 +1762,6 @@ export function DocsLayoutExactWithData(__anchor, _, __block) {
 				});
 
 				_$_.append(__anchor, div_64);
-				_$_.pop_component();
 			})
 		},
 		_$_.active_block
@@ -1840,9 +1789,7 @@ export function DocsLayoutExactWithoutData(__anchor, _, __block) {
 			prevLink,
 			nextLink,
 			toc,
-			children: _$_.ripple_element(function render_children(__anchor, _, __block) {
-				_$_.push_component();
-
+			children: _$_.ripple_element(function render_children(__anchor, __block) {
 				var div_65 = root_80();
 
 				{
@@ -1856,7 +1803,6 @@ export function DocsLayoutExactWithoutData(__anchor, _, __block) {
 				});
 
 				_$_.append(__anchor, div_65);
-				_$_.pop_component();
 			})
 		},
 		_$_.active_block
@@ -1939,9 +1885,7 @@ export function NestedTemplateInLayout(__anchor, _, __block) {
 		node_78,
 		{
 			data: doc,
-			children: _$_.ripple_element(function render_children(__anchor, _, __block) {
-				_$_.push_component();
-
+			children: _$_.ripple_element(function render_children(__anchor, __block) {
 				var div_69 = root_85();
 
 				{
@@ -1955,7 +1899,6 @@ export function NestedTemplateInLayout(__anchor, _, __block) {
 				});
 
 				_$_.append(__anchor, div_69);
-				_$_.pop_component();
 			})
 		},
 		_$_.active_block

--- a/packages/ripple/tests/hydration/compiled/client/html.js
+++ b/packages/ripple/tests/hydration/compiled/client/html.js
@@ -7,7 +7,7 @@ var root_2 = _$_.template(`<div><!></div>`, 0);
 var root_3 = _$_.template(`<section><!></section>`, 0);
 var root_4 = _$_.template(`<div><!><!></div>`, 0);
 var root_5 = _$_.template(`<div><!><button>Increment</button></div>`, 0);
-var root_6 = _$_.template(`<div class="wrapper"><div class="inner"><!></div></div>`, 0);
+var root_6 = _$_.template(`<div class="wrapper"><div class="inner"> </div></div>`, 0);
 var root_8 = _$_.template(`<div class="vp-doc"><!></div>`, 0);
 var root_7 = _$_.template(`<!>`, 1, 1);
 var root_10 = _$_.template(`<h1>Title</h1><div class="content"><!></div>`, 1, 2);
@@ -23,23 +23,23 @@ var root_19 = _$_.template(`<div class="edit-link"><a>Edit</a></div>`, 0);
 var root_20 = _$_.template(`<nav class="prev-next"><a> </a></nav>`, 0);
 var root_22 = _$_.template(`<li><a> </a></li>`, 0);
 var root_21 = _$_.template(`<div class="toc"><ul></ul></div>`, 0);
-var root_18 = _$_.template(`<div class="layout"><div class="content-container"><article><div><!></div></article><!><!><!></div><aside><!></aside></div>`, 0);
+var root_18 = _$_.template(`<div class="layout"><div class="content-container"><article><div> </div></article><!><!><!></div><aside><!></aside></div>`, 0);
 var root_24 = _$_.template(`<div class="vp-doc"><!></div>`, 0);
 var root_23 = _$_.template(`<!>`, 1, 1);
 var root_26 = _$_.template(`<div class="vp-doc"><!></div>`, 0);
 var root_25 = _$_.template(`<!>`, 1, 1);
 var root_28 = _$_.template(`<div class="vp-doc"><!></div>`, 0);
 var root_27 = _$_.template(`<!>`, 1, 1);
-var root_30 = _$_.template(`<h1 class="heading"><!></h1>`, 0);
-var root_31 = _$_.template(`<h2 class="heading"><!></h2>`, 0);
+var root_30 = _$_.template(`<h1 class="heading"> </h1>`, 0);
+var root_31 = _$_.template(`<h2 class="heading"> </h2>`, 0);
 var root_29 = _$_.template(`<!>`, 1, 1);
 var root_32 = _$_.template(`<div class="code-block"><div class="header"><button>Copy</button><span class="lang">js</span></div><div class="content"><!></div></div>`, 0);
-var root_33 = _$_.template(`<div class="wrapper"><div class="inner"><!></div></div>`, 0);
+var root_33 = _$_.template(`<div class="wrapper"><div class="inner"> </div></div>`, 0);
 var root_35 = _$_.template(`<!><p>First paragraph</p><p>Second paragraph</p><!><p>After code</p>`, 1, 5);
 var root_34 = _$_.template(`<!>`, 1, 1);
 var root_37 = _$_.template(`<div class="indicator"></div>`, 0);
 var root_36 = _$_.template(`<div><!><a><span> </span></a></div>`, 0);
-var root_39 = _$_.template(`<div class="section-items"><!></div>`, 0);
+var root_39 = _$_.template(`<div class="section-items"> </div>`, 0);
 var root_38 = _$_.template(`<section class="sidebar-section"><div class="section-header"><h2> </h2><button>Toggle</button></div><!></section>`, 0);
 var root_41 = _$_.template(`<!><!>`, 1, 2);
 var root_42 = _$_.template(`<!><!>`, 1, 2);
@@ -47,7 +47,7 @@ var root_40 = _$_.template(`<aside class="sidebar"><nav><div class="group"><!></
 var root_43 = _$_.template(`<header class="page-header"><div class="logo">MyApp</div></header>`, 0);
 var root_45 = _$_.template(`<div class="edit-link"><a href="/edit">Edit</a></div>`, 0);
 var root_44 = _$_.template(`<div class="layout"><!><div class="content-wrapper"><!><main class="main-content"><div class="article"><div><h1>Introduction</h1><p>Welcome to the docs.</p></div></div><!><!></main></div></div>`, 0);
-var root_46 = _$_.template(`<article class="doc-content"><div><!></div></article>`, 0);
+var root_46 = _$_.template(`<article class="doc-content"><div> </div></article>`, 0);
 var root_47 = _$_.template(`<footer class="doc-footer">Footer</footer>`, 0);
 var root_49 = _$_.template(`<h1>Title</h1><p>Content goes here.</p>`, 1, 2);
 var root_50 = _$_.template(`<div class="edit-link"><a href="/edit">Edit</a></div>`, 0);
@@ -57,7 +57,7 @@ var root_53 = _$_.template(`<div class="doc-content"><!></div>`, 0);
 var root_54 = _$_.template(`<div class="edit-link"><a href="/edit">Edit</a></div>`, 0);
 var root_52 = _$_.template(`<div class="content-container"><!><!><!></div>`, 0);
 var root_56 = _$_.template(`<div class="edit-link"><a href="/edit">Edit</a></div>`, 0);
-var root_55 = _$_.template(`<div class="content-container"><article class="doc-content"><div><!></div></article><!><!></div>`, 0);
+var root_55 = _$_.template(`<div class="content-container"><article class="doc-content"><div> </div></article><!><!></div>`, 0);
 var root_58 = _$_.template(`<div class="doc-content"><!></div>`, 0);
 var root_57 = _$_.template(`<!>`, 1, 1);
 var root_59 = _$_.template(`<header class="header">Header</header>`, 0);
@@ -65,7 +65,7 @@ var root_60 = _$_.template(`<aside class="sidebar">Sidebar</aside>`, 0);
 var root_61 = _$_.template(`<footer class="footer">Footer</footer>`, 0);
 var root_63 = _$_.template(`<div class="edit-link"><a href="/edit">Edit on GitHub</a></div>`, 0);
 var root_64 = _$_.template(`<nav class="prev-next"><a> </a></nav>`, 0);
-var root_62 = _$_.template(`<div class="layout"><!><div class="docs-wrapper"><!><main class="docs-main"><div class="docs-container"><div class="content"><div class="content-container"><article class="doc-content"><div><!></div></article><!><!><!></div></div></div></main></div></div>`, 0);
+var root_62 = _$_.template(`<div class="layout"><!><div class="docs-wrapper"><!><main class="docs-main"><div class="docs-container"><div class="content"><div class="content-container"><article class="doc-content"><div> </div></article><!><!><!></div></div></div></main></div></div>`, 0);
 var root_66 = _$_.template(`<div class="doc-content"><!></div>`, 0);
 var root_65 = _$_.template(`<!>`, 1, 1);
 var root_68 = _$_.template(`<div class="doc-content"><!></div>`, 0);
@@ -77,14 +77,14 @@ var root_74 = _$_.template(`<a class="pager next"><span class="title"> </span></
 var root_71 = _$_.template(`<nav class="prev-next"><!><!></nav>`, 0);
 var root_76 = _$_.template(`<a> </a>`, 0);
 var root_75 = _$_.template(`<div class="aside-content"><nav class="outline"></nav></div>`, 0);
-var root_69 = _$_.template(`<div class="layout"><!><div class="docs-wrapper"><!><main class="docs-main"><div class="docs-container"><div class="content"><div class="content-container"><article class="doc-content"><div><!></div></article><!><!><!></div></div><aside class="aside"><!></aside></div></main></div></div>`, 0);
+var root_69 = _$_.template(`<div class="layout"><!><div class="docs-wrapper"><!><main class="docs-main"><div class="docs-container"><div class="content"><div class="content-container"><article class="doc-content"><div> </div></article><!><!><!></div></div><aside class="aside"><!></aside></div></main></div></div>`, 0);
 var root_78 = _$_.template(`<div class="doc-content"><!></div>`, 0);
 var root_77 = _$_.template(`<!>`, 1, 1);
 var root_80 = _$_.template(`<div class="doc-content"><!></div>`, 0);
 var root_79 = _$_.template(`<!>`, 1, 1);
 var root_81 = _$_.template(`<div><template id="t1"></template><p class="content">Main content</p></div>`, 0);
 var root_82 = _$_.template(`<div class="wrapper"><h1>Title</h1><template id="data-template"></template><p class="after-template">Content after template</p></div>`, 0);
-var root_83 = _$_.template(`<div class="layout"><template id="page-data"></template><main><!></main></div>`, 0);
+var root_83 = _$_.template(`<div class="layout"><template id="page-data"></template><main> </main></div>`, 0);
 var root_85 = _$_.template(`<div class="doc-content"><!></div>`, 0);
 var root_84 = _$_.template(`<!>`, 1, 1);
 
@@ -224,15 +224,12 @@ export function HtmlWrapper(__anchor, { children }, __block) {
 		var div_7 = _$_.child(div_6);
 
 		{
-			var expression = _$_.child(div_7);
+			var expression = _$_.child(div_7, true);
 
+			_$_.expression(expression, () => children);
 			_$_.pop(div_7);
 		}
 	}
-
-	_$_.render(() => {
-		_$_.expression(expression, () => children);
-	});
 
 	_$_.append(__anchor, div_6);
 	_$_.pop_component();
@@ -460,8 +457,9 @@ export function DocLayout(
 				var div_15 = _$_.child(article_1);
 
 				{
-					var expression_1 = _$_.child(div_15);
+					var expression_1 = _$_.child(div_15, true);
 
+					_$_.expression(expression_1, () => children);
 					_$_.pop(div_15);
 				}
 			}
@@ -500,26 +498,14 @@ export function DocLayout(
 						{
 							var expression_2 = _$_.child(a_2, true);
 
+							_$_.expression(expression_2, () => nextLink.text);
 							_$_.pop(a_2);
 						}
 					}
 
-					_$_.render(
-						(__prev) => {
-							var __a = nextLink.text;
-
-							if (__prev.a !== __a) {
-								_$_.set_text(expression_2, __prev.a = __a);
-							}
-
-							var __b = nextLink.href;
-
-							if (__prev.b !== __b) {
-								_$_.set_attribute(a_2, 'href', __prev.b = __b);
-							}
-						},
-						{ a: ' ', b: void 0 }
-					);
+					_$_.render(() => {
+						_$_.set_attribute(a_2, 'href', nextLink.href);
+					});
 
 					_$_.append(__anchor, nav_1);
 				};
@@ -560,26 +546,14 @@ export function DocLayout(
 										{
 											var expression_3 = _$_.child(a_3, true);
 
+											_$_.expression(expression_3, () => item.text);
 											_$_.pop(a_3);
 										}
 									}
 
-									_$_.render(
-										(__prev) => {
-											var __a = item.text;
-
-											if (__prev.a !== __a) {
-												_$_.set_text(expression_3, __prev.a = __a);
-											}
-
-											var __b = item.href;
-
-											if (__prev.b !== __b) {
-												_$_.set_attribute(a_3, 'href', __prev.b = __b);
-											}
-										},
-										{ a: ' ', b: void 0 }
-									);
+									_$_.render(() => {
+										_$_.set_attribute(a_3, 'href', item.href);
+									});
 
 									_$_.append(__anchor, li_1);
 								},
@@ -601,10 +575,6 @@ export function DocLayout(
 			_$_.pop(aside_1);
 		}
 	}
-
-	_$_.render(() => {
-		_$_.expression(expression_1, () => children);
-	});
 
 	_$_.append(__anchor, div_14);
 	_$_.pop_component();
@@ -736,14 +706,11 @@ function DynamicHeading(__anchor, { level, children }, __block) {
 			var h1_2 = root_30();
 
 			{
-				var expression_4 = _$_.child(h1_2);
+				var expression_4 = _$_.child(h1_2, true);
 
+				_$_.expression(expression_4, () => children);
 				_$_.pop(h1_2);
 			}
-
-			_$_.render(() => {
-				_$_.expression(expression_4, () => children);
-			});
 
 			_$_.append(__anchor, h1_2);
 		};
@@ -752,14 +719,11 @@ function DynamicHeading(__anchor, { level, children }, __block) {
 			var h2_1 = root_31();
 
 			{
-				var expression_5 = _$_.child(h2_1);
+				var expression_5 = _$_.child(h2_1, true);
 
+				_$_.expression(expression_5, () => children);
 				_$_.pop(h2_1);
 			}
-
-			_$_.render(() => {
-				_$_.expression(expression_5, () => children);
-			});
 
 			_$_.append(__anchor, h2_1);
 		};
@@ -819,15 +783,12 @@ function ContentWrapper(__anchor, { children }, __block) {
 		var div_26 = _$_.child(div_25);
 
 		{
-			var expression_6 = _$_.child(div_26);
+			var expression_6 = _$_.child(div_26, true);
 
+			_$_.expression(expression_6, () => children);
 			_$_.pop(div_26);
 		}
 	}
-
-	_$_.render(() => {
-		_$_.expression(expression_6, () => children);
-	});
 
 	_$_.append(__anchor, div_25);
 	_$_.pop_component();
@@ -912,7 +873,7 @@ function NavItem(__anchor, { href, text: label, active = false }, __block) {
 			{
 				var expression_8 = _$_.child(span_1, true);
 
-				expression_8.nodeValue = label;
+				_$_.expression(expression_8, () => label);
 				_$_.pop(span_1);
 			}
 		}
@@ -939,7 +900,7 @@ function SidebarSection(__anchor, { title, children }, __block) {
 			{
 				var expression_9 = _$_.child(h2_2, true);
 
-				expression_9.nodeValue = title;
+				_$_.expression(expression_9, () => title);
 				_$_.pop(h2_2);
 			}
 
@@ -957,14 +918,11 @@ function SidebarSection(__anchor, { title, children }, __block) {
 				var div_30 = root_39();
 
 				{
-					var expression_10 = _$_.child(div_30);
+					var expression_10 = _$_.child(div_30, true);
 
+					_$_.expression(expression_10, () => children);
 					_$_.pop(div_30);
 				}
-
-				_$_.render(() => {
-					_$_.expression(expression_10, () => children);
-				});
 
 				_$_.append(__anchor, div_30);
 			};
@@ -1162,15 +1120,12 @@ function ArticleWrapper(__anchor, { children }, __block) {
 		var div_37 = _$_.child(article_2);
 
 		{
-			var expression_11 = _$_.child(div_37);
+			var expression_11 = _$_.child(div_37, true);
 
+			_$_.expression(expression_11, () => children);
 			_$_.pop(div_37);
 		}
 	}
-
-	_$_.render(() => {
-		_$_.expression(expression_11, () => children);
-	});
 
 	_$_.append(__anchor, article_2);
 	_$_.pop_component();
@@ -1316,8 +1271,9 @@ function InlineArticleLayout(__anchor, { children }, __block) {
 			var div_44 = _$_.child(article_3);
 
 			{
-				var expression_12 = _$_.child(div_44);
+				var expression_12 = _$_.child(div_44, true);
 
+				_$_.expression(expression_12, () => children);
 				_$_.pop(div_44);
 			}
 		}
@@ -1343,10 +1299,6 @@ function InlineArticleLayout(__anchor, { children }, __block) {
 		SimpleFooter(node_54, {}, _$_.active_block);
 		_$_.pop(div_43);
 	}
-
-	_$_.render(() => {
-		_$_.expression(expression_12, () => children);
-	});
 
 	_$_.append(__anchor, div_43);
 	_$_.pop_component();
@@ -1454,8 +1406,9 @@ function DocsLayoutInner(
 								var div_49 = _$_.child(article_4);
 
 								{
-									var expression_13 = _$_.child(div_49);
+									var expression_13 = _$_.child(div_49, true);
 
+									_$_.expression(expression_13, () => children);
 									_$_.pop(div_49);
 								}
 							}
@@ -1488,26 +1441,14 @@ function DocsLayoutInner(
 										{
 											var expression_14 = _$_.child(a_5, true);
 
+											_$_.expression(expression_14, () => nextLink.text);
 											_$_.pop(a_5);
 										}
 									}
 
-									_$_.render(
-										(__prev) => {
-											var __a = nextLink.text;
-
-											if (__prev.a !== __a) {
-												_$_.set_text(expression_14, __prev.a = __a);
-											}
-
-											var __b = nextLink.href;
-
-											if (__prev.b !== __b) {
-												_$_.set_attribute(a_5, 'href', __prev.b = __b);
-											}
-										},
-										{ a: ' ', b: void 0 }
-									);
+									_$_.render(() => {
+										_$_.set_attribute(a_5, 'href', nextLink.href);
+									});
 
 									_$_.append(__anchor, nav_4);
 								};
@@ -1531,10 +1472,6 @@ function DocsLayoutInner(
 
 		_$_.pop(div_47);
 	}
-
-	_$_.render(() => {
-		_$_.expression(expression_13, () => children);
-	});
 
 	_$_.append(__anchor, div_47);
 	_$_.pop_component();
@@ -1659,8 +1596,9 @@ function DocsLayoutExact(
 								var div_58 = _$_.child(article_5);
 
 								{
-									var expression_15 = _$_.child(div_58);
+									var expression_15 = _$_.child(div_58, true);
 
+									_$_.expression(expression_15, () => children);
 									_$_.pop(div_58);
 								}
 							}
@@ -1706,26 +1644,14 @@ function DocsLayoutExact(
 													{
 														var expression_16 = _$_.child(span_2, true);
 
+														_$_.expression(expression_16, () => prevLink.text);
 														_$_.pop(span_2);
 													}
 												}
 
-												_$_.render(
-													(__prev) => {
-														var __a = prevLink.text;
-
-														if (__prev.a !== __a) {
-															_$_.set_text(expression_16, __prev.a = __a);
-														}
-
-														var __b = prevLink.href;
-
-														if (__prev.b !== __b) {
-															_$_.set_attribute(a_7, 'href', __prev.b = __b);
-														}
-													},
-													{ a: ' ', b: void 0 }
-												);
+												_$_.render(() => {
+													_$_.set_attribute(a_7, 'href', prevLink.href);
+												});
 
 												_$_.append(__anchor, a_7);
 											};
@@ -1753,26 +1679,14 @@ function DocsLayoutExact(
 													{
 														var expression_17 = _$_.child(span_4, true);
 
+														_$_.expression(expression_17, () => nextLink.text);
 														_$_.pop(span_4);
 													}
 												}
 
-												_$_.render(
-													(__prev) => {
-														var __a = nextLink.text;
-
-														if (__prev.a !== __a) {
-															_$_.set_text(expression_17, __prev.a = __a);
-														}
-
-														var __b = nextLink.href;
-
-														if (__prev.b !== __b) {
-															_$_.set_attribute(a_8, 'href', __prev.b = __b);
-														}
-													},
-													{ a: ' ', b: void 0 }
-												);
+												_$_.render(() => {
+													_$_.set_attribute(a_8, 'href', nextLink.href);
+												});
 
 												_$_.append(__anchor, a_8);
 											};
@@ -1824,25 +1738,13 @@ function DocsLayoutExact(
 												{
 													var expression_18 = _$_.child(a_9, true);
 
+													_$_.expression(expression_18, () => item.text);
 													_$_.pop(a_9);
 												}
 
-												_$_.render(
-													(__prev) => {
-														var __a = item.text;
-
-														if (__prev.a !== __a) {
-															_$_.set_text(expression_18, __prev.a = __a);
-														}
-
-														var __b = item.href;
-
-														if (__prev.b !== __b) {
-															_$_.set_attribute(a_9, 'href', __prev.b = __b);
-														}
-													},
-													{ a: ' ', b: void 0 }
-												);
+												_$_.render(() => {
+													_$_.set_attribute(a_9, 'href', item.href);
+												});
 
 												_$_.append(__anchor, a_9);
 											},
@@ -1871,10 +1773,6 @@ function DocsLayoutExact(
 
 		_$_.pop(div_56);
 	}
-
-	_$_.render(() => {
-		_$_.expression(expression_15, () => children);
-	});
 
 	_$_.append(__anchor, div_56);
 	_$_.pop_component();
@@ -2015,24 +1913,16 @@ function LayoutWithTemplate(__anchor, { children, data }, __block) {
 		var main_4 = _$_.sibling(template_3);
 
 		{
-			var expression_19 = _$_.child(main_4);
+			var expression_19 = _$_.child(main_4, true);
 
+			_$_.expression(expression_19, () => children);
 			_$_.pop(main_4);
 		}
 	}
 
-	_$_.render(
-		(__prev) => {
-			var __a = _$_.with_scope(__block, () => JSON.stringify(data));
-
-			if (__prev.a !== __a) {
-				template_3.innerHTML = __prev.a = __a;
-			}
-
-			_$_.expression(expression_19, () => children);
-		},
-		{ a: '' }
-	);
+	_$_.render(() => {
+		template_3.innerHTML = _$_.with_scope(__block, () => JSON.stringify(data));
+	});
 
 	_$_.append(__anchor, div_68);
 	_$_.pop_component();

--- a/packages/ripple/tests/hydration/compiled/client/html.js
+++ b/packages/ripple/tests/hydration/compiled/client/html.js
@@ -7,7 +7,7 @@ var root_2 = _$_.template(`<div><!></div>`, 0);
 var root_3 = _$_.template(`<section><!></section>`, 0);
 var root_4 = _$_.template(`<div><!><!></div>`, 0);
 var root_5 = _$_.template(`<div><!><button>Increment</button></div>`, 0);
-var root_6 = _$_.template(`<div class="wrapper"><div class="inner"> </div></div>`, 0);
+var root_6 = _$_.template(`<div class="wrapper"><div class="inner"><!></div></div>`, 0);
 var root_8 = _$_.template(`<div class="vp-doc"><!></div>`, 0);
 var root_7 = _$_.template(`<!>`, 1, 1);
 var root_10 = _$_.template(`<h1>Title</h1><div class="content"><!></div>`, 1, 2);
@@ -23,23 +23,23 @@ var root_19 = _$_.template(`<div class="edit-link"><a>Edit</a></div>`, 0);
 var root_20 = _$_.template(`<nav class="prev-next"><a> </a></nav>`, 0);
 var root_22 = _$_.template(`<li><a> </a></li>`, 0);
 var root_21 = _$_.template(`<div class="toc"><ul></ul></div>`, 0);
-var root_18 = _$_.template(`<div class="layout"><div class="content-container"><article><div> </div></article><!><!><!></div><aside><!></aside></div>`, 0);
+var root_18 = _$_.template(`<div class="layout"><div class="content-container"><article><div><!></div></article><!><!><!></div><aside><!></aside></div>`, 0);
 var root_24 = _$_.template(`<div class="vp-doc"><!></div>`, 0);
 var root_23 = _$_.template(`<!>`, 1, 1);
 var root_26 = _$_.template(`<div class="vp-doc"><!></div>`, 0);
 var root_25 = _$_.template(`<!>`, 1, 1);
 var root_28 = _$_.template(`<div class="vp-doc"><!></div>`, 0);
 var root_27 = _$_.template(`<!>`, 1, 1);
-var root_30 = _$_.template(`<h1 class="heading"> </h1>`, 0);
-var root_31 = _$_.template(`<h2 class="heading"> </h2>`, 0);
+var root_30 = _$_.template(`<h1 class="heading"><!></h1>`, 0);
+var root_31 = _$_.template(`<h2 class="heading"><!></h2>`, 0);
 var root_29 = _$_.template(`<!>`, 1, 1);
 var root_32 = _$_.template(`<div class="code-block"><div class="header"><button>Copy</button><span class="lang">js</span></div><div class="content"><!></div></div>`, 0);
-var root_33 = _$_.template(`<div class="wrapper"><div class="inner"> </div></div>`, 0);
+var root_33 = _$_.template(`<div class="wrapper"><div class="inner"><!></div></div>`, 0);
 var root_35 = _$_.template(`<!><p>First paragraph</p><p>Second paragraph</p><!><p>After code</p>`, 1, 5);
 var root_34 = _$_.template(`<!>`, 1, 1);
 var root_37 = _$_.template(`<div class="indicator"></div>`, 0);
 var root_36 = _$_.template(`<div><!><a><span> </span></a></div>`, 0);
-var root_39 = _$_.template(`<div class="section-items"> </div>`, 0);
+var root_39 = _$_.template(`<div class="section-items"><!></div>`, 0);
 var root_38 = _$_.template(`<section class="sidebar-section"><div class="section-header"><h2> </h2><button>Toggle</button></div><!></section>`, 0);
 var root_41 = _$_.template(`<!><!>`, 1, 2);
 var root_42 = _$_.template(`<!><!>`, 1, 2);
@@ -47,7 +47,7 @@ var root_40 = _$_.template(`<aside class="sidebar"><nav><div class="group"><!></
 var root_43 = _$_.template(`<header class="page-header"><div class="logo">MyApp</div></header>`, 0);
 var root_45 = _$_.template(`<div class="edit-link"><a href="/edit">Edit</a></div>`, 0);
 var root_44 = _$_.template(`<div class="layout"><!><div class="content-wrapper"><!><main class="main-content"><div class="article"><div><h1>Introduction</h1><p>Welcome to the docs.</p></div></div><!><!></main></div></div>`, 0);
-var root_46 = _$_.template(`<article class="doc-content"><div> </div></article>`, 0);
+var root_46 = _$_.template(`<article class="doc-content"><div><!></div></article>`, 0);
 var root_47 = _$_.template(`<footer class="doc-footer">Footer</footer>`, 0);
 var root_49 = _$_.template(`<h1>Title</h1><p>Content goes here.</p>`, 1, 2);
 var root_50 = _$_.template(`<div class="edit-link"><a href="/edit">Edit</a></div>`, 0);
@@ -57,7 +57,7 @@ var root_53 = _$_.template(`<div class="doc-content"><!></div>`, 0);
 var root_54 = _$_.template(`<div class="edit-link"><a href="/edit">Edit</a></div>`, 0);
 var root_52 = _$_.template(`<div class="content-container"><!><!><!></div>`, 0);
 var root_56 = _$_.template(`<div class="edit-link"><a href="/edit">Edit</a></div>`, 0);
-var root_55 = _$_.template(`<div class="content-container"><article class="doc-content"><div> </div></article><!><!></div>`, 0);
+var root_55 = _$_.template(`<div class="content-container"><article class="doc-content"><div><!></div></article><!><!></div>`, 0);
 var root_58 = _$_.template(`<div class="doc-content"><!></div>`, 0);
 var root_57 = _$_.template(`<!>`, 1, 1);
 var root_59 = _$_.template(`<header class="header">Header</header>`, 0);
@@ -65,7 +65,7 @@ var root_60 = _$_.template(`<aside class="sidebar">Sidebar</aside>`, 0);
 var root_61 = _$_.template(`<footer class="footer">Footer</footer>`, 0);
 var root_63 = _$_.template(`<div class="edit-link"><a href="/edit">Edit on GitHub</a></div>`, 0);
 var root_64 = _$_.template(`<nav class="prev-next"><a> </a></nav>`, 0);
-var root_62 = _$_.template(`<div class="layout"><!><div class="docs-wrapper"><!><main class="docs-main"><div class="docs-container"><div class="content"><div class="content-container"><article class="doc-content"><div> </div></article><!><!><!></div></div></div></main></div></div>`, 0);
+var root_62 = _$_.template(`<div class="layout"><!><div class="docs-wrapper"><!><main class="docs-main"><div class="docs-container"><div class="content"><div class="content-container"><article class="doc-content"><div><!></div></article><!><!><!></div></div></div></main></div></div>`, 0);
 var root_66 = _$_.template(`<div class="doc-content"><!></div>`, 0);
 var root_65 = _$_.template(`<!>`, 1, 1);
 var root_68 = _$_.template(`<div class="doc-content"><!></div>`, 0);
@@ -77,14 +77,14 @@ var root_74 = _$_.template(`<a class="pager next"><span class="title"> </span></
 var root_71 = _$_.template(`<nav class="prev-next"><!><!></nav>`, 0);
 var root_76 = _$_.template(`<a> </a>`, 0);
 var root_75 = _$_.template(`<div class="aside-content"><nav class="outline"></nav></div>`, 0);
-var root_69 = _$_.template(`<div class="layout"><!><div class="docs-wrapper"><!><main class="docs-main"><div class="docs-container"><div class="content"><div class="content-container"><article class="doc-content"><div> </div></article><!><!><!></div></div><aside class="aside"><!></aside></div></main></div></div>`, 0);
+var root_69 = _$_.template(`<div class="layout"><!><div class="docs-wrapper"><!><main class="docs-main"><div class="docs-container"><div class="content"><div class="content-container"><article class="doc-content"><div><!></div></article><!><!><!></div></div><aside class="aside"><!></aside></div></main></div></div>`, 0);
 var root_78 = _$_.template(`<div class="doc-content"><!></div>`, 0);
 var root_77 = _$_.template(`<!>`, 1, 1);
 var root_80 = _$_.template(`<div class="doc-content"><!></div>`, 0);
 var root_79 = _$_.template(`<!>`, 1, 1);
 var root_81 = _$_.template(`<div><template id="t1"></template><p class="content">Main content</p></div>`, 0);
 var root_82 = _$_.template(`<div class="wrapper"><h1>Title</h1><template id="data-template"></template><p class="after-template">Content after template</p></div>`, 0);
-var root_83 = _$_.template(`<div class="layout"><template id="page-data"></template><main> </main></div>`, 0);
+var root_83 = _$_.template(`<div class="layout"><template id="page-data"></template><main><!></main></div>`, 0);
 var root_85 = _$_.template(`<div class="doc-content"><!></div>`, 0);
 var root_84 = _$_.template(`<!>`, 1, 1);
 
@@ -224,7 +224,7 @@ export function HtmlWrapper(__anchor, { children }, __block) {
 		var div_7 = _$_.child(div_6);
 
 		{
-			var expression = _$_.child(div_7, true);
+			var expression = _$_.child(div_7);
 
 			_$_.expression(expression, () => children);
 			_$_.pop(div_7);
@@ -457,7 +457,7 @@ export function DocLayout(
 				var div_15 = _$_.child(article_1);
 
 				{
-					var expression_1 = _$_.child(div_15, true);
+					var expression_1 = _$_.child(div_15);
 
 					_$_.expression(expression_1, () => children);
 					_$_.pop(div_15);
@@ -706,7 +706,7 @@ function DynamicHeading(__anchor, { level, children }, __block) {
 			var h1_2 = root_30();
 
 			{
-				var expression_4 = _$_.child(h1_2, true);
+				var expression_4 = _$_.child(h1_2);
 
 				_$_.expression(expression_4, () => children);
 				_$_.pop(h1_2);
@@ -719,7 +719,7 @@ function DynamicHeading(__anchor, { level, children }, __block) {
 			var h2_1 = root_31();
 
 			{
-				var expression_5 = _$_.child(h2_1, true);
+				var expression_5 = _$_.child(h2_1);
 
 				_$_.expression(expression_5, () => children);
 				_$_.pop(h2_1);
@@ -783,7 +783,7 @@ function ContentWrapper(__anchor, { children }, __block) {
 		var div_26 = _$_.child(div_25);
 
 		{
-			var expression_6 = _$_.child(div_26, true);
+			var expression_6 = _$_.child(div_26);
 
 			_$_.expression(expression_6, () => children);
 			_$_.pop(div_26);
@@ -918,7 +918,7 @@ function SidebarSection(__anchor, { title, children }, __block) {
 				var div_30 = root_39();
 
 				{
-					var expression_10 = _$_.child(div_30, true);
+					var expression_10 = _$_.child(div_30);
 
 					_$_.expression(expression_10, () => children);
 					_$_.pop(div_30);
@@ -1120,7 +1120,7 @@ function ArticleWrapper(__anchor, { children }, __block) {
 		var div_37 = _$_.child(article_2);
 
 		{
-			var expression_11 = _$_.child(div_37, true);
+			var expression_11 = _$_.child(div_37);
 
 			_$_.expression(expression_11, () => children);
 			_$_.pop(div_37);
@@ -1271,7 +1271,7 @@ function InlineArticleLayout(__anchor, { children }, __block) {
 			var div_44 = _$_.child(article_3);
 
 			{
-				var expression_12 = _$_.child(div_44, true);
+				var expression_12 = _$_.child(div_44);
 
 				_$_.expression(expression_12, () => children);
 				_$_.pop(div_44);
@@ -1406,7 +1406,7 @@ function DocsLayoutInner(
 								var div_49 = _$_.child(article_4);
 
 								{
-									var expression_13 = _$_.child(div_49, true);
+									var expression_13 = _$_.child(div_49);
 
 									_$_.expression(expression_13, () => children);
 									_$_.pop(div_49);
@@ -1596,7 +1596,7 @@ function DocsLayoutExact(
 								var div_58 = _$_.child(article_5);
 
 								{
-									var expression_15 = _$_.child(div_58, true);
+									var expression_15 = _$_.child(div_58);
 
 									_$_.expression(expression_15, () => children);
 									_$_.pop(div_58);
@@ -1913,7 +1913,7 @@ function LayoutWithTemplate(__anchor, { children, data }, __block) {
 		var main_4 = _$_.sibling(template_3);
 
 		{
-			var expression_19 = _$_.child(main_4, true);
+			var expression_19 = _$_.child(main_4);
 
 			_$_.expression(expression_19, () => children);
 			_$_.pop(main_4);

--- a/packages/ripple/tests/hydration/compiled/client/if-children.js
+++ b/packages/ripple/tests/hydration/compiled/client/if-children.js
@@ -88,9 +88,7 @@ export function TestIfWithChildren(__anchor, _, __block) {
 	IfWithChildren(
 		node_1,
 		{
-			children: _$_.ripple_element(function render_children(__anchor, _, __block) {
-				_$_.push_component();
-
+			children: _$_.ripple_element(function render_children(__anchor, __block) {
 				var fragment_1 = root_4();
 				var node_2 = _$_.first_child_frag(fragment_1);
 
@@ -100,7 +98,6 @@ export function TestIfWithChildren(__anchor, _, __block) {
 
 				ChildItem(node_3, { text: "Item 2" }, _$_.active_block);
 				_$_.append(__anchor, fragment_1);
-				_$_.pop_component();
 			})
 		},
 		_$_.active_block
@@ -191,9 +188,7 @@ export function TestIfWithSiblingsAndChildren(__anchor, _, __block) {
 	IfWithSiblingsAndChildren(
 		node_6,
 		{
-			children: _$_.ripple_element(function render_children(__anchor, _, __block) {
-				_$_.push_component();
-
+			children: _$_.ripple_element(function render_children(__anchor, __block) {
 				var fragment_3 = root_10();
 				var node_7 = _$_.first_child_frag(fragment_3);
 
@@ -203,7 +198,6 @@ export function TestIfWithSiblingsAndChildren(__anchor, _, __block) {
 
 				ChildItem(node_8, { text: "Item B" }, _$_.active_block);
 				_$_.append(__anchor, fragment_3);
-				_$_.pop_component();
 			})
 		},
 		_$_.active_block

--- a/packages/ripple/tests/hydration/compiled/client/if-children.js
+++ b/packages/ripple/tests/hydration/compiled/client/if-children.js
@@ -1,14 +1,14 @@
 // @ts-nocheck
 import * as _$_ from 'ripple/internal/client';
 
-var root_1 = _$_.template(`<div class="content"><!></div>`, 0);
+var root_1 = _$_.template(`<div class="content"> </div>`, 0);
 var root = _$_.template(`<div class="container"><div role="button" class="header">Toggle</div><!></div>`, 0);
 var root_2 = _$_.template(`<div class="item"> </div>`, 0);
 var root_4 = _$_.template(`<!><!>`, 1, 2);
 var root_3 = _$_.template(`<!>`, 1, 1);
 var root_6 = _$_.template(`<div class="content"><span>Static child 1</span><span>Static child 2</span></div>`, 0);
 var root_5 = _$_.template(`<div class="container"><div role="button" class="header">Toggle</div><!></div>`, 0);
-var root_8 = _$_.template(`<div class="items"><!></div>`, 0);
+var root_8 = _$_.template(`<div class="items"> </div>`, 0);
 var root_7 = _$_.template(`<section class="group"><div role="button" class="item"><div class="indicator"></div><h2 class="text">Title</h2><div class="caret"><svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24"><path d="m9 18 6-6-6-6"></path></svg></div></div><!></section>`, 0);
 var root_10 = _$_.template(`<!><!>`, 1, 2);
 var root_9 = _$_.template(`<!>`, 1, 1);
@@ -42,14 +42,11 @@ export function IfWithChildren(__anchor, { children }, __block) {
 				var div_3 = root_1();
 
 				{
-					var expression = _$_.child(div_3);
+					var expression = _$_.child(div_3, true);
 
+					_$_.expression(expression, () => children);
 					_$_.pop(div_3);
 				}
-
-				_$_.render(() => {
-					_$_.expression(expression, () => children);
-				});
 
 				_$_.append(__anchor, div_3);
 			};
@@ -74,7 +71,7 @@ export function ChildItem(__anchor, { text: label }, __block) {
 	{
 		var expression_1 = _$_.child(div_4, true);
 
-		expression_1.nodeValue = label;
+		_$_.expression(expression_1, () => label);
 		_$_.pop(div_4);
 	}
 
@@ -164,14 +161,11 @@ export function IfWithSiblingsAndChildren(__anchor, { children }, __block) {
 				var div_9 = root_8();
 
 				{
-					var expression_2 = _$_.child(div_9);
+					var expression_2 = _$_.child(div_9, true);
 
+					_$_.expression(expression_2, () => children);
 					_$_.pop(div_9);
 				}
-
-				_$_.render(() => {
-					_$_.expression(expression_2, () => children);
-				});
 
 				_$_.append(__anchor, div_9);
 			};
@@ -378,6 +372,7 @@ export function DomChildrenThenStaticSiblings(__anchor, _, __block) {
 			{
 				var expression_3 = _$_.child(li_1, true);
 
+				_$_.expression(expression_3, () => 'Item count: ' + _$_.with_scope(__block, () => String(_$_.get(lazy_6))));
 				_$_.pop(li_1);
 			}
 		}
@@ -389,11 +384,6 @@ export function DomChildrenThenStaticSiblings(__anchor, _, __block) {
 
 	button_5.__click = () => _$_.update(lazy_6);
 	_$_.next();
-
-	_$_.render(() => {
-		_$_.set_text(expression_3, 'Item count: ' + _$_.with_scope(__block, () => String(_$_.get(lazy_6))));
-	});
-
 	_$_.append(__anchor, fragment_6, true);
 	_$_.pop_component();
 }

--- a/packages/ripple/tests/hydration/compiled/client/if-children.js
+++ b/packages/ripple/tests/hydration/compiled/client/if-children.js
@@ -1,14 +1,14 @@
 // @ts-nocheck
 import * as _$_ from 'ripple/internal/client';
 
-var root_1 = _$_.template(`<div class="content"> </div>`, 0);
+var root_1 = _$_.template(`<div class="content"><!></div>`, 0);
 var root = _$_.template(`<div class="container"><div role="button" class="header">Toggle</div><!></div>`, 0);
 var root_2 = _$_.template(`<div class="item"> </div>`, 0);
 var root_4 = _$_.template(`<!><!>`, 1, 2);
 var root_3 = _$_.template(`<!>`, 1, 1);
 var root_6 = _$_.template(`<div class="content"><span>Static child 1</span><span>Static child 2</span></div>`, 0);
 var root_5 = _$_.template(`<div class="container"><div role="button" class="header">Toggle</div><!></div>`, 0);
-var root_8 = _$_.template(`<div class="items"> </div>`, 0);
+var root_8 = _$_.template(`<div class="items"><!></div>`, 0);
 var root_7 = _$_.template(`<section class="group"><div role="button" class="item"><div class="indicator"></div><h2 class="text">Title</h2><div class="caret"><svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24"><path d="m9 18 6-6-6-6"></path></svg></div></div><!></section>`, 0);
 var root_10 = _$_.template(`<!><!>`, 1, 2);
 var root_9 = _$_.template(`<!>`, 1, 1);
@@ -42,7 +42,7 @@ export function IfWithChildren(__anchor, { children }, __block) {
 				var div_3 = root_1();
 
 				{
-					var expression = _$_.child(div_3, true);
+					var expression = _$_.child(div_3);
 
 					_$_.expression(expression, () => children);
 					_$_.pop(div_3);
@@ -161,7 +161,7 @@ export function IfWithSiblingsAndChildren(__anchor, { children }, __block) {
 				var div_9 = root_8();
 
 				{
-					var expression_2 = _$_.child(div_9, true);
+					var expression_2 = _$_.child(div_9);
 
 					_$_.expression(expression_2, () => children);
 					_$_.pop(div_9);

--- a/packages/ripple/tests/hydration/compiled/client/mixed-control-flow.js
+++ b/packages/ripple/tests/hydration/compiled/client/mixed-control-flow.js
@@ -68,25 +68,13 @@ export function MixedControlFlowStatic(__anchor, _, __block) {
 											{
 												var expression = _$_.child(div_1, true);
 
+												_$_.expression(expression, () => `A-${_$_.get(pattern).id}`);
 												_$_.pop(div_1);
 											}
 
-											_$_.render(
-												(__prev) => {
-													var __a = `A-${_$_.get(pattern).id}`;
-
-													if (__prev.a !== __a) {
-														_$_.set_text(expression, __prev.a = __a);
-													}
-
-													var __b = `row row-${_$_.get(pattern).id} kind-a`;
-
-													if (__prev.b !== __b) {
-														_$_.set_class(div_1, __prev.b = __b, void 0, true);
-													}
-												},
-												{ a: ' ', b: Symbol() }
-											);
+											_$_.render(() => {
+												_$_.set_class(div_1, `row row-${_$_.get(pattern).id} kind-a`, void 0, true);
+											});
 
 											_$_.append(__anchor, div_1);
 										});
@@ -119,25 +107,13 @@ export function MixedControlFlowStatic(__anchor, _, __block) {
 											{
 												var expression_1 = _$_.child(div_3, true);
 
+												_$_.expression(expression_1, () => `B-${_$_.get(pattern).id}`);
 												_$_.pop(div_3);
 											}
 
-											_$_.render(
-												(__prev) => {
-													var __a = `B-${_$_.get(pattern).id}`;
-
-													if (__prev.a !== __a) {
-														_$_.set_text(expression_1, __prev.a = __a);
-													}
-
-													var __b = `row row-${_$_.get(pattern).id} kind-b`;
-
-													if (__prev.b !== __b) {
-														_$_.set_class(div_3, __prev.b = __b, void 0, true);
-													}
-												},
-												{ a: ' ', b: Symbol() }
-											);
+											_$_.render(() => {
+												_$_.set_class(div_3, `row row-${_$_.get(pattern).id} kind-b`, void 0, true);
+											});
 
 											_$_.append(__anchor, div_3);
 										});
@@ -246,25 +222,13 @@ export function MixedControlFlowReactive(__anchor, _, __block) {
 											{
 												var expression_2 = _$_.child(p_1, true);
 
+												_$_.expression(expression_2, () => `A:${_$_.get(pattern_1).label}`);
 												_$_.pop(p_1);
 											}
 
-											_$_.render(
-												(__prev) => {
-													var __a = `A:${_$_.get(pattern_1).label}`;
-
-													if (__prev.a !== __a) {
-														_$_.set_text(expression_2, __prev.a = __a);
-													}
-
-													var __b = `item item-${_$_.get(pattern_1).id}`;
-
-													if (__prev.b !== __b) {
-														_$_.set_class(p_1, __prev.b = __b, void 0, true);
-													}
-												},
-												{ a: ' ', b: Symbol() }
-											);
+											_$_.render(() => {
+												_$_.set_class(p_1, `item item-${_$_.get(pattern_1).id}`, void 0, true);
+											});
 
 											_$_.append(__anchor, p_1);
 										});
@@ -293,25 +257,13 @@ export function MixedControlFlowReactive(__anchor, _, __block) {
 											{
 												var expression_3 = _$_.child(p_3, true);
 
+												_$_.expression(expression_3, () => `B:${_$_.get(pattern_1).label}`);
 												_$_.pop(p_3);
 											}
 
-											_$_.render(
-												(__prev) => {
-													var __a = `B:${_$_.get(pattern_1).label}`;
-
-													if (__prev.a !== __a) {
-														_$_.set_text(expression_3, __prev.a = __a);
-													}
-
-													var __b = `item item-${_$_.get(pattern_1).id}`;
-
-													if (__prev.b !== __b) {
-														_$_.set_class(p_3, __prev.b = __b, void 0, true);
-													}
-												},
-												{ a: ' ', b: Symbol() }
-											);
+											_$_.render(() => {
+												_$_.set_class(p_3, `item item-${_$_.get(pattern_1).id}`, void 0, true);
+											});
 
 											_$_.append(__anchor, p_3);
 										});
@@ -409,7 +361,7 @@ export function MixedControlFlowAsyncPending(__anchor, _, __block) {
 									{
 										var expression_4 = _$_.child(div_7, true);
 
-										expression_4.nodeValue = `pending ${row}`;
+										_$_.expression(expression_4, () => `pending ${row}`);
 										_$_.pop(div_7);
 									}
 
@@ -471,7 +423,7 @@ function AsyncRow(__anchor, { label }, __block) {
 		{
 			var expression_5 = _$_.child(div_9, true);
 
-			expression_5.nodeValue = value;
+			_$_.expression(expression_5, () => value);
 			_$_.pop(div_9);
 		}
 

--- a/packages/ripple/tests/hydration/compiled/client/nested-control-flow.js
+++ b/packages/ripple/tests/hydration/compiled/client/nested-control-flow.js
@@ -94,25 +94,13 @@ export function ForIf(__anchor, _, __block) {
 						{
 							var expression = _$_.child(li_1, true);
 
+							_$_.expression(expression, () => _$_.get(pattern).label);
 							_$_.pop(li_1);
 						}
 
-						_$_.render(
-							(__prev) => {
-								var __a = _$_.get(pattern).label;
-
-								if (__prev.a !== __a) {
-									_$_.set_text(expression, __prev.a = __a);
-								}
-
-								var __b = `item item-${_$_.get(pattern).id}`;
-
-								if (__prev.b !== __b) {
-									_$_.set_class(li_1, __prev.b = __b, void 0, true);
-								}
-							},
-							{ a: ' ', b: Symbol() }
-						);
+						_$_.render(() => {
+							_$_.set_class(li_1, `item item-${_$_.get(pattern).id}`, void 0, true);
+						});
 
 						_$_.append(__anchor, li_1);
 					};
@@ -162,25 +150,13 @@ export function ForSwitch(__anchor, _, __block) {
 						{
 							var expression_1 = _$_.child(li_2, true);
 
+							_$_.expression(expression_1, () => `A-${_$_.get(pattern_1).id}`);
 							_$_.pop(li_2);
 						}
 
-						_$_.render(
-							(__prev) => {
-								var __a = `A-${_$_.get(pattern_1).id}`;
-
-								if (__prev.a !== __a) {
-									_$_.set_text(expression_1, __prev.a = __a);
-								}
-
-								var __b = `item item-${_$_.get(pattern_1).id} kind-a`;
-
-								if (__prev.b !== __b) {
-									_$_.set_class(li_2, __prev.b = __b, void 0, true);
-								}
-							},
-							{ a: ' ', b: Symbol() }
-						);
+						_$_.render(() => {
+							_$_.set_class(li_2, `item item-${_$_.get(pattern_1).id} kind-a`, void 0, true);
+						});
 
 						_$_.append(__anchor, fragment_2);
 					};
@@ -191,25 +167,13 @@ export function ForSwitch(__anchor, _, __block) {
 						{
 							var expression_2 = _$_.child(li_3, true);
 
+							_$_.expression(expression_2, () => `B-${_$_.get(pattern_1).id}`);
 							_$_.pop(li_3);
 						}
 
-						_$_.render(
-							(__prev) => {
-								var __a = `B-${_$_.get(pattern_1).id}`;
-
-								if (__prev.a !== __a) {
-									_$_.set_text(expression_2, __prev.a = __a);
-								}
-
-								var __b = `item item-${_$_.get(pattern_1).id} kind-b`;
-
-								if (__prev.b !== __b) {
-									_$_.set_class(li_3, __prev.b = __b, void 0, true);
-								}
-							},
-							{ a: ' ', b: Symbol() }
-						);
+						_$_.render(() => {
+							_$_.set_class(li_3, `item item-${_$_.get(pattern_1).id} kind-b`, void 0, true);
+						});
 
 						_$_.append(__anchor, li_3);
 					};
@@ -385,25 +349,13 @@ export function ForIfSwitchSingle(__anchor, _, __block) {
 								{
 									var expression_3 = _$_.child(li_4, true);
 
+									_$_.expression(expression_3, () => `A-${_$_.get(pattern_2).id}`);
 									_$_.pop(li_4);
 								}
 
-								_$_.render(
-									(__prev) => {
-										var __a = `A-${_$_.get(pattern_2).id}`;
-
-										if (__prev.a !== __a) {
-											_$_.set_text(expression_3, __prev.a = __a);
-										}
-
-										var __b = `item item-${_$_.get(pattern_2).id} kind-a`;
-
-										if (__prev.b !== __b) {
-											_$_.set_class(li_4, __prev.b = __b, void 0, true);
-										}
-									},
-									{ a: ' ', b: Symbol() }
-								);
+								_$_.render(() => {
+									_$_.set_class(li_4, `item item-${_$_.get(pattern_2).id} kind-a`, void 0, true);
+								});
 
 								_$_.append(__anchor, fragment_9);
 							};
@@ -414,25 +366,13 @@ export function ForIfSwitchSingle(__anchor, _, __block) {
 								{
 									var expression_4 = _$_.child(li_5, true);
 
+									_$_.expression(expression_4, () => `D-${_$_.get(pattern_2).id}`);
 									_$_.pop(li_5);
 								}
 
-								_$_.render(
-									(__prev) => {
-										var __a = `D-${_$_.get(pattern_2).id}`;
-
-										if (__prev.a !== __a) {
-											_$_.set_text(expression_4, __prev.a = __a);
-										}
-
-										var __b = `item item-${_$_.get(pattern_2).id} kind-default`;
-
-										if (__prev.b !== __b) {
-											_$_.set_class(li_5, __prev.b = __b, void 0, true);
-										}
-									},
-									{ a: ' ', b: Symbol() }
-								);
+								_$_.render(() => {
+									_$_.set_class(li_5, `item item-${_$_.get(pattern_2).id} kind-default`, void 0, true);
+								});
 
 								_$_.append(__anchor, li_5);
 							};
@@ -504,25 +444,13 @@ export function ForIfSwitchMulti(__anchor, _, __block) {
 								{
 									var expression_5 = _$_.child(li_6, true);
 
+									_$_.expression(expression_5, () => `A-${_$_.get(pattern_3).id}`);
 									_$_.pop(li_6);
 								}
 
-								_$_.render(
-									(__prev) => {
-										var __a = `A-${_$_.get(pattern_3).id}`;
-
-										if (__prev.a !== __a) {
-											_$_.set_text(expression_5, __prev.a = __a);
-										}
-
-										var __b = `item item-${_$_.get(pattern_3).id} kind-a`;
-
-										if (__prev.b !== __b) {
-											_$_.set_class(li_6, __prev.b = __b, void 0, true);
-										}
-									},
-									{ a: ' ', b: Symbol() }
-								);
+								_$_.render(() => {
+									_$_.set_class(li_6, `item item-${_$_.get(pattern_3).id} kind-a`, void 0, true);
+								});
 
 								_$_.append(__anchor, fragment_12);
 							};
@@ -533,25 +461,13 @@ export function ForIfSwitchMulti(__anchor, _, __block) {
 								{
 									var expression_6 = _$_.child(li_7, true);
 
+									_$_.expression(expression_6, () => `B-${_$_.get(pattern_3).id}`);
 									_$_.pop(li_7);
 								}
 
-								_$_.render(
-									(__prev) => {
-										var __a = `B-${_$_.get(pattern_3).id}`;
-
-										if (__prev.a !== __a) {
-											_$_.set_text(expression_6, __prev.a = __a);
-										}
-
-										var __b = `item item-${_$_.get(pattern_3).id} kind-b`;
-
-										if (__prev.b !== __b) {
-											_$_.set_class(li_7, __prev.b = __b, void 0, true);
-										}
-									},
-									{ a: ' ', b: Symbol() }
-								);
+								_$_.render(() => {
+									_$_.set_class(li_7, `item item-${_$_.get(pattern_3).id} kind-b`, void 0, true);
+								});
 
 								_$_.append(__anchor, li_7);
 							};
@@ -624,25 +540,13 @@ export function ForIfSwitchWithDisabled(__anchor, _, __block) {
 								{
 									var expression_7 = _$_.child(li_8, true);
 
+									_$_.expression(expression_7, () => `A-${_$_.get(pattern_4).id}`);
 									_$_.pop(li_8);
 								}
 
-								_$_.render(
-									(__prev) => {
-										var __a = `A-${_$_.get(pattern_4).id}`;
-
-										if (__prev.a !== __a) {
-											_$_.set_text(expression_7, __prev.a = __a);
-										}
-
-										var __b = `item item-${_$_.get(pattern_4).id} kind-a`;
-
-										if (__prev.b !== __b) {
-											_$_.set_class(li_8, __prev.b = __b, void 0, true);
-										}
-									},
-									{ a: ' ', b: Symbol() }
-								);
+								_$_.render(() => {
+									_$_.set_class(li_8, `item item-${_$_.get(pattern_4).id} kind-a`, void 0, true);
+								});
 
 								_$_.append(__anchor, fragment_15);
 							};
@@ -653,25 +557,13 @@ export function ForIfSwitchWithDisabled(__anchor, _, __block) {
 								{
 									var expression_8 = _$_.child(li_9, true);
 
+									_$_.expression(expression_8, () => `B-${_$_.get(pattern_4).id}`);
 									_$_.pop(li_9);
 								}
 
-								_$_.render(
-									(__prev) => {
-										var __a = `B-${_$_.get(pattern_4).id}`;
-
-										if (__prev.a !== __a) {
-											_$_.set_text(expression_8, __prev.a = __a);
-										}
-
-										var __b = `item item-${_$_.get(pattern_4).id} kind-b`;
-
-										if (__prev.b !== __b) {
-											_$_.set_class(li_9, __prev.b = __b, void 0, true);
-										}
-									},
-									{ a: ' ', b: Symbol() }
-								);
+								_$_.render(() => {
+									_$_.set_class(li_9, `item item-${_$_.get(pattern_4).id} kind-b`, void 0, true);
+								});
 
 								_$_.append(__anchor, li_9);
 							};
@@ -802,25 +694,13 @@ export function ForSwitchTry(__anchor, _, __block) {
 									{
 										var expression_9 = _$_.child(li_10, true);
 
+										_$_.expression(expression_9, () => `A-${_$_.get(pattern_5).id}`);
 										_$_.pop(li_10);
 									}
 
-									_$_.render(
-										(__prev) => {
-											var __a = `A-${_$_.get(pattern_5).id}`;
-
-											if (__prev.a !== __a) {
-												_$_.set_text(expression_9, __prev.a = __a);
-											}
-
-											var __b = `item item-${_$_.get(pattern_5).id} kind-a`;
-
-											if (__prev.b !== __b) {
-												_$_.set_class(li_10, __prev.b = __b, void 0, true);
-											}
-										},
-										{ a: ' ', b: Symbol() }
-									);
+									_$_.render(() => {
+										_$_.set_class(li_10, `item item-${_$_.get(pattern_5).id} kind-a`, void 0, true);
+									});
 
 									_$_.append(__anchor, li_10);
 								});
@@ -832,25 +712,13 @@ export function ForSwitchTry(__anchor, _, __block) {
 								{
 									var expression_10 = _$_.child(li_11, true);
 
+									_$_.expression(expression_10, () => `pending ${_$_.get(pattern_5).id}`);
 									_$_.pop(li_11);
 								}
 
-								_$_.render(
-									(__prev) => {
-										var __a = `pending ${_$_.get(pattern_5).id}`;
-
-										if (__prev.a !== __a) {
-											_$_.set_text(expression_10, __prev.a = __a);
-										}
-
-										var __b = `pending pending-${_$_.get(pattern_5).id}`;
-
-										if (__prev.b !== __b) {
-											_$_.set_class(li_11, __prev.b = __b, void 0, true);
-										}
-									},
-									{ a: ' ', b: Symbol() }
-								);
+								_$_.render(() => {
+									_$_.set_class(li_11, `pending pending-${_$_.get(pattern_5).id}`, void 0, true);
+								});
 
 								_$_.append(__anchor, li_11);
 							}
@@ -872,25 +740,13 @@ export function ForSwitchTry(__anchor, _, __block) {
 									{
 										var expression_11 = _$_.child(li_12, true);
 
+										_$_.expression(expression_11, () => `B-${_$_.get(pattern_5).id}`);
 										_$_.pop(li_12);
 									}
 
-									_$_.render(
-										(__prev) => {
-											var __a = `B-${_$_.get(pattern_5).id}`;
-
-											if (__prev.a !== __a) {
-												_$_.set_text(expression_11, __prev.a = __a);
-											}
-
-											var __b = `item item-${_$_.get(pattern_5).id} kind-b`;
-
-											if (__prev.b !== __b) {
-												_$_.set_class(li_12, __prev.b = __b, void 0, true);
-											}
-										},
-										{ a: ' ', b: Symbol() }
-									);
+									_$_.render(() => {
+										_$_.set_class(li_12, `item item-${_$_.get(pattern_5).id} kind-b`, void 0, true);
+									});
 
 									_$_.append(__anchor, li_12);
 								});
@@ -902,25 +758,13 @@ export function ForSwitchTry(__anchor, _, __block) {
 								{
 									var expression_12 = _$_.child(li_13, true);
 
+									_$_.expression(expression_12, () => `pending ${_$_.get(pattern_5).id}`);
 									_$_.pop(li_13);
 								}
 
-								_$_.render(
-									(__prev) => {
-										var __a = `pending ${_$_.get(pattern_5).id}`;
-
-										if (__prev.a !== __a) {
-											_$_.set_text(expression_12, __prev.a = __a);
-										}
-
-										var __b = `pending pending-${_$_.get(pattern_5).id}`;
-
-										if (__prev.b !== __b) {
-											_$_.set_class(li_13, __prev.b = __b, void 0, true);
-										}
-									},
-									{ a: ' ', b: Symbol() }
-								);
+								_$_.render(() => {
+									_$_.set_class(li_13, `pending pending-${_$_.get(pattern_5).id}`, void 0, true);
+								});
 
 								_$_.append(__anchor, li_13);
 							}
@@ -985,25 +829,13 @@ export function ForIfTry(__anchor, _, __block) {
 									{
 										var expression_13 = _$_.child(li_14, true);
 
+										_$_.expression(expression_13, () => `item-${_$_.get(pattern_6).id}`);
 										_$_.pop(li_14);
 									}
 
-									_$_.render(
-										(__prev) => {
-											var __a = `item-${_$_.get(pattern_6).id}`;
-
-											if (__prev.a !== __a) {
-												_$_.set_text(expression_13, __prev.a = __a);
-											}
-
-											var __b = `item item-${_$_.get(pattern_6).id}`;
-
-											if (__prev.b !== __b) {
-												_$_.set_class(li_14, __prev.b = __b, void 0, true);
-											}
-										},
-										{ a: ' ', b: Symbol() }
-									);
+									_$_.render(() => {
+										_$_.set_class(li_14, `item item-${_$_.get(pattern_6).id}`, void 0, true);
+									});
 
 									_$_.append(__anchor, li_14);
 								});
@@ -1015,25 +847,13 @@ export function ForIfTry(__anchor, _, __block) {
 								{
 									var expression_14 = _$_.child(li_15, true);
 
+									_$_.expression(expression_14, () => `pending ${_$_.get(pattern_6).id}`);
 									_$_.pop(li_15);
 								}
 
-								_$_.render(
-									(__prev) => {
-										var __a = `pending ${_$_.get(pattern_6).id}`;
-
-										if (__prev.a !== __a) {
-											_$_.set_text(expression_14, __prev.a = __a);
-										}
-
-										var __b = `pending pending-${_$_.get(pattern_6).id}`;
-
-										if (__prev.b !== __b) {
-											_$_.set_class(li_15, __prev.b = __b, void 0, true);
-										}
-									},
-									{ a: ' ', b: Symbol() }
-								);
+								_$_.render(() => {
+									_$_.set_class(li_15, `pending pending-${_$_.get(pattern_6).id}`, void 0, true);
+								});
 
 								_$_.append(__anchor, li_15);
 							}
@@ -1093,25 +913,13 @@ export function ForIfSwitchTrySingle(__anchor, _, __block) {
 											{
 												var expression_15 = _$_.child(li_16, true);
 
+												_$_.expression(expression_15, () => `A-${_$_.get(pattern_7).id}`);
 												_$_.pop(li_16);
 											}
 
-											_$_.render(
-												(__prev) => {
-													var __a = `A-${_$_.get(pattern_7).id}`;
-
-													if (__prev.a !== __a) {
-														_$_.set_text(expression_15, __prev.a = __a);
-													}
-
-													var __b = `item item-${_$_.get(pattern_7).id} kind-a`;
-
-													if (__prev.b !== __b) {
-														_$_.set_class(li_16, __prev.b = __b, void 0, true);
-													}
-												},
-												{ a: ' ', b: Symbol() }
-											);
+											_$_.render(() => {
+												_$_.set_class(li_16, `item item-${_$_.get(pattern_7).id} kind-a`, void 0, true);
+											});
 
 											_$_.append(__anchor, li_16);
 										});
@@ -1123,25 +931,13 @@ export function ForIfSwitchTrySingle(__anchor, _, __block) {
 										{
 											var expression_16 = _$_.child(li_17, true);
 
+											_$_.expression(expression_16, () => `pending ${_$_.get(pattern_7).id}`);
 											_$_.pop(li_17);
 										}
 
-										_$_.render(
-											(__prev) => {
-												var __a = `pending ${_$_.get(pattern_7).id}`;
-
-												if (__prev.a !== __a) {
-													_$_.set_text(expression_16, __prev.a = __a);
-												}
-
-												var __b = `pending pending-${_$_.get(pattern_7).id}`;
-
-												if (__prev.b !== __b) {
-													_$_.set_class(li_17, __prev.b = __b, void 0, true);
-												}
-											},
-											{ a: ' ', b: Symbol() }
-										);
+										_$_.render(() => {
+											_$_.set_class(li_17, `pending pending-${_$_.get(pattern_7).id}`, void 0, true);
+										});
 
 										_$_.append(__anchor, li_17);
 									}
@@ -1163,25 +959,13 @@ export function ForIfSwitchTrySingle(__anchor, _, __block) {
 											{
 												var expression_17 = _$_.child(li_18, true);
 
+												_$_.expression(expression_17, () => `D-${_$_.get(pattern_7).id}`);
 												_$_.pop(li_18);
 											}
 
-											_$_.render(
-												(__prev) => {
-													var __a = `D-${_$_.get(pattern_7).id}`;
-
-													if (__prev.a !== __a) {
-														_$_.set_text(expression_17, __prev.a = __a);
-													}
-
-													var __b = `item item-${_$_.get(pattern_7).id} kind-default`;
-
-													if (__prev.b !== __b) {
-														_$_.set_class(li_18, __prev.b = __b, void 0, true);
-													}
-												},
-												{ a: ' ', b: Symbol() }
-											);
+											_$_.render(() => {
+												_$_.set_class(li_18, `item item-${_$_.get(pattern_7).id} kind-default`, void 0, true);
+											});
 
 											_$_.append(__anchor, li_18);
 										});
@@ -1193,25 +977,13 @@ export function ForIfSwitchTrySingle(__anchor, _, __block) {
 										{
 											var expression_18 = _$_.child(li_19, true);
 
+											_$_.expression(expression_18, () => `pending ${_$_.get(pattern_7).id}`);
 											_$_.pop(li_19);
 										}
 
-										_$_.render(
-											(__prev) => {
-												var __a = `pending ${_$_.get(pattern_7).id}`;
-
-												if (__prev.a !== __a) {
-													_$_.set_text(expression_18, __prev.a = __a);
-												}
-
-												var __b = `pending pending-${_$_.get(pattern_7).id}`;
-
-												if (__prev.b !== __b) {
-													_$_.set_class(li_19, __prev.b = __b, void 0, true);
-												}
-											},
-											{ a: ' ', b: Symbol() }
-										);
+										_$_.render(() => {
+											_$_.set_class(li_19, `pending pending-${_$_.get(pattern_7).id}`, void 0, true);
+										});
 
 										_$_.append(__anchor, li_19);
 									}
@@ -1293,25 +1065,13 @@ export function ForIfSwitchTryMulti(__anchor, _, __block) {
 											{
 												var expression_19 = _$_.child(li_20, true);
 
+												_$_.expression(expression_19, () => `A-${_$_.get(pattern_8).id}`);
 												_$_.pop(li_20);
 											}
 
-											_$_.render(
-												(__prev) => {
-													var __a = `A-${_$_.get(pattern_8).id}`;
-
-													if (__prev.a !== __a) {
-														_$_.set_text(expression_19, __prev.a = __a);
-													}
-
-													var __b = `item item-${_$_.get(pattern_8).id} kind-a`;
-
-													if (__prev.b !== __b) {
-														_$_.set_class(li_20, __prev.b = __b, void 0, true);
-													}
-												},
-												{ a: ' ', b: Symbol() }
-											);
+											_$_.render(() => {
+												_$_.set_class(li_20, `item item-${_$_.get(pattern_8).id} kind-a`, void 0, true);
+											});
 
 											_$_.append(__anchor, li_20);
 										});
@@ -1323,25 +1083,13 @@ export function ForIfSwitchTryMulti(__anchor, _, __block) {
 										{
 											var expression_20 = _$_.child(li_21, true);
 
+											_$_.expression(expression_20, () => `pending ${_$_.get(pattern_8).id}`);
 											_$_.pop(li_21);
 										}
 
-										_$_.render(
-											(__prev) => {
-												var __a = `pending ${_$_.get(pattern_8).id}`;
-
-												if (__prev.a !== __a) {
-													_$_.set_text(expression_20, __prev.a = __a);
-												}
-
-												var __b = `pending pending-${_$_.get(pattern_8).id}`;
-
-												if (__prev.b !== __b) {
-													_$_.set_class(li_21, __prev.b = __b, void 0, true);
-												}
-											},
-											{ a: ' ', b: Symbol() }
-										);
+										_$_.render(() => {
+											_$_.set_class(li_21, `pending pending-${_$_.get(pattern_8).id}`, void 0, true);
+										});
 
 										_$_.append(__anchor, li_21);
 									}
@@ -1363,25 +1111,13 @@ export function ForIfSwitchTryMulti(__anchor, _, __block) {
 											{
 												var expression_21 = _$_.child(li_22, true);
 
+												_$_.expression(expression_21, () => `B-${_$_.get(pattern_8).id}`);
 												_$_.pop(li_22);
 											}
 
-											_$_.render(
-												(__prev) => {
-													var __a = `B-${_$_.get(pattern_8).id}`;
-
-													if (__prev.a !== __a) {
-														_$_.set_text(expression_21, __prev.a = __a);
-													}
-
-													var __b = `item item-${_$_.get(pattern_8).id} kind-b`;
-
-													if (__prev.b !== __b) {
-														_$_.set_class(li_22, __prev.b = __b, void 0, true);
-													}
-												},
-												{ a: ' ', b: Symbol() }
-											);
+											_$_.render(() => {
+												_$_.set_class(li_22, `item item-${_$_.get(pattern_8).id} kind-b`, void 0, true);
+											});
 
 											_$_.append(__anchor, li_22);
 										});
@@ -1393,25 +1129,13 @@ export function ForIfSwitchTryMulti(__anchor, _, __block) {
 										{
 											var expression_22 = _$_.child(li_23, true);
 
+											_$_.expression(expression_22, () => `pending ${_$_.get(pattern_8).id}`);
 											_$_.pop(li_23);
 										}
 
-										_$_.render(
-											(__prev) => {
-												var __a = `pending ${_$_.get(pattern_8).id}`;
-
-												if (__prev.a !== __a) {
-													_$_.set_text(expression_22, __prev.a = __a);
-												}
-
-												var __b = `pending pending-${_$_.get(pattern_8).id}`;
-
-												if (__prev.b !== __b) {
-													_$_.set_class(li_23, __prev.b = __b, void 0, true);
-												}
-											},
-											{ a: ' ', b: Symbol() }
-										);
+										_$_.render(() => {
+											_$_.set_class(li_23, `pending pending-${_$_.get(pattern_8).id}`, void 0, true);
+										});
 
 										_$_.append(__anchor, li_23);
 									}

--- a/packages/ripple/tests/hydration/compiled/client/portal.js
+++ b/packages/ripple/tests/hydration/compiled/client/portal.js
@@ -29,13 +29,10 @@ export function SimplePortal(__anchor, _, __block) {
 					return typeof document !== 'undefined' ? document.body : null;
 				},
 
-				children: _$_.ripple_element(function render_children(__anchor, _, __block) {
-					_$_.push_component();
-
+				children: _$_.ripple_element(function render_children(__anchor, __block) {
 					var div_2 = root_1();
 
 					_$_.append(__anchor, div_2);
-					_$_.pop_component();
 				})
 			},
 			_$_.active_block
@@ -73,13 +70,10 @@ export function ConditionalPortal(__anchor, _, __block) {
 							return typeof document !== 'undefined' ? document.body : null;
 						},
 
-						children: _$_.ripple_element(function render_children(__anchor, _, __block) {
-							_$_.push_component();
-
+						children: _$_.ripple_element(function render_children(__anchor, __block) {
 							var div_4 = root_4();
 
 							_$_.append(__anchor, div_4);
-							_$_.pop_component();
 						})
 					},
 					_$_.active_block
@@ -116,13 +110,10 @@ export function PortalWithMainContent(__anchor, _, __block) {
 					return typeof document !== 'undefined' ? document.body : null;
 				},
 
-				children: _$_.ripple_element(function render_children(__anchor, _, __block) {
-					_$_.push_component();
-
+				children: _$_.ripple_element(function render_children(__anchor, __block) {
 					var div_7 = root_6();
 
 					_$_.append(__anchor, div_7);
-					_$_.pop_component();
 				})
 			},
 			_$_.active_block
@@ -154,13 +145,10 @@ export function NestedContentWithPortal(__anchor, _, __block) {
 					return typeof document !== 'undefined' ? document.body : null;
 				},
 
-				children: _$_.ripple_element(function render_children(__anchor, _, __block) {
-					_$_.push_component();
-
+				children: _$_.ripple_element(function render_children(__anchor, __block) {
 					var div_10 = root_8();
 
 					_$_.append(__anchor, div_10);
-					_$_.pop_component();
 				})
 			},
 			_$_.active_block

--- a/packages/ripple/tests/hydration/compiled/client/reactivity.js
+++ b/packages/ripple/tests/hydration/compiled/client/reactivity.js
@@ -19,12 +19,9 @@ export function TrackedState(__anchor, _, __block) {
 	{
 		var expression = _$_.child(div_1, true);
 
+		_$_.expression(expression, () => _$_.get(lazy));
 		_$_.pop(div_1);
 	}
-
-	_$_.render(() => {
-		_$_.set_text(expression, _$_.get(lazy));
-	});
 
 	_$_.append(__anchor, div_1);
 	_$_.pop_component();
@@ -42,13 +39,10 @@ export function CounterWithInitial(__anchor, props, __block) {
 		{
 			var expression_1 = _$_.child(span_1, true);
 
+			_$_.expression(expression_1, () => _$_.get(lazy_1));
 			_$_.pop(span_1);
 		}
 	}
-
-	_$_.render(() => {
-		_$_.set_text(expression_1, _$_.get(lazy_1));
-	});
 
 	_$_.append(__anchor, div_2);
 	_$_.pop_component();
@@ -76,12 +70,9 @@ export function ComputedValues(__anchor, _, __block) {
 	{
 		var expression_2 = _$_.child(div_3, true);
 
+		_$_.expression(expression_2, sum);
 		_$_.pop(div_3);
 	}
-
-	_$_.render(() => {
-		_$_.set_text(expression_2, sum());
-	});
 
 	_$_.append(__anchor, div_3);
 	_$_.pop_component();
@@ -99,6 +90,7 @@ export function MultipleTracked(__anchor, _, __block) {
 	{
 		var expression_3 = _$_.child(div_4, true);
 
+		_$_.expression(expression_3, () => _$_.get(lazy_4));
 		_$_.pop(div_4);
 	}
 
@@ -107,6 +99,7 @@ export function MultipleTracked(__anchor, _, __block) {
 	{
 		var expression_4 = _$_.child(div_5, true);
 
+		_$_.expression(expression_4, () => _$_.get(lazy_5));
 		_$_.pop(div_5);
 	}
 
@@ -115,34 +108,11 @@ export function MultipleTracked(__anchor, _, __block) {
 	{
 		var expression_5 = _$_.child(div_6, true);
 
+		_$_.expression(expression_5, () => _$_.get(lazy_6));
 		_$_.pop(div_6);
 	}
 
 	_$_.next(2);
-
-	_$_.render(
-		(__prev) => {
-			var __a = _$_.get(lazy_4);
-
-			if (__prev.a !== __a) {
-				_$_.set_text(expression_3, __prev.a = __a);
-			}
-
-			var __b = _$_.get(lazy_5);
-
-			if (__prev.b !== __b) {
-				_$_.set_text(expression_4, __prev.b = __b);
-			}
-
-			var __c = _$_.get(lazy_6);
-
-			if (__prev.c !== __c) {
-				_$_.set_text(expression_5, __prev.c = __c);
-			}
-		},
-		{ a: ' ', b: ' ', c: ' ' }
-	);
-
 	_$_.append(__anchor, fragment_1, true);
 	_$_.pop_component();
 }
@@ -158,12 +128,9 @@ export function DerivedState(__anchor, _, __block) {
 	{
 		var expression_6 = _$_.child(div_7, true);
 
+		_$_.expression(expression_6, fullName);
 		_$_.pop(div_7);
 	}
-
-	_$_.render(() => {
-		_$_.set_text(expression_6, fullName());
-	});
 
 	_$_.append(__anchor, div_7);
 	_$_.pop_component();

--- a/packages/ripple/tests/hydration/compiled/client/return.js
+++ b/packages/ripple/tests/hydration/compiled/client/return.js
@@ -1711,12 +1711,9 @@ export function ReactiveOuterInnerReturns(__anchor, _, __block) {
 		{
 			var expression = _$_.child(div_39, true);
 
+			_$_.expression(expression, () => _$_.get(lazy_4) ? 'a-on rest' : 'a-off rest');
 			_$_.pop(div_39);
 		}
-
-		_$_.render(() => {
-			_$_.set_text(expression, _$_.get(lazy_4) ? 'a-on rest' : 'a-off rest');
-		});
 
 		_$_.append(__anchor, div_39);
 	};

--- a/packages/ripple/tests/hydration/compiled/client/try.js
+++ b/packages/ripple/tests/hydration/compiled/client/try.js
@@ -60,7 +60,7 @@ function AsyncList(__anchor, _, __block) {
 					{
 						var expression = _$_.child(li_1, true);
 
-						expression.nodeValue = item;
+						_$_.expression(expression, () => item);
 						_$_.pop(li_1);
 					}
 
@@ -120,7 +120,7 @@ function AsyncContent(__anchor, _, __block) {
 		{
 			var expression_1 = _$_.child(div_3, true);
 
-			expression_1.nodeValue = value;
+			_$_.expression(expression_1, () => value);
 			_$_.pop(div_3);
 		}
 

--- a/packages/ripple/tsconfig.typecheck.json
+++ b/packages/ripple/tsconfig.typecheck.json
@@ -1,4 +1,5 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["./src/runtime/"]
+  "include": ["./src/"],
+  "exclude": ["./tests/"]
 }


### PR DESCRIPTION
```jsx
component App() {
  const div = <tsx><div>Hello world</div></tsx>

  {div}
}
```

This now works!


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core parsing, analysis, code generation, and client runtime DOM lifecycle for expressions, so regressions could affect rendering/hydration and template semantics across many components.
> 
> **Overview**
> Adds native `<tsx>...</tsx>` support as an expression by introducing a new `Tsx` AST node, extending the parser to only allow expression-level JSX when wrapped in `<tsx>` (and validating non-self-closing / proper closing tags), and updating the Prettier plugin to format `Tsx` blocks.
> 
> Updates analyzer/transform passes to treat `Tsx` as template/control-flow content, convert JSX children into Ripple template nodes (`jsx_to_ripple_node`), and adjust client/server codegen so `<tsx>` can be returned/assigned/passed as a `RippleElement` (including simplifying `RippleElement.render` call signatures and skipping component push/pop for generated render functions).
> 
> Tightens correctness by rejecting side-effecting template expressions (assignments/updates/mutating calls) and reworking client expression rendering to correctly clean up DOM ranges when a `RippleElement` inserts nodes before an anchor; tests/snapshots updated and a new `tsx.test.ripple` suite added.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05efe2beee381afc592bae5baf0bf76791c47494. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->