### PR TITLE
Changeset for trackAsync

### DIFF
--- a/.changeset/long-mouses-worry.md
+++ b/.changeset/long-mouses-worry.md
@@ -7,6 +7,15 @@
 ---
 
 Add a release changeset for the async tracking work introduced in commit
-`4eb4d6851573d771d65f1e85b1b442ad3cdc53d2`, including `trackAsync`/`trackPending`
-runtime and compiler updates, compat-react async boundary behavior, and related
-editor tooling updates.
+`4eb4d6851573d771d65f1e85b1b442ad3cdc53d2`.
+
+This ships async tracking as a first-class feature in Ripple:
+
+- add `trackAsync()` and `trackPending()` support so async values can be read
+  through Ripple's reactive runtime without using direct component-level `await`
+- update compiler/runtime behavior for `try`/`catch`/`pending` boundaries so
+  async pending and error states can render and recover correctly in client and
+  SSR paths
+- align `@ripple-ts/compat-react` async boundary behavior with the new Ripple
+  async tracking semantics
+- update editor/tooling integration to match the new async syntax/runtime shape

--- a/.changeset/long-mouses-worry.md
+++ b/.changeset/long-mouses-worry.md
@@ -11,8 +11,10 @@ Add a release changeset for the async tracking work introduced in commit
 
 This ships async tracking as a first-class feature in Ripple:
 
+- remove and prohibit direct component-level `await`; async component flows now
+  require using `trackAsync()` (with `trackPending()` for pending state checks)
 - add `trackAsync()` and `trackPending()` support so async values can be read
-  through Ripple's reactive runtime without using direct component-level `await`
+  through Ripple's reactive runtime using tracked async values
 - update compiler/runtime behavior for `try`/`catch`/`pending` boundaries so
   async pending and error states can render and recover correctly in client and
   SSR paths

--- a/.changeset/long-mouses-worry.md
+++ b/.changeset/long-mouses-worry.md
@@ -1,0 +1,12 @@
+---
+'ripple': patch
+'@ripple-ts/compat-react': patch
+'@ripple-ts/prettier-plugin': patch
+'@ripple-ts/language-server': patch
+'@ripple-ts/vscode-plugin': patch
+---
+
+Add a release changeset for the async tracking work introduced in commit
+`4eb4d6851573d771d65f1e85b1b442ad3cdc53d2`, including `trackAsync`/`trackPending`
+runtime and compiler updates, compat-react async boundary behavior, and related
+editor tooling updates.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
This PR adds a dedicated release changeset for the functionality introduced in commit `4eb4d6851573d771d65f1e85b1b442ad3cdc53d2`.

The changeset now describes the actual behavior shipped by that work:

- Component-level `await` usage is removed and prohibited; async component flows must use `trackAsync()` instead (with `trackPending()` for pending-state checks).
- Ripple adds first-class async tracking APIs (`trackAsync()` / `trackPending()`) so async values participate in reactive reads as tracked async values.
- Compiler and runtime behavior for `try`/`catch`/`pending` boundaries is updated so async pending and error states render and recover correctly in both client rendering and SSR.
- `@ripple-ts/compat-react` is aligned with the new async boundary semantics so interop behavior matches Ripple's async model.
- Tooling/editor integrations are updated to reflect the new async syntax/runtime shape.

## Why this PR exists
Commit `4eb4d685...` already landed on `main`, but it was missing a functionality-oriented release note for versioning. This PR supplies that missing changeset entry.

## Testing
- not run (changeset-only documentation/versioning update)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-07ac9682-a633-41d3-aba5-84a8bd6fde40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-07ac9682-a633-41d3-aba5-84a8bd6fde40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

