### PR TITLE
fix children prop ordering when spreads follow explicit children

### DIFF
--- a/.changeset/tasty-mirrors-tease.md
+++ b/.changeset/tasty-mirrors-tease.md
@@ -2,4 +2,4 @@
 'ripple': patch
 ---
 
-fix: children prop ordering when spreads follow explicit children
+fix: preserve children prop precedence after spreads

--- a/.changeset/tasty-mirrors-tease.md
+++ b/.changeset/tasty-mirrors-tease.md
@@ -1,0 +1,5 @@
+---
+'ripple': patch
+---
+
+fix: children prop ordering when spreads follow explicit children

--- a/packages/ripple/src/compiler/phases/3-transform/client/index.js
+++ b/packages/ripple/src/compiler/phases/3-transform/client/index.js
@@ -1659,6 +1659,7 @@ const visitors = {
 			const props = [];
 			/** @type {AST.Property | null} */
 			let children_prop = null;
+			let has_explicit_children_prop = false;
 
 			for (const attr of node.attributes) {
 				if (attr.type === 'Attribute') {
@@ -1690,6 +1691,8 @@ const visitors = {
 										b.block([b.return(b.call('_$_.normalize_children', property))]),
 									),
 								);
+								props.push(children_prop);
+								has_explicit_children_prop = true;
 								continue;
 							}
 
@@ -1707,6 +1710,8 @@ const visitors = {
 									b.id('children'),
 									b.call('_$_.normalize_children', property),
 								);
+								props.push(children_prop);
+								has_explicit_children_prop = true;
 								continue;
 							}
 
@@ -1822,7 +1827,7 @@ const visitors = {
 				}
 			}
 
-			if (children_prop) {
+			if (children_prop && !has_explicit_children_prop) {
 				props.push(children_prop);
 			}
 

--- a/packages/ripple/src/compiler/phases/3-transform/server/index.js
+++ b/packages/ripple/src/compiler/phases/3-transform/server/index.js
@@ -1060,6 +1060,7 @@ const visitors = {
 			const props = [];
 			/** @type {AST.Property | null} */
 			let children_prop = null;
+			let has_explicit_children_prop = false;
 
 			const apply_parent_css_scope = state.applyParentCssScope;
 
@@ -1083,6 +1084,8 @@ const visitors = {
 								b.id('children'),
 								b.call('_$_.normalize_children', property),
 							);
+							props.push(children_prop);
+							has_explicit_children_prop = true;
 							continue;
 						}
 
@@ -1135,7 +1138,7 @@ const visitors = {
 				}
 			}
 
-			if (children_prop) {
+			if (children_prop && !has_explicit_children_prop) {
 				props.push(children_prop);
 			}
 

--- a/packages/ripple/tests/client/basic/basic.components.test.rsrx
+++ b/packages/ripple/tests/client/basic/basic.components.test.rsrx
@@ -231,6 +231,24 @@ describe('basic client > components & composition', () => {
 		expect(container.querySelector('.text-prop')?.textContent).toBe('hello');
 	});
 
+	it('lets later spreads override explicit children props', () => {
+		component Card(props: PropsWithChildren<{}>) {
+			<div class="card">{props.children}</div>
+		}
+
+		component Basic() {
+			const props = { children: 'override' };
+
+			<Card children="fallback" {...props}>
+				<span>{'content'}</span>
+			</Card>
+		}
+
+		render(Basic);
+
+		expect(container.querySelector('.card')?.textContent).toBe('override');
+	});
+
 	it('it retains this context with bracketed prop functions and keeps original chaining', () => {
 		component App() {
 			const SYMBOL_PROP = Symbol();

--- a/packages/ripple/tests/client/compiler/compiler.basic.test.rsrx
+++ b/packages/ripple/tests/client/compiler/compiler.basic.test.rsrx
@@ -539,6 +539,30 @@ export component App() {
 		expect(result).toContain('children: _$_.normalize_children(fallback) ?? _$_.ripple_element(');
 	});
 
+	it('preserves explicit children source order relative to spreads in client output', () => {
+		const source = `
+component Card(props) {
+	<div>{props.children}</div>
+}
+
+export component App() {
+	const fallback = 'fallback';
+	const props = { children: 'override' };
+
+	<Card children={fallback} {...props}>
+		<span>{'content'}</span>
+	</Card>
+}
+`;
+
+		const result = compile(source, 'test.ripple', { mode: 'client' }).js.code;
+		const spread_call = result.slice(result.indexOf('_$_.spread_props(() => ['));
+
+		expect(spread_call).toMatch(
+			/\[\s*\{\s*children: _\$_\.normalize_children\(fallback\)[\s\S]*?\},\s*props\s*\]/,
+		);
+	});
+
 	it('should not error on `this` MemberExpression with a UpdateExpression', () => {
 		const code = `
 class Test {

--- a/packages/ripple/tests/server/basic.components.test.rsrx
+++ b/packages/ripple/tests/server/basic.components.test.rsrx
@@ -199,6 +199,26 @@ describe('basic server > components & composition', () => {
 		expect(buttonSpan.textContent).toBe('Click me!');
 	});
 
+	it('lets later spreads override explicit children props', async () => {
+		component Card(props: PropsWithChildren<{}>) {
+			<div class="card">{props.children}</div>
+		}
+
+		component Basic() {
+			const props = { children: 'override' };
+
+			<Card children="fallback" {...props}>
+				<span>{'content'}</span>
+			</Card>
+		}
+
+		const { body } = await render(Basic);
+		const { document } = parseHtml(body);
+
+		expect(document.querySelector('.card')?.textContent).toBe('override');
+		expect(body).toBeHtml('<div class="card">override</div>');
+	});
+
 	it('handles empty string children', async () => {
 		component Button({ children }: PropsWithChildren<{}>) {
 			{children}

--- a/packages/ripple/tests/server/compiler.test.rsrx
+++ b/packages/ripple/tests/server/compiler.test.rsrx
@@ -115,6 +115,30 @@ export component App() {
 		expect((result.match(/children:/g) || []).length).toBe(1);
 		expect(result).toContain('children: _$_.normalize_children(fallback) ?? _$_.ripple_element(');
 	});
+
+	it('preserves explicit children source order relative to spreads in SSR output', () => {
+		const source = `
+component Card(props) {
+	<div>{props.children}</div>
+}
+
+export component App() {
+	const fallback = 'fallback';
+	const props = { children: 'override' };
+
+	<Card children={fallback} {...props}>
+		<span>{'content'}</span>
+	</Card>
+}
+`;
+
+		const result = compile(source, 'test.ripple', { mode: 'server' }).js.code;
+		const args_object = result.slice(result.indexOf('const args = ['));
+
+		expect(args_object.indexOf('normalize_children(fallback)')).toBeLessThan(
+			args_object.indexOf('...props'),
+		);
+	});
 });
 
 describe('compiler server block tests', () => {


### PR DESCRIPTION
## Problem
Composite component transforms currently reorder explicit `children` props when a spread follows them. A call like:
```tsx
<Card children={fallback} {...props} />
```
should preserve left-to-right prop precedence, allowing the later spread to override children. Instead, the generated output effectively moves children to the end, so fallback incorrectly wins in both client and SSR output.
## Fix
- push explicit `children` props into the generated props list at their original source position
- continue merging implicit child content into that same prop with `??`
- only synthesize a trailing `children` prop when no explicit `children` prop was provided
- add client and server regression tests covering compile output and runtime rendering

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the component transform in both client and SSR compilers, which can change generated output and runtime rendering for any component usage that mixes `children` and spread props.
> 
> **Overview**
> Fixes composite component codegen so an explicit `children` attribute is emitted **in source order** relative to later `{...spreads}`, restoring normal left-to-right prop precedence (so later spreads can override `children`).
> 
> Updates both client and server transforms to only append a synthesized trailing `children` prop when no explicit `children` was provided, while still merging implicit child content into the same `children` value via `??`.
> 
> Adds regression tests for client + SSR covering both compiled output ordering and runtime rendering, and includes a patch changeset entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 628a72c1a61d65c32a5b328eec8ba524308d6394. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->