### PR TITLE
Fixes to tsrx/react

### DIFF
--- a/.changeset/fix-react-lazy-and-hoisting.md
+++ b/.changeset/fix-react-lazy-and-hoisting.md
@@ -1,0 +1,5 @@
+---
+'@tsrx/react': patch
+---
+
+Fix static hoisting incorrectly hoisting elements that reference component-scope bindings as JSX tag names (including JSXMemberExpression objects like `<ui.Button />`), and fix lazy destructuring transforms incorrectly rewriting references to block-scoped variables that shadow lazy binding names

--- a/packages/tsrx-react/src/transform.js
+++ b/packages/tsrx-react/src/transform.js
@@ -288,10 +288,7 @@ function apply_lazy_transforms(node, lazy_bindings) {
 		}
 
 		if (shadowed.size > 0) {
-			const inner_bindings = new Map(lazy_bindings);
-			for (const name of shadowed) {
-				inner_bindings.delete(name);
-			}
+			const inner_bindings = remove_shadowed(lazy_bindings, shadowed);
 			if (inner_bindings.size === 0) return node;
 
 			// Only transform the body, not the params
@@ -306,6 +303,34 @@ function apply_lazy_transforms(node, lazy_bindings) {
 		if (new_body !== node.body) {
 			return { ...node, body: new_body };
 		}
+		return node;
+	}
+
+	// Handle block-scoped variable shadowing (const/let/var that shadows a lazy name)
+	if (node.type === 'BlockStatement' || node.type === 'Program') {
+		const block_bindings = collect_block_shadowed_names(node.body, lazy_bindings);
+		const effective_bindings =
+			block_bindings.size > 0 ? remove_shadowed(lazy_bindings, block_bindings) : lazy_bindings;
+		if (effective_bindings.size === 0 && block_bindings.size > 0) return node;
+
+		let changed = false;
+		const new_body = node.body.map((/** @type {any} */ stmt) => {
+			const transformed = apply_lazy_transforms(stmt, effective_bindings);
+			if (transformed !== stmt) changed = true;
+			return transformed;
+		});
+		return changed ? { ...node, body: new_body } : node;
+	}
+
+	// Handle catch clause parameter shadowing
+	if (node.type === 'CatchClause') {
+		/** @type {Set<string>} */
+		const shadowed = new Set();
+		if (node.param) collect_shadowed_names(node.param, lazy_bindings, shadowed);
+		const effective_bindings =
+			shadowed.size > 0 ? remove_shadowed(lazy_bindings, shadowed) : lazy_bindings;
+		const new_body = apply_lazy_transforms(node.body, effective_bindings);
+		if (new_body !== node.body) return { ...node, body: new_body };
 		return node;
 	}
 
@@ -446,6 +471,46 @@ function collect_shadowed_names(pattern, lazy_bindings, shadowed) {
 			if (element) collect_shadowed_names(element, lazy_bindings, shadowed);
 		}
 	}
+}
+
+/**
+ * Collect variable names declared in block-level statements that shadow lazy bindings.
+ * Scans VariableDeclarations (const/let/var) and FunctionDeclarations at the top level of a block.
+ *
+ * @param {any[]} statements
+ * @param {Map<string, LazyBinding>} lazy_bindings
+ * @returns {Set<string>}
+ */
+function collect_block_shadowed_names(statements, lazy_bindings) {
+	/** @type {Set<string>} */
+	const shadowed = new Set();
+	for (const stmt of statements) {
+		if (stmt.type === 'VariableDeclaration') {
+			for (const decl of stmt.declarations) {
+				if (decl.id) collect_shadowed_names(decl.id, lazy_bindings, shadowed);
+			}
+		} else if (stmt.type === 'FunctionDeclaration' && stmt.id) {
+			if (lazy_bindings.has(stmt.id.name)) {
+				shadowed.add(stmt.id.name);
+			}
+		}
+	}
+	return shadowed;
+}
+
+/**
+ * Create a new lazy_bindings map with the shadowed names removed.
+ *
+ * @param {Map<string, LazyBinding>} lazy_bindings
+ * @param {Set<string>} shadowed
+ * @returns {Map<string, LazyBinding>}
+ */
+function remove_shadowed(lazy_bindings, shadowed) {
+	const result = new Map(lazy_bindings);
+	for (const name of shadowed) {
+		result.delete(name);
+	}
+	return result;
 }
 
 /**
@@ -1072,9 +1137,10 @@ function references_scope_bindings(node, scope_bindings) {
 		return scope_bindings.has(node.name);
 	}
 
-	// Capitalized JSXIdentifier tag names are component variable references (e.g. <MyComponent />)
+	// JSXIdentifier is a variable reference when capitalized (tag name like <MyComponent />)
+	// or when it's the object of a JSXMemberExpression (e.g. ui in <ui.Button />)
 	if (node.type === 'JSXIdentifier') {
-		return /^[A-Z]/.test(node.name) && scope_bindings.has(node.name);
+		return scope_bindings.has(node.name);
 	}
 
 	if (Array.isArray(node)) {

--- a/packages/tsrx-react/src/transform.js
+++ b/packages/tsrx-react/src/transform.js
@@ -407,6 +407,9 @@ function apply_lazy_transforms(node, lazy_bindings) {
 	// Replace lazy variable declaration patterns with generated identifiers
 	if (node.type === 'VariableDeclarator' && node.id?.metadata?.lazy_id) {
 		const lazy_id = create_generated_identifier(node.id.metadata.lazy_id);
+		if (node.id.typeAnnotation) {
+			lazy_id.typeAnnotation = node.id.typeAnnotation;
+		}
 		return {
 			...node,
 			id: lazy_id,
@@ -786,9 +789,15 @@ function build_render_statements(body_nodes, return_null_when_empty, transform_c
 	const statements = [];
 	const render_nodes = [];
 
+	// Create a new bindings map so inner-scope bindings from
+	// collect_statement_bindings don't leak to the caller's scope.
+	const saved_bindings = transform_context.available_bindings;
+	transform_context.available_bindings = new Map(saved_bindings);
+
 	for (const child of body_nodes) {
 		if (is_bare_return_statement(child)) {
 			statements.push(create_component_return_statement(render_nodes, child));
+			transform_context.available_bindings = saved_bindings;
 			return statements;
 		}
 
@@ -815,6 +824,7 @@ function build_render_statements(body_nodes, return_null_when_empty, transform_c
 		});
 	}
 
+	transform_context.available_bindings = saved_bindings;
 	return statements;
 }
 

--- a/packages/tsrx-react/src/transform.js
+++ b/packages/tsrx-react/src/transform.js
@@ -592,6 +592,9 @@ function collect_block_shadowed_names(statements, lazy_bindings) {
 	for (const stmt of statements) {
 		if (stmt.type === 'VariableDeclaration') {
 			for (const decl of stmt.declarations) {
+				// Skip lazy destructuring patterns — they ARE the lazy bindings,
+				// not local declarations that shadow them.
+				if (decl.id?.metadata?.lazy_id) continue;
 				if (decl.id) collect_shadowed_names(decl.id, lazy_bindings, shadowed);
 			}
 		} else if (stmt.type === 'FunctionDeclaration' && stmt.id) {
@@ -683,18 +686,22 @@ function component_to_function_declaration(component, transform_context, walk_he
 	// Replace lazy param patterns with generated identifiers
 	const final_params = lazy_bindings.size > 0 ? replace_lazy_params(params) : params;
 
+	// Wrap body_statements in a BlockStatement so that apply_lazy_transforms
+	// runs collect_block_shadowed_names and detects body-level declarations
+	// (e.g. `const name = ...`) that shadow lazy binding names.
+	const body_block = /** @type {any} */ ({
+		type: 'BlockStatement',
+		body: body_statements,
+		metadata: { path: [] },
+	});
+	const final_body =
+		lazy_bindings.size > 0 ? apply_lazy_transforms(body_block, lazy_bindings) : body_block;
+
 	const fn = /** @type {any} */ ({
 		type: 'FunctionDeclaration',
 		id: component.id,
 		params: final_params,
-		body: {
-			type: 'BlockStatement',
-			body:
-				lazy_bindings.size > 0
-					? apply_lazy_transforms(body_statements, lazy_bindings)
-					: body_statements,
-			metadata: { path: [] },
-		},
+		body: final_body,
 		async: false,
 		generator: false,
 		metadata: {

--- a/packages/tsrx-react/src/transform.js
+++ b/packages/tsrx-react/src/transform.js
@@ -1224,6 +1224,9 @@ function references_scope_bindings(node, scope_bindings) {
 		// Skip non-computed member expression property access
 		if (key === 'property' && node.type === 'MemberExpression' && !node.computed) continue;
 
+		// Skip JSXMemberExpression property (e.g. Button in <Icons.Button /> is a label, not a reference)
+		if (key === 'property' && node.type === 'JSXMemberExpression') continue;
+
 		// Skip JSXAttribute names — they are attribute labels, not variable references
 		if (key === 'name' && node.type === 'JSXAttribute') continue;
 

--- a/packages/tsrx-react/src/transform.js
+++ b/packages/tsrx-react/src/transform.js
@@ -11,7 +11,7 @@ import { renderStylesheets, setLocation } from '@tsrx/core';
  *   local_statement_component_index: number,
  *   needs_error_boundary: boolean,
  *   needs_suspense: boolean,
- *   helper_state: { base_name: string, next_id: number, helpers: AST.FunctionDeclaration[] } | null,
+ *   helper_state: { base_name: string, next_id: number, helpers: AST.FunctionDeclaration[], statics: any[] } | null,
  *   available_bindings: Map<string, AST.Identifier>,
  * }} TransformContext
  */
@@ -132,7 +132,7 @@ export function transform(ast, source, filename) {
 /**
  * @param {any} component
  * @param {TransformContext} transform_context
- * @param {{ base_name: string, next_id: number, helpers: AST.FunctionDeclaration[] }} [walk_helper_state]
+ * @param {{ base_name: string, next_id: number, helpers: AST.FunctionDeclaration[], statics: any[] }} [walk_helper_state]
  * @returns {AST.FunctionDeclaration}
  */
 function component_to_function_declaration(component, transform_context, walk_helper_state) {
@@ -172,6 +172,7 @@ function component_to_function_declaration(component, transform_context, walk_he
 	transform_context.available_bindings = saved_bindings;
 
 	fn.metadata.generated_helpers = helper_state.helpers;
+	fn.metadata.generated_statics = helper_state.statics;
 
 	if (fn.id) {
 		fn.id.metadata = /** @type {AST.Identifier['metadata']} */ ({
@@ -186,7 +187,7 @@ function component_to_function_declaration(component, transform_context, walk_he
 
 /**
  * @param {any[]} body_nodes
- * @param {{ base_name: string, next_id: number, helpers: AST.FunctionDeclaration[] }} helper_state
+ * @param {{ base_name: string, next_id: number, helpers: AST.FunctionDeclaration[], statics: any[] }} helper_state
  * @param {Map<string, AST.Identifier>} available_bindings
  * @param {TransformContext} transform_context
  * @returns {any[]}
@@ -227,6 +228,8 @@ function build_component_statements(
 			transform_context.available_bindings = bindings;
 		}
 	}
+
+	hoist_static_render_nodes(render_nodes, transform_context);
 
 	const split_node = body_nodes[split_index];
 	const consequent_body =
@@ -302,6 +305,8 @@ function build_render_statements(body_nodes, return_null_when_empty, transform_c
 			collect_statement_bindings(child, transform_context.available_bindings);
 		}
 	}
+
+	hoist_static_render_nodes(render_nodes, transform_context);
 
 	const return_arg = build_return_expression(render_nodes);
 	if (return_arg || return_null_when_empty) {
@@ -428,7 +433,7 @@ function is_hook_callee(callee) {
 
 /**
  * @param {any[]} body_nodes
- * @param {{ base_name: string, next_id: number, helpers: AST.FunctionDeclaration[] }} helper_state
+ * @param {{ base_name: string, next_id: number, helpers: AST.FunctionDeclaration[], statics: any[] }} helper_state
  * @param {Map<string, AST.Identifier>} available_bindings
  * @param {any} source_node
  * @param {string} suffix
@@ -468,7 +473,7 @@ function create_helper_component_expression(
 /**
  * @param {AST.Identifier} helper_id
  * @param {any[]} body_nodes
- * @param {{ base_name: string, next_id: number, helpers: AST.FunctionDeclaration[] }} helper_state
+ * @param {{ base_name: string, next_id: number, helpers: AST.FunctionDeclaration[], statics: any[] }} helper_state
  * @param {Map<string, AST.Identifier>} available_bindings
  * @param {AST.Identifier[]} helper_bindings
  * @param {any} source_node
@@ -587,7 +592,7 @@ function create_helper_component_element(helper_id, bindings, source_node) {
 }
 
 /**
- * @param {{ base_name: string, next_id: number, helpers: AST.FunctionDeclaration[] }} helper_state
+ * @param {{ base_name: string, next_id: number, helpers: AST.FunctionDeclaration[], statics: any[] }} helper_state
  * @param {string} suffix
  * @returns {string}
  */
@@ -598,13 +603,14 @@ function create_helper_name(helper_state, suffix) {
 
 /**
  * @param {string} base_name
- * @returns {{ base_name: string, next_id: number, helpers: AST.FunctionDeclaration[] }}
+ * @returns {{ base_name: string, next_id: number, helpers: AST.FunctionDeclaration[], statics: any[] }}
  */
 function create_helper_state(base_name) {
 	return {
 		base_name,
 		next_id: 0,
 		helpers: [],
+		statics: [],
 	};
 }
 
@@ -685,6 +691,84 @@ function collect_pattern_bindings(pattern, bindings) {
 }
 
 /**
+ * Check if a node references any of the given scope bindings.
+ * Used to determine if a JSX element is static and can be hoisted to module level.
+ *
+ * @param {any} node
+ * @param {Map<string, AST.Identifier>} scope_bindings
+ * @returns {boolean}
+ */
+function references_scope_bindings(node, scope_bindings) {
+	if (!node || typeof node !== 'object') return false;
+	if (scope_bindings.size === 0) return false;
+
+	if (node.type === 'Identifier') {
+		return scope_bindings.has(node.name);
+	}
+
+	// JSXIdentifier nodes are tag names or attribute names, not variable references
+	if (node.type === 'JSXIdentifier') return false;
+
+	if (Array.isArray(node)) {
+		return node.some((child) => references_scope_bindings(child, scope_bindings));
+	}
+
+	for (const key of Object.keys(node)) {
+		if (key === 'loc' || key === 'start' || key === 'end' || key === 'metadata') continue;
+
+		// Skip non-computed, non-shorthand property keys (they are labels, not references)
+		if (key === 'key' && node.type === 'Property' && !node.computed && !node.shorthand) continue;
+
+		// Skip non-computed member expression property access
+		if (key === 'property' && node.type === 'MemberExpression' && !node.computed) continue;
+
+		if (references_scope_bindings(node[key], scope_bindings)) return true;
+	}
+
+	return false;
+}
+
+/**
+ * Hoist static JSX elements from render_nodes to module level.
+ * A JSX element is static if it doesn't reference any component-scope bindings.
+ * Hoisting prevents React from recreating the element on every render, allowing
+ * the reconciler to skip diffing when it sees the same element identity.
+ *
+ * @param {any[]} render_nodes
+ * @param {TransformContext} transform_context
+ */
+function hoist_static_render_nodes(render_nodes, transform_context) {
+	if (!transform_context.helper_state) return;
+
+	for (let i = 0; i < render_nodes.length; i++) {
+		const node = render_nodes[i];
+		if (node.type !== 'JSXElement') continue;
+		if (references_scope_bindings(node, transform_context.available_bindings)) continue;
+
+		const name = create_helper_name(transform_context.helper_state, 'static');
+		const id = create_generated_identifier(name);
+
+		transform_context.helper_state.statics.push(
+			/** @type {any} */ ({
+				type: 'VariableDeclaration',
+				kind: 'const',
+				declarations: [
+					{
+						type: 'VariableDeclarator',
+						id,
+						init: node,
+						metadata: { path: [] },
+					},
+				],
+				metadata: { path: [] },
+			}),
+		);
+
+		render_nodes[i] = to_jsx_expression_container(clone_identifier(id), node);
+	}
+}
+
+/**
  * @param {AST.Identifier} identifier
  * @returns {AST.Identifier}
  */
@@ -718,9 +802,11 @@ function create_null_literal() {
 function expand_component_helpers(program) {
 	program.body = program.body.flatMap((statement) => {
 		if (statement.type === 'FunctionDeclaration') {
-			const helpers = /** @type {any} */ (statement.metadata)?.generated_helpers;
-			if (helpers?.length) {
-				return [...helpers, statement];
+			const meta = /** @type {any} */ (statement.metadata);
+			const statics = meta?.generated_statics || [];
+			const helpers = meta?.generated_helpers || [];
+			if (statics.length || helpers.length) {
+				return [...statics, ...helpers, statement];
 			}
 		}
 
@@ -729,9 +815,11 @@ function expand_component_helpers(program) {
 				statement.type === 'ExportDefaultDeclaration') &&
 			statement.declaration?.type === 'FunctionDeclaration'
 		) {
-			const helpers = /** @type {any} */ (statement.declaration.metadata)?.generated_helpers;
-			if (helpers?.length) {
-				return [...helpers, statement];
+			const meta = /** @type {any} */ (statement.declaration.metadata);
+			const statics = meta?.generated_statics || [];
+			const helpers = meta?.generated_helpers || [];
+			if (statics.length || helpers.length) {
+				return [...statics, ...helpers, statement];
 			}
 		}
 
@@ -1656,6 +1744,15 @@ function try_statement_to_jsx_child(node, transform_context) {
 		}
 
 		const catch_body_nodes = handler.body.body || [];
+
+		// Add catch params to available_bindings so static hoisting
+		// correctly identifies references to err/reset as non-static
+		const saved_catch_bindings = transform_context.available_bindings;
+		transform_context.available_bindings = new Map(saved_catch_bindings);
+		for (const param of catch_params) {
+			collect_pattern_bindings(param, transform_context.available_bindings);
+		}
+
 		const fallback_fn = {
 			type: 'ArrowFunctionExpression',
 			params: catch_params,
@@ -1669,6 +1766,8 @@ function try_statement_to_jsx_child(node, transform_context) {
 			expression: false,
 			metadata: { path: [] },
 		};
+
+		transform_context.available_bindings = saved_catch_bindings;
 
 		result = create_jsx_element(
 			'TsrxErrorBoundary',

--- a/packages/tsrx-react/src/transform.js
+++ b/packages/tsrx-react/src/transform.js
@@ -11,6 +11,8 @@ import { renderStylesheets, setLocation } from '@tsrx/core';
  *   local_statement_component_index: number,
  *   needs_error_boundary: boolean,
  *   needs_suspense: boolean,
+ *   helper_state: { base_name: string, next_id: number, helpers: AST.FunctionDeclaration[] } | null,
+ *   available_bindings: Map<string, AST.Identifier>,
  * }} TransformContext
  */
 
@@ -39,6 +41,8 @@ export function transform(ast, source, filename) {
 		local_statement_component_index: 0,
 		needs_error_boundary: false,
 		needs_suspense: false,
+		helper_state: null,
+		available_bindings: new Map(),
 	};
 
 	walk(/** @type {any} */ (ast), transform_context, {
@@ -56,8 +60,24 @@ export function transform(ast, source, filename) {
 
 	const transformed = walk(/** @type {any} */ (ast), transform_context, {
 		Component(node, { next, state }) {
+			const as_any = /** @type {any} */ (node);
+
+			// Set up helper_state and bindings BEFORE next() so that nested
+			// hook_safe_* calls (inside Element children) can register helpers
+			// and access available bindings during the bottom-up walk.
+			const helper_state = create_helper_state(as_any.id?.name || 'Component');
+			const saved_helper_state = state.helper_state;
+			const saved_bindings = state.available_bindings;
+			state.helper_state = helper_state;
+			state.available_bindings = collect_param_bindings(as_any.params || []);
+
 			const inner = /** @type {any} */ (next() ?? node);
-			return /** @type {any} */ (component_to_function_declaration(inner, state));
+
+			// Restore context
+			state.helper_state = saved_helper_state;
+			state.available_bindings = saved_bindings;
+
+			return /** @type {any} */ (component_to_function_declaration(inner, state, helper_state));
 		},
 
 		Tsx(node, { next }) {
@@ -112,10 +132,19 @@ export function transform(ast, source, filename) {
 /**
  * @param {any} component
  * @param {TransformContext} transform_context
+ * @param {{ base_name: string, next_id: number, helpers: AST.FunctionDeclaration[] }} [walk_helper_state]
  * @returns {AST.FunctionDeclaration}
  */
-function component_to_function_declaration(component, transform_context) {
-	const helper_state = create_helper_state(component.id?.name || 'Component');
+function component_to_function_declaration(component, transform_context, walk_helper_state) {
+	const helper_state = walk_helper_state || create_helper_state(component.id?.name || 'Component');
+	const param_bindings = collect_param_bindings(component.params || []);
+
+	// Save and set context for this component scope
+	const saved_helper_state = transform_context.helper_state;
+	const saved_bindings = transform_context.available_bindings;
+	transform_context.helper_state = helper_state;
+	transform_context.available_bindings = new Map(param_bindings);
+
 	const fn = /** @type {any} */ ({
 		type: 'FunctionDeclaration',
 		id: component.id,
@@ -125,7 +154,7 @@ function component_to_function_declaration(component, transform_context) {
 			body: build_component_statements(
 				/** @type {any[]} */ (component.body),
 				helper_state,
-				collect_param_bindings(component.params || []),
+				param_bindings,
 				transform_context,
 			),
 			metadata: { path: [] },
@@ -137,6 +166,10 @@ function component_to_function_declaration(component, transform_context) {
 			is_component: true,
 		},
 	});
+
+	// Restore context
+	transform_context.helper_state = saved_helper_state;
+	transform_context.available_bindings = saved_bindings;
 
 	fn.metadata.generated_helpers = helper_state.helpers;
 
@@ -191,6 +224,7 @@ function build_component_statements(
 		} else {
 			statements.push(child);
 			collect_statement_bindings(child, bindings);
+			transform_context.available_bindings = bindings;
 		}
 	}
 
@@ -265,6 +299,7 @@ function build_render_statements(body_nodes, return_null_when_empty, transform_c
 			render_nodes.push(to_jsx_child(child, transform_context));
 		} else {
 			statements.push(child);
+			collect_statement_bindings(child, transform_context.available_bindings);
 		}
 	}
 
@@ -1144,11 +1179,17 @@ function hook_safe_statement_body_to_jsx_child(body_nodes, transform_context) {
 		create_generated_identifier(create_local_statement_component_name(transform_context)),
 		source_node,
 	);
+	const helper_bindings = Array.from(transform_context.available_bindings.values());
+
+	// Save and isolate bindings for the helper body
+	const saved_bindings = transform_context.available_bindings;
+	transform_context.available_bindings = new Map(saved_bindings);
+
 	const helper_fn = set_loc(
 		/** @type {any} */ ({
 			type: 'FunctionDeclaration',
 			id: helper_id,
-			params: [],
+			params: helper_bindings.length > 0 ? [create_helper_props_pattern(helper_bindings)] : [],
 			body: {
 				type: 'BlockStatement',
 				body: build_render_statements(body_nodes, true, transform_context),
@@ -1165,6 +1206,19 @@ function hook_safe_statement_body_to_jsx_child(body_nodes, transform_context) {
 		source_node,
 	);
 
+	// Restore bindings
+	transform_context.available_bindings = saved_bindings;
+
+	// Register helper for hoisting to module level
+	if (transform_context.helper_state) {
+		transform_context.helper_state.helpers.push(helper_fn);
+
+		return to_jsx_expression_container(
+			/** @type {any} */ (create_helper_component_element(helper_id, helper_bindings, source_node)),
+			source_node,
+		);
+	}
+
 	return to_jsx_expression_container(
 		/** @type {any} */ ({
 			type: 'CallExpression',
@@ -1177,7 +1231,7 @@ function hook_safe_statement_body_to_jsx_child(body_nodes, transform_context) {
 						helper_fn,
 						{
 							type: 'ReturnStatement',
-							argument: create_helper_component_element(helper_id, [], source_node),
+							argument: create_helper_component_element(helper_id, helper_bindings, source_node),
 							metadata: { path: [] },
 						},
 					],
@@ -1206,8 +1260,10 @@ function create_local_statement_component_name(transform_context) {
 }
 
 /**
- * Wraps a list of body nodes into a locally-declared component and returns
- * statements that declare the component then return `<ComponentName />`.
+ * Wraps a list of body nodes into a component and returns
+ * statements that return `<ComponentName prop1={prop1} ... />`.
+ * The component is hoisted to module level via helper_state to avoid
+ * recreating the component identity on every render.
  * Used when a control flow branch contains hook calls that must be moved
  * into their own component boundary to satisfy the Rules of Hooks.
  *
@@ -1222,12 +1278,17 @@ function hook_safe_render_statements(body_nodes, key_expression, transform_conte
 		create_generated_identifier(create_local_statement_component_name(transform_context)),
 		source_node,
 	);
+	const helper_bindings = Array.from(transform_context.available_bindings.values());
+
+	// Save and isolate bindings for the helper body
+	const saved_bindings = transform_context.available_bindings;
+	transform_context.available_bindings = new Map(saved_bindings);
 
 	const helper_fn = set_loc(
 		/** @type {any} */ ({
 			type: 'FunctionDeclaration',
 			id: helper_id,
-			params: [],
+			params: helper_bindings.length > 0 ? [create_helper_props_pattern(helper_bindings)] : [],
 			body: {
 				type: 'BlockStatement',
 				body: build_render_statements(body_nodes, true, transform_context),
@@ -1244,7 +1305,19 @@ function hook_safe_render_statements(body_nodes, key_expression, transform_conte
 		source_node,
 	);
 
-	const component_element = create_helper_component_element(helper_id, [], source_node);
+	// Restore bindings
+	transform_context.available_bindings = saved_bindings;
+
+	// Register helper for hoisting to module level
+	if (transform_context.helper_state) {
+		transform_context.helper_state.helpers.push(helper_fn);
+	}
+
+	const component_element = create_helper_component_element(
+		helper_id,
+		helper_bindings,
+		source_node,
+	);
 
 	if (key_expression) {
 		component_element.openingElement.attributes.push(
@@ -1258,7 +1331,6 @@ function hook_safe_render_statements(body_nodes, key_expression, transform_conte
 	}
 
 	return [
-		helper_fn,
 		{
 			type: 'ReturnStatement',
 			argument: component_element,
@@ -1411,6 +1483,20 @@ function for_of_statement_to_jsx_child(node, transform_context) {
 	const has_hooks = body_contains_top_level_hook_call(loop_body);
 	const key_expression = has_hooks ? find_key_expression_in_body(loop_body) : undefined;
 
+	// Add loop params to available bindings so hoisted helpers receive them as props
+	const saved_bindings = transform_context.available_bindings;
+	transform_context.available_bindings = new Map(saved_bindings);
+	for (const param of loop_params) {
+		collect_pattern_bindings(param, transform_context.available_bindings);
+	}
+
+	const body_statements = has_hooks
+		? hook_safe_render_statements(loop_body, key_expression, transform_context)
+		: build_render_statements(loop_body, true, transform_context);
+
+	// Restore bindings
+	transform_context.available_bindings = saved_bindings;
+
 	return to_jsx_expression_container(
 		/** @type {any} */ ({
 			type: 'CallExpression',
@@ -1428,9 +1514,7 @@ function for_of_statement_to_jsx_child(node, transform_context) {
 					params: loop_params,
 					body: /** @type {any} */ ({
 						type: 'BlockStatement',
-						body: has_hooks
-							? hook_safe_render_statements(loop_body, key_expression, transform_context)
-							: build_render_statements(loop_body, true, transform_context),
+						body: body_statements,
 						metadata: { path: [] },
 					}),
 					async: false,

--- a/packages/tsrx-react/src/transform.js
+++ b/packages/tsrx-react/src/transform.js
@@ -69,7 +69,16 @@ export function transform(ast, source, filename) {
 			const saved_helper_state = state.helper_state;
 			const saved_bindings = state.available_bindings;
 			state.helper_state = helper_state;
-			state.available_bindings = collect_param_bindings(as_any.params || []);
+
+			// Pre-collect ALL component body bindings (params + top-level statements)
+			// so that Element children processed during the bottom-up walk can see
+			// the full scope. Without this, hoisted helpers would miss body-level
+			// variables like `const [x] = useState(...)` and produce ReferenceErrors.
+			const body_bindings = collect_param_bindings(as_any.params || []);
+			for (const child of as_any.body || []) {
+				collect_statement_bindings(child, body_bindings);
+			}
+			state.available_bindings = body_bindings;
 
 			const inner = /** @type {any} */ (next() ?? node);
 
@@ -1416,6 +1425,19 @@ function hook_safe_render_statements(body_nodes, key_expression, transform_conte
 				metadata: { path: [] },
 			}),
 		);
+	}
+
+	// When helper_state is null (no enclosing component context), inline the
+	// helper via an IIFE so the function declaration isn't silently dropped.
+	if (!transform_context.helper_state) {
+		return [
+			helper_fn,
+			{
+				type: 'ReturnStatement',
+				argument: component_element,
+				metadata: { path: [] },
+			},
+		];
 	}
 
 	return [

--- a/packages/tsrx-react/src/transform.js
+++ b/packages/tsrx-react/src/transform.js
@@ -76,13 +76,19 @@ export function transform(ast, source, filename) {
 			const saved_bindings = state.available_bindings;
 			state.helper_state = helper_state;
 
-			// Pre-collect ALL component body bindings (params + top-level statements)
+			// Pre-collect component body bindings (params + top-level statements)
 			// so that Element children processed during the bottom-up walk can see
 			// the full scope. Without this, hoisted helpers would miss body-level
 			// variables like `const [x] = useState(...)` and produce ReferenceErrors.
+			// Only collect up to the split point — bindings declared after a
+			// hook-safe split aren't in scope at the return statement and would
+			// cause ReferenceErrors if passed as helper props.
 			const body_bindings = collect_param_bindings(as_any.params || []);
-			for (const child of as_any.body || []) {
-				collect_statement_bindings(child, body_bindings);
+			const body = as_any.body || [];
+			const split_index = find_hook_safe_split_index(body);
+			const collect_end = split_index === -1 ? body.length : split_index;
+			for (let i = 0; i < collect_end; i += 1) {
+				collect_statement_bindings(body[i], body_bindings);
 			}
 			state.available_bindings = body_bindings;
 
@@ -382,6 +388,34 @@ function apply_lazy_transforms(node, lazy_bindings) {
 		const new_body = apply_lazy_transforms(node.body, effective_bindings);
 		if (new_body !== node.body) changed = true;
 		return changed ? { ...node, right: new_right, body: new_body } : node;
+	}
+
+	// Handle switch-case variable shadowing (const/let inside case consequent arrays)
+	if (node.type === 'SwitchStatement') {
+		let changed = false;
+		const new_discriminant = apply_lazy_transforms(node.discriminant, lazy_bindings);
+		if (new_discriminant !== node.discriminant) changed = true;
+		const new_cases = node.cases.map((/** @type {any} */ switch_case) => {
+			const case_bindings = collect_block_shadowed_names(switch_case.consequent, lazy_bindings);
+			const effective_bindings =
+				case_bindings.size > 0 ? remove_shadowed(lazy_bindings, case_bindings) : lazy_bindings;
+			let case_changed = false;
+			const new_test = switch_case.test
+				? apply_lazy_transforms(switch_case.test, lazy_bindings)
+				: null;
+			if (new_test !== switch_case.test) case_changed = true;
+			const new_consequent = switch_case.consequent.map((/** @type {any} */ stmt) => {
+				const transformed = apply_lazy_transforms(stmt, effective_bindings);
+				if (transformed !== stmt) case_changed = true;
+				return transformed;
+			});
+			if (case_changed) {
+				changed = true;
+				return { ...switch_case, test: new_test, consequent: new_consequent };
+			}
+			return switch_case;
+		});
+		return changed ? { ...node, discriminant: new_discriminant, cases: new_cases } : node;
 	}
 
 	// Handle assignment: `name = value` → `__lazy0.name = value`

--- a/packages/tsrx-react/src/transform.js
+++ b/packages/tsrx-react/src/transform.js
@@ -280,6 +280,15 @@ function apply_lazy_transforms(node, lazy_bindings) {
 		node.type === 'FunctionExpression' ||
 		node.type === 'ArrowFunctionExpression'
 	) {
+		// Transform default parameter values (e.g. (step = count) => ...) with the
+		// outer lazy_bindings, since defaults are evaluated in the outer scope.
+		let params_changed = false;
+		const new_params = (node.params || []).map((/** @type {any} */ param) => {
+			const transformed = transform_param_defaults(param, lazy_bindings);
+			if (transformed !== param) params_changed = true;
+			return transformed;
+		});
+
 		// Check if any params shadow a lazy binding — if so, exclude those names
 		/** @type {Set<string>} */
 		const shadowed = new Set();
@@ -287,21 +296,19 @@ function apply_lazy_transforms(node, lazy_bindings) {
 			collect_shadowed_names(param, lazy_bindings, shadowed);
 		}
 
-		if (shadowed.size > 0) {
-			const inner_bindings = remove_shadowed(lazy_bindings, shadowed);
-			if (inner_bindings.size === 0) return node;
+		const inner_bindings =
+			shadowed.size > 0 ? remove_shadowed(lazy_bindings, shadowed) : lazy_bindings;
+		if (inner_bindings.size === 0 && !params_changed) return node;
 
-			// Only transform the body, not the params
-			const new_body = apply_lazy_transforms(node.body, inner_bindings);
-			if (new_body !== node.body) {
-				return { ...node, body: new_body };
-			}
-			return node;
-		}
+		const new_body =
+			inner_bindings.size > 0 ? apply_lazy_transforms(node.body, inner_bindings) : node.body;
 
-		const new_body = apply_lazy_transforms(node.body, lazy_bindings);
-		if (new_body !== node.body) {
-			return { ...node, body: new_body };
+		if (new_body !== node.body || params_changed) {
+			return {
+				...node,
+				params: params_changed ? new_params : node.params,
+				body: new_body,
+			};
 		}
 		return node;
 	}
@@ -472,6 +479,24 @@ function apply_lazy_transforms(node, lazy_bindings) {
 	}
 
 	return changed ? result : node;
+}
+
+/**
+ * Transform default values in function parameters without touching param names.
+ * E.g. `(step = count)` where `count` is a lazy binding → `(step = __lazy0[0])`.
+ *
+ * @param {any} param
+ * @param {Map<string, LazyBinding>} lazy_bindings
+ * @returns {any}
+ */
+function transform_param_defaults(param, lazy_bindings) {
+	if (param?.type === 'AssignmentPattern') {
+		const new_right = apply_lazy_transforms(param.right, lazy_bindings);
+		if (new_right !== param.right) {
+			return { ...param, right: new_right };
+		}
+	}
+	return param;
 }
 
 /**

--- a/packages/tsrx-react/src/transform.js
+++ b/packages/tsrx-react/src/transform.js
@@ -334,6 +334,49 @@ function apply_lazy_transforms(node, lazy_bindings) {
 		return node;
 	}
 
+	// Handle for-loop variable shadowing
+	if (node.type === 'ForStatement') {
+		/** @type {Set<string>} */
+		const shadowed = new Set();
+		if (node.init?.type === 'VariableDeclaration') {
+			for (const decl of node.init.declarations) {
+				if (decl.id) collect_shadowed_names(decl.id, lazy_bindings, shadowed);
+			}
+		}
+		const effective_bindings =
+			shadowed.size > 0 ? remove_shadowed(lazy_bindings, shadowed) : lazy_bindings;
+		let changed = false;
+		const new_init = apply_lazy_transforms(node.init, effective_bindings);
+		if (new_init !== node.init) changed = true;
+		const new_test = apply_lazy_transforms(node.test, effective_bindings);
+		if (new_test !== node.test) changed = true;
+		const new_update = apply_lazy_transforms(node.update, effective_bindings);
+		if (new_update !== node.update) changed = true;
+		const new_body = apply_lazy_transforms(node.body, effective_bindings);
+		if (new_body !== node.body) changed = true;
+		return changed
+			? { ...node, init: new_init, test: new_test, update: new_update, body: new_body }
+			: node;
+	}
+
+	if (node.type === 'ForOfStatement' || node.type === 'ForInStatement') {
+		/** @type {Set<string>} */
+		const shadowed = new Set();
+		if (node.left?.type === 'VariableDeclaration') {
+			for (const decl of node.left.declarations) {
+				if (decl.id) collect_shadowed_names(decl.id, lazy_bindings, shadowed);
+			}
+		}
+		const effective_bindings =
+			shadowed.size > 0 ? remove_shadowed(lazy_bindings, shadowed) : lazy_bindings;
+		let changed = false;
+		const new_right = apply_lazy_transforms(node.right, lazy_bindings);
+		if (new_right !== node.right) changed = true;
+		const new_body = apply_lazy_transforms(node.body, effective_bindings);
+		if (new_body !== node.body) changed = true;
+		return changed ? { ...node, right: new_right, body: new_body } : node;
+	}
+
 	// Handle assignment: `name = value` → `__lazy0.name = value`
 	if (node.type === 'AssignmentExpression' && node.left.type === 'Identifier') {
 		const binding = lazy_bindings.get(node.left.name);

--- a/packages/tsrx-react/src/transform.js
+++ b/packages/tsrx-react/src/transform.js
@@ -281,6 +281,7 @@ function apply_lazy_transforms(node, lazy_bindings) {
 		node.type === 'ArrowFunctionExpression'
 	) {
 		// Check if any params shadow a lazy binding — if so, exclude those names
+		/** @type {Set<string>} */
 		const shadowed = new Set();
 		for (const param of node.params || []) {
 			collect_shadowed_names(param, lazy_bindings, shadowed);

--- a/packages/tsrx-react/src/transform.js
+++ b/packages/tsrx-react/src/transform.js
@@ -13,7 +13,12 @@ import { renderStylesheets, setLocation } from '@tsrx/core';
  *   needs_suspense: boolean,
  *   helper_state: { base_name: string, next_id: number, helpers: AST.FunctionDeclaration[], statics: any[] } | null,
  *   available_bindings: Map<string, AST.Identifier>,
+ *   lazy_next_id: number,
  * }} TransformContext
+ */
+
+/**
+ * @typedef {{ source_name: string, read: () => any }} LazyBinding
  */
 
 /**
@@ -43,6 +48,7 @@ export function transform(ast, source, filename) {
 		needs_suspense: false,
 		helper_state: null,
 		available_bindings: new Map(),
+		lazy_next_id: 0,
 	};
 
 	walk(/** @type {any} */ (ast), transform_context, {
@@ -138,6 +144,339 @@ export function transform(ast, source, filename) {
 	return { ast: expanded, code: result.code, map: result.map, css };
 }
 
+// --- Lazy destructuring support ---
+
+/**
+ * Generate a unique lazy identifier name for a lazy destructuring pattern.
+ * @param {TransformContext} transform_context
+ * @returns {string}
+ */
+function generate_lazy_id(transform_context) {
+	return `__lazy${transform_context.lazy_next_id++}`;
+}
+
+/**
+ * Collect lazy bindings from a destructuring pattern.
+ * For `&{name, age}`, maps `name` → `source.name`, `age` → `source.age`.
+ * For `&[a, b]`, maps `a` → `source[0]`, `b` → `source[1]`.
+ * Handles nested AssignmentPattern (default values) and RestElement.
+ *
+ * @param {any} pattern - The ObjectPattern or ArrayPattern with lazy: true
+ * @param {string} source_name - The generated identifier name for the source
+ * @param {Map<string, LazyBinding>} lazy_bindings - Map to populate
+ */
+function collect_lazy_bindings(pattern, source_name, lazy_bindings) {
+	if (pattern.type === 'ObjectPattern') {
+		for (const prop of pattern.properties || []) {
+			if (prop.type === 'RestElement') {
+				// Rest element in object pattern — skip for now (complex to transform)
+				continue;
+			}
+			const value = prop.value;
+			const actual = value.type === 'AssignmentPattern' ? value.left : value;
+			if (actual.type === 'Identifier') {
+				const key = prop.key;
+				const computed = prop.computed || key.type !== 'Identifier';
+				lazy_bindings.set(actual.name, {
+					source_name,
+					read: () => ({
+						type: 'MemberExpression',
+						object: create_generated_identifier(source_name),
+						property: computed
+							? { ...key }
+							: { type: 'Identifier', name: key.name, metadata: { path: [] } },
+						computed,
+						optional: false,
+						metadata: { path: [] },
+					}),
+				});
+			}
+		}
+	} else if (pattern.type === 'ArrayPattern') {
+		for (let i = 0; i < (pattern.elements || []).length; i++) {
+			const element = pattern.elements[i];
+			if (!element) continue;
+			if (element.type === 'RestElement') {
+				// Rest element in array pattern — skip for now
+				continue;
+			}
+			const actual = element.type === 'AssignmentPattern' ? element.left : element;
+			if (actual.type === 'Identifier') {
+				const index = i;
+				lazy_bindings.set(actual.name, {
+					source_name,
+					read: () => ({
+						type: 'MemberExpression',
+						object: create_generated_identifier(source_name),
+						property: { type: 'Literal', value: index, raw: String(index), metadata: { path: [] } },
+						computed: true,
+						optional: false,
+						metadata: { path: [] },
+					}),
+				});
+			}
+		}
+	}
+}
+
+/**
+ * Collect lazy bindings from component params and body variable declarations
+ * WITHOUT modifying any AST nodes. Returns a map of binding name → accessor info.
+ * Stores the generated identifier name on the pattern's metadata for later replacement.
+ *
+ * @param {any[]} params - Component params (metadata annotated, not structurally mutated)
+ * @param {any[]} body - Component body (metadata annotated, not structurally mutated)
+ * @param {TransformContext} transform_context
+ * @returns {Map<string, LazyBinding>}
+ */
+function collect_lazy_bindings_from_component(params, body, transform_context) {
+	/** @type {Map<string, LazyBinding>} */
+	const lazy_bindings = new Map();
+
+	// Collect from lazy params
+	for (const param of params) {
+		const pattern = param.type === 'AssignmentPattern' ? param.left : param;
+
+		if ((pattern.type === 'ObjectPattern' || pattern.type === 'ArrayPattern') && pattern.lazy) {
+			const lazy_name = generate_lazy_id(transform_context);
+			collect_lazy_bindings(pattern, lazy_name, lazy_bindings);
+			pattern.metadata = { ...pattern.metadata, lazy_id: lazy_name };
+		}
+	}
+
+	// Collect from lazy variable declarations in body
+	for (const statement of body) {
+		if (statement.type !== 'VariableDeclaration') continue;
+
+		for (const declarator of statement.declarations || []) {
+			const pattern = declarator.id;
+			if ((pattern.type === 'ObjectPattern' || pattern.type === 'ArrayPattern') && pattern.lazy) {
+				const lazy_name = generate_lazy_id(transform_context);
+				collect_lazy_bindings(pattern, lazy_name, lazy_bindings);
+				pattern.metadata = { ...pattern.metadata, lazy_id: lazy_name };
+			}
+		}
+	}
+
+	return lazy_bindings;
+}
+
+/**
+ * Walk an AST node tree and replace identifier references that match lazy bindings
+ * with their corresponding member expressions (e.g., `name` → `__lazy0.name`).
+ * Also handles AssignmentExpression and UpdateExpression targets.
+ *
+ * @param {any} node - The AST node to walk
+ * @param {Map<string, LazyBinding>} lazy_bindings - Map of lazy binding names
+ * @returns {any}
+ */
+function apply_lazy_transforms(node, lazy_bindings) {
+	if (!node || typeof node !== 'object') return node;
+	if (Array.isArray(node)) return node.map((child) => apply_lazy_transforms(child, lazy_bindings));
+
+	// Don't recurse into nested function declarations (helper components have their own scope)
+	if (
+		node.type === 'FunctionDeclaration' ||
+		node.type === 'FunctionExpression' ||
+		node.type === 'ArrowFunctionExpression'
+	) {
+		// Check if any params shadow a lazy binding — if so, exclude those names
+		const shadowed = new Set();
+		for (const param of node.params || []) {
+			collect_shadowed_names(param, lazy_bindings, shadowed);
+		}
+
+		if (shadowed.size > 0) {
+			const inner_bindings = new Map(lazy_bindings);
+			for (const name of shadowed) {
+				inner_bindings.delete(name);
+			}
+			if (inner_bindings.size === 0) return node;
+
+			// Only transform the body, not the params
+			const new_body = apply_lazy_transforms(node.body, inner_bindings);
+			if (new_body !== node.body) {
+				return { ...node, body: new_body };
+			}
+			return node;
+		}
+
+		const new_body = apply_lazy_transforms(node.body, lazy_bindings);
+		if (new_body !== node.body) {
+			return { ...node, body: new_body };
+		}
+		return node;
+	}
+
+	// Handle assignment: `name = value` → `__lazy0.name = value`
+	if (node.type === 'AssignmentExpression' && node.left.type === 'Identifier') {
+		const binding = lazy_bindings.get(node.left.name);
+		if (binding) {
+			return {
+				...node,
+				left: binding.read(),
+				right: apply_lazy_transforms(node.right, lazy_bindings),
+			};
+		}
+	}
+
+	// Handle update: `count++` → `__lazy0[0]++`
+	if (node.type === 'UpdateExpression' && node.argument.type === 'Identifier') {
+		const binding = lazy_bindings.get(node.argument.name);
+		if (binding) {
+			return { ...node, argument: binding.read() };
+		}
+	}
+
+	// Replace lazy variable declaration patterns with generated identifiers
+	if (node.type === 'VariableDeclarator' && node.id?.metadata?.lazy_id) {
+		const lazy_id = create_generated_identifier(node.id.metadata.lazy_id);
+		return {
+			...node,
+			id: lazy_id,
+			init: apply_lazy_transforms(node.init, lazy_bindings),
+		};
+	}
+
+	// Handle identifier references in expression position
+	if (node.type === 'Identifier') {
+		const binding = lazy_bindings.get(node.name);
+		if (binding) {
+			return binding.read();
+		}
+		return node;
+	}
+
+	// Skip JSXIdentifier (component/element names)
+	if (node.type === 'JSXIdentifier') return node;
+
+	// Handle shorthand properties: `{ name }` → `{ name: __lazy0.name }`
+	if (node.type === 'Property' && node.shorthand && node.value?.type === 'Identifier') {
+		const binding = lazy_bindings.get(node.value.name);
+		if (binding) {
+			return {
+				...node,
+				shorthand: false,
+				value: binding.read(),
+			};
+		}
+	}
+
+	// Recurse into child nodes
+	let changed = false;
+	const result = /** @type {any} */ ({});
+
+	for (const key of Object.keys(node)) {
+		if (key === 'loc' || key === 'start' || key === 'end') {
+			result[key] = node[key];
+			continue;
+		}
+
+		// Skip non-computed property keys (they're labels, not references)
+		if (key === 'key' && node.type === 'Property' && !node.computed && !node.shorthand) {
+			result[key] = node[key];
+			continue;
+		}
+
+		// Skip non-computed member expression property names
+		if (key === 'property' && node.type === 'MemberExpression' && !node.computed) {
+			result[key] = node[key];
+			continue;
+		}
+
+		// Skip JSXAttribute name
+		if (key === 'name' && node.type === 'JSXAttribute') {
+			result[key] = node[key];
+			continue;
+		}
+
+		// Skip variable declaration id (the lazy declaration itself was already replaced)
+		if (key === 'id' && node.type === 'VariableDeclarator') {
+			result[key] = node[key];
+			continue;
+		}
+
+		const child = node[key];
+		const transformed = apply_lazy_transforms(child, lazy_bindings);
+		result[key] = transformed;
+		if (transformed !== child) changed = true;
+	}
+
+	return changed ? result : node;
+}
+
+/**
+ * Collect names from a pattern that shadow lazy bindings.
+ * @param {any} pattern
+ * @param {Map<string, LazyBinding>} lazy_bindings
+ * @param {Set<string>} shadowed
+ */
+function collect_shadowed_names(pattern, lazy_bindings, shadowed) {
+	if (!pattern || typeof pattern !== 'object') return;
+
+	if (pattern.type === 'Identifier' && lazy_bindings.has(pattern.name)) {
+		shadowed.add(pattern.name);
+		return;
+	}
+
+	if (pattern.type === 'AssignmentPattern') {
+		collect_shadowed_names(pattern.left, lazy_bindings, shadowed);
+		return;
+	}
+
+	if (pattern.type === 'RestElement') {
+		collect_shadowed_names(pattern.argument, lazy_bindings, shadowed);
+		return;
+	}
+
+	if (pattern.type === 'ObjectPattern') {
+		for (const prop of pattern.properties || []) {
+			if (prop.type === 'RestElement') {
+				collect_shadowed_names(prop.argument, lazy_bindings, shadowed);
+			} else {
+				collect_shadowed_names(prop.value, lazy_bindings, shadowed);
+			}
+		}
+		return;
+	}
+
+	if (pattern.type === 'ArrayPattern') {
+		for (const element of pattern.elements || []) {
+			if (element) collect_shadowed_names(element, lazy_bindings, shadowed);
+		}
+	}
+}
+
+/**
+ * Replace lazy parameter patterns with their generated identifiers.
+ * A param `&{name, age}: Props` becomes `__lazy0: Props`.
+ *
+ * @param {any[]} params
+ * @returns {any[]}
+ */
+function replace_lazy_params(params) {
+	return params.map((param) => {
+		const pattern = param.type === 'AssignmentPattern' ? param.left : param;
+
+		if (
+			(pattern.type === 'ObjectPattern' || pattern.type === 'ArrayPattern') &&
+			pattern.lazy &&
+			pattern.metadata?.lazy_id
+		) {
+			const lazy_id = create_generated_identifier(pattern.metadata.lazy_id);
+			if (pattern.typeAnnotation) {
+				lazy_id.typeAnnotation = pattern.typeAnnotation;
+			}
+			if (param.type === 'AssignmentPattern') {
+				return { ...param, left: lazy_id };
+			}
+			return lazy_id;
+		}
+
+		return param;
+	});
+}
+
 /**
  * @param {any} component
  * @param {TransformContext} transform_context
@@ -146,7 +485,16 @@ export function transform(ast, source, filename) {
  */
 function component_to_function_declaration(component, transform_context, walk_helper_state) {
 	const helper_state = walk_helper_state || create_helper_state(component.id?.name || 'Component');
-	const param_bindings = collect_param_bindings(component.params || []);
+	const params = component.params || [];
+	const body = /** @type {any[]} */ (component.body || []);
+
+	// Collect param bindings from original patterns (lazy patterns still intact).
+	const param_bindings = collect_param_bindings(params);
+
+	// Collect lazy binding info WITHOUT mutating patterns. Stores lazy_id on metadata
+	// for later replacement. Body bindings (count, setCount, etc.) are still in the
+	// original patterns, so collect_statement_bindings during build will find them.
+	const lazy_bindings = collect_lazy_bindings_from_component(params, body, transform_context);
 
 	// Save and set context for this component scope
 	const saved_helper_state = transform_context.helper_state;
@@ -154,18 +502,26 @@ function component_to_function_declaration(component, transform_context, walk_he
 	transform_context.helper_state = helper_state;
 	transform_context.available_bindings = new Map(param_bindings);
 
+	const body_statements = build_component_statements(
+		body,
+		helper_state,
+		param_bindings,
+		transform_context,
+	);
+
+	// Replace lazy param patterns with generated identifiers
+	const final_params = lazy_bindings.size > 0 ? replace_lazy_params(params) : params;
+
 	const fn = /** @type {any} */ ({
 		type: 'FunctionDeclaration',
 		id: component.id,
-		params: component.params || [],
+		params: final_params,
 		body: {
 			type: 'BlockStatement',
-			body: build_component_statements(
-				/** @type {any[]} */ (component.body),
-				helper_state,
-				param_bindings,
-				transform_context,
-			),
+			body:
+				lazy_bindings.size > 0
+					? apply_lazy_transforms(body_statements, lazy_bindings)
+					: body_statements,
 			metadata: { path: [] },
 		},
 		async: false,
@@ -715,8 +1071,10 @@ function references_scope_bindings(node, scope_bindings) {
 		return scope_bindings.has(node.name);
 	}
 
-	// JSXIdentifier nodes are tag names or attribute names, not variable references
-	if (node.type === 'JSXIdentifier') return false;
+	// Capitalized JSXIdentifier tag names are component variable references (e.g. <MyComponent />)
+	if (node.type === 'JSXIdentifier') {
+		return /^[A-Z]/.test(node.name) && scope_bindings.has(node.name);
+	}
 
 	if (Array.isArray(node)) {
 		return node.some((child) => references_scope_bindings(child, scope_bindings));
@@ -730,6 +1088,9 @@ function references_scope_bindings(node, scope_bindings) {
 
 		// Skip non-computed member expression property access
 		if (key === 'property' && node.type === 'MemberExpression' && !node.computed) continue;
+
+		// Skip JSXAttribute names — they are attribute labels, not variable references
+		if (key === 'name' && node.type === 'JSXAttribute') continue;
 
 		if (references_scope_bindings(node[key], scope_bindings)) return true;
 	}

--- a/packages/tsrx-react/tests/basic.test.js
+++ b/packages/tsrx-react/tests/basic.test.js
@@ -1114,4 +1114,40 @@ describe('lazy destructuring', () => {
 		expect(code).not.toContain('App__static2');
 		expect(code).toContain('<Widget');
 	});
+
+	it('does not hoist elements using JSXMemberExpression with component-scope object', () => {
+		const { code } = compile(
+			`export component App({ui}: {ui: any}) {
+				<div>{"static"}</div>
+				<ui.Button />
+			}`,
+			'App.tsrx',
+		);
+
+		// Pure static element can still be hoisted
+		expect(code).toContain('App__static1');
+		// Element using a component-scope binding as JSXMemberExpression object must NOT be hoisted
+		expect(code).not.toContain('App__static2');
+		expect(code).toContain('<ui.Button');
+	});
+
+	it('does not rewrite locally shadowed names inside blocks', () => {
+		const { code } = compile(
+			`export component App(&{name}: Props) {
+				const handler = () => {
+					const name = 'local';
+					return name;
+				};
+				<div>{name}</div>
+			}`,
+			'App.tsrx',
+		);
+
+		// The prop reference should be rewritten
+		expect(code).toContain('__lazy0.name');
+		// The callback should use the local 'name', not the lazy accessor
+		expect(code).toContain("const name = 'local'");
+		expect(code).toContain('return name');
+		expect(code).not.toMatch(/return __lazy0\.name/);
+	});
 });

--- a/packages/tsrx-react/tests/basic.test.js
+++ b/packages/tsrx-react/tests/basic.test.js
@@ -1225,4 +1225,55 @@ describe('lazy destructuring', () => {
 		// it was declared inside the first if block, not in the component scope
 		expect(code).not.toContain('localVar={localVar}');
 	});
+
+	it('does not pass post-split bindings as helper component props', () => {
+		const { code } = compile(
+			`import { useState, useEffect } from 'react';
+
+			export component App() {
+				const [count, setCount] = useState(0);
+
+				if (count > 2) {
+					return;
+				}
+
+				const laterVar = 'after split';
+
+				useEffect(() => {
+					console.log(laterVar);
+				}, [laterVar]);
+
+				<div>{laterVar}</div>
+			}`,
+			'App.tsrx',
+		);
+
+		// The continuation helper should receive count/setCount from before the split
+		expect(code).toContain('App__Continue');
+		expect(code).toContain('count={count}');
+
+		// laterVar is declared AFTER the split — it must NOT appear as a prop
+		// on the helper element at the call site (it's not in scope there)
+		expect(code).not.toContain('laterVar={laterVar}');
+	});
+
+	it('does not rewrite switch-case variables that shadow lazy bindings', () => {
+		const { code } = compile(
+			`export component App(&{ name }: { name: string }) {
+				switch (name) {
+					case 'test': {
+						const name = 'local';
+						console.log(name);
+						break;
+					}
+				}
+				<div>{name}</div>
+			}`,
+			'App.tsrx',
+		);
+
+		// The 'name' inside the switch case should NOT be rewritten to a lazy accessor
+		expect(code).toContain("const name = 'local'");
+		expect(code).toContain('console.log(name)');
+	});
 });

--- a/packages/tsrx-react/tests/basic.test.js
+++ b/packages/tsrx-react/tests/basic.test.js
@@ -1276,4 +1276,21 @@ describe('lazy destructuring', () => {
 		expect(code).toContain("const name = 'local'");
 		expect(code).toContain('console.log(name)');
 	});
+
+	it('does not rewrite body-level variables that shadow lazy bindings', () => {
+		const { code } = compile(
+			`export component App(&{ name }: { name: string }) {
+				const name = 'override';
+				<div>{name}</div>
+			}`,
+			'App.tsrx',
+		);
+
+		// The body-level 'name' shadows the lazy binding — references should
+		// use the local variable, not the lazy accessor
+		expect(code).toContain("const name = 'override'");
+		// The div should use plain 'name', not __lazy0.name
+		expect(code).toContain('{name}');
+		expect(code).not.toContain('__lazy0.name');
+	});
 });

--- a/packages/tsrx-react/tests/basic.test.js
+++ b/packages/tsrx-react/tests/basic.test.js
@@ -1169,4 +1169,20 @@ describe('lazy destructuring', () => {
 		expect(code).toContain('console.log(name)');
 		expect(code).not.toMatch(/console\.log\(__lazy0\.name\)/);
 	});
+
+	it('transforms default parameter values referencing lazy bindings', () => {
+		const { code } = compile(
+			`export component App() {
+				const &[count] = useState(0);
+				const handler = (step = count) => step + 1;
+				<div>{count}</div>
+			}`,
+			'App.tsrx',
+		);
+
+		// The default value should be rewritten to the lazy accessor
+		expect(code).toContain('step = __lazy0[0]');
+		// The param name 'step' itself should NOT be rewritten
+		expect(code).toContain('step + 1');
+	});
 });

--- a/packages/tsrx-react/tests/basic.test.js
+++ b/packages/tsrx-react/tests/basic.test.js
@@ -483,7 +483,7 @@ describe('@tsrx/react basic', () => {
 
 		expect(code).toContain('function StatementBodyHook1() {');
 		expect(code).toContain('const [x] = useState(1);');
-		expect(code).toContain('return <StatementBodyHook1 />;');
+		expect(code).toContain('<StatementBodyHook1 />');
 		expect(mappings.errors).toEqual([]);
 	});
 
@@ -958,6 +958,6 @@ describe('@tsrx/react basic', () => {
 
 		expect(code).toContain('function StatementBodyHook');
 		// Key should appear on both the inner element and wrapper component
-		expect(code).toContain('<StatementBodyHook1 key={item} />');
+		expect(code).toContain('<StatementBodyHook1 items={items} item={item} key={item} />');
 	});
 });

--- a/packages/tsrx-react/tests/basic.test.js
+++ b/packages/tsrx-react/tests/basic.test.js
@@ -1185,4 +1185,18 @@ describe('lazy destructuring', () => {
 		// The param name 'step' itself should NOT be rewritten
 		expect(code).toContain('step + 1');
 	});
+
+	it('hoists JSXMemberExpression elements when only the property matches a scope binding', () => {
+		const { code } = compile(
+			`import Icons from './Icons';
+			export component App({Button}: {Button: any}) {
+				<Icons.Button />
+			}`,
+			'App.tsrx',
+		);
+
+		// Icons.Button should be hoisted — Button is a property label, not a variable reference
+		// Only the object (Icons) matters, and it's a module-scope import
+		expect(code).toContain('App__static1');
+	});
 });

--- a/packages/tsrx-react/tests/basic.test.js
+++ b/packages/tsrx-react/tests/basic.test.js
@@ -154,7 +154,7 @@ describe('@tsrx/react basic', () => {
 
 		expect(css).not.toBeNull();
 		expect(code).toContain(`className="${css.hash}"`);
-		expect(code).toContain('return <div className=');
+		expect(code).toContain(`App__static1 = <div className="${css.hash}">`);
 		expect(css.code).toContain(`.div.${css.hash}`);
 	});
 
@@ -174,7 +174,7 @@ describe('@tsrx/react basic', () => {
 
 		expect(code).toContain('const count = 2;');
 		expect(code).toContain('if (count > 1) {');
-		expect(code).toContain("return <div>{'Count is more than one'}</div>;");
+		expect(code).toContain("App__static1 = <div>{'Count is more than one'}</div>");
 		expect(code).toContain('return null;');
 		expect(code).toContain('<button>{count}</button>');
 	});
@@ -194,8 +194,8 @@ describe('@tsrx/react basic', () => {
 		);
 
 		expect(code).toContain('if (ready) {');
-		expect(code).toContain("return <div>{'Ready'}</div>;");
-		expect(code).toContain("return <div>{'Loading'}</div>;");
+		expect(code).toContain("App__static2 = <div>{'Ready'}</div>");
+		expect(code).toContain("App__static1 = <div>{'Loading'}</div>");
 	});
 
 	it('renders component-body for-of statements as React expressions', () => {
@@ -250,7 +250,7 @@ describe('@tsrx/react basic', () => {
 
 		expect(code).toContain('if (count > 2) {');
 		expect(code).toContain('return (() => {');
-		expect(code).toContain("return <div>{'Count is more than one'}</div>;");
+		expect(code).toContain("App__static1 = <div>{'Count is more than one'}</div>");
 		expect(code).toContain('return null;');
 		expect(code).toContain('<button>{count}</button>');
 	});
@@ -439,7 +439,7 @@ describe('@tsrx/react basic', () => {
 		expect(code).toContain('function Child() {');
 		expect(code).toContain('const x = 1;');
 		expect(code).toContain('console.log(x);');
-		expect(code).toContain('return <div>{(() => {');
+		expect(code).toContain('Child__static1 = <div>{(() => {');
 		expect(code).toContain('return null;');
 	});
 

--- a/packages/tsrx-react/tests/basic.test.js
+++ b/packages/tsrx-react/tests/basic.test.js
@@ -961,3 +961,157 @@ describe('@tsrx/react basic', () => {
 		expect(code).toContain('<StatementBodyHook1 items={items} item={item} key={item} />');
 	});
 });
+
+describe('lazy destructuring', () => {
+	it('transforms lazy object destructuring in component params', () => {
+		const { code } = compile(
+			`export component App(&{name, age}: Props) {
+				<div>{name}{age}</div>
+			}`,
+			'App.tsrx',
+		);
+
+		// Param should be replaced with generated identifier
+		expect(code).toContain('function App(__lazy0: Props)');
+		// References should be member expressions
+		expect(code).toContain('__lazy0.name');
+		expect(code).toContain('__lazy0.age');
+	});
+
+	it('transforms lazy array destructuring in variable declarations', () => {
+		const { code } = compile(
+			`export component App() {
+				let &[count, setCount] = useState(0);
+				<div>{count}</div>
+			}`,
+			'App.tsrx',
+		);
+
+		// Declaration should use generated identifier
+		expect(code).toContain('let __lazy0 = useState(0)');
+		// Reference should be array index access
+		expect(code).toContain('__lazy0[0]');
+	});
+
+	it('transforms lazy object destructuring in variable declarations', () => {
+		const { code } = compile(
+			`export component App() {
+				const &{data, error} = useSWR("/api");
+				<div>{data}{error}</div>
+			}`,
+			'App.tsrx',
+		);
+
+		expect(code).toContain('const __lazy0 = useSWR("/api")');
+		expect(code).toContain('__lazy0.data');
+		expect(code).toContain('__lazy0.error');
+	});
+
+	it('handles assignment to lazy array bindings', () => {
+		const { code } = compile(
+			`export component App() {
+				let &[val] = getState();
+				val = 10;
+				val++;
+				++val;
+				<div>{val}</div>
+			}`,
+			'App.tsrx',
+		);
+
+		expect(code).toContain('__lazy0[0] = 10');
+		expect(code).toContain('__lazy0[0]++');
+		expect(code).toContain('++__lazy0[0]');
+	});
+
+	it('handles shorthand object properties with lazy bindings', () => {
+		const { code } = compile(
+			`export component App(&{name}: Props) {
+				const obj = {name};
+				<div>{obj}</div>
+			}`,
+			'App.tsrx',
+		);
+
+		// Shorthand {name} should expand to {name: __lazy0.name}
+		expect(code).toContain('name: __lazy0.name');
+	});
+
+	it('handles shadowing in inner functions', () => {
+		const { code } = compile(
+			`export component App(&{name}: Props) {
+				const fn = (name: string) => name.toUpperCase();
+				<div>{fn(name)}</div>
+			}`,
+			'App.tsrx',
+		);
+
+		// Inner param shadows lazy binding - should stay as `name`
+		expect(code).toContain('(name: string) => name.toUpperCase()');
+		// Outer reference should use lazy accessor
+		expect(code).toContain('fn(__lazy0.name)');
+	});
+
+	it('does not hoist static elements that reference lazy bindings', () => {
+		const { code } = compile(
+			`export component App() {
+				const &[count] = useState(0);
+				<div>{"static"}</div>
+				<div>{count}</div>
+			}`,
+			'App.tsrx',
+		);
+
+		// The truly static element should be hoisted
+		expect(code).toContain('App__static1');
+		expect(code).toContain('App__static1 = <div>{"static"}</div>');
+		// The element referencing count should NOT be hoisted
+		expect(code).toContain('__lazy0[0]');
+		expect(code).not.toContain('App__static2');
+	});
+
+	it('combines lazy params and lazy variables', () => {
+		const { code } = compile(
+			`export component App(&{name}: Props) {
+				const &[count, setCount] = useState(0);
+				<div>{name}{count}</div>
+			}`,
+			'App.tsrx',
+		);
+
+		// Param uses __lazy0, variable uses __lazy1
+		expect(code).toContain('function App(__lazy0: Props)');
+		expect(code).toContain('const __lazy1 = useState(0)');
+		expect(code).toContain('__lazy0.name');
+		expect(code).toContain('__lazy1[0]');
+	});
+
+	it('transforms lazy bindings inside callbacks', () => {
+		const { code } = compile(
+			`export component App() {
+				let &[count, setCount] = useState(0);
+				const handler = () => setCount(count + 1);
+				<div>{count}</div>
+			}`,
+			'App.tsrx',
+		);
+
+		expect(code).toContain('() => __lazy0[1](__lazy0[0] + 1)');
+	});
+
+	it('does not hoist elements using component-scope bindings as tag names', () => {
+		const { code } = compile(
+			`export component App({Widget}: {Widget: any}) {
+				<div>{"static"}</div>
+				<Widget />
+			}`,
+			'App.tsrx',
+		);
+
+		// Pure static element can still be hoisted
+		expect(code).toContain('App__static1');
+		// Element using a component-scope binding (prop) as tag name must NOT be hoisted
+		expect(code).not.toContain('App__static2');
+		expect(code).toContain('<Widget');
+	});
+});

--- a/packages/tsrx-react/tests/basic.test.js
+++ b/packages/tsrx-react/tests/basic.test.js
@@ -1150,4 +1150,23 @@ describe('lazy destructuring', () => {
 		expect(code).toContain('return name');
 		expect(code).not.toMatch(/return __lazy0\.name/);
 	});
+
+	it('does not rewrite loop variables that shadow lazy bindings', () => {
+		const { code } = compile(
+			`export component App(&{name}: Props) {
+				const items = ['a', 'b'];
+				for (const name of items) {
+					console.log(name);
+				}
+				<div>{name}</div>
+			}`,
+			'App.tsrx',
+		);
+
+		// The prop reference in JSX should be rewritten
+		expect(code).toContain('__lazy0.name');
+		// The for-of loop variable should NOT be rewritten
+		expect(code).toContain('console.log(name)');
+		expect(code).not.toMatch(/console\.log\(__lazy0\.name\)/);
+	});
 });

--- a/packages/tsrx-react/tests/basic.test.js
+++ b/packages/tsrx-react/tests/basic.test.js
@@ -1199,4 +1199,30 @@ describe('lazy destructuring', () => {
 		// Only the object (Icons) matters, and it's a module-scope import
 		expect(code).toContain('App__static1');
 	});
+
+	it('does not leak inner-scope bindings into helper component props', () => {
+		const { code } = compile(
+			`import { useState } from 'react';
+
+			export component App() {
+				const show = true;
+				if (show) {
+					const localVar = 'hello';
+					<div>{localVar}</div>
+				}
+				if (show) {
+					const [val] = useState(0);
+					<span>{val}</span>
+				}
+			}`,
+			'App.tsrx',
+		);
+
+		// The hook-bearing branch gets a helper component
+		expect(code).toContain('function StatementBodyHook');
+
+		// The helper component should NOT receive 'localVar' as a prop —
+		// it was declared inside the first if block, not in the component scope
+		expect(code).not.toContain('localVar={localVar}');
+	});
 });

--- a/packages/vite-plugin-react/tests/runtime.test.tsrx
+++ b/packages/vite-plugin-react/tests/runtime.test.tsrx
@@ -606,6 +606,55 @@ component FullyStaticApp() {
 	</div>
 }
 
+// ── Lazy destructuring: object in props ──
+
+component LazyPropsChild(&{ name, age }: { name: string; age: number }) {
+	<div class="lazy-props">
+		{name}
+		{' is '}
+		{age}
+	</div>
+}
+
+component LazyPropsApp() {
+	<LazyPropsChild name="Alice" age={30} />
+}
+
+// ── Lazy destructuring: array in variable ──
+
+component LazyArrayApp() {
+	let &[count, setCount] = useState(0);
+	<p class="lazy-count">{count}</p>
+	<button class="lazy-inc" onClick={() => setCount(count + 1)}>{'+'}</button>
+}
+
+// ── Lazy destructuring: object in variable ──
+
+component LazyObjVarApp() {
+	const &{ x, y } = usePosition();
+	<p class="lazy-pos">
+		{x}
+		{','}
+		{y}
+	</p>
+}
+
+function usePosition() {
+	return { x: 10, y: 20 };
+}
+
+// ── Lazy destructuring: combined props + variable ──
+
+component LazyCombinedApp(&{ label }: { label: string }) {
+	const &[count, setCount] = useState(0);
+	<p class="lazy-combined">
+		{label}
+		{': '}
+		{count}
+	</p>
+	<button class="lazy-combined-inc" onClick={() => setCount(count + 1)}>{'+'}</button>
+}
+
 // ── Tests ──
 
 describe('tsrx-react runtime', () => {
@@ -1050,5 +1099,36 @@ describe('tsrx-react runtime', () => {
 		await render(FullyStaticApp);
 		expect(text('.all-static h2')).toBe('Title');
 		expect(text('.all-static p')).toBe('Paragraph');
+	});
+
+	// ── Lazy destructuring ──
+
+	it('lazy object destructuring in props works at runtime', async () => {
+		await render(LazyPropsApp);
+		expect(text('.lazy-props')).toBe('Alice is 30');
+	});
+
+	it('lazy array destructuring in variables works at runtime', async () => {
+		await render(LazyArrayApp);
+		expect(text('.lazy-count')).toBe('0');
+
+		await click('.lazy-inc');
+		expect(text('.lazy-count')).toBe('1');
+
+		await click('.lazy-inc');
+		expect(text('.lazy-count')).toBe('2');
+	});
+
+	it('lazy object destructuring in variables works at runtime', async () => {
+		await render(LazyObjVarApp);
+		expect(text('.lazy-pos')).toBe('10,20');
+	});
+
+	it('combined lazy props and lazy variables work at runtime', async () => {
+		await render(LazyCombinedApp, { label: 'Count' });
+		expect(text('.lazy-combined')).toBe('Count: 0');
+
+		await click('.lazy-combined-inc');
+		expect(text('.lazy-combined')).toBe('Count: 1');
 	});
 });

--- a/packages/vite-plugin-react/tests/runtime.test.tsrx
+++ b/packages/vite-plugin-react/tests/runtime.test.tsrx
@@ -569,6 +569,43 @@ component HookInSwitchWithScopeApp() {
 	</button>
 }
 
+// ── Static hoisting: mixed static and dynamic siblings ──
+
+component StaticHoistMixedApp() {
+	const [count, setCount] = useState(0);
+
+	<header class="static-header">
+		<h1>{'Static Title'}</h1>
+	</header>
+	<p class="dynamic-count">{count}</p>
+	<footer class="static-footer">{'Static Footer'}</footer>
+
+	<button class="hoist-inc" onClick={() => setCount(count + 1)}>{'inc'}</button>
+}
+
+// ── Static hoisting: static element inside control flow ──
+
+component StaticHoistInBranchApp() {
+	const [show, setShow] = useState(true);
+
+	if (show) {
+		<div class="branch-static">
+			<span>{'Always the same'}</span>
+		</div>
+	}
+
+	<button class="hoist-toggle" onClick={() => setShow(!show)}>{'toggle'}</button>
+}
+
+// ── Static hoisting: fully static component ──
+
+component FullyStaticApp() {
+	<div class="all-static">
+		<h2>{'Title'}</h2>
+		<p>{'Paragraph'}</p>
+	</div>
+}
+
 // ── Tests ──
 
 describe('tsrx-react runtime', () => {
@@ -981,5 +1018,37 @@ describe('tsrx-react runtime', () => {
 
 		await click('.switch-scope-tab');
 		expect(text('.switch-scope-val')).toBe('dark:info');
+	});
+
+	// ── Static hoisting ──
+
+	it('hoists static elements while keeping dynamic siblings interactive', async () => {
+		await render(StaticHoistMixedApp);
+		expect(text('.static-header h1')).toBe('Static Title');
+		expect(text('.dynamic-count')).toBe('0');
+		expect(text('.static-footer')).toBe('Static Footer');
+
+		await click('.hoist-inc');
+		expect(text('.dynamic-count')).toBe('1');
+		// Static elements remain unchanged
+		expect(text('.static-header h1')).toBe('Static Title');
+		expect(text('.static-footer')).toBe('Static Footer');
+	});
+
+	it('hoists static elements inside control flow branches', async () => {
+		await render(StaticHoistInBranchApp);
+		expect(text('.branch-static span')).toBe('Always the same');
+
+		await click('.hoist-toggle');
+		expect(container.querySelector('.branch-static')).toBeNull();
+
+		await click('.hoist-toggle');
+		expect(text('.branch-static span')).toBe('Always the same');
+	});
+
+	it('renders a fully static component correctly', async () => {
+		await render(FullyStaticApp);
+		expect(text('.all-static h2')).toBe('Title');
+		expect(text('.all-static p')).toBe('Paragraph');
 	});
 });

--- a/packages/vite-plugin-react/tests/runtime.test.tsrx
+++ b/packages/vite-plugin-react/tests/runtime.test.tsrx
@@ -461,6 +461,114 @@ component HookInBothBranchesApp() {
 	</button>
 }
 
+// ── Hook inside if-branch closing over parent scope ──
+
+component HookClosingOverScopeApp() {
+	const [multiplier, setMultiplier] = useState(2);
+
+	if (multiplier > 0) {
+		const [base, setBase] = useState(5);
+		<p class="scope-result">{base * multiplier}</p>
+		<button class="scope-inc-base" onClick={() => setBase(base + 1)}>{'inc base'}</button>
+	}
+
+	<button class="scope-inc-mult" onClick={() => setMultiplier(multiplier + 1)}>
+		{'inc multiplier'}
+	</button>
+}
+
+// ── Hook inside element children (hooks in nested <div> body) ──
+
+component HookInsideElementApp() {
+	const [label, setLabel] = useState('greeting');
+
+	<div class="outer">
+		<h2>{label}</h2>
+		if (label === 'greeting') {
+			const [msg, setMsg] = useState('Hello');
+			<p class="inner-msg">{msg}</p>
+			<button class="inner-update" onClick={() => setMsg('Hi there')}>{'update'}</button>
+		}
+	</div>
+
+	<button
+		class="outer-toggle"
+		onClick={() => setLabel(label === 'greeting' ? 'farewell' : 'greeting')}
+	>
+		{'toggle'}
+	</button>
+}
+
+// ── Hook inside for-of closing over parent scope ──
+
+component HookInForClosingScopeApp() {
+	const [prefix, setPrefix] = useState('item');
+	const [items, setItems] = useState(['a', 'b']);
+
+	for (const item of items) {
+		const [active, setActive] = useState(false);
+		<div class="for-scope-item" key={item}>
+			<span class="for-scope-label">{prefix + '-' + item + (active ? '!' : '')}</span>
+			<button class={'for-scope-toggle-' + item} onClick={() => setActive(!active)}>
+				{'toggle'}
+			</button>
+		</div>
+	}
+
+	<button class="for-scope-prefix" onClick={() => setPrefix('thing')}>{'change prefix'}</button>
+}
+
+// ── Early return before hooks with parent scope ──
+
+component EarlyReturnWithHooksApp() {
+	const [count, setCount] = useState(0);
+	const [skip, setSkip] = useState(false);
+
+	if (skip) {
+		return;
+	}
+
+	const [doubled, setDoubled] = useState(0);
+
+	<p class="early-count">{count}</p>
+	<p class="early-doubled">{doubled}</p>
+	<button
+		class="early-inc"
+		onClick={() => {
+			setCount(count + 1);
+			setDoubled((count + 1) * 2);
+		}}
+	>
+		{'inc'}
+	</button>
+	<button class="early-skip" onClick={() => setSkip(true)}>{'skip'}</button>
+}
+
+// ── Hook inside switch closing over parent scope ──
+
+component HookInSwitchWithScopeApp() {
+	const [tab, setTab] = useState('counter');
+	const [theme, setTheme] = useState('light');
+
+	switch (tab) {
+		case 'counter':
+			const [n, setN] = useState(0);
+			<p class="switch-scope-val">{theme + ':' + n}</p>
+			<button class="switch-scope-inc" onClick={() => setN(n + 1)}>{'inc'}</button>
+			break;
+		case 'info':
+			<p class="switch-scope-val">{theme + ':info'}</p>
+			break;
+	}
+
+	<button class="switch-scope-tab" onClick={() => setTab(tab === 'counter' ? 'info' : 'counter')}>
+		{'switch tab'}
+	</button>
+	<button class="switch-scope-theme" onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}>
+		{'switch theme'}
+	</button>
+}
+
 // ── Tests ──
 
 describe('tsrx-react runtime', () => {
@@ -798,5 +906,80 @@ describe('tsrx-react runtime', () => {
 
 		await click('.branch-inc');
 		expect(text('.branch-val')).toBe('21');
+	});
+
+	// ── Hoisted hooks closing over parent scope ──
+
+	it('hook in if-branch correctly closes over parent scope variables', async () => {
+		await render(HookClosingOverScopeApp);
+		// base=5, multiplier=2 → 10
+		expect(text('.scope-result')).toBe('10');
+
+		await click('.scope-inc-base');
+		// base=6, multiplier=2 → 12
+		expect(text('.scope-result')).toBe('12');
+
+		await click('.scope-inc-mult');
+		// base=6, multiplier=3 → 18
+		expect(text('.scope-result')).toBe('18');
+	});
+
+	it('hook inside element children works with parent scope', async () => {
+		await render(HookInsideElementApp);
+		expect(text('h2')).toBe('greeting');
+		expect(text('.inner-msg')).toBe('Hello');
+
+		await click('.inner-update');
+		expect(text('.inner-msg')).toBe('Hi there');
+
+		await click('.outer-toggle');
+		expect(text('h2')).toBe('farewell');
+		expect(container.querySelector('.inner-msg')).toBeNull();
+
+		await click('.outer-toggle');
+		expect(text('h2')).toBe('greeting');
+		// Hook state resets since the component remounts
+		expect(text('.inner-msg')).toBe('Hello');
+	});
+
+	it('hook in for-of loop correctly uses parent scope variables', async () => {
+		await render(HookInForClosingScopeApp);
+		const labels = container.querySelectorAll('.for-scope-label');
+		expect(labels[0].textContent).toBe('item-a');
+		expect(labels[1].textContent).toBe('item-b');
+
+		await click('.for-scope-toggle-a');
+		expect(container.querySelector('.for-scope-label')!.textContent).toBe('item-a!');
+
+		await click('.for-scope-prefix');
+		expect(container.querySelector('.for-scope-label')!.textContent).toBe('thing-a!');
+	});
+
+	it('early return before hooks passes scope correctly to continuation', async () => {
+		await render(EarlyReturnWithHooksApp);
+		expect(text('.early-count')).toBe('0');
+		expect(text('.early-doubled')).toBe('0');
+
+		await click('.early-inc');
+		expect(text('.early-count')).toBe('1');
+		expect(text('.early-doubled')).toBe('2');
+
+		await click('.early-skip');
+		expect(container.querySelector('.early-count')).toBeNull();
+		expect(container.querySelector('.early-doubled')).toBeNull();
+	});
+
+	it('hook in switch case correctly uses parent scope variables', async () => {
+		await render(HookInSwitchWithScopeApp);
+		expect(text('.switch-scope-val')).toBe('light:0');
+
+		await click('.switch-scope-inc');
+		expect(text('.switch-scope-val')).toBe('light:1');
+
+		await click('.switch-scope-theme');
+		expect(text('.switch-scope-val')).toBe('dark:1');
+
+		await click('.switch-scope-tab');
+		expect(text('.switch-scope-val')).toBe('dark:info');
 	});
 });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches the core AST-to-JSX transform and changes codegen shape (hoisting/statics, helper component props, lazy destructuring rewrites), which can subtly affect runtime behavior and scoping despite added test coverage.
> 
> **Overview**
> Fixes `@tsrx/react` codegen around **static JSX hoisting**, **hook-safe helper extraction**, and **lazy destructuring**.
> 
> Static hoisting now lifts truly-static `JSXElement`s into module-level `const` declarations (emitted via `generated_statics`) while avoiding incorrect hoists when elements reference component-scope bindings *including as tag names* (e.g. `<Widget />`, `<ui.Button />`). Helper components created for hook-safe control-flow/statement bodies are now hoisted and receive the correct in-scope bindings as props, with tighter scope tracking to avoid leaking inner-block or post-split bindings.
> 
> Adds a full lazy-destructuring transform (`&{...}` / `&[...]`) that rewrites references to `__lazyN` member/index reads and correctly handles shadowing across blocks/functions/loops/switch/catch, plus assignment/update and shorthand object properties. Tests were updated and expanded (unit + runtime) to cover these cases and regressions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7fdcba0d5204995df3fe441d6bdcfe863c32be2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->