### PR TITLE
fix: scoped styles apply correctly when child content is rendered through a parent component

### DIFF
--- a/.changeset/fresh-grapes-dance.md
+++ b/.changeset/fresh-grapes-dance.md
@@ -1,0 +1,5 @@
+---
+"ripple": patch
+---
+
+fix: scoped styles apply correctly when child content is rendered through a parent component

--- a/packages/ripple/src/compiler/phases/3-transform/client/index.js
+++ b/packages/ripple/src/compiler/phases/3-transform/client/index.js
@@ -2033,6 +2033,7 @@ const visitors = {
 
 		const component_scope = context.state.scopes.get(node) || context.state.scope;
 		const is_ripple_element = context.state.is_ripple_element;
+		const is_synthetic_children = node.id?.name === 'render_children';
 		const transformed_body = transform_body(node.body, {
 			...context,
 			state: {
@@ -2042,6 +2043,7 @@ const visitors = {
 				metadata,
 				scope: component_scope,
 				is_ripple_element: false,
+				applyParentCssScope: is_synthetic_children ? context.state.applyParentCssScope : undefined,
 			},
 		});
 

--- a/packages/ripple/src/compiler/phases/3-transform/server/index.js
+++ b/packages/ripple/src/compiler/phases/3-transform/server/index.js
@@ -404,7 +404,13 @@ const visitors = {
 			b.stmt(b.call('_$_.push_component')),
 			...transform_body(node.body, {
 				...context,
-				state: { ...context.state, component: node, metadata },
+				state: {
+					...context.state,
+					component: node,
+					metadata,
+					applyParentCssScope:
+						node.id?.name === 'render_children' ? context.state.applyParentCssScope : undefined,
+				},
 			}),
 			b.stmt(b.call('_$_.pop_component')),
 		);

--- a/packages/ripple/tests/client/composite/composite.render.test.ripple
+++ b/packages/ripple/tests/client/composite/composite.render.test.ripple
@@ -192,3 +192,49 @@ describe('composite > render', () => {
 		expect(div.innerHTML).not.toContain('<undefined');
 	});
 });
+
+describe('scoped styles with children', () => {
+	it('generates correct CSS hashes for wrapper and child with empty style in App', () => {
+		component Wrapper(&{ children }: { children?: Component }) {
+			<div class="green">
+				{'Wrapper'}
+				{children}
+			</div>
+
+			<style>
+				.green {
+					color: green;
+				}
+			</style>
+		}
+
+		component Child() {
+			<div class="red">{'Child'}</div>
+
+			<style>
+				.red {
+					color: red;
+				}
+			</style>
+		}
+
+		component App() {
+			<Wrapper>
+				<Child />
+			</Wrapper>
+			<style></style>
+		}
+
+		render(App);
+
+		const wrapper = container.querySelector('.green');
+		const child = container.querySelector('.red');
+
+		const wrapper_classes = Array.from(wrapper.classList).filter((c) => c.startsWith('ripple-'));
+		const child_classes = Array.from(child.classList).filter((c) => c.startsWith('ripple-'));
+
+		expect(wrapper_classes).toHaveLength(1);
+		expect(child_classes).toHaveLength(1);
+		expect(wrapper_classes[0]).not.toBe(child_classes[0]);
+	});
+});


### PR DESCRIPTION
Fixes #851 

### Summary
Scoped styles don't apply to child content rendered through a parent component using children. When a component uses the `children` prop, child components now correctly use their own CSS hash instead of incorrectly inheriting from the parent wrapper component.
### Problem
When using a wrapper component that renders children via `{children}`:
```tsx
component Wrapper({ children }) {
  <div class="green">
    {children}
  </div>
  <style>.green { color: green; }</style>
}
component Child() {
  <div class="red">Child</div>
  <style>.red { color: red; }</style>
}
export component App() {
  <Wrapper>
    <Child />
  </Wrapper>
}
```
The Child component would incorrectly use Wrapper's CSS hash, causing scoped styles to not apply correctly.
### Solution
In both client and server transform phases, when processing a component:
- For `render_children` (synthetic component wrapping children): preserve parent's `applyParentCssScope`
- For real child components: reset to `undefined` so they use their own CSS hash
### Files Changed
- `packages/ripple/src/compiler/phases/3-transform/client/index.js` - Client-side transform
- `packages/ripple/src/compiler/phases/3-transform/server/index.js` - Server-side transform
- `packages/ripple/tests/client/composite/composite.render.test.ripple` - Test case

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core client/SSR compiler transform state propagation for CSS scoping; regressions could affect style hashing across nested component rendering, though the change is narrowly gated to `render_children` plus new coverage.
> 
> **Overview**
> Fixes scoped-style hashing when components render child content via `children` by ensuring only the synthetic `render_children` wrapper preserves `applyParentCssScope`, while real child components reset it so they use their own CSS hash (applied in both client and server transform phases).
> 
> Adds a regression test covering wrapper + child components (including an empty `<style>` in `App`) to assert the wrapper and child get distinct `ripple-*` scope classes, and publishes the fix as a patch via a changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d601a3fc2efb0907d965b6cb811df31eea10bcdf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->