### PR TITLE
docs: remove outdated SSR "coming soon" note from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,6 @@ human and LLM developer experience.
 - 🛠️ **Developer Tools**: VSCode extension, Prettier, and ESLint support
 - 🎨 **Scoped Styling**: Component-level CSS with automatic scoping
 
-> **Note:** SSR support is coming soon! Currently SPA-only.
-
 ## 🚀 Quick Start
 
 ### Using CLI (Recommended)


### PR DESCRIPTION
I think SSR is already supported.
I remove outdated note to avoid confusion.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no impact on runtime behavior or APIs.
> 
> **Overview**
> Removes the README note stating that SSR is “coming soon” and that Ripple is currently SPA-only, to avoid misleading users about SSR availability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcc0f1463c8821283a05fd84396c2015f88f63c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->