### PR TITLE
Fix tsrx parser issue

### DIFF
--- a/.changeset/parse-stmt-in-element.md
+++ b/.changeset/parse-stmt-in-element.md
@@ -1,0 +1,5 @@
+---
+'@tsrx/core': patch
+---
+
+Fix parser crash when a JS statement inside an element template body has no trailing whitespace before the closing tag (e.g. `<ul>var a = "123"</ul>`). The tokenizer previously misread `</` as a less-than operator followed by a regexp.

--- a/packages/ripple/tests/client/compiler/compiler.basic.test.tsrx
+++ b/packages/ripple/tests/client/compiler/compiler.basic.test.tsrx
@@ -688,6 +688,26 @@ export component App() {
 		expect(result).toContain('_$_.normalize_children(');
 	});
 
+	it(
+		'parses a JS statement inside an element with no trailing whitespace before the closing tag',
+		() => {
+			const source = `component TodoList({ items }: { items: { text: string }[] }) {
+  <ul>var a = "123"</ul>
+}`;
+			const ast = parse(source);
+			const comp = ast.body[0] as unknown as AST.Component;
+			const ul = comp.body.find((n) => n.type === 'Element') as AST.Element;
+			expect(ul.id.name).toBe('ul');
+			expect(ul.children).toHaveLength(1);
+			const decl = ul.children[0] as unknown as AST.VariableDeclaration;
+			expect(decl.type).toBe('VariableDeclaration');
+			expect(decl.kind).toBe('var');
+			expect((decl.declarations[0].id as AST.Identifier).name).toBe('a');
+			expect((decl.declarations[0].init as AST.Literal).value).toBe('123');
+			expect(ul.closingElement?.name?.name).toBe('ul');
+		},
+	);
+
 	it('uses spread_props for spreads that may contain children', () => {
 		const source = `
 component Card(props) {

--- a/packages/tsrx/src/parse/index.js
+++ b/packages/tsrx/src/parse/index.js
@@ -111,6 +111,68 @@ export function isWhitespaceTextNode(node) {
 }
 
 /**
+ * @type {AcornPlugin}
+ */
+function elementTemplateClosingTagPlugin(Base) {
+	const jsxTagStart = /** @type {any} */ (Base).acornTypeScript?.tokTypes?.jsxTagStart;
+	if (!jsxTagStart) return Base;
+
+	/**
+	 * @param {any} parser
+	 */
+	function inElementTemplateBodyDirect(parser) {
+		const stack = parser.context;
+		const top = stack[stack.length - 1];
+		const below = stack[stack.length - 2];
+		return top && top.token === '{' && below && below.token === '<tag>...</tag>';
+	}
+
+	/**
+	 * @param {any} parser
+	 */
+	function inElementTemplateBodyAnywhere(parser) {
+		const stack = parser.context;
+		for (let i = 1; i < stack.length; i++) {
+			if (
+				stack[i] &&
+				stack[i].token === '{' &&
+				stack[i - 1] &&
+				stack[i - 1].token === '<tag>...</tag>'
+			) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	return class extends Base {
+		/** @param {number} code */
+		// @ts-ignore — extending acorn's Parser with internal hooks
+		getTokenFromCode(code) {
+			if (code === 60 /* '<' */ && !(/** @type {any} */ (this).inType)) {
+				const self = /** @type {any} */ (this);
+				const nextChar =
+					self.pos + 1 < self.input.length ? self.input.charCodeAt(self.pos + 1) : -1;
+				if (nextChar === 47 /* '/' */ && inElementTemplateBodyDirect(self)) {
+					++self.pos;
+					return self.finishToken(jsxTagStart);
+				}
+			}
+			// @ts-ignore — super dispatches to next layer in the plugin chain
+			return super.getTokenFromCode(code);
+		}
+
+		// @ts-ignore — extending acorn's Parser with internal hooks
+		canInsertSemicolon() {
+			const self = /** @type {any} */ (this);
+			if (self.type === jsxTagStart && inElementTemplateBodyAnywhere(self)) return true;
+			// @ts-ignore
+			return super.canInsertSemicolon();
+		}
+	};
+}
+
+/**
  * Create a parser by composing Acorn with TypeScript/JSX support and optional framework plugins.
  *
  * This is the core factory for building tsrx-based parsers. Framework plugins (like TSRXPlugin)
@@ -125,6 +187,7 @@ export function createParser(...plugins) {
 			acorn.Parser.extend(
 				tsPlugin({ jsx: true }),
 				...plugins.map((p) => /** @type {AcornPlugin} */ (/** @type {unknown} */ (p))),
+				elementTemplateClosingTagPlugin,
 			)
 		)
 	);


### PR DESCRIPTION
Should fix some of the issues in https://github.com/Ripple-TS/ripple/issues/891

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches low-level Acorn tokenization/ASI behavior; a mistake could change how `<` is tokenized and impact JSX/TypeScript parsing in edge cases.
> 
> **Overview**
> Fixes a tokenizer edge case where `</` immediately after a JS statement in an element template body (no trailing whitespace) could be mis-tokenized and crash parsing.
> 
> Adds an Acorn parser plugin (`elementTemplateClosingTagPlugin`) that detects `</` in element-template-body context and forces the `jsxTagStart` token, plus allows ASI (`canInsertSemicolon`) before a closing tag; includes a regression test covering `<ul>var a = "123"</ul>` and a patch changeset for `@tsrx/core`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e8df95253dc7c9c570fa9bf772c2972771f692d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->