### PR TITLE
Add keys to loops for React transform

### DIFF
--- a/.changeset/young-schools-count.md
+++ b/.changeset/young-schools-count.md
@@ -1,0 +1,9 @@
+---
+"@tsrx/react": patch
+---
+
+Fix React `for` loop key generation in compiled output:
+
+- Ensure hook-extracted loop wrapper components receive a `key` when using `for (...; index index)` and no explicit key is provided.
+- Ensure non-hook loop item elements also receive an implicit `key={index}` fallback in the same indexed-loop scenario.
+- Add regression tests covering both hook and non-hook conditional loop paths.

--- a/packages/tsrx-react/src/transform.js
+++ b/packages/tsrx-react/src/transform.js
@@ -1529,7 +1529,11 @@ function for_of_statement_to_jsx_child(node, transform_context) {
 	const loop_params = get_for_of_iteration_params(node.left, node.index);
 	const loop_body = node.body.type === 'BlockStatement' ? node.body.body : [node.body];
 	const has_hooks = body_contains_top_level_hook_call(loop_body);
-	const key_expression = has_hooks ? find_key_expression_in_body(loop_body) : undefined;
+	const explicit_key_expression = has_hooks ? find_key_expression_in_body(loop_body) : undefined;
+	const key_expression =
+		has_hooks && explicit_key_expression == null && node.index
+			? clone_expression_node(node.index)
+			: explicit_key_expression;
 
 	// Add loop params to available bindings so hoisted helpers receive them as props
 	const saved_bindings = transform_context.available_bindings;

--- a/packages/tsrx-react/src/transform.js
+++ b/packages/tsrx-react/src/transform.js
@@ -1534,6 +1534,10 @@ function for_of_statement_to_jsx_child(node, transform_context) {
 		has_hooks && explicit_key_expression == null && node.index
 			? clone_expression_node(node.index)
 			: explicit_key_expression;
+	const implicit_non_hook_key_expression =
+		!has_hooks && node.index && find_key_expression_in_body(loop_body) == null
+			? clone_expression_node(node.index)
+			: undefined;
 
 	// Add loop params to available bindings so hoisted helpers receive them as props
 	const saved_bindings = transform_context.available_bindings;
@@ -1545,6 +1549,10 @@ function for_of_statement_to_jsx_child(node, transform_context) {
 	const body_statements = has_hooks
 		? hook_safe_render_statements(loop_body, key_expression, transform_context)
 		: build_render_statements(loop_body, true, transform_context);
+
+	if (implicit_non_hook_key_expression) {
+		apply_key_to_render_statements(body_statements, implicit_non_hook_key_expression);
+	}
 
 	// Restore bindings
 	transform_context.available_bindings = saved_bindings;
@@ -1580,6 +1588,46 @@ function for_of_statement_to_jsx_child(node, transform_context) {
 			metadata: { path: [] },
 		}),
 	);
+}
+
+/**
+ * @param {any[]} statements
+ * @param {any} key_expression
+ * @returns {void}
+ */
+function apply_key_to_render_statements(statements, key_expression) {
+	for (let i = statements.length - 1; i >= 0; i -= 1) {
+		const statement = statements[i];
+		if (statement?.type !== 'ReturnStatement' || !statement.argument) {
+			continue;
+		}
+
+		if (statement.argument.type === 'JSXElement') {
+			const attributes = statement.argument.openingElement?.attributes || [];
+			const has_key = attributes.some(
+				(/** @type {any} */ attr) =>
+					attr.type === 'JSXAttribute' &&
+					attr.name?.type === 'JSXIdentifier' &&
+					attr.name.name === 'key',
+			);
+
+			if (!has_key) {
+				attributes.push(
+					/** @type {any} */ ({
+						type: 'JSXAttribute',
+						name: { type: 'JSXIdentifier', name: 'key', metadata: { path: [] } },
+						value: to_jsx_expression_container(
+							clone_expression_node(key_expression),
+							key_expression,
+						),
+						metadata: { path: [] },
+					}),
+				);
+			}
+		}
+
+		return;
+	}
 }
 
 /**

--- a/packages/tsrx-react/tests/basic.test.js
+++ b/packages/tsrx-react/tests/basic.test.js
@@ -1049,6 +1049,38 @@ describe('@tsrx/react basic', () => {
 			'<StatementBodyHook1 items={items} item={item} index={index} key={index} />',
 		);
 	});
+
+	it('adds index key to non-hook loop items in conditional branches', () => {
+		const { code } = compile(
+			`export component FeatureCard({
+				title,
+				items,
+				ready,
+			}: {
+				title: string;
+				items: string[];
+				ready: boolean;
+			}) {
+				<section class="feature-card">
+					<h2>{title}</h2>
+
+					if (ready) {
+						<ul>
+							for (const item of items; index index) {
+								<li>{item}</li>
+							}
+						</ul>
+					} else {
+						<p>{'Loading output...'}</p>
+					}
+				</section>
+			}`,
+			'FeatureCard.tsrx',
+		);
+
+		expect(code).toContain('items.map((item, index) =>');
+		expect(code).toContain('return <li key={index}>{item}</li>;');
+	});
 });
 
 describe('lazy destructuring', () => {

--- a/packages/tsrx-react/tests/basic.test.js
+++ b/packages/tsrx-react/tests/basic.test.js
@@ -1027,6 +1027,28 @@ describe('@tsrx/react basic', () => {
 		// Key should appear on both the inner element and wrapper component
 		expect(code).toContain('<StatementBodyHook1 items={items} item={item} key={item} />');
 	});
+
+	it('adds index key to hook wrapper component when loop has index and no explicit key', () => {
+		const { code } = compile(
+			`import { useState } from 'react';
+
+			export component Component({ items }: { items: string[] }) {
+				<ul>
+					for (const item of items; index index) {
+						const state = useState(0);
+						<li>{item}</li>
+					}
+				</ul>
+			}`,
+			'Component.tsrx',
+		);
+
+		expect(code).toContain('function StatementBodyHook');
+		expect(code).toContain('items.map((item, index) =>');
+		expect(code).toContain(
+			'<StatementBodyHook1 items={items} item={item} index={index} key={index} />',
+		);
+	});
 });
 
 describe('lazy destructuring', () => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches the React codegen for `for-of` control flow, which can subtly affect rendered output and reconciliation behavior across many components. Risk is mitigated by added regression tests, but key insertion logic could still change output in edge loop bodies.
> 
> **Overview**
> Fixes React TSRX compiled output so indexed `for (...; index ...)` loops always produce stable keys when none are explicitly provided.
> 
> For hook-containing loop bodies that are extracted into wrapper components, the wrapper now receives an implicit `key={index}` fallback. For non-hook loop bodies, the transform now injects `key={index}` onto the returned JSX element when missing (including when the loop appears inside conditional branches), with new tests covering both scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5814af6d2ef25f1346910adea8d041147e53930. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->