### PR TITLE
switch vscode, ts plugin, lang server to esm with a build

### DIFF
--- a/.changeset/esm-build-packages.md
+++ b/.changeset/esm-build-packages.md
@@ -1,0 +1,11 @@
+---
+'@ripple-ts/language-server': patch
+'@ripple-ts/typescript-plugin': patch
+'@ripple-ts/vscode-plugin': patch
+---
+
+Convert the Ripple language server, TypeScript plugin, and VS Code extension codebases from CommonJS source files to ESM source files, while publishing built dist entrypoints instead of source files.
+
+This updates package metadata such as `type: module` and dist-based `main` paths, replaces `require` and `module.exports` usage with `import` and `export`, and adds tsdown bundling configs that emit CommonJS dist output plus a dist/package.json that forces `type: commonjs`.
+
+Development builds also include sourcemaps.

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ tmp
 dist
 debug
 .build-hash
+.build-hash-built
 **/*.d.tsrx.ts
 
 # Temporary folders

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ website/.vitepress/cache/
 tmp
 dist
 debug
+.build-hash
 **/*.d.tsrx.ts
 
 # Temporary folders

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,13 +6,14 @@
       "type": "extensionHost",
       "request": "launch",
       "autoAttachChildProcesses": true,
+      "preLaunchTask": "build-vscode-plugin",
       "args": [
         "--disable-extension=ripple-ts.ripple-ts-vscode-plugin",
         "--extensionDevelopmentPath=${workspaceFolder}/packages/vscode-plugin/",
         "${workspaceFolder}/playground"
       ],
-      "outFiles": ["${workspaceFolder}/packages/vscode-plugin/src/**/*.js"],
-      "sourceMaps": false,
+      "outFiles": ["${workspaceFolder}/packages/vscode-plugin/dist/**/*.js"],
+      "sourceMaps": true,
       "env": {
         "RIPPLE_DEBUG": "true"
       }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,6 +13,7 @@
   "js/ts.preferences.useAliasesForRenames": false,
   "js/ts.preferences.importModuleSpecifierEnding": "js",
   "js/ts.experimental.useTsgo": true,
+  "explorer.excludeGitIgnore": true,
 
   "[json]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -17,6 +17,18 @@
       "label": "client-runtime-prelaunch",
       "dependsOn": ["delete-client-chrome-debug-profile", "wait-for-vite"],
       "dependsOrder": "parallel"
+    },
+    {
+      "label": "build-vscode-plugin",
+      "type": "shell",
+      "command": "node scripts/build-if-changed.js packages/typescript-plugin packages/language-server packages/vscode-plugin",
+      "options": {
+        "shell": {
+          "args": ["-i", "-c"]
+        }
+      },
+      "group": "build",
+      "problemMatcher": []
     }
   ]
 }

--- a/packages/language-server/bin/language-server.js
+++ b/packages/language-server/bin/language-server.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
 
-const { createRippleLanguageServer } = require('../src/server.js');
+import { createRippleLanguageServer } from '../src/server.js';
 
 createRippleLanguageServer();

--- a/packages/language-server/index.js
+++ b/packages/language-server/index.js
@@ -1,1 +1,1 @@
-module.exports = require('./src/server');
+export { createRippleLanguageServer } from './src/server.js';

--- a/packages/language-server/index.js
+++ b/packages/language-server/index.js
@@ -1,1 +1,0 @@
-export { createRippleLanguageServer } from './src/server.js';

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -2,7 +2,7 @@
   "name": "@ripple-ts/language-server",
   "version": "0.3.18",
   "description": "Language Server Protocol implementation for Ripple",
-  "main": "dist/index.js",
+  "main": "dist/server.js",
   "type": "module",
   "bin": {
     "ripple-language-server": "bin/language-server.js"

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -2,12 +2,16 @@
   "name": "@ripple-ts/language-server",
   "version": "0.3.18",
   "description": "Language Server Protocol implementation for Ripple",
-  "main": "index.js",
+  "main": "dist/index.js",
+  "type": "module",
   "bin": {
     "ripple-language-server": "bin/language-server.js"
   },
   "author": "Dominic Gannaway",
   "license": "MIT",
+  "scripts": {
+    "build": "tsdown"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Ripple-TS/ripple.git",
@@ -23,7 +27,8 @@
     "vscode-uri": "catalog:default"
   },
   "devDependencies": {
-    "@tsrx/ripple": "workspace:*"
+    "@tsrx/ripple": "workspace:*",
+    "tsdown": "catalog:default"
   },
   "peerDependencies": {
     "typescript": "catalog:peer"

--- a/packages/language-server/src/autoInsertPlugin.js
+++ b/packages/language-server/src/autoInsertPlugin.js
@@ -1,6 +1,6 @@
 /** @import { LanguageServicePlugin } from '@volar/language-server' */
 
-const { getVirtualCode, createLogging, is_ripple_document } = require('./utils.js');
+import { getVirtualCode, createLogging, is_ripple_document } from './utils.js';
 
 const { log } = createLogging('[Ripple Auto-Insert Plugin]');
 
@@ -32,7 +32,7 @@ const VOID_ELEMENTS = new Set([
  * Handles auto-closing tags when typing '>' after a tag name
  * @returns {LanguageServicePlugin}
  */
-function createAutoInsertPlugin() {
+export function createAutoInsertPlugin() {
 	return {
 		name: 'ripple-auto-insert',
 		capabilities: {
@@ -161,7 +161,3 @@ function createAutoInsertPlugin() {
 		},
 	};
 }
-
-module.exports = {
-	createAutoInsertPlugin,
-};

--- a/packages/language-server/src/compileErrorDiagnosticPlugin.js
+++ b/packages/language-server/src/compileErrorDiagnosticPlugin.js
@@ -3,18 +3,17 @@
  * @import {TextDocument} from 'vscode-languageserver-textdocument';
  * @import {TSRXVirtualCodeInstance} from '@ripple-ts/typescript-plugin/src/language.js';
  */
-// @ts-ignore: ESM type import is fine
 /** @import {TSRXCompileError} from '@tsrx/ripple'; */
 
-const { getVirtualCode, createLogging } = require('./utils.js');
+import { getVirtualCode, createLogging } from './utils.js';
 
 const { log } = createLogging('[Ripple Compile Error Diagnostic Plugin]');
-const { DiagnosticSeverity } = require('@volar/language-server');
+import { DiagnosticSeverity } from '@volar/language-server';
 
 /**
  * @returns {LanguageServicePlugin}
  */
-function createCompileErrorDiagnosticPlugin() {
+export function createCompileErrorDiagnosticPlugin() {
 	log('Creating Ripple diagnostic plugin...');
 
 	return {
@@ -154,7 +153,3 @@ function get_end_offset_from_error(error, start_offset) {
 function get_start_offset_from_error(error) {
 	return error.pos ?? 0;
 }
-
-module.exports = {
-	createCompileErrorDiagnosticPlugin,
-};

--- a/packages/language-server/src/completionPlugin.js
+++ b/packages/language-server/src/completionPlugin.js
@@ -1,13 +1,13 @@
 /** @import { LanguageServicePlugin, TextEdit, CompletionItem } from '@volar/language-server'; */
 
-const { CompletionItemKind, InsertTextFormat } = require('@volar/language-server');
-const {
+import { CompletionItemKind, InsertTextFormat } from '@volar/language-server';
+import {
 	getVirtualCode,
 	createLogging,
 	isInsideImport,
 	isInsideExport,
 	is_ripple_document,
-} = require('./utils.js');
+} from './utils.js';
 
 const { log } = createLogging('[Ripple Completion Plugin]');
 
@@ -361,7 +361,7 @@ const RIPPLE_IMPORTS = [
 /**
  * @returns {LanguageServicePlugin}
  */
-function createCompletionPlugin() {
+export function createCompletionPlugin() {
 	return {
 		name: 'ripple-completion-enhancer',
 		capabilities: {
@@ -506,7 +506,3 @@ function createCompletionPlugin() {
 		},
 	};
 }
-
-module.exports = {
-	createCompletionPlugin,
-};

--- a/packages/language-server/src/definitionPlugin.js
+++ b/packages/language-server/src/definitionPlugin.js
@@ -1,18 +1,15 @@
 /** @import { LanguageServicePlugin, LocationLink } from '@volar/language-server'; */
-// @ts-ignore type-only import from ESM module into CJS is fine
 /** @import { DefinitionLocation } from '@tsrx/ripple'; */
 
-const { TextDocument } = require('vscode-languageserver-textdocument');
-const { getVirtualCode, createLogging, getWordFromPosition } = require('./utils.js');
-const path = require('path');
-const fs = require('fs');
-
-const {
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { getVirtualCode, createLogging, getWordFromPosition } from './utils.js';
+import path from 'path';
+import {
 	normalizeFileNameOrUri,
 	getRippleDirForFile,
 	getCachedTypeDefinitionFile,
 	getCachedTypeMatches,
-} = require('@ripple-ts/typescript-plugin/src/language.js');
+} from '@ripple-ts/typescript-plugin/src/language.js';
 
 const { log } = createLogging('[Ripple Definition Plugin]');
 /** @type {string | undefined} */
@@ -21,7 +18,7 @@ let ripple_dir;
 /**
  * @returns {LanguageServicePlugin}
  */
-function createDefinitionPlugin() {
+export function createDefinitionPlugin() {
 	return {
 		name: 'ripple-definition',
 		capabilities: {
@@ -209,7 +206,3 @@ function createDefinitionPlugin() {
 		},
 	};
 }
-
-module.exports = {
-	createDefinitionPlugin,
-};

--- a/packages/language-server/src/documentHighlightPlugin.js
+++ b/packages/language-server/src/documentHighlightPlugin.js
@@ -1,7 +1,7 @@
 /** @import { LanguageServicePlugin } from '@volar/language-server' */
 /** @import { LanguageServicePluginInstance } from '@volar/language-server' */
 
-const { getVirtualCode, getWordFromPosition, createLogging } = require('./utils.js');
+import { getVirtualCode, getWordFromPosition, createLogging } from './utils.js';
 const { log } = createLogging('[Ripple Document Highlight Plugin]');
 
 /**
@@ -9,7 +9,7 @@ const { log } = createLogging('[Ripple Document Highlight Plugin]');
  * Provides word highlighting (grey background) for custom Ripple keywords like 'pending'
  * @returns {LanguageServicePlugin}
  */
-function createDocumentHighlightPlugin() {
+export function createDocumentHighlightPlugin() {
 	return {
 		name: 'ripple-document-highlight',
 		capabilities: {
@@ -116,7 +116,3 @@ function createDocumentHighlightPlugin() {
 		},
 	};
 }
-
-module.exports = {
-	createDocumentHighlightPlugin,
-};

--- a/packages/language-server/src/hoverPlugin.js
+++ b/packages/language-server/src/hoverPlugin.js
@@ -5,20 +5,20 @@
 	MarkupContent,
 } from '@volar/language-server'; */
 
-const {
+import {
 	getVirtualCode,
 	createLogging,
 	getWordFromPosition,
 	concatMarkdownContents,
 	deobfuscateIdentifiers,
-} = require('./utils.js');
+} from './utils.js';
 
 const { log, logError } = createLogging('[Ripple Hover Plugin]');
 
 /**
  * @returns {LanguageServicePlugin}
  */
-function createHoverPlugin() {
+export function createHoverPlugin() {
 	return {
 		name: 'ripple-hover',
 		capabilities: {
@@ -144,7 +144,3 @@ function createHoverPlugin() {
 		},
 	};
 }
-
-module.exports = {
-	createHoverPlugin,
-};

--- a/packages/language-server/src/server.js
+++ b/packages/language-server/src/server.js
@@ -1,28 +1,28 @@
 ﻿/** @import {CompilerOptions} from 'typescript' */
 
-const { createLogging } = require('./utils.js');
-const {
+import { createLogging } from './utils.js';
+import {
 	createConnection,
 	createServer,
 	createTypeScriptProject,
-} = require('@volar/language-server/node');
-const { createCompileErrorDiagnosticPlugin } = require('./compileErrorDiagnosticPlugin.js');
-const { createDefinitionPlugin } = require('./definitionPlugin.js');
-const { createHoverPlugin } = require('./hoverPlugin.js');
-const { createCompletionPlugin } = require('./completionPlugin.js');
-const { createAutoInsertPlugin } = require('./autoInsertPlugin.js');
-const { createTypeScriptDiagnosticFilterPlugin } = require('./typescriptDiagnosticPlugin.js');
-const { createDocumentHighlightPlugin } = require('./documentHighlightPlugin.js');
-const {
+} from '@volar/language-server/node';
+import { createCompileErrorDiagnosticPlugin } from './compileErrorDiagnosticPlugin.js';
+import { createDefinitionPlugin } from './definitionPlugin.js';
+import { createHoverPlugin } from './hoverPlugin.js';
+import { createCompletionPlugin } from './completionPlugin.js';
+import { createAutoInsertPlugin } from './autoInsertPlugin.js';
+import { createTypeScriptDiagnosticFilterPlugin } from './typescriptDiagnosticPlugin.js';
+import { createDocumentHighlightPlugin } from './documentHighlightPlugin.js';
+import {
 	getRippleLanguagePlugin,
 	resolveConfig,
-} = require('@ripple-ts/typescript-plugin/src/language.js');
-const { createTypeScriptServices } = require('./typescriptService.js');
-const { create: createCssService } = require('volar-service-css');
+} from '@ripple-ts/typescript-plugin/src/language.js';
+import { createTypeScriptServices } from './typescriptService.js';
+import { create as createCssService } from 'volar-service-css';
 
 const { log, logError } = createLogging('[Ripple Language Server]');
 
-function createRippleLanguageServer() {
+export function createRippleLanguageServer() {
 	const connection = createConnection();
 	const server = createServer(connection);
 
@@ -156,7 +156,3 @@ function createRippleLanguageServer() {
 
 	return { connection, server };
 }
-
-module.exports = {
-	createRippleLanguageServer,
-};

--- a/packages/language-server/src/typescriptDiagnosticPlugin.js
+++ b/packages/language-server/src/typescriptDiagnosticPlugin.js
@@ -8,7 +8,7 @@
 @import {TextDocument} from 'vscode-languageserver-textdocument';
  */
 
-const { getVirtualCode, createLogging, deobfuscateIdentifiers } = require('./utils.js');
+import { getVirtualCode, createLogging, deobfuscateIdentifiers } from './utils.js';
 
 const { log, logError } = createLogging('[Ripple TypeScript Diagnostic Plugin]');
 
@@ -93,7 +93,7 @@ function processDiagnostics(document, context, diagnostics) {
  * to work correctly, as volar matches diagnostics by pluginIndex.
  * @returns {LanguageServicePlugin}
  */
-function createTypeScriptDiagnosticFilterPlugin() {
+export function createTypeScriptDiagnosticFilterPlugin() {
 	log('Creating TypeScript diagnostic filter plugin...');
 
 	return {
@@ -137,7 +137,3 @@ function createTypeScriptDiagnosticFilterPlugin() {
 		},
 	};
 }
-
-module.exports = {
-	createTypeScriptDiagnosticFilterPlugin,
-};

--- a/packages/language-server/src/typescriptService.js
+++ b/packages/language-server/src/typescriptService.js
@@ -3,12 +3,15 @@
  * @import {TextDocument} from 'vscode-languageserver-textdocument'
  */
 
-// Monkey-patch getUserPreferences to inject Ripple-specific defaults.
-// volar-service-typescript accesses getUserPreferences through the module object
-// at call time (not at import time), so patching the property after import works.
-// We use default import (not `import *`) because the bundler treats namespace objects as frozen.
-import getUserPreferencesModule from 'volar-service-typescript/lib/configs/getUserPreferences';
-import { create } from 'volar-service-typescript';
+import { createRequire } from 'node:module';
+
+// Use createRequire to get a real require() that hits Node's module cache.
+// This guarantees the monkey-patch targets the same exports object that all
+// other consumers (semantic.js, codeAction.js, etc.) see via their require() calls,
+// regardless of how the bundler handles ESM imports.
+const require = createRequire(import.meta.url);
+const getUserPreferencesModule = require('volar-service-typescript/lib/configs/getUserPreferences');
+const { create } = require('volar-service-typescript');
 
 const originalGetUserPreferences = getUserPreferencesModule.getUserPreferences;
 

--- a/packages/language-server/src/typescriptService.js
+++ b/packages/language-server/src/typescriptService.js
@@ -3,8 +3,13 @@
  * @import {TextDocument} from 'vscode-languageserver-textdocument'
  */
 
-// Monkey-patch getUserPreferences before requiring the main module
-const getUserPreferencesModule = require('volar-service-typescript/lib/configs/getUserPreferences');
+// Monkey-patch getUserPreferences to inject Ripple-specific defaults.
+// volar-service-typescript accesses getUserPreferences through the module object
+// at call time (not at import time), so patching the property after import works.
+// We use default import (not `import *`) because the bundler treats namespace objects as frozen.
+import getUserPreferencesModule from 'volar-service-typescript/lib/configs/getUserPreferences';
+import { create } from 'volar-service-typescript';
+
 const originalGetUserPreferences = getUserPreferencesModule.getUserPreferences;
 
 /**
@@ -29,18 +34,11 @@ getUserPreferencesModule.getUserPreferences = async function (context, document)
 	};
 };
 
-// Now require the main module which will use our patched getUserPreferences
-const { create } = require('volar-service-typescript');
-
 /**
  * Create TypeScript services with Ripple-specific enhancements.
  * @param {typeof import('typescript')} ts
  * @returns {ReturnType<typeof create>}
  */
-function createTypeScriptServices(ts) {
+export function createTypeScriptServices(ts) {
 	return create(ts);
 }
-
-module.exports = {
-	createTypeScriptServices,
-};

--- a/packages/language-server/src/typescriptService.js
+++ b/packages/language-server/src/typescriptService.js
@@ -5,10 +5,12 @@
 
 import { createRequire } from 'node:module';
 
-// Use createRequire to get a real require() that hits Node's module cache.
-// This guarantees the monkey-patch targets the same exports object that all
-// other consumers (semantic.js, codeAction.js, etc.) see via their require() calls,
-// regardless of how the bundler handles ESM imports.
+// Monkey-patch getUserPreferences to inject Ripple-specific defaults.
+// We use createRequire to get the raw CJS module.exports object, bypassing
+// the bundler's __toESM wrapper which interferes with property assignment.
+// volar-service-typescript is also externalized (via regex in tsdown config)
+// so that its internal consumers (semantic.js, codeAction.js, etc.) load
+// getUserPreferences from the same Node module cache entry we patch here.
 const require = createRequire(import.meta.url);
 const getUserPreferencesModule = require('volar-service-typescript/lib/configs/getUserPreferences');
 const { create } = require('volar-service-typescript');

--- a/packages/language-server/src/utils.js
+++ b/packages/language-server/src/utils.js
@@ -1,16 +1,15 @@
 /** @import { TextDocument } from 'vscode-languageserver-textdocument' */
 /** @import { LanguageServiceContext, Mapper, SourceScript } from '@volar/language-server' */
 /** @import {TSRXVirtualCodeInstance} from '@ripple-ts/typescript-plugin/src/language.js'; */
-// @ts-ignore: ESM type import is fine
 /** @import { isIdentifierObfuscated, deobfuscateIdentifier, IDENTIFIER_OBFUSCATION_PREFIX } from '@tsrx/core' */
 
-const { URI } = require('vscode-uri');
-const {
+import { URI } from 'vscode-uri';
+import {
 	createLogging,
 	getWordFromPosition,
 	charAllowedWordRegex,
 	DEBUG,
-} = require('@ripple-ts/typescript-plugin/src/utils.js');
+} from '@ripple-ts/typescript-plugin/src/utils.js';
 
 const IMPORT_EXPORT_REGEX = {
 	import: {
@@ -24,7 +23,7 @@ const IMPORT_EXPORT_REGEX = {
 	from: /from\s*['"][^'"]*['"]\s*;?/,
 };
 
-const RIPPLE_EXTENSIONS = ['.tsrx'];
+export const RIPPLE_EXTENSIONS = ['.tsrx'];
 
 /** @type {typeof isIdentifierObfuscated} */
 let is_identifier_obfuscated;
@@ -58,7 +57,7 @@ function escapeRegExp(source) {
  * @param {string} text
  * @returns {string}
  */
-function deobfuscateIdentifiers(text) {
+export function deobfuscateIdentifiers(text) {
 	return text.replace(obfuscated_identifier_regex, (match) => deobfuscate_identifier(match));
 }
 
@@ -66,7 +65,7 @@ function deobfuscateIdentifiers(text) {
  * @param  {...string} contents
  * @returns string
  */
-function concatMarkdownContents(...contents) {
+export function concatMarkdownContents(...contents) {
 	return contents.join('\n\n<br>\n\n---\n\n<br><br>\n\n');
 }
 
@@ -82,7 +81,7 @@ function concatMarkdownContents(...contents) {
 		sourceMap: Mapper | undefined;
 	}}
  */
-function getVirtualCode(document, context) {
+export function getVirtualCode(document, context) {
 	const uri = URI.parse(document.uri);
 	const decoded = /** @type {[documentUri: URI, embeddedCodeId: string]} */ (
 		context.decodeEmbeddedDocumentUri(uri)
@@ -139,7 +138,7 @@ function isInsideImportOrExport(type, text, start) {
  * @param {number} start
  * @returns {boolean}
  */
-function isInsideImport(text, start) {
+export function isInsideImport(text, start) {
 	return isInsideImportOrExport('import', text, start);
 }
 
@@ -148,7 +147,7 @@ function isInsideImport(text, start) {
  * @param {number} start
  * @returns {boolean}
  */
-function isInsideExport(text, start) {
+export function isInsideExport(text, start) {
 	return isInsideImportOrExport('export', text, start);
 }
 
@@ -156,19 +155,8 @@ function isInsideExport(text, start) {
  * @param {string} document_uri
  * @returns {boolean}
  */
-function is_ripple_document(document_uri) {
+export function is_ripple_document(document_uri) {
 	return RIPPLE_EXTENSIONS.some((extension) => document_uri.endsWith(extension));
 }
 
-module.exports = {
-	RIPPLE_EXTENSIONS,
-	getVirtualCode,
-	getWordFromPosition,
-	is_ripple_document,
-	isInsideImport,
-	isInsideExport,
-	createLogging,
-	concatMarkdownContents,
-	deobfuscateIdentifiers,
-	DEBUG,
-};
+export { createLogging, getWordFromPosition, DEBUG };

--- a/packages/language-server/tsconfig.json
+++ b/packages/language-server/tsconfig.json
@@ -2,15 +2,14 @@
   "compilerOptions": {
     "module": "esnext",
     "moduleResolution": "bundler",
-    "target": "es2022",
-    "lib": ["es2022"],
+    "target": "esnext",
+    "lib": ["esnext"],
     "allowJs": true,
     "checkJs": true,
     "noEmit": true,
     "strict": true,
     "esModuleInterop": true,
     "resolveJsonModule": true,
-    "skipLibCheck": true,
     "types": []
   },
   "include": ["src/**/*.js", "index.js", "bin/**/*.js"],

--- a/packages/language-server/tsconfig.json
+++ b/packages/language-server/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
-    "module": "node16",
-    "moduleResolution": "node16",
-    "target": "es2020",
-    "lib": ["es2020"],
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "es2022",
+    "lib": ["es2022"],
     "allowJs": true,
     "checkJs": true,
     "noEmit": true,

--- a/packages/language-server/tsconfig.typecheck.json
+++ b/packages/language-server/tsconfig.typecheck.json
@@ -1,9 +1,6 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "module": "esnext",
-    "moduleResolution": "bundler",
-    "lib": ["esnext", "dom", "dom.iterable"],
-    "target": "esnext"
+    "lib": ["es2022", "dom", "dom.iterable"]
   }
 }

--- a/packages/language-server/tsconfig.typecheck.json
+++ b/packages/language-server/tsconfig.typecheck.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "lib": ["es2022", "dom", "dom.iterable"]
+    "lib": ["esnext", "dom", "dom.iterable"],
+    "skipLibCheck": true
   }
 }

--- a/packages/language-server/tsdown.config.js
+++ b/packages/language-server/tsdown.config.js
@@ -8,7 +8,7 @@ const isDev = process.env.NODE_ENV !== 'production';
 
 export default defineConfig({
 	inlineOnly: false,
-	entry: ['src/index.js'],
+	entry: ['src/server.js', 'bin/language-server.js'],
 	format: ['cjs'],
 	outExtensions: () => ({ js: '.js' }),
 	platform: 'node',
@@ -17,9 +17,9 @@ export default defineConfig({
 	sourcemap: isDev,
 	outputOptions: {
 		legalComments: 'inline',
-		minify: true,
+		minify: false,
 	},
-	external: ['@tsrx/react', '@tsrx/ripple', '@tsrx/core', 'typescript'],
+	external: ['@tsrx/react', '@tsrx/ripple', '@tsrx/core', 'typescript', 'vscode-uri'],
 	clean: true,
 	noExternal: /.+/,
 	hooks: {

--- a/packages/language-server/tsdown.config.js
+++ b/packages/language-server/tsdown.config.js
@@ -3,7 +3,7 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const dirname = path.dirname(fileURLToPath(import.meta.url));
 const isDev = process.env.NODE_ENV !== 'production';
 
 export default defineConfig({
@@ -24,7 +24,7 @@ export default defineConfig({
 	noExternal: /.+/,
 	hooks: {
 		'build:done': () => {
-			fs.writeFileSync(path.join(__dirname, 'dist', 'package.json'), '{"type":"commonjs"}\n');
+			fs.writeFileSync(path.join(dirname, 'dist', 'package.json'), '{"type":"commonjs"}\n');
 		},
 	},
 });

--- a/packages/language-server/tsdown.config.js
+++ b/packages/language-server/tsdown.config.js
@@ -5,6 +5,17 @@ import { fileURLToPath } from 'url';
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 const isDev = process.env.NODE_ENV !== 'production';
+const ROOT_EXTERNAL_PACKAGES = [
+	'@tsrx/react',
+	'@tsrx/ripple',
+	'@tsrx/core',
+	'typescript',
+	'vscode-uri',
+	// need this for monkey patching
+	'volar-service-typescript',
+	/* also definitely need it for monkey patching */
+	/^volar-service-typescript(?:\/.*)?$/,
+];
 
 export default defineConfig({
 	inlineOnly: false,
@@ -19,7 +30,7 @@ export default defineConfig({
 		legalComments: 'inline',
 		minify: false,
 	},
-	external: ['@tsrx/react', '@tsrx/ripple', '@tsrx/core', 'typescript', 'vscode-uri'],
+	external: [...ROOT_EXTERNAL_PACKAGES],
 	clean: true,
 	noExternal: /.+/,
 	hooks: {

--- a/packages/sublime-text-plugin/src/language-server/package-lock.json
+++ b/packages/sublime-text-plugin/src/language-server/package-lock.json
@@ -15,7 +15,8 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@ripple-ts/language-server": {
       "version": "0.2.208",
@@ -56,6 +57,7 @@
       "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.9.tgz",
       "integrity": "sha512-lVJX6qEgs/4DOcRTpo56tmKzVPtoWAaVbL4hfO7t7NVwl9AAXzQR6cihesW1BmNMPl+bK6dreu2sOKBP2Q9CIA==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "acorn": "^8.9.0"
       }
@@ -64,7 +66,8 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@volar/language-core": {
       "version": "2.4.28",
@@ -145,6 +148,7 @@
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
       "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -153,19 +157,22 @@
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.2.tgz",
       "integrity": "sha512-nPRkjWzzDQlsejL1WVifk5rvcFi/y1onBRxjaFMjZeR9mFpqu2gmAZ9xUB9/IEanEP/vBtGeGganC/GO1fmufg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/esm-env": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
       "integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/esrap": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.3.tgz",
       "integrity": "sha512-8fOS+GIGCQZl/ZIlhl59htOlms6U8NvX6ZYgYHpRU/b6tVSh3uHkOHZikl3D4cMbYM0JlpBe+p/BkZEi8J9XIQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15"
       }
@@ -175,6 +182,7 @@
       "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
       "integrity": "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "^1.0.6"
       }
@@ -184,6 +192,7 @@
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
@@ -192,7 +201,8 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz",
       "integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/path-browserify": {
       "version": "1.0.1",
@@ -376,7 +386,8 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.4.tgz",
       "integrity": "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     }
   }
 }

--- a/packages/sublime-text-plugin/src/language-server/package-lock.json
+++ b/packages/sublime-text-plugin/src/language-server/package-lock.json
@@ -15,8 +15,7 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@ripple-ts/language-server": {
       "version": "0.2.208",
@@ -57,7 +56,6 @@
       "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.9.tgz",
       "integrity": "sha512-lVJX6qEgs/4DOcRTpo56tmKzVPtoWAaVbL4hfO7t7NVwl9AAXzQR6cihesW1BmNMPl+bK6dreu2sOKBP2Q9CIA==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "acorn": "^8.9.0"
       }
@@ -66,8 +64,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@volar/language-core": {
       "version": "2.4.28",
@@ -148,7 +145,6 @@
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
       "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -157,22 +153,19 @@
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.2.tgz",
       "integrity": "sha512-nPRkjWzzDQlsejL1WVifk5rvcFi/y1onBRxjaFMjZeR9mFpqu2gmAZ9xUB9/IEanEP/vBtGeGganC/GO1fmufg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/esm-env": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
       "integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/esrap": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.3.tgz",
       "integrity": "sha512-8fOS+GIGCQZl/ZIlhl59htOlms6U8NvX6ZYgYHpRU/b6tVSh3uHkOHZikl3D4cMbYM0JlpBe+p/BkZEi8J9XIQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15"
       }
@@ -182,7 +175,6 @@
       "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
       "integrity": "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "^1.0.6"
       }
@@ -192,7 +184,6 @@
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
@@ -201,8 +192,7 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz",
       "integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/path-browserify": {
       "version": "1.0.1",
@@ -386,8 +376,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.4.tgz",
       "integrity": "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     }
   }
 }

--- a/packages/typescript-plugin/package.json
+++ b/packages/typescript-plugin/package.json
@@ -4,7 +4,8 @@
   "license": "MIT",
   "author": "Dominic Gannaway",
   "version": "0.3.18",
-  "main": "src/index.js",
+  "main": "dist/index.js",
+  "type": "module",
   "homepage": "https://ripple-ts.com",
   "repository": {
     "type": "git",
@@ -12,9 +13,7 @@
     "directory": "packages/typescript-plugin"
   },
   "scripts": {
-    "build": "tsdown",
-    "dist": "perl -pi -e 's/\"main\": \"src\\/index.js\"/\"main\": \"dist\\/index.js\"/' package.json",
-    "src": "perl -pi -e 's/\"main\": \"dist\\/index.js\"/\"main\": \"src\\/index.js\"/' package.json"
+    "build": "tsdown"
   },
   "bugs": {
     "url": "https://github.com/Ripple-TS/ripple/issues"

--- a/packages/typescript-plugin/src/index.js
+++ b/packages/typescript-plugin/src/index.js
@@ -1,12 +1,10 @@
-const {
-	createLanguageServicePlugin,
-} = require('@volar/typescript/lib/quickstart/createLanguageServicePlugin.js');
-const { getRippleLanguagePlugin } = require('./language.js');
+import { createLanguageServicePlugin } from '@volar/typescript/lib/quickstart/createLanguageServicePlugin.js';
+import { getRippleLanguagePlugin } from './language.js';
 
 // This TypeScript plugin is loaded by TypeScript's tsserver when configured in tsconfig.json.
 // Note: When using the Ripple VS Code extension, the language server handles everything,
 // so this plugin is redundant but harmless (both instances work independently).
 // This plugin is useful for non-VS Code editors or when not using the language server.
-module.exports = createLanguageServicePlugin(() => ({
+export default createLanguageServicePlugin(() => ({
 	languagePlugins: [getRippleLanguagePlugin()],
 }));

--- a/packages/typescript-plugin/src/language.js
+++ b/packages/typescript-plugin/src/language.js
@@ -1,6 +1,4 @@
-// @ts-ignore: JSDoc @import is type-only, no runtime require() is generated
 /** @import { CodeMapping } from '@tsrx/ripple' */
-// @ts-ignore: JSDoc @import is type-only, no runtime require() is generated
 /** @import {TSRXCompileError, VolarMappingsResult} from '@tsrx/ripple' */
 
 /** @typedef {{ compile_to_volar_mappings(source: string, filename: string, options?: { loose?: boolean }): VolarMappingsResult }} TSRXCompilerModule */
@@ -16,17 +14,20 @@
 
 /** @typedef {InstanceType<typeof import('./language.js')["TSRXVirtualCode"]>} TSRXVirtualCodeInstance */
 
-const ts = require('typescript');
-const { forEachEmbeddedCode } = require('@volar/language-core');
-const fs = require('fs');
-const path = require('path');
-const { createLogging, DEBUG } = require('./utils.js');
+import ts from 'typescript';
+import { forEachEmbeddedCode } from '@volar/language-core';
+import fs from 'fs';
+import path from 'path';
+import { createRequire } from 'module';
+import { createLogging, DEBUG } from './utils.js';
+
+const require = createRequire(import.meta.url);
 
 const { log, logWarning, logError } = createLogging('[Ripple Language]');
-const RIPPLE_EXTENSIONS = ['.tsrx'];
+export const RIPPLE_EXTENSIONS = ['.tsrx'];
 /** @typedef {[string, string[], string[], string[]]} CompilerCandidate */
 /** @type {CompilerCandidate[]} */
-const COMPILER_CANDIDATES = [
+export const COMPILER_CANDIDATES = [
 	[
 		'@tsrx/ripple',
 		['node_modules', '@tsrx', 'ripple'],
@@ -45,14 +46,14 @@ const COMPILER_CANDIDATES = [
  * @param {string} file_name
  * @returns {boolean}
  */
-function is_ripple_file(file_name) {
+export function is_ripple_file(file_name) {
 	return RIPPLE_EXTENSIONS.some((extension) => file_name.endsWith(extension));
 }
 
 /**
  * @returns {RippleLanguagePlugin}
  */
-function getRippleLanguagePlugin() {
+export function getRippleLanguagePlugin() {
 	log('Creating Ripple language plugin...');
 
 	return {
@@ -121,7 +122,7 @@ function getRippleLanguagePlugin() {
 /**
  * @implements {VirtualCode}
  */
-class TSRXVirtualCode {
+export class TSRXVirtualCode {
 	/** @type {string} */
 	id = 'root';
 	/** @type {string} */
@@ -551,7 +552,7 @@ function restore_typed_dot_in_transpiled_code(transpiled, dotPosition) {
  * @param {{ options?: CompilerOptions } & T} config
  * @returns {{ options: CompilerOptions } & T}
  */
-const resolveConfig = (config) => {
+export const resolveConfig = (config) => {
 	const baseOptions = config.options ?? /** @type {CompilerOptions} */ ({});
 	/** @type {CompilerOptions} */
 	const options = { ...baseOptions };
@@ -603,7 +604,7 @@ const resolveConfig = (config) => {
 };
 
 /** @type {Map<string, string | null>} */
-const path2RipplePathMap = new Map();
+export const path2RipplePathMap = new Map();
 /** @type {Map<string, string>} */
 const pathToTypesCache = new Map();
 /** @type {Map<string, RegExpMatchArray>} */
@@ -615,7 +616,7 @@ const pathToPackageManifestCache = new Map();
  * @param {ScriptId} fileNameOrUri
  * @returns {string}
  */
-function normalizeFileNameOrUri(fileNameOrUri) {
+export function normalizeFileNameOrUri(fileNameOrUri) {
 	return typeof fileNameOrUri === 'string'
 		? fileNameOrUri
 		: fileNameOrUri.fsPath.replace(/\\/g, '/');
@@ -722,7 +723,7 @@ function package_manifest_matches_compiler(package_manifest, compiler_name, pack
 function get_tsrx_compiler(normalized_file_name) {
 	const compiler_path = get_compiler_entry_for_file(normalized_file_name);
 	if (compiler_path) {
-		return /** @type {TSRXCompilerModule} */ (require(compiler_path));
+		return require(compiler_path);
 	}
 }
 
@@ -732,7 +733,7 @@ function get_tsrx_compiler(normalized_file_name) {
  * @param {Map<string, string | null>} [compiler_path_map]
  * @returns {string | undefined}
  */
-function find_workspace_compiler_entry_for_file(
+export function find_workspace_compiler_entry_for_file(
 	normalized_file_name,
 	exists_sync = fs.existsSync,
 	compiler_path_map = path2RipplePathMap,
@@ -786,7 +787,7 @@ function find_workspace_compiler_entry_for_file(
  * @param {string} normalized_file_name
  * @returns {string | undefined}
  */
-function get_compiler_entry_for_file(normalized_file_name) {
+export function get_compiler_entry_for_file(normalized_file_name) {
 	const ext = path.extname(normalized_file_name);
 	const package_manifest = get_nearest_package_manifest(path.dirname(normalized_file_name));
 
@@ -842,7 +843,7 @@ function get_compiler_entry_for_file(normalized_file_name) {
  * @param {string} typesFilePath
  * @returns {string | undefined}
  */
-function getCachedTypeDefinitionFile(typesFilePath) {
+export function getCachedTypeDefinitionFile(typesFilePath) {
 	const cached = pathToTypesCache.get(typesFilePath);
 	if (cached) {
 		return cached;
@@ -872,7 +873,7 @@ function getCachedTypeDefinitionFile(typesFilePath) {
  * @param {string} text
  * @returns {RegExpMatchArray | undefined}
  */
-function getCachedTypeMatches(typeName, text) {
+export function getCachedTypeMatches(typeName, text) {
 	const cached = typeNameMatchCache.get(typeName);
 	if (cached) {
 		return cached;
@@ -896,7 +897,7 @@ function getCachedTypeMatches(typeName, text) {
  * @param {string} normalized_file_name
  * @returns {string | undefined}
  */
-function get_compiler_dir_for_file(normalized_file_name) {
+export function get_compiler_dir_for_file(normalized_file_name) {
 	const entry = get_compiler_entry_for_file(normalized_file_name);
 	if (entry) {
 		// Walk up from .../src/index.js to the package root
@@ -904,24 +905,10 @@ function get_compiler_dir_for_file(normalized_file_name) {
 	}
 }
 
-module.exports = {
-	getRippleDirForFile: get_compiler_dir_for_file,
-	normalizeFileNameOrUri,
-	getRippleLanguagePlugin,
-	getCachedTypeDefinitionFile,
-	getCachedTypeMatches,
-	TSRXVirtualCode,
-	resolveConfig,
-	// Exported for testing
-	is_ripple_file,
-	find_workspace_compiler_entry_for_file,
-	get_compiler_entry_for_file,
-	COMPILER_CANDIDATES,
-	RIPPLE_EXTENSIONS,
-	path2RipplePathMap,
-	/** Reset module-level state used in tests. */
-	_reset_for_test() {
-		path2RipplePathMap.clear();
-		pathToPackageManifestCache.clear();
-	},
-};
+export { get_compiler_dir_for_file as getRippleDirForFile };
+
+/** Reset module-level state used in tests. */
+export function _reset_for_test() {
+	path2RipplePathMap.clear();
+	pathToPackageManifestCache.clear();
+}

--- a/packages/typescript-plugin/src/language.js
+++ b/packages/typescript-plugin/src/language.js
@@ -19,9 +19,11 @@ import { forEachEmbeddedCode } from '@volar/language-core';
 import fs from 'fs';
 import path from 'path';
 import { createRequire } from 'module';
+import { fileURLToPath } from 'url';
 import { createLogging, DEBUG } from './utils.js';
 
 const require = createRequire(import.meta.url);
+const root_dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const { log, logWarning, logError } = createLogging('[Ripple Language]');
 export const RIPPLE_EXTENSIONS = ['.tsrx'];
@@ -799,7 +801,7 @@ export function get_compiler_entry_for_file(normalized_file_name) {
 	const warn_message = `No supported tsrx compiler found in workspace for ${normalized_file_name}.`;
 
 	// Fallback: look for a packaged compiler.
-	let current_dir = __dirname;
+	let current_dir = root_dirname;
 
 	while (current_dir) {
 		/** @type {Array<[string, string, string[]]>} */

--- a/packages/typescript-plugin/src/utils.js
+++ b/packages/typescript-plugin/src/utils.js
@@ -1,6 +1,6 @@
-const DEBUG = process.env.RIPPLE_DEBUG === 'true';
+export const DEBUG = process.env.RIPPLE_DEBUG === 'true';
 // Matches valid JS/CSS identifier characters: word chars, dashes (CSS), $, and # (Ripple shorthands)
-const charAllowedWordRegex = /[\w\-$#]/;
+export const charAllowedWordRegex = /[\w\-$#]/;
 
 /**
  * Create a logging utility with a specific label
@@ -11,7 +11,7 @@ const charAllowedWordRegex = /[\w\-$#]/;
  * 	logWarning: (...args: unknown[]) => void,
  * }}
  */
-function createLogging(label) {
+export function createLogging(label) {
 	return {
 		log(...args) {
 			if (DEBUG) {
@@ -37,7 +37,7 @@ function createLogging(label) {
  * @param {number} start
  * @returns {{word: string, start: number, end: number}}
  */
-function getWordFromPosition(text, start) {
+export function getWordFromPosition(text, start) {
 	let wordStart = start;
 	let wordEnd = start;
 	while (wordStart > 0 && charAllowedWordRegex.test(text[wordStart - 1])) {
@@ -55,10 +55,3 @@ function getWordFromPosition(text, start) {
 		end: wordEnd,
 	};
 }
-
-module.exports = {
-	createLogging,
-	getWordFromPosition,
-	charAllowedWordRegex,
-	DEBUG,
-};

--- a/packages/typescript-plugin/tsconfig.json
+++ b/packages/typescript-plugin/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
-    "module": "node20",
-    "moduleResolution": "node16",
-    "target": "es2021",
-    "lib": ["es2021"],
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "es2022",
+    "lib": ["es2022"],
     "allowJs": true,
     "checkJs": true,
     "noEmit": true,

--- a/packages/typescript-plugin/tsconfig.json
+++ b/packages/typescript-plugin/tsconfig.json
@@ -2,8 +2,8 @@
   "compilerOptions": {
     "module": "esnext",
     "moduleResolution": "bundler",
-    "target": "es2022",
-    "lib": ["es2022"],
+    "target": "esnext",
+    "lib": ["esnext"],
     "allowJs": true,
     "checkJs": true,
     "noEmit": true,

--- a/packages/typescript-plugin/tsdown.config.js
+++ b/packages/typescript-plugin/tsdown.config.js
@@ -3,7 +3,7 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const dirname = path.dirname(fileURLToPath(import.meta.url));
 const isDev = process.env.NODE_ENV !== 'production';
 
 export default defineConfig({
@@ -24,7 +24,7 @@ export default defineConfig({
 	noExternal: /.+/,
 	hooks: {
 		'build:done': () => {
-			fs.writeFileSync(path.join(__dirname, 'dist', 'package.json'), '{"type":"commonjs"}\n');
+			fs.writeFileSync(path.join(dirname, 'dist', 'package.json'), '{"type":"commonjs"}\n');
 		},
 	},
 });

--- a/packages/vscode-plugin/package.json
+++ b/packages/vscode-plugin/package.json
@@ -17,7 +17,8 @@
   "categories": [
     "Programming Languages"
   ],
-  "main": "src/extension.js",
+  "main": "dist/extension.js",
+  "type": "module",
   "icon": "icons/logo.png",
   "repository": {
     "type": "git",
@@ -26,11 +27,11 @@
   },
   "scripts": {
     "build": "tsdown",
-    "dist": "node ../../scripts/transform-package.js packages/vscode-plugin/package.json main dist/extension.js && node ../../scripts/transform-package.js packages/vscode-plugin/package.json name ripple-ts-vscode-plugin",
-    "src": "node ../../scripts/transform-package.js packages/vscode-plugin/package.json main src/extension.js && node ../../scripts/transform-package.js packages/vscode-plugin/package.json name @ripple-ts/vscode-plugin",
     "repack-vsix": "node scripts/repack-vsix.js",
     "delete-unpacked": "node ../../scripts/remove.js packages/vscode-plugin/vscode-plugin",
-    "package": "pnpm delete-unpacked && pnpm dist && node ../../scripts/regenerate-textmate && vsce package --no-dependencies --out=vscode-plugin.vsix && pnpm src && pnpm repack-vsix || pnpm src",
+    "pkg-name-release": "node ../../scripts/transform-package.js packages/vscode-plugin/package.json name ripple-ts-vscode-plugin",
+    "pkg-name-back": "node ../../scripts/transform-package.js packages/vscode-plugin/package.json name @ripple-ts/vscode-plugin",
+    "package": "pnpm delete-unpacked && pnpm pkg-name-release && node ../../scripts/regenerate-textmate && NODE_ENV=production tsdown && vsce package --no-dependencies --out=vscode-plugin.vsix && pnpm pkg-name-back && pnpm repack-vsix || pnpm pkg-name-back",
     "install-package": "code --install-extension vscode-plugin.vsix",
     "build-and-package": "pnpm build && pnpm package",
     "build-package-and-install": "pnpm build && pnpm package && pnpm install-package",
@@ -50,12 +51,14 @@
   "peerDependencies": {
     "typescript": "catalog:vscode",
     "@tsrx/react": "workspace:*",
-    "@tsrx/ripple": "workspace:*"
+    "@tsrx/ripple": "workspace:*",
+    "@types/vscode": "catalog:default"
   },
   "devDependencies": {
     "tsdown": "catalog:default",
     "@vscode/vsce": "catalog:default",
-    "adm-zip": "catalog:default"
+    "adm-zip": "catalog:default",
+    "@types/adm-zip": "catalog:default"
   },
   "contributes": {
     "breakpoints": [

--- a/packages/vscode-plugin/package.json
+++ b/packages/vscode-plugin/package.json
@@ -31,7 +31,7 @@
     "delete-unpacked": "node ../../scripts/remove.js packages/vscode-plugin/vscode-plugin",
     "pkg-name-release": "node ../../scripts/transform-package.js packages/vscode-plugin/package.json name ripple-ts-vscode-plugin",
     "pkg-name-back": "node ../../scripts/transform-package.js packages/vscode-plugin/package.json name @ripple-ts/vscode-plugin",
-    "package": "pnpm delete-unpacked && pnpm pkg-name-release && node ../../scripts/regenerate-textmate && NODE_ENV=production tsdown && vsce package --no-dependencies --out=vscode-plugin.vsix && pnpm pkg-name-back && pnpm repack-vsix || pnpm pkg-name-back",
+    "package": "pnpm delete-unpacked && pnpm pkg-name-release && node ../../scripts/regenerate-textmate && vsce package --no-dependencies --out=vscode-plugin.vsix && pnpm pkg-name-back && pnpm repack-vsix || pnpm pkg-name-back",
     "install-package": "code --install-extension vscode-plugin.vsix",
     "build-and-package": "pnpm build && pnpm package",
     "build-package-and-install": "pnpm build && pnpm package && pnpm install-package",

--- a/packages/vscode-plugin/scripts/repack-vsix.js
+++ b/packages/vscode-plugin/scripts/repack-vsix.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
-const fs = require('fs');
-const path = require('path');
-const AdmZip = require('adm-zip');
+import fs from 'fs';
+import path from 'path';
+import AdmZip from 'adm-zip';
 
 /**
  * @param {string} message

--- a/packages/vscode-plugin/src/extension.js
+++ b/packages/vscode-plugin/src/extension.js
@@ -47,13 +47,12 @@
  * - Result: The TypeScript command appears in the context menu for Ripple files
  */
 
-const vscode = require('vscode');
-const path = require('path');
-const fs = require('fs');
-const protocol = require('@volar/language-server/protocol');
-/** @type {typeof import('vscode-languageclient/node')} */
-const lsp = require('vscode-languageclient/node');
-const { activateAutoInsertion, createLabsInfo } = require('@volar/vscode');
+import vscode from 'vscode';
+import path from 'node:path';
+import fs from 'node:fs';
+import protocol from '@volar/language-server/protocol';
+import * as lsp from 'vscode-languageclient/node';
+import { activateAutoInsertion, createLabsInfo } from '@volar/vscode';
 const RIPPLE_FILE_SELECTORS = ['**/*.tsrx'];
 const RIPPLE_FILE_EXCLUDE_GLOB = '**/{node_modules,dist,build,.git}/**';
 const TSGO_CONFIGURATION_SECTIONS = ['js/ts', 'typescript'];
@@ -75,7 +74,7 @@ let client;
 /**
  * @param {import('vscode').ExtensionContext} context
  */
-async function activate(context) {
+export async function activate(context) {
 	console.log('Ripple extension starting...');
 
 	await warn_about_local_tsgo_usage(context);
@@ -546,7 +545,7 @@ function registerFormatter() {
 	);
 }
 
-async function deactivate() {
+export async function deactivate() {
 	console.log('Deactivating Ripple extension...');
 	if (client) {
 		try {
@@ -608,11 +607,8 @@ async function patchTypeScriptExtension() {
 		return { success: false, reason: 'alreadyActive' };
 	}
 
-	const fs = require('node:fs');
 	const originalReadFileSync = fs.readFileSync;
-	const extensionJsPath = require.resolve('./dist/extension.js', {
-		paths: [tsExtension.extensionPath],
-	});
+	const extensionJsPath = path.join(tsExtension.extensionPath, 'dist', 'extension.js');
 
 	/**
 	 * @param {import('node:fs').PathOrFileDescriptor} path
@@ -664,8 +660,3 @@ async function patchTypeScriptExtension() {
 
 	return { success: true, reason: 'patched' };
 }
-
-module.exports = {
-	activate,
-	deactivate,
-};

--- a/packages/vscode-plugin/src/server.js
+++ b/packages/vscode-plugin/src/server.js
@@ -1,4 +1,4 @@
-const { createRippleLanguageServer } = require('@ripple-ts/language-server/src/server.js');
+import { createRippleLanguageServer } from '@ripple-ts/language-server/src/server.js';
 
 try {
 	createRippleLanguageServer();

--- a/packages/vscode-plugin/tsconfig.json
+++ b/packages/vscode-plugin/tsconfig.json
@@ -1,7 +1,12 @@
 {
   "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "es2022",
     "allowJs": true,
-    "noEmit": true
+    "checkJs": true,
+    "noEmit": true,
+    "esModuleInterop": true
   },
   "include": ["./src/**/*", "./tests/**/*", "./scripts/**/*"],
   "exclude": ["dist", "node_modules"]

--- a/packages/vscode-plugin/tsconfig.json
+++ b/packages/vscode-plugin/tsconfig.json
@@ -2,7 +2,8 @@
   "compilerOptions": {
     "module": "esnext",
     "moduleResolution": "bundler",
-    "target": "es2022",
+    "lib": ["esnext"],
+    "target": "esnext",
     "allowJs": true,
     "checkJs": true,
     "noEmit": true,

--- a/packages/vscode-plugin/tsconfig.typecheck.json
+++ b/packages/vscode-plugin/tsconfig.typecheck.json
@@ -1,8 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "lib": ["esnext", "dom", "dom.iterable"],
     "skipLibCheck": true
-  },
-  "include": ["./src/**/*", "./scripts/**/*"],
-  "exclude": ["dist", "node_modules"]
+  }
 }

--- a/packages/vscode-plugin/tsdown.config.js
+++ b/packages/vscode-plugin/tsdown.config.js
@@ -16,6 +16,12 @@ const ROOT_EXTERNAL_PACKAGES = [
 	'volar-service-css',
 	'vscode-uri',
 	'@ripple-ts/typescript-plugin',
+	// this definitely has to be external as we monkey patch it at runtime
+	'volar-service-typescript',
+];
+const REGEX_EXTERNAL_PACKAGES = [
+	// also definitely need it for monkey patching
+	/^volar-service-typescript(?:\/.*)?$/,
 ];
 // Always external (bundled by VS Code or handled separately)
 const ALWAYS_EXTERNAL = ['vscode', '@ripple-ts/typescript-plugin'];
@@ -23,7 +29,7 @@ const OUT_DIR = 'dist';
 
 // Compute all external packages by collecting dependency trees
 const computed = getAllExternalPackages(ROOT_EXTERNAL_PACKAGES);
-const allExternalPackages = [...ALWAYS_EXTERNAL, ...computed];
+const allExternalPackages = [...ALWAYS_EXTERNAL, ...computed, ...REGEX_EXTERNAL_PACKAGES];
 
 console.log(`ℹ️  Found ${computed.length} packages to mark as external`);
 
@@ -43,7 +49,7 @@ export default defineConfig({
 	outExtensions: () => ({ js: '.js' }),
 	platform: 'node',
 	target: 'node20',
-	external: allExternalPackages,
+	external: [...allExternalPackages],
 	noExternal: /.+/,
 	hooks: {
 		'build:done': () => {

--- a/packages/vscode-plugin/tsdown.config.js
+++ b/packages/vscode-plugin/tsdown.config.js
@@ -5,7 +5,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import { getAllExternalPackages } from '../../scripts/collect-external-deps.js';
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // Root packages to treat as external (their full dependency trees will be copied)
 const ROOT_EXTERNAL_PACKAGES = [
@@ -48,10 +48,10 @@ export default defineConfig({
 	hooks: {
 		'build:done': () => {
 			// Write a CJS package.json so Node.js treats dist/*.js as CommonJS
-			fs.writeFileSync(path.join(__dirname, OUT_DIR, 'package.json'), '{"type":"commonjs"}\n');
+			fs.writeFileSync(path.join(dirname, OUT_DIR, 'package.json'), '{"type":"commonjs"}\n');
 
-			const scriptPath = path.join(__dirname, '../../scripts/copy-external-deps.js');
-			const distPath = path.join(__dirname, OUT_DIR);
+			const scriptPath = path.join(dirname, '../../scripts/copy-external-deps.js');
+			const distPath = path.join(dirname, OUT_DIR);
 
 			execSync(`node "${scriptPath}" "${distPath}" ${ROOT_EXTERNAL_PACKAGES.join(' ')}`, {
 				stdio: 'inherit',
@@ -59,7 +59,7 @@ export default defineConfig({
 
 			// Remove nested dist folder from typescript-plugin
 			const nestedDistPath = path.join(
-				__dirname,
+				dirname,
 				OUT_DIR,
 				'node_modules',
 				'@ripple-ts',

--- a/packages/vscode-plugin/tsdown.config.js
+++ b/packages/vscode-plugin/tsdown.config.js
@@ -57,16 +57,19 @@ export default defineConfig({
 				stdio: 'inherit',
 			});
 
-			// Remove nested dist folder from typescript-plugin
-			const nestedDistPath = path.join(
+			// Remove unnecessary files from typescript-plugin (only dist/ and package.json needed)
+			const tsPluginPath = path.join(
 				dirname,
 				OUT_DIR,
 				'node_modules',
 				'@ripple-ts',
 				'typescript-plugin',
-				'dist',
 			);
-			execSync(`rm -rf "${nestedDistPath}"`, { stdio: 'inherit' });
+			for (const entry of fs.readdirSync(tsPluginPath)) {
+				if (entry !== 'dist' && entry !== 'package.json') {
+					execSync(`rm -rf "${path.join(tsPluginPath, entry)}"`, { stdio: 'inherit' });
+				}
+			}
 		},
 	},
 });

--- a/packages/vscode-plugin/tsdown.config.js
+++ b/packages/vscode-plugin/tsdown.config.js
@@ -1,5 +1,6 @@
 import { defineConfig } from 'tsdown';
 import { execSync } from 'child_process';
+import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { getAllExternalPackages } from '../../scripts/collect-external-deps.js';
@@ -26,23 +27,29 @@ const allExternalPackages = [...ALWAYS_EXTERNAL, ...computed];
 
 console.log(`ℹ️  Found ${computed.length} packages to mark as external`);
 
+const isDev = process.env.NODE_ENV !== 'production';
+
 export default defineConfig({
 	inlineOnly: false,
 	entry: ['src/extension.js', 'src/server.js'],
 	outDir: OUT_DIR,
+	sourcemap: isDev,
 	outputOptions: {
 		legalComments: 'inline',
 		minify: false,
 	},
 	clean: true,
 	format: ['cjs'],
-	fixedExtension: false,
+	outExtensions: () => ({ js: '.js' }),
 	platform: 'node',
 	target: 'node20',
 	external: allExternalPackages,
 	noExternal: /.+/,
 	hooks: {
 		'build:done': () => {
+			// Write a CJS package.json so Node.js treats dist/*.js as CommonJS
+			fs.writeFileSync(path.join(__dirname, OUT_DIR, 'package.json'), '{"type":"commonjs"}\n');
+
 			const scriptPath = path.join(__dirname, '../../scripts/copy-external-deps.js');
 			const distPath = path.join(__dirname, OUT_DIR);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ catalogs:
     '@tailwindcss/vite':
       specifier: ^4.1.12
       version: 4.2.1
+    '@types/adm-zip':
+      specifier: ^0.5.8
+      version: 0.5.8
     '@types/bun':
       specifier: ^1.3.9
       version: 1.3.10
@@ -48,6 +51,9 @@ catalogs:
     '@types/react-dom':
       specifier: ^19.2.2
       version: 19.2.3
+    '@types/vscode':
+      specifier: ^1.116.0
+      version: 1.116.0
     '@typescript-eslint/parser':
       specifier: ^8.56.1
       version: 8.56.1
@@ -70,14 +76,14 @@ catalogs:
       specifier: ~2.4.28
       version: 2.4.28
     '@vscode/vsce':
-      specifier: ^3.6.2
-      version: 3.7.1
+      specifier: ^3.9.1
+      version: 3.9.1
     acorn:
       specifier: ^8.15.0
       version: 8.16.0
     adm-zip:
-      specifier: ^0.5.16
-      version: 0.5.16
+      specifier: ^0.5.17
+      version: 0.5.17
     clsx:
       specifier: ^2.1.1
       version: 2.1.1
@@ -501,6 +507,9 @@ importers:
       '@tsrx/ripple':
         specifier: workspace:*
         version: link:../tsrx-ripple
+      tsdown:
+        specifier: catalog:default
+        version: 0.20.3(@typescript/native-preview@7.0.0-dev.20260418.1)(typescript@5.9.3)
 
   packages/nvim-plugin: {}
 
@@ -797,6 +806,9 @@ importers:
       '@tsrx/ripple':
         specifier: workspace:*
         version: link:../tsrx-ripple
+      '@types/vscode':
+        specifier: catalog:default
+        version: 1.116.0
       '@volar/language-core':
         specifier: catalog:default
         version: 2.4.28
@@ -822,12 +834,15 @@ importers:
         specifier: catalog:default
         version: 3.1.0
     devDependencies:
+      '@types/adm-zip':
+        specifier: catalog:default
+        version: 0.5.8
       '@vscode/vsce':
         specifier: catalog:default
-        version: 3.7.1
+        version: 3.9.1
       adm-zip:
         specifier: catalog:default
-        version: 0.5.16
+        version: 0.5.17
       tsdown:
         specifier: catalog:default
         version: 0.20.3(@typescript/native-preview@7.0.0-dev.20260418.1)(typescript@5.9.3)
@@ -2294,6 +2309,9 @@ packages:
   '@types/adm-zip@0.5.7':
     resolution: {integrity: sha512-DNEs/QvmyRLurdQPChqq0Md4zGvPwHerAJYWk9l2jCbD1VPpnzRJorOdiq4zsw09NFbYnhfsoEhWtxIzXpn2yw==}
 
+  '@types/adm-zip@0.5.8':
+    resolution: {integrity: sha512-RVVH7QvZYbN+ihqZ4kX/dMiowf6o+Jk1fNwiSdx0NahBJLU787zkULhGhJM8mf/obmLGmgdMM0bXsQTmyfbR7Q==}
+
   '@types/bun@1.3.10':
     resolution: {integrity: sha512-0+rlrUrOrTSskibryHbvQkDOWRJwJZqZlxrUs1u4oOoTln8+WIXBPmAuCF35SWB2z4Zl3E84Nl/D0P7803nigQ==}
 
@@ -2367,6 +2385,9 @@ packages:
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@types/vscode@1.116.0':
+    resolution: {integrity: sha512-sYHp4MO6BqJ2PD7Hjt0hlIS3tMaYsVPJrd0RUjDJ8HtOYnyJIEej0bLSccM8rE77WrC+Xox/kdBwEFDO8MsxNA==}
 
   '@types/web-bluetooth@0.0.21':
     resolution: {integrity: sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==}
@@ -2569,8 +2590,8 @@ packages:
   '@vscode/vsce-sign@2.0.9':
     resolution: {integrity: sha512-8IvaRvtFyzUnGGl3f5+1Cnor3LqaUWvhaUjAYO8Y39OUYlOf3cRd+dowuQYLpZcP3uwSG+mURwjEBOSq4SOJ0g==}
 
-  '@vscode/vsce@3.7.1':
-    resolution: {integrity: sha512-OTm2XdMt2YkpSn2Nx7z2EJtSuhRHsTPYsSK59hr3v8jRArK+2UEoju4Jumn1CmpgoBLGI6ReHLJ/czYltNUW3g==}
+  '@vscode/vsce@3.9.1':
+    resolution: {integrity: sha512-MPn5p+DoudI+3GfJSpAZZraE1lgLv0LcwbH3+xy7RgEhty3UIkmUMUA+5jPTDaxXae00AnX5u77FxGM8FhfKKA==}
     engines: {node: '>= 20'}
     hasBin: true
 
@@ -2700,6 +2721,10 @@ packages:
 
   adm-zip@0.5.16:
     resolution: {integrity: sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==}
+    engines: {node: '>=12.0'}
+
+  adm-zip@0.5.17:
+    resolution: {integrity: sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==}
     engines: {node: '>=12.0'}
 
   agent-base@7.1.4:
@@ -3407,9 +3432,6 @@ packages:
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
-
-  fd-slicer@1.1.0:
-    resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -4126,9 +4148,6 @@ packages:
 
   lodash.truncate@4.4.2:
     resolution: {integrity: sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==}
-
-  lodash@4.17.23:
-    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
 
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
@@ -5248,10 +5267,6 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
-  undici@7.22.0:
-    resolution: {integrity: sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==}
-    engines: {node: '>=20.18.1'}
-
   undici@7.25.0:
     resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
     engines: {node: '>=20.18.1'}
@@ -5690,8 +5705,9 @@ packages:
     resolution: {integrity: sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=23}
 
-  yauzl@2.10.0:
-    resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
+  yauzl@3.3.0:
+    resolution: {integrity: sha512-PtGEvEP30p7sbIBJKUBjUnqgTVOyMURc4dLo9iNyAJnNIEz9pm88cCXF21w94Kg3k6RXkeZh5DHOGS0qEONvNQ==}
+    engines: {node: '>=12'}
 
   yazl@2.5.1:
     resolution: {integrity: sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==}
@@ -6366,7 +6382,7 @@ snapshots:
       agent-base: 7.1.4
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
-      lru-cache: 11.2.6
+      lru-cache: 11.3.5
       socks-proxy-agent: 8.0.5
     transitivePeerDependencies:
       - supports-color
@@ -6950,7 +6966,7 @@ snapshots:
       chalk: 4.1.2
       debug: 4.4.3
       js-yaml: 4.1.1
-      lodash: 4.17.23
+      lodash: 4.18.1
       pluralize: 2.0.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
@@ -6984,6 +7000,10 @@ snapshots:
     optional: true
 
   '@types/adm-zip@0.5.7':
+    dependencies:
+      '@types/node': 25.3.3
+
+  '@types/adm-zip@0.5.8':
     dependencies:
       '@types/node': 25.3.3
 
@@ -7062,6 +7082,8 @@ snapshots:
   '@types/sarif@2.1.7': {}
 
   '@types/unist@3.0.3': {}
+
+  '@types/vscode@1.116.0': {}
 
   '@types/web-bluetooth@0.0.21': {}
 
@@ -7314,7 +7336,7 @@ snapshots:
       '@vscode/vsce-sign-win32-arm64': 2.0.6
       '@vscode/vsce-sign-win32-x64': 2.0.6
 
-  '@vscode/vsce@3.7.1':
+  '@vscode/vsce@3.9.1':
     dependencies:
       '@azure/identity': 4.13.0
       '@secretlint/node': 10.2.2
@@ -7343,7 +7365,7 @@ snapshots:
       typed-rest-client: 1.8.11
       url-join: 4.0.1
       xml2js: 0.5.0
-      yauzl: 2.10.0
+      yauzl: 3.3.0
       yazl: 2.5.1
     optionalDependencies:
       keytar: 7.9.0
@@ -7465,6 +7487,8 @@ snapshots:
   acorn@8.16.0: {}
 
   adm-zip@0.5.16: {}
+
+  adm-zip@0.5.17: {}
 
   agent-base@7.1.4: {}
 
@@ -7657,7 +7681,7 @@ snapshots:
       '@npmcli/fs': 5.0.0
       fs-minipass: 3.0.3
       glob: 13.0.6
-      lru-cache: 11.2.6
+      lru-cache: 11.3.5
       minipass: 7.1.3
       minipass-collect: 2.0.1
       minipass-flush: 1.0.5
@@ -7713,7 +7737,7 @@ snapshots:
       parse5: 7.3.0
       parse5-htmlparser2-tree-adapter: 7.1.0
       parse5-parser-stream: 7.1.2
-      undici: 7.22.0
+      undici: 7.25.0
       whatwg-mimetype: 4.0.0
 
   chownr@1.1.4: {}
@@ -8244,7 +8268,7 @@ snapshots:
       hono: 4.12.4
       mcp-proxy: 6.4.0
       strict-event-emitter-types: 2.0.0
-      undici: 7.22.0
+      undici: 7.25.0
       uri-templates: 0.2.0
       xsschema: 0.4.0-beta.5(@valibot/to-json-schema@1.5.0(valibot@1.2.0(typescript@5.9.3)))(effect@3.19.19)(sury@10.0.4)(zod-to-json-schema@3.25.1(zod@4.3.6))(zod@4.3.6)
       yargs: 18.0.0
@@ -8261,10 +8285,6 @@ snapshots:
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
-
-  fd-slicer@1.1.0:
-    dependencies:
-      pend: 1.2.0
 
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
@@ -8974,8 +8994,6 @@ snapshots:
   lodash.startcase@4.4.0: {}
 
   lodash.truncate@4.4.2: {}
-
-  lodash@4.17.23: {}
 
   lodash@4.18.1: {}
 
@@ -10202,8 +10220,6 @@ snapshots:
 
   undici-types@7.18.2: {}
 
-  undici@7.22.0: {}
-
   undici@7.25.0: {}
 
   unicorn-magic@0.1.0: {}
@@ -10617,10 +10633,10 @@ snapshots:
       y18n: 5.0.8
       yargs-parser: 22.0.0
 
-  yauzl@2.10.0:
+  yauzl@3.3.0:
     dependencies:
       buffer-crc32: 0.2.13
-      fd-slicer: 1.1.0
+      pend: 1.2.0
 
   yazl@2.5.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,6 +17,7 @@ catalogs:
     "@rollup/pluginutils": ^5.3.0
     "@sveltejs/acorn-typescript": ^1.0.9
     "@tailwindcss/vite": ^4.1.12
+    "@types/adm-zip": ^0.5.8
     "@types/bun": ^1.3.9
     "@types/eslint": ^9.6.1
     "@types/estree": ^1.0.8
@@ -25,7 +26,7 @@ catalogs:
     "@types/prompts": ^2.4.9
     "@types/react": ^19.2.2
     "@types/react-dom": ^19.2.2
-    "@types/vscode": ^1.107.0
+    "@types/vscode": ^1.116.0
     "@typescript-eslint/parser": *ts_eslint_parser
     "@typescript-eslint/types": ^8.40.0
     "@vercel/nft": ^1.3.2
@@ -33,9 +34,9 @@ catalogs:
     "@volar/language-server": ~2.4.28
     "@volar/typescript": ~2.4.28
     "@volar/vscode": ~2.4.28
-    "@vscode/vsce": ^3.6.2
+    "@vscode/vsce": ^3.9.1
     acorn: ^8.15.0
-    adm-zip: ^0.5.16
+    adm-zip: ^0.5.17
     clsx: ^2.1.1
     commander: ^14.0.3
     degit: ^2.8.4

--- a/scripts/build-if-changed.js
+++ b/scripts/build-if-changed.js
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+
+/**
+ * Build packages only if their source files have changed since the last build.
+ *
+ * Usage: node scripts/build-if-changed.js <package-dir> [<package-dir> ...]
+ *
+ * Each package-dir is relative to the workspace root (e.g. "packages/vscode-plugin").
+ * Source dirs are auto-detected: src/ is always included, bin/ is included if it exists.
+ * A hash of all source files is stored in <package-dir>/dist/.build-hash.
+ * If the hash matches, the build is skipped.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import crypto from 'crypto';
+import { execSync } from 'child_process';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+
+const package_dirs = process.argv.slice(2);
+
+if (package_dirs.length === 0) {
+	console.error('Usage: node scripts/build-if-changed.js <package-dir> [<package-dir> ...]');
+	process.exit(1);
+}
+
+/**
+ * Recursively collect all file paths under a directory, sorted for determinism.
+ * @param {string} dir
+ * @returns {string[]}
+ */
+function collect_files(dir) {
+	if (!fs.existsSync(dir)) return [];
+	const results = [];
+	for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+		const full = path.join(dir, entry.name);
+		if (entry.isDirectory()) {
+			results.push(...collect_files(full));
+		} else {
+			results.push(full);
+		}
+	}
+	return results;
+}
+
+/**
+ * Compute a SHA-256 hash of all source files in a package.
+ * @param {string} pkg_path - Absolute path to the package
+ * @returns {string}
+ */
+function compute_hash(pkg_path) {
+	const hash = crypto.createHash('sha256');
+	const src_dirs = ['src', 'bin'].filter((d) => fs.existsSync(path.join(pkg_path, d)));
+	const files = src_dirs.flatMap((d) => collect_files(path.join(pkg_path, d))).sort();
+
+	for (const file of files) {
+		// Include relative path in hash so renames are detected
+		hash.update(path.relative(pkg_path, file));
+		hash.update(fs.readFileSync(file));
+	}
+	return hash.digest('hex');
+}
+
+const to_build = [];
+
+for (const dir of package_dirs) {
+	const pkg_path = path.resolve(root, dir);
+	const hash_file = path.join(pkg_path, 'dist', '.build-hash');
+	const current_hash = compute_hash(pkg_path);
+
+	let stored_hash = '';
+	try {
+		stored_hash = fs.readFileSync(hash_file, 'utf8').trim();
+	} catch {}
+
+	if (current_hash === stored_hash) {
+		console.log(`✔ ${dir} — no changes, skipping build`);
+	} else {
+		console.log(`⟳ ${dir} — changes detected, will build`);
+		to_build.push({ dir, pkg_path, hash_file, current_hash });
+	}
+}
+
+if (to_build.length === 0) {
+	console.log('All packages up to date.');
+	process.exit(0);
+}
+
+const filters = to_build.map(({ pkg_path }) => {
+	const pkg_json = JSON.parse(fs.readFileSync(path.join(pkg_path, 'package.json'), 'utf8'));
+	return `--filter ${pkg_json.name}`;
+});
+
+const cmd = `pnpm ${filters.join(' ')} build`;
+console.log(`\n▶ ${cmd}\n`);
+execSync(cmd, { stdio: 'inherit', cwd: root });
+
+// Write hashes after successful build
+for (const { hash_file, current_hash } of to_build) {
+	fs.writeFileSync(hash_file, current_hash + '\n');
+}

--- a/scripts/build-if-changed.js
+++ b/scripts/build-if-changed.js
@@ -1,14 +1,17 @@
 #!/usr/bin/env node
 
 /**
- * Build packages only if their source files have changed since the last build.
+ * Incremental build for packages that bundle workspace dependencies.
  *
  * Usage: node scripts/build-if-changed.js <package-dir> [<package-dir> ...]
  *
- * Each package-dir is relative to the workspace root (e.g. "packages/vscode-plugin").
- * Source dirs are auto-detected: src/ is always included, bin/ is included if it exists.
- * A hash of all source files is stored in <package-dir>/dist/.build-hash.
- * If the hash matches, the build is skipped.
+ * Computes a SHA-256 hash of src/ and bin/ for each package under packages/
+ * and writes it to <package>/.build-hash (gitignored). These per-package
+ * hashes can be reused by other scripts.
+ *
+ * To decide whether the specified build targets need rebuilding, all
+ * per-package hashes are combined. If the combined hash differs from the
+ * last successful build, only the specified packages are rebuilt.
  */
 
 import fs from 'fs';
@@ -17,18 +20,19 @@ import crypto from 'crypto';
 import { execSync } from 'child_process';
 import { fileURLToPath } from 'url';
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const root = path.resolve(__dirname, '..');
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(dirname, '..');
+const packages_dir = path.join(root, 'packages');
 
-const package_dirs = process.argv.slice(2);
+const build_targets = process.argv.slice(2);
 
-if (package_dirs.length === 0) {
+if (build_targets.length === 0) {
 	console.error('Usage: node scripts/build-if-changed.js <package-dir> [<package-dir> ...]');
 	process.exit(1);
 }
 
 /**
- * Recursively collect all file paths under a directory, sorted for determinism.
+ * Recursively collect all file paths under a directory.
  * @param {string} dir
  * @returns {string[]}
  */
@@ -36,69 +40,73 @@ function collect_files(dir) {
 	if (!fs.existsSync(dir)) return [];
 	const results = [];
 	for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+		if (entry.name === 'node_modules') continue;
 		const full = path.join(dir, entry.name);
 		if (entry.isDirectory()) {
 			results.push(...collect_files(full));
-		} else {
+		} else if (!entry.name.endsWith('-lock.json') && entry.name !== 'yarn.lock') {
 			results.push(full);
 		}
 	}
 	return results;
 }
 
-/**
- * Compute a SHA-256 hash of all source files in a package.
- * @param {string} pkg_path - Absolute path to the package
- * @returns {string}
- */
-function compute_hash(pkg_path) {
-	const hash = crypto.createHash('sha256');
-	const src_dirs = ['src', 'bin'].filter((d) => fs.existsSync(path.join(pkg_path, d)));
-	const files = src_dirs.flatMap((d) => collect_files(path.join(pkg_path, d))).sort();
+// Compute and write per-package hashes
+const all_packages = fs
+	.readdirSync(packages_dir, { withFileTypes: true })
+	.filter((e) => e.isDirectory())
+	.map((e) => e.name)
+	.sort();
 
+const combined = crypto.createHash('sha256');
+
+for (const name of all_packages) {
+	const pkg_path = path.join(packages_dir, name);
+	const src_dirs = ['src', 'bin'].filter((d) => fs.existsSync(path.join(pkg_path, d)));
+	if (src_dirs.length === 0) continue;
+
+	const hash = crypto.createHash('sha256');
+	const files = src_dirs.flatMap((d) => collect_files(path.join(pkg_path, d))).sort();
 	for (const file of files) {
-		// Include relative path in hash so renames are detected
 		hash.update(path.relative(pkg_path, file));
 		hash.update(fs.readFileSync(file));
 	}
-	return hash.digest('hex');
+
+	const pkg_hash = hash.digest('hex');
+	fs.writeFileSync(path.join(pkg_path, '.build-hash'), pkg_hash + '\n');
+	combined.update(name);
+	combined.update(pkg_hash);
 }
 
-const to_build = [];
+const combined_hash = combined.digest('hex');
 
-for (const dir of package_dirs) {
-	const pkg_path = path.resolve(root, dir);
-	const hash_file = path.join(pkg_path, 'dist', '.build-hash');
-	const current_hash = compute_hash(pkg_path);
-
-	let stored_hash = '';
+// Check if any build target needs rebuilding
+const build_hash_files = build_targets.map((dir) => path.join(root, dir, '.build-hash-built'));
+const needs_build = build_hash_files.some((f) => {
 	try {
-		stored_hash = fs.readFileSync(hash_file, 'utf8').trim();
-	} catch {}
-
-	if (current_hash === stored_hash) {
-		console.log(`✔ ${dir} — no changes, skipping build`);
-	} else {
-		console.log(`⟳ ${dir} — changes detected, will build`);
-		to_build.push({ dir, pkg_path, hash_file, current_hash });
+		return fs.readFileSync(f, 'utf8').trim() !== combined_hash;
+	} catch {
+		return true;
 	}
-}
+});
 
-if (to_build.length === 0) {
+if (!needs_build) {
 	console.log('All packages up to date.');
 	process.exit(0);
 }
 
-const filters = to_build.map(({ pkg_path }) => {
-	const pkg_json = JSON.parse(fs.readFileSync(path.join(pkg_path, 'package.json'), 'utf8'));
+console.log('Changes detected, rebuilding specified packages...\n');
+
+const filters = build_targets.map((dir) => {
+	const pkg_json = JSON.parse(fs.readFileSync(path.join(root, dir, 'package.json'), 'utf8'));
 	return `--filter ${pkg_json.name}`;
 });
 
 const cmd = `pnpm ${filters.join(' ')} build`;
-console.log(`\n▶ ${cmd}\n`);
+console.log(`▶ ${cmd}\n`);
 execSync(cmd, { stdio: 'inherit', cwd: root });
 
-// Write hashes after successful build
-for (const { hash_file, current_hash } of to_build) {
-	fs.writeFileSync(hash_file, current_hash + '\n');
+// Write combined hash to build targets after successful build
+for (const f of build_hash_files) {
+	fs.writeFileSync(f, combined_hash + '\n');
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk due to broad module-system and packaging changes across the language server, TypeScript plugin, and VS Code extension; runtime loading/bundling edge cases (CJS/ESM interop, externals, activation/debug flows) are the main failure modes.
> 
> **Overview**
> **Converts the Ripple language server, TypeScript plugin, and VS Code extension source code from CommonJS to ESM**, switching `require`/`module.exports` to `import`/`export` and updating entrypoints (`main`/bin) to point at built `dist` output with `type: module`.
> 
> Adds `tsdown` build configs to bundle to **CommonJS `dist` artifacts** (including a generated `dist/package.json` forcing `type: commonjs`), enables sourcemaps in dev, and updates TS configs to `esnext` + `bundler` resolution.
> 
> Updates VS Code dev workflow to build from `dist` before launching (new `build-if-changed` incremental build script, new VS Code task/launch wiring), adjusts extension packaging scripts, and refreshes related deps/types (e.g. `@types/vscode`, `adm-zip`, `vsce`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59bd86a5d643bfe43b7cbc447d92163f0f4ec6ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->