### PR TITLE
Fix Ripple hydration issue

### DIFF
--- a/.changeset/strong-rabbits-rest.md
+++ b/.changeset/strong-rabbits-rest.md
@@ -1,0 +1,5 @@
+---
+"@tsrx/ripple": patch
+---
+
+Fix a hydration edge case where sibling traversal after nested DOM children (such as <pre><code>{html ...}</code></pre> chains) could leave the hydrate pointer on the wrong node and throw a hydration error during client hydration. Added hydration regression coverage for the website-like code-block sibling pattern.

--- a/packages/ripple/tests/hydration/compiled/client/html.js
+++ b/packages/ripple/tests/hydration/compiled/client/html.js
@@ -87,6 +87,7 @@ var root_82 = _$_.template(`<div class="wrapper"><h1>Title</h1><template id="dat
 var root_83 = _$_.template(`<div class="layout"><template id="page-data"></template><main><!></main></div>`, 0);
 var root_85 = _$_.template(`<div class="doc-content"><!></div>`, 0);
 var root_84 = _$_.template(`<!>`, 1, 1);
+var root_86 = _$_.template(`<section class="readable-section"><p>Ergonomics</p><h2>Sibling traversal pattern</h2><p>Before first block</p><p>Before second block</p><pre class="code-block"><code><!></code></pre><p>Between one and two</p><pre class="code-block"><code><!></code></pre><p>Between two and three</p><pre class="code-block"><code><!></code></pre></section>`, 0);
 
 import { track } from 'ripple';
 
@@ -1905,6 +1906,75 @@ export function NestedTemplateInLayout(__anchor, _, __block) {
 	);
 
 	_$_.append(__anchor, fragment_19);
+	_$_.pop_component();
+}
+
+export function HtmlCodeBlocksWithSiblingChain(__anchor, _, __block) {
+	_$_.push_component();
+
+	const html1 = '<span class="kw">const</span> <span class="id">a</span> = 1;';
+	const html2 = '<span class="kw">const</span> <span class="id">b</span> = 2;';
+	const html3 = '<span class="kw">const</span> <span class="id">c</span> = 3;';
+	var section_3 = root_86();
+
+	{
+		var p_5 = _$_.child(section_3);
+		var h2_3 = _$_.sibling(p_5);
+		var p_4 = _$_.sibling(h2_3);
+		var p_3 = _$_.sibling(p_4);
+		var pre_1 = _$_.sibling(p_3);
+
+		{
+			var code_1 = _$_.child(pre_1);
+
+			{
+				var node_80 = _$_.child(code_1);
+
+				_$_.pop(code_1);
+			}
+		}
+
+		_$_.pop(pre_1);
+
+		var p_6 = _$_.sibling(pre_1);
+		var pre_2 = _$_.sibling(p_6);
+
+		{
+			var code_2 = _$_.child(pre_2);
+
+			{
+				var node_81 = _$_.child(code_2);
+
+				_$_.pop(code_2);
+			}
+		}
+
+		_$_.pop(pre_2);
+
+		var p_7 = _$_.sibling(pre_2);
+		var pre_3 = _$_.sibling(p_7);
+
+		{
+			var code_3 = _$_.child(pre_3);
+
+			{
+				var node_82 = _$_.child(code_3);
+
+				_$_.pop(code_3);
+			}
+		}
+	}
+
+	_$_.render(
+		(__prev) => {
+			_$_.html(node_80, () => html1);
+			_$_.html(node_81, () => html2);
+			_$_.html(node_82, () => html3);
+		},
+		{}
+	);
+
+	_$_.append(__anchor, section_3);
 	_$_.pop_component();
 }
 

--- a/packages/ripple/tests/hydration/compiled/client/if-children.js
+++ b/packages/ripple/tests/hydration/compiled/client/if-children.js
@@ -370,6 +370,8 @@ export function DomChildrenThenStaticSiblings(__anchor, _, __block) {
 				_$_.pop(li_1);
 			}
 		}
+
+		_$_.pop(ul_1);
 	}
 
 	_$_.pop(div_17);
@@ -386,6 +388,22 @@ export function StaticListThenStaticSiblings(__anchor, _, __block) {
 	_$_.push_component();
 
 	var div_18 = root_19();
+
+	{
+		var ul_2 = _$_.child(div_18);
+
+		{
+			var li_2 = _$_.child(ul_2);
+
+			_$_.pop(li_2);
+
+			var li_3 = _$_.sibling(li_2);
+
+			_$_.pop(li_3);
+		}
+
+		_$_.pop(ul_2);
+	}
 
 	_$_.append(__anchor, div_18);
 	_$_.pop_component();

--- a/packages/ripple/tests/hydration/compiled/server/html.js
+++ b/packages/ripple/tests/hydration/compiled/server/html.js
@@ -2311,3 +2311,132 @@ export function NestedTemplateInLayout() {
 
 	_$_.pop_component();
 }
+
+export function HtmlCodeBlocksWithSiblingChain() {
+	_$_.push_component();
+
+	const html1 = '<span class="kw">const</span> <span class="id">a</span> = 1;';
+	const html2 = '<span class="kw">const</span> <span class="id">b</span> = 2;';
+	const html3 = '<span class="kw">const</span> <span class="id">c</span> = 3;';
+
+	_$_.regular_block(() => {
+		_$_.output_push('<section');
+		_$_.output_push(' class="readable-section"');
+		_$_.output_push('>');
+
+		{
+			_$_.output_push('<p');
+			_$_.output_push('>');
+
+			{
+				_$_.output_push('Ergonomics');
+			}
+
+			_$_.output_push('</p>');
+			_$_.output_push('<h2');
+			_$_.output_push('>');
+
+			{
+				_$_.output_push('Sibling traversal pattern');
+			}
+
+			_$_.output_push('</h2>');
+			_$_.output_push('<p');
+			_$_.output_push('>');
+
+			{
+				_$_.output_push('Before first block');
+			}
+
+			_$_.output_push('</p>');
+			_$_.output_push('<p');
+			_$_.output_push('>');
+
+			{
+				_$_.output_push('Before second block');
+			}
+
+			_$_.output_push('</p>');
+			_$_.output_push('<pre');
+			_$_.output_push(' class="code-block"');
+			_$_.output_push('>');
+
+			{
+				_$_.output_push('<code');
+				_$_.output_push('>');
+
+				{
+					const html_value_27 = String(html1 ?? '');
+
+					_$_.output_push('<!--' + _$_.hash(html_value_27) + '-->');
+					_$_.output_push(html_value_27);
+					_$_.output_push('<!---->');
+				}
+
+				_$_.output_push('</code>');
+			}
+
+			_$_.output_push('</pre>');
+			_$_.output_push('<p');
+			_$_.output_push('>');
+
+			{
+				_$_.output_push('Between one and two');
+			}
+
+			_$_.output_push('</p>');
+			_$_.output_push('<pre');
+			_$_.output_push(' class="code-block"');
+			_$_.output_push('>');
+
+			{
+				_$_.output_push('<code');
+				_$_.output_push('>');
+
+				{
+					const html_value_28 = String(html2 ?? '');
+
+					_$_.output_push('<!--' + _$_.hash(html_value_28) + '-->');
+					_$_.output_push(html_value_28);
+					_$_.output_push('<!---->');
+				}
+
+				_$_.output_push('</code>');
+			}
+
+			_$_.output_push('</pre>');
+			_$_.output_push('<p');
+			_$_.output_push('>');
+
+			{
+				_$_.output_push('Between two and three');
+			}
+
+			_$_.output_push('</p>');
+			_$_.output_push('<pre');
+			_$_.output_push(' class="code-block"');
+			_$_.output_push('>');
+
+			{
+				_$_.output_push('<code');
+				_$_.output_push('>');
+
+				{
+					const html_value_29 = String(html3 ?? '');
+
+					_$_.output_push('<!--' + _$_.hash(html_value_29) + '-->');
+					_$_.output_push(html_value_29);
+					_$_.output_push('<!---->');
+				}
+
+				_$_.output_push('</code>');
+			}
+
+			_$_.output_push('</pre>');
+		}
+
+		_$_.output_push('</section>');
+	});
+
+	_$_.pop_component();
+}

--- a/packages/ripple/tests/hydration/components/html.tsrx
+++ b/packages/ripple/tests/hydration/components/html.tsrx
@@ -532,3 +532,27 @@ export component NestedTemplateInLayout() {
 		<div class="doc-content">{html doc.html}</div>
 	</LayoutWithTemplate>
 }
+
+export component HtmlCodeBlocksWithSiblingChain() {
+	const html1 = '<span class="kw">const</span> <span class="id">a</span> = 1;';
+	const html2 = '<span class="kw">const</span> <span class="id">b</span> = 2;';
+	const html3 = '<span class="kw">const</span> <span class="id">c</span> = 3;';
+
+	<section class="readable-section">
+		<p>{'Ergonomics'}</p>
+		<h2>{'Sibling traversal pattern'}</h2>
+		<p>{'Before first block'}</p>
+		<p>{'Before second block'}</p>
+		<pre class="code-block">
+			<code>{html html1}</code>
+		</pre>
+		<p>{'Between one and two'}</p>
+		<pre class="code-block">
+			<code>{html html2}</code>
+		</pre>
+		<p>{'Between two and three'}</p>
+		<pre class="code-block">
+			<code>{html html3}</code>
+		</pre>
+	</section>
+}

--- a/packages/ripple/tests/hydration/html.test.js
+++ b/packages/ripple/tests/hydration/html.test.js
@@ -194,6 +194,21 @@ describe('hydration > html tags', () => {
 		expect(html).toContain('Footer');
 	});
 
+	it('hydrates html code blocks followed by static and dynamic sibling chains', async () => {
+		await hydrateComponent(
+			ServerComponents.HtmlCodeBlocksWithSiblingChain,
+			ClientComponents.HtmlCodeBlocksWithSiblingChain,
+		);
+		const html = container.innerHTML;
+		expect(html).toContain('Sibling traversal pattern');
+		expect(html).toContain('Between one and two');
+		expect(html).toContain('Between two and three');
+		expect(html).toContain('const');
+		expect(html).toContain('a');
+		expect(html).toContain('b');
+		expect(html).toContain('c');
+	});
+
 	it('hydrates full DocsLayout with data mismatch (StylingPage exact reproduction)', async () => {
 		await hydrateComponent(
 			ServerComponents.DocsLayoutWithData,

--- a/packages/tsrx-ripple/src/transform/client/index.js
+++ b/packages/tsrx-ripple/src/transform/client/index.js
@@ -3607,7 +3607,7 @@ function transform_children(children, context) {
 
 			const current_prev = prev;
 			/** @type {AST.Identifier | null} */
-			let cached;
+			let cached = null;
 			/**
 			 * @param {boolean} [is_text]
 			 * @param {boolean} [is_controlled]
@@ -3699,38 +3699,23 @@ function transform_children(children, context) {
 								child.expression.type !== 'Literal'),
 					);
 
-					// Add pop() if we have DOM element children AND the Element visitor didn't already add pop()
-					if (has_dom_element_children && !element_visitor_adds_pop) {
-						// Only add pop() if next_node will actually generate a sibling() call.
-						// Static Text nodes (Literals) and static Elements don't call flush_node().
-						let needs_sibling_call = false;
-						if (next_node.type === 'Element') {
-							// Static DOM elements with no dynamic content don't generate sibling()
-							if (is_element_dom_element(next_node)) {
-								needs_sibling_call = element_has_dynamic_content(next_node);
-							} else {
-								// Components always generate sibling()
-								needs_sibling_call = true;
-							}
-						} else if (next_node.type === 'TSRXExpression' || next_node.type === 'Text') {
-							// Only dynamic text generates sibling()
-							needs_sibling_call = next_node.expression.type !== 'Literal';
-						} else if (
-							next_node.type === 'Html' ||
-							next_node.type === 'IfStatement' ||
-							next_node.type === 'TryStatement' ||
-							next_node.type === 'ForOfStatement' ||
-							next_node.type === 'SwitchStatement' ||
-							next_node.type === 'Tsx' ||
-							next_node.type === 'TsxCompat'
-						) {
-							needs_sibling_call = true;
-						}
+					const has_following_renderable_sibling = normalized
+						.slice(node_idx + 1)
+						.some(
+							(sibling) =>
+								sibling.type !== 'VariableDeclaration' && sibling.type !== 'EmptyStatement',
+						);
 
-						if (needs_sibling_call) {
-							const id = flush_node();
-							state.init?.push(b.stmt(b.call('_$_.pop', id)));
-						}
+					// Add pop() if we have DOM element children, the Element visitor didn't already
+					// add one, and there is another renderable sibling afterward. This keeps
+					// hydrate_node anchored at the current element before sibling() traversal.
+					if (
+						has_dom_element_children &&
+						!element_visitor_adds_pop &&
+						has_following_renderable_sibling
+					) {
+						const id = cached ?? flush_node();
+						state.init?.push(b.stmt(b.call('_$_.pop', id)));
 					}
 				}
 			} else if (node.type === 'TsxCompat' || node.type === 'Tsx') {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches the client transform that emits hydration navigation (`child`/`sibling`/`pop`) and could affect hydration behavior across many components if the new `pop()` insertion conditions are wrong. Added tests reduce regression risk but coverage is still pattern-based.
> 
> **Overview**
> Fixes a hydration edge case where the client compiler could leave the hydrate pointer nested too deep after traversing DOM element children, causing subsequent `sibling()` traversal to target the wrong node and throw during client hydration.
> 
> Updates the client transform to cache the current sibling node id and to insert `_$_.pop(...)` **only when** an element has DOM-element children, the element visitor didn’t already add a pop, and there is another renderable sibling later in the normalized list.
> 
> Adds regression coverage via a new `HtmlCodeBlocksWithSiblingChain` component/test (plus updated compiled fixtures) to reproduce the `<pre><code>{html ...}</code></pre>` code-block sibling chain pattern, and includes a patch changeset for `@tsrx/ripple`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8368be3e3d8630a9fd947ee811a8bde98edbee7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->