### PR TITLE
Fix solid transform

### DIFF
--- a/.changeset/tsrx-solid-mid-template-iife.md
+++ b/.changeset/tsrx-solid-mid-template-iife.md
@@ -1,0 +1,12 @@
+---
+'@tsrx/solid': patch
+---
+
+Wrap element children that mix JSX with plain statements
+(`VariableDeclaration`, `ExpressionStatement`, `DebuggerStatement`, etc.) in
+an IIFE so the statements execute as JS during render and keep their locals
+scoped to the enclosing element. Previously those statements were emitted
+directly as JSX children, which made them render as literal text rather
+than run — e.g. mid-template `const [state, setState] = createSignal()` or
+`console.log(...)` between JSX siblings printed their source instead of
+executing. Matches the React target's existing behaviour.

--- a/packages/tsrx-solid/src/transform.js
+++ b/packages/tsrx-solid/src/transform.js
@@ -1103,7 +1103,22 @@ function to_jsx_element(node, transform_context) {
  */
 function create_element_children(children, transform_context) {
 	if (children.length === 0) return [];
-	// Solid doesn't need React's hook-safe IIFE wrapping; every child is inline.
+
+	// If any child is a plain statement (VariableDeclaration, ExpressionStatement,
+	// DebuggerStatement, etc.) interleaved with JSX, we can't emit it as a JSX
+	// child directly — Solid's JSX runtime would treat the node as an opaque
+	// value and the source code would print as literal text. Wrap the whole
+	// children list in an IIFE so the statements execute during render and
+	// their locals scope to the block, matching the authored intent of
+	// mid-template locals.
+	const has_non_jsx_child = children.some(
+		(/** @type {any} */ child) => child && !is_jsx_child(child),
+	);
+	if (has_non_jsx_child) {
+		const body_jsx = body_to_jsx_child(children, transform_context);
+		return [jsx_child_wrap(iife_if_arrow(body_jsx))];
+	}
+
 	return children.map((/** @type {any} */ child) => to_jsx_child(child, transform_context));
 }
 

--- a/packages/tsrx-solid/tests/basic.test.js
+++ b/packages/tsrx-solid/tests/basic.test.js
@@ -360,6 +360,40 @@ describe('@tsrx/solid basic', () => {
 			expect(code).toMatch(/<Match when=\{kind === 'b'\}>/);
 		});
 
+		it('element children mixing JSX and statements wrap in an IIFE', () => {
+			// Regression: plain statements (VariableDeclaration, ExpressionStatement,
+			// DebuggerStatement) interleaved with JSX children must execute as JS
+			// rather than print as literal text. The transform wraps the whole
+			// child list in an IIFE so the statements run and their locals stay
+			// scoped to the block — matching the React target's behaviour.
+			const { code } = compile(
+				`component FeatureCard({ items }: { items: string[] }) {
+					<ul>
+						const [state, setState] = createSignal();
+						for (const item of items; index i) {
+							<li>{item}</li>
+						}
+						<div>
+							console.log('logged');
+							debugger;
+						</div>
+					</ul>
+				}`,
+				'FeatureCard.tsrx',
+			);
+			// Outer <ul> wraps mixed statement + JSX children in an IIFE.
+			expect(code).toMatch(/<ul>\{\(\(\) =>\s*\{/);
+			expect(code).toContain('createSignal()');
+			// Inner <div> with only statements also wraps in an IIFE so they run
+			// as JS rather than render as children.
+			expect(code).toMatch(/<div>\{\(\(\) =>\s*\{/);
+			expect(code).toContain("console.log('logged')");
+			expect(code).toContain('debugger');
+			// Statements must not leak into the output as literal JSX text.
+			expect(code).not.toMatch(/<ul>const \[state/);
+			expect(code).not.toMatch(/<div>console\.log/);
+		});
+
 		it('early-return keeps non-JSX after statements in outer body', () => {
 			// Regression: non-JSX statements declared after `if (cond) return;`
 			// (e.g. createSignal calls) must run once at setup rather than

--- a/packages/vite-plugin-solid/tests/runtime.test.tsrx
+++ b/packages/vite-plugin-solid/tests/runtime.test.tsrx
@@ -559,6 +559,31 @@ component FullyStaticApp() {
 	</div>
 }
 
+// ── Mid-template locals + interleaved statements inside element children ──
+// `.tsrx` lets you declare locals and run plain statements between JSX
+// children. The Solid transform wraps the block in an IIFE so the statements
+// execute as JS during render, their locals stay scoped to the enclosing
+// element, and no source code leaks through as literal text.
+
+const mid_template_log: string[] = [];
+
+component MidTemplateLocalsApp() {
+	<div class="mid-template-shell">
+		const [count, setCount] = createSignal(0);
+
+		for (const item of ['a', 'b']; index i) {
+			<span class="mid-template-item">{item}</span>
+		}
+
+		<p class="mid-template-count">{count()}</p>
+		<button class="mid-template-inc" onClick={() => setCount(count() + 1)}>{'inc'}</button>
+
+		<div class="mid-template-side">
+			mid_template_log.push('ran');
+		</div>
+	</div>
+}
+
 // ── Lazy destructuring: object in props ──
 
 component LazyPropsChild(&{ name, age }: { name: string; age: number }) {
@@ -1009,6 +1034,38 @@ describe('tsrx-solid runtime', () => {
 		await render(FullyStaticApp);
 		expect(text('.all-static h2')).toBe('Title');
 		expect(text('.all-static p')).toBe('Paragraph');
+	});
+
+	// ── Mid-template locals + interleaved statements ──
+
+	it('executes mid-template statements and keeps locals scoped to the element', async () => {
+		mid_template_log.length = 0;
+		await render(MidTemplateLocalsApp);
+
+		// The inner <div> body is a pure statement (`mid_template_log.push('ran')`).
+		// If the transform emitted it as a JSX text child the source code would
+		// render as literal text; the IIFE wrapping lets the side effect fire
+		// and leaves the element visually empty.
+		expect(mid_template_log).toEqual(['ran']);
+		expect(container.querySelector('.mid-template-side')!.textContent).toBe('');
+
+		// Siblings around the local declaration render normally.
+		const items = container.querySelectorAll('.mid-template-item');
+		expect(items.length).toBe(2);
+		expect(items[0].textContent).toBe('a');
+		expect(items[1].textContent).toBe('b');
+
+		// The locally-declared signal stays reactive across clicks — declared
+		// mid-template yet closed over by sibling JSX in the same IIFE scope.
+		expect(text('.mid-template-count')).toBe('0');
+		await click('.mid-template-inc');
+		expect(text('.mid-template-count')).toBe('1');
+		await click('.mid-template-inc');
+		expect(text('.mid-template-count')).toBe('2');
+
+		// Re-rendering shouldn't duplicate the side-effect — the IIFE runs
+		// once during setup, not on every reactive update.
+		expect(mid_template_log).toEqual(['ran']);
 	});
 
 	// ── Lazy destructuring ──

--- a/website-new/docs/introduction.md
+++ b/website-new/docs/introduction.md
@@ -19,9 +19,7 @@ who has previously worked on React, Svelte, Lexical, and Inferno.
 
 The `.tsrx` syntax you'll learn here is also the source language of
 [TSRX](https://tsrx.dev) — a TypeScript language extension that compiles the
-same component file to React, Solid, or Ripple. If you prefer to keep an
-existing React or Solid runtime while adopting the authoring ergonomics,
-start from the [TSRX website](https://tsrx.dev) instead.
+same component file to React, Solid, or Ripple.
 
 :::
 

--- a/website/docs/introduction.md
+++ b/website/docs/introduction.md
@@ -19,9 +19,7 @@ who has previously worked on React, Svelte, Lexical, and Inferno.
 
 The `.tsrx` syntax you'll learn here is also the source language of
 [TSRX](https://tsrx.dev) — a TypeScript language extension that compiles the
-same component file to React, Solid, or Ripple. If you prefer to keep an
-existing React or Solid runtime while adopting the authoring ergonomics,
-start from the [TSRX website](https://tsrx.dev) instead.
+same component file to React, Solid, or Ripple.
 
 :::
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes Solid TSRX code generation for element children, which can affect runtime rendering/side-effect ordering for templates that include mid-template statements. Scope is narrow but compiler-output changes can cause subtle regressions in generated JSX.
> 
> **Overview**
> Fixes the Solid target’s element-children transform so *plain statements inside template children* (e.g. `const` declarations, `console.log`, `debugger`) are no longer emitted as JSX text. When an element’s children include any non-JSX nodes, the transform now wraps the entire children block in an IIFE so statements execute during render and locals remain scoped to the element (matching the React target behavior).
> 
> Adds compile-time and runtime regression tests covering mixed JSX + statements and statement-only children, plus a patch changeset and a small docs tweak removing extra introductory guidance text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfe6fd30155ce2c308a624744ade8a87c15858d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->