### PR TITLE
allow js-scoped components inside elements

### DIFF
--- a/packages/ripple/tests/client/basic/basic.components.test.rsrx
+++ b/packages/ripple/tests/client/basic/basic.components.test.rsrx
@@ -520,4 +520,50 @@ describe('basic client > components & composition', () => {
 		render(App);
 		expect(container.querySelector('.card').textContent).toBe('explicit');
 	});
+
+	it('renders components declared inside composite element children', () => {
+		component Wrapper(props: PropsWithChildren<{}>) {
+			<div class="wrapper">{props.children}</div>
+		}
+
+		component App() {
+			<Wrapper>
+				component Inner() {
+					<span class="inner">{'inner content'}</span>
+				}
+
+				<Inner />
+			</Wrapper>
+		}
+
+		render(App);
+		expect(container.querySelector('.wrapper .inner').textContent).toBe('inner content');
+	});
+
+	it('renders nested components declared inside composite children with prop passing', () => {
+		component Wrapper(props: PropsWithChildren<{}>) {
+			<div class="wrapper">{props.children}</div>
+		}
+
+		component App() {
+			<Wrapper>
+				component Z() {
+					<div class="z">{'I am Z'}</div>
+				}
+
+				component Child(&{ Z }: { Z: Component }) {
+					<div class="child">
+						{'Child Component: '}
+						<Z />
+					</div>
+				}
+
+				<Child {Z} />
+			</Wrapper>
+		}
+
+		render(App);
+		expect(container.querySelector('.wrapper .child').textContent).toBe('Child Component: I am Z');
+		expect(container.querySelector('.wrapper .z').textContent).toBe('I am Z');
+	});
 });

--- a/packages/ripple/tests/client/compiler/compiler.basic.test.rsrx
+++ b/packages/ripple/tests/client/compiler/compiler.basic.test.rsrx
@@ -486,7 +486,7 @@ export component App() {
 		expect(() => compile(code, 'test.ripple')).not.toThrow();
 	});
 
-	it('rejects component declarations inside composite children', () => {
+	it('allows component declarations inside composite children', () => {
 		const source = `
 export component App() {
 	<ark.div class="host-class" data-value="42">
@@ -497,8 +497,22 @@ export component App() {
 }
 `;
 
-		expect(() => compile_to_volar_mappings(source, 'test.ripple')).toThrow(
-			/Component declarations cannot be used inside composite component children/,
+		expect(() => compile_to_volar_mappings(source, 'test.ripple')).not.toThrow();
+	});
+
+	it('rejects parent element attributes referencing child-declared components', () => {
+		const source = `
+export component App() {
+	<Test {Z}>
+		component Z() {
+			<div>{'hello'}</div>
+		}
+	</Test>
+}
+`;
+
+		expect(() => compile(source, 'test.ripple')).toThrow(
+			/Cannot use component 'Z' as a prop on its parent element/
 		);
 	});
 

--- a/packages/ripple/tests/client/compiler/compiler.basic.test.rsrx
+++ b/packages/ripple/tests/client/compiler/compiler.basic.test.rsrx
@@ -512,7 +512,7 @@ export component App() {
 `;
 
 		expect(() => compile(source, 'test.ripple')).toThrow(
-			/Cannot use component 'Z' as a prop on its parent element/
+			/Cannot use component 'Z' as a prop on its parent element/,
 		);
 	});
 

--- a/packages/ripple/tests/server/basic.components.test.rsrx
+++ b/packages/ripple/tests/server/basic.components.test.rsrx
@@ -349,4 +349,52 @@ describe('basic server > components & composition', () => {
 		const { document } = parseHtml(body);
 		expect(document.querySelector('.card').textContent).toBe('explicit');
 	});
+
+	it('renders components declared inside composite element children', async () => {
+		component Wrapper(props: PropsWithChildren<{}>) {
+			<div class="wrapper">{props.children}</div>
+		}
+
+		component App() {
+			<Wrapper>
+				component Inner() {
+					<span class="inner">{'inner content'}</span>
+				}
+
+				<Inner />
+			</Wrapper>
+		}
+
+		const { body } = await render(App);
+		const { document } = parseHtml(body);
+		expect(document.querySelector('.wrapper .inner').textContent).toBe('inner content');
+	});
+
+	it('renders nested components declared inside composite children with prop passing', async () => {
+		component Wrapper(props: PropsWithChildren<{}>) {
+			<div class="wrapper">{props.children}</div>
+		}
+
+		component App() {
+			<Wrapper>
+				component Z() {
+					<div class="z">{'I am Z'}</div>
+				}
+
+				component Child(&{ Z }: { Z: Component }) {
+					<div class="child">
+						{'Child Component: '}
+						<Z />
+					</div>
+				}
+
+				<Child {Z} />
+			</Wrapper>
+		}
+
+		const { body } = await render(App);
+		const { document } = parseHtml(body);
+		expect(document.querySelector('.wrapper .child').textContent).toBe('Child Component: I am Z');
+		expect(document.querySelector('.wrapper .z').textContent).toBe('I am Z');
+	});
 });

--- a/packages/tsrx-ripple/src/analyze/index.js
+++ b/packages/tsrx-ripple/src/analyze/index.js
@@ -2066,15 +2066,45 @@ const visitors = {
 			/** @type {(AST.Node | AST.Expression)[]} */
 			let implicit_children = [];
 
+			// Collect names of components declared in children
+			/** @type {Set<string>} */
+			const child_component_names = new Set();
+			for (const child of node.children) {
+				if (child.type === 'Component' && child.id) {
+					child_component_names.add(child.id.name);
+				}
+			}
+
+			// Validate that parent element attributes don't reference child-declared components
+			if (child_component_names.size > 0) {
+				for (const attr of node.attributes) {
+					if (attr.type === 'Attribute' && attr.value !== null && attr.value.type === 'Identifier') {
+						if (child_component_names.has(attr.value.name)) {
+							error(
+								`Cannot use component '${attr.value.name}' as a prop on its parent element. Component declarations inside children are not in scope for the parent element's attributes.`,
+								state.analysis.module.filename,
+								attr.value,
+								context.state.loose ? context.state.analysis.errors : undefined,
+								context.state.analysis.comments,
+							);
+						}
+					} else if (attr.type === 'SpreadAttribute' && attr.argument.type === 'Identifier') {
+						if (child_component_names.has(attr.argument.name)) {
+							error(
+								`Cannot use component '${attr.argument.name}' as a prop on its parent element. Component declarations inside children are not in scope for the parent element's attributes.`,
+								state.analysis.module.filename,
+								attr.argument,
+								context.state.loose ? context.state.analysis.errors : undefined,
+								context.state.analysis.comments,
+							);
+						}
+					}
+				}
+			}
+
 			for (const child of node.children) {
 				if (child.type === 'Component') {
-					error(
-						'Component declarations cannot be used inside composite component children. Pass them as explicit props on the template element instead.',
-						state.analysis.module.filename,
-						child.id || child,
-						context.state.loose ? context.state.analysis.errors : undefined,
-						context.state.analysis.comments,
-					);
+					visit(child, state);
 				} else if (child.type !== 'EmptyStatement') {
 					implicit_children.push(
 						child.type === 'TSRXExpression' || child.type === 'Text' || child.type === 'Html'

--- a/packages/tsrx-ripple/src/analyze/index.js
+++ b/packages/tsrx-ripple/src/analyze/index.js
@@ -2078,7 +2078,11 @@ const visitors = {
 			// Validate that parent element attributes don't reference child-declared components
 			if (child_component_names.size > 0) {
 				for (const attr of node.attributes) {
-					if (attr.type === 'Attribute' && attr.value !== null && attr.value.type === 'Identifier') {
+					if (
+						attr.type === 'Attribute' &&
+						attr.value !== null &&
+						attr.value.type === 'Identifier'
+					) {
 						if (child_component_names.has(attr.value.name)) {
 							error(
 								`Cannot use component '${attr.value.name}' as a prop on its parent element. Component declarations inside children are not in scope for the parent element's attributes.`,

--- a/packages/tsrx-ripple/src/transform/client/index.js
+++ b/packages/tsrx-ripple/src/transform/client/index.js
@@ -2808,7 +2808,7 @@ function transform_ts_child(node, context) {
 			const is_dom_element = is_element_dom_element(node);
 			const component_scope = /** @type {ScopeInterface} */ (context.state.scopes.get(node));
 			const thunk =
-				/** @type {AST.Identifier} */ (node.id).name === 'style' || node.children.length === 0
+				/** @type {AST.Identifier} */ (node.id).name === 'style'
 					? null
 					: b.thunk(
 							b.block(

--- a/packages/tsrx-ripple/src/transform/client/index.js
+++ b/packages/tsrx-ripple/src/transform/client/index.js
@@ -1179,18 +1179,20 @@ const visitors = {
 			return b.jsx_fragment(children);
 		}
 
-		const all_children = node.children
-			.map((child) => jsx_to_ripple_node(/** @type {AST.Node} */ (child)))
-			.flat()
-			.filter((child) => child != null && child.type !== 'EmptyStatement');
-
-		for (const child of all_children) {
-			if (child.type === 'Component') {
-				state.init?.push(/** @type {AST.Statement} */ (visit(child, state)));
+		/** @type {AST.Node[]} */
+		const children_filtered = [];
+		for (const raw_child of node.children) {
+			const result = jsx_to_ripple_node(/** @type {AST.Node} */ (raw_child));
+			const items = Array.isArray(result) ? result : [result];
+			for (const child of items) {
+				if (child == null || child.type === 'EmptyStatement') continue;
+				if (child.type === 'Component') {
+					state.init?.push(/** @type {AST.Statement} */ (visit(child, state)));
+				} else {
+					children_filtered.push(child);
+				}
 			}
 		}
-
-		const children_filtered = all_children.filter((child) => child.type !== 'Component');
 
 		const children_component = b.component(b.id('render_children'), [], children_filtered);
 

--- a/packages/tsrx-ripple/src/transform/client/index.js
+++ b/packages/tsrx-ripple/src/transform/client/index.js
@@ -1179,12 +1179,20 @@ const visitors = {
 			return b.jsx_fragment(children);
 		}
 
-		const children_filtered = node.children
+		const all_children = node.children
 			.map((child) => jsx_to_ripple_node(/** @type {AST.Node} */ (child)))
 			.flat()
-			.filter(
-				(child) => child != null && child.type !== 'EmptyStatement' && child.type !== 'Component',
-			);
+			.filter((child) => child != null && child.type !== 'EmptyStatement');
+
+		for (const child of all_children) {
+			if (child.type === 'Component') {
+				state.init?.push(/** @type {AST.Statement} */ (visit(child, state)));
+			}
+		}
+
+		const children_filtered = all_children.filter(
+			(child) => child.type !== 'Component',
+		);
 
 		const children_component = b.component(b.id('render_children'), [], children_filtered);
 
@@ -1766,6 +1774,12 @@ const visitors = {
 					const name = is_spreading ? '#class' : 'class';
 					const value = state.component.css.hash;
 					props.push(b.prop('init', b.key(name), b.literal(value)));
+				}
+			}
+
+			for (const child of node.children) {
+				if (child.type === 'Component') {
+					state.init?.push(/** @type {AST.Statement} */ (visit(child, state)));
 				}
 			}
 
@@ -2793,41 +2807,13 @@ function transform_ts_child(node, context) {
 		if (!node.selfClosing && !node.unclosed && !has_children_props && node.children.length > 0) {
 			const is_dom_element = is_element_dom_element(node);
 			const component_scope = /** @type {ScopeInterface} */ (context.state.scopes.get(node));
-			/** @type {AST.Node[]} */
-			const non_component_children = [];
-
-			for (let i = 0; i < node.children.length; i++) {
-				const child = node.children[i];
-				if (!is_dom_element && child.type === 'Component' && child.id) {
-					const transformed_component = /** @type {AST.FunctionDeclaration} */ (
-						visit(child, {
-							...state,
-							scope: component_scope,
-						})
-					);
-					const func = b.arrow(
-						transformed_component.params,
-						transformed_component.body,
-						transformed_component.async,
-					);
-					func.metadata = { ...func.metadata, is_component: true };
-					const id = b.jsx_id(
-						/** @type {AST.Identifier} */ (child.id).name,
-						/** @type {AST.NodeWithLocation} */ (child.id),
-					);
-					id.metadata = { ...id.metadata, is_component: true };
-					attributes.push(b.jsx_attribute(id, b.jsx_expression_container(func)));
-				} else {
-					non_component_children.push(child);
-				}
-			}
 			const thunk =
 				/** @type {AST.Identifier} */ (node.id).name === 'style' ||
-				non_component_children.length === 0
+				node.children.length === 0
 					? null
 					: b.thunk(
 							b.block(
-								transform_body(non_component_children, {
+								transform_body(node.children, {
 									...context,
 									state: {
 										...state,

--- a/packages/tsrx-ripple/src/transform/client/index.js
+++ b/packages/tsrx-ripple/src/transform/client/index.js
@@ -1190,9 +1190,7 @@ const visitors = {
 			}
 		}
 
-		const children_filtered = all_children.filter(
-			(child) => child.type !== 'Component',
-		);
+		const children_filtered = all_children.filter((child) => child.type !== 'Component');
 
 		const children_component = b.component(b.id('render_children'), [], children_filtered);
 
@@ -2808,8 +2806,7 @@ function transform_ts_child(node, context) {
 			const is_dom_element = is_element_dom_element(node);
 			const component_scope = /** @type {ScopeInterface} */ (context.state.scopes.get(node));
 			const thunk =
-				/** @type {AST.Identifier} */ (node.id).name === 'style' ||
-				node.children.length === 0
+				/** @type {AST.Identifier} */ (node.id).name === 'style' || node.children.length === 0
 					? null
 					: b.thunk(
 							b.block(

--- a/packages/tsrx-ripple/src/transform/server/index.js
+++ b/packages/tsrx-ripple/src/transform/server/index.js
@@ -1102,6 +1102,12 @@ const visitors = {
 				}
 			}
 
+			for (const child of node.children) {
+				if (child.type === 'Component') {
+					state.init?.push(/** @type {AST.Statement} */ (visit(child, state)));
+				}
+			}
+
 			const children_filtered = node.children.filter(
 				(child) => child.type !== 'EmptyStatement' && child.type !== 'Component',
 			);


### PR DESCRIPTION
Resolves and closes #865

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes compiler analysis and both client/server transforms to allow nested component declarations inside composite element children, which can affect codegen ordering/scope and potentially regress rendering in edge cases.
> 
> **Overview**
> **Allows declaring `component` blocks inside composite element children** (rather than rejecting them), enabling inline “scoped” components to be rendered and passed around within that children block.
> 
> The analyzer now visits these child-declared components but adds a new validation that **parent element attributes/spreads cannot reference components declared in its children** (explicit compile error).
> 
> Client and server transforms are updated to **hoist/init child-declared components** during element/tsx child processing (instead of filtering them out or rewriting them into props), and tests are added/updated to cover the new behavior and the new compile-time restriction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9fa2e31c8932b566a0f726b1c810e418b6fa9ea4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->