### PR TITLE
better handling of await expressions

### DIFF
--- a/packages/ripple/tests/client/basic/basic.errors.test.tsrx
+++ b/packages/ripple/tests/client/basic/basic.errors.test.tsrx
@@ -195,7 +195,7 @@ describe('basic client > errors', () => {
 		`;
 		expect(() => {
 			compile(code, 'test.tsrx', { mode: 'client' });
-		}).toThrow('`await` is not allowed inside client components');
+		}).toThrow(/`await` is not allowed inside components\./);
 	});
 
 	it('should throw error for while loop inside a component', () => {

--- a/packages/tsrx-react/src/transform.js
+++ b/packages/tsrx-react/src/transform.js
@@ -50,6 +50,7 @@ import {
 export function transform(ast, source, filename) {
 	/** @type {any[]} */
 	const stylesheets = [];
+	const module_uses_server_directive = has_use_server_directive(ast);
 
 	/** @type {TransformContext} */
 	const transform_context = {
@@ -67,6 +68,22 @@ export function transform(ast, source, filename) {
 	walk(/** @type {any} */ (ast), transform_context, {
 		Component(node, { next, state }) {
 			const as_any = /** @type {any} */ (node);
+			const await_expression = find_first_top_level_await_in_component_body(as_any.body || []);
+
+			if (await_expression && !module_uses_server_directive) {
+				throw create_compile_error(
+					await_expression,
+					'React components can only use `await` when the module has a top-level "use server" directive.',
+				);
+			}
+
+			if (await_expression) {
+				as_any.metadata = /** @type {any} */ ({
+					...(as_any.metadata || {}),
+					contains_top_level_await: true,
+				});
+			}
+
 			const css = as_any.css;
 			if (css) {
 				stylesheets.push(css);
@@ -194,6 +211,9 @@ function component_to_function_declaration(component, transform_context, walk_he
 	const helper_state = walk_helper_state || create_helper_state(component.id?.name || 'Component');
 	const params = component.params || [];
 	const body = /** @type {any[]} */ (component.body || []);
+	const is_async_component =
+		!!component?.metadata?.contains_top_level_await ||
+		find_first_top_level_await_in_component_body(body) !== null;
 
 	// Collect param bindings from original patterns (lazy patterns still intact).
 	const param_bindings = collect_param_bindings(params);
@@ -235,7 +255,7 @@ function component_to_function_declaration(component, transform_context, walk_he
 		id: component.id,
 		params: final_params,
 		body: final_body,
-		async: false,
+		async: is_async_component,
 		generator: false,
 		metadata: {
 			path: [],
@@ -512,6 +532,90 @@ function is_hook_callee(callee) {
 	}
 
 	return false;
+}
+
+/**
+ * @param {AST.Program} program
+ * @returns {boolean}
+ */
+function has_use_server_directive(program) {
+	for (const statement of program.body || []) {
+		if (statement.type !== 'ExpressionStatement') {
+			break;
+		}
+
+		if (statement.directive === 'use server') {
+			return true;
+		}
+
+		if (statement.directive == null) {
+			break;
+		}
+	}
+
+	return false;
+}
+
+/**
+ * @param {any[]} body_nodes
+ * @returns {any | null}
+ */
+function find_first_top_level_await_in_component_body(body_nodes) {
+	for (const node of body_nodes) {
+		const found = find_first_top_level_await(node, false);
+		if (found) return found;
+	}
+	return null;
+}
+
+/**
+ * @param {any} node
+ * @param {boolean} inside_nested_function
+ * @returns {any | null}
+ */
+function find_first_top_level_await(node, inside_nested_function) {
+	if (!node || typeof node !== 'object') {
+		return null;
+	}
+
+	if (Array.isArray(node)) {
+		for (const child of node) {
+			const found = find_first_top_level_await(child, inside_nested_function);
+			if (found) return found;
+		}
+		return null;
+	}
+
+	if (
+		node.type === 'FunctionDeclaration' ||
+		node.type === 'FunctionExpression' ||
+		node.type === 'ArrowFunctionExpression'
+	) {
+		// Ignore nested function bodies - only direct component-level awaits require async component.
+		if (inside_nested_function) {
+			return null;
+		}
+		return find_first_top_level_await(node.body, true);
+	}
+
+	if (inside_nested_function) {
+		return null;
+	}
+
+	if (node.type === 'AwaitExpression') {
+		return node;
+	}
+
+	for (const key of Object.keys(node)) {
+		if (key === 'loc' || key === 'start' || key === 'end' || key === 'metadata') {
+			continue;
+		}
+
+		const found = find_first_top_level_await(node[key], false);
+		if (found) return found;
+	}
+
+	return null;
 }
 
 /**

--- a/packages/tsrx-react/src/transform.js
+++ b/packages/tsrx-react/src/transform.js
@@ -8,6 +8,7 @@ import {
 	renderStylesheets,
 	setLocation,
 	applyLazyTransforms as apply_lazy_transforms,
+	findFirstTopLevelAwaitInComponentBody as find_first_top_level_await_in_component_body,
 	collectLazyBindingsFromComponent as collect_lazy_bindings_from_component,
 	preallocateLazyIds as preallocate_lazy_ids,
 	replaceLazyParams as replace_lazy_params,
@@ -540,82 +541,26 @@ function is_hook_callee(callee) {
  */
 function has_use_server_directive(program) {
 	for (const statement of program.body || []) {
-		if (statement.type !== 'ExpressionStatement') {
-			break;
-		}
+		const directive = /** @type {any} */ (statement).directive;
 
-		if (statement.directive === 'use server') {
+		if (directive === 'use server') {
 			return true;
 		}
 
-		if (statement.directive == null) {
+		if (
+			statement.type === 'ExpressionStatement' &&
+			statement.expression?.type === 'Literal' &&
+			statement.expression.value === 'use server'
+		) {
+			return true;
+		}
+
+		if (directive == null) {
 			break;
 		}
 	}
 
 	return false;
-}
-
-/**
- * @param {any[]} body_nodes
- * @returns {any | null}
- */
-function find_first_top_level_await_in_component_body(body_nodes) {
-	for (const node of body_nodes) {
-		const found = find_first_top_level_await(node, false);
-		if (found) return found;
-	}
-	return null;
-}
-
-/**
- * @param {any} node
- * @param {boolean} inside_nested_function
- * @returns {any | null}
- */
-function find_first_top_level_await(node, inside_nested_function) {
-	if (!node || typeof node !== 'object') {
-		return null;
-	}
-
-	if (Array.isArray(node)) {
-		for (const child of node) {
-			const found = find_first_top_level_await(child, inside_nested_function);
-			if (found) return found;
-		}
-		return null;
-	}
-
-	if (
-		node.type === 'FunctionDeclaration' ||
-		node.type === 'FunctionExpression' ||
-		node.type === 'ArrowFunctionExpression'
-	) {
-		// Ignore nested function bodies - only direct component-level awaits require async component.
-		if (inside_nested_function) {
-			return null;
-		}
-		return find_first_top_level_await(node.body, true);
-	}
-
-	if (inside_nested_function) {
-		return null;
-	}
-
-	if (node.type === 'AwaitExpression') {
-		return node;
-	}
-
-	for (const key of Object.keys(node)) {
-		if (key === 'loc' || key === 'start' || key === 'end' || key === 'metadata') {
-			continue;
-		}
-
-		const found = find_first_top_level_await(node[key], false);
-		if (found) return found;
-	}
-
-	return null;
 }
 
 /**
@@ -1623,6 +1568,13 @@ function find_key_expression_in_body(body_nodes) {
  * @returns {ESTreeJSX.JSXExpressionContainer}
  */
 function for_of_statement_to_jsx_child(node, transform_context) {
+	if (node.await) {
+		throw create_compile_error(
+			node,
+			'React TSRX does not support `for await...of` in component templates.',
+		);
+	}
+
 	if (node.key) {
 		throw create_compile_error(
 			node.key,

--- a/packages/tsrx-react/tests/basic.test.js
+++ b/packages/tsrx-react/tests/basic.test.js
@@ -68,6 +68,46 @@ describe('@tsrx/react basic', () => {
 		expect(code).toContain("{'Hello world'}");
 	});
 
+	it('rejects await in components without top-level use server directive', () => {
+		expect(() =>
+			compile(
+				`export component App() {
+					const data = await fetchData();
+					<div>{data}</div>
+				}`,
+				'App.tsrx',
+			),
+		).toThrow(/use server/);
+	});
+
+	it('emits async component functions for await when use server directive is present', () => {
+		const { code } = compile(
+			`'use server';
+
+			export component App() {
+				const data = await fetchData();
+				<div>{data}</div>
+			}`,
+			'App.tsrx',
+		);
+
+		expect(code).toContain('export async function App()');
+		expect(code).toContain('const data = await fetchData()');
+	});
+
+	it('does not require use server for await inside nested async functions', () => {
+		const { code } = compile(
+			`export component App() {
+				const load = async () => await fetchData();
+				<button onClick={load}>{'Load'}</button>
+			}`,
+			'App.tsrx',
+		);
+
+		expect(code).toContain('export function App()');
+		expect(code).not.toContain('export async function App()');
+	});
+
 	it('emits the text content and scoped css for the basic styled example', () => {
 		const { code, css } = compile(
 			`export component App() {

--- a/packages/tsrx-react/tests/basic.test.js
+++ b/packages/tsrx-react/tests/basic.test.js
@@ -95,6 +95,34 @@ describe('@tsrx/react basic', () => {
 		expect(code).toContain('const data = await fetchData()');
 	});
 
+	it('treats for await...of as top-level await and requires use server', () => {
+		expect(() =>
+			compile(
+				`export component App({ items }: { items: AsyncIterable<string> }) {
+					for await (const item of items) {
+						<div>{item}</div>
+					}
+				}`,
+				'App.tsrx',
+			),
+		).toThrow(/use server/);
+	});
+
+	it('rejects for await...of in templates even when use server is present', () => {
+		expect(() =>
+			compile(
+				`'use server';
+
+				export component App({ items }: { items: AsyncIterable<string> }) {
+					for await (const item of items) {
+						<div>{item}</div>
+					}
+				}`,
+				'App.tsrx',
+			),
+		).toThrow(/does not support `for await\.\.\.of`/);
+	});
+
 	it('does not require use server for await inside nested async functions', () => {
 		const { code } = compile(
 			`export component App() {

--- a/packages/tsrx-ripple/src/analyze/index.js
+++ b/packages/tsrx-ripple/src/analyze/index.js
@@ -2172,7 +2172,7 @@ const visitors = {
 				end: /** @type {AST.NodeWithLocation} */ (node).start + 'await'.length,
 			};
 			error(
-				'`await` is not allowed inside client components. Use `trackAsync(() => ...)` with an upstream `try { ... } pending { ... }` boundary instead.',
+				'`await` is not allowed inside components. Use `trackAsync(() => ...)` with an upstream `try { ... } pending { ... }` boundary instead.',
 				context.state.analysis.module.filename,
 				adjusted_node,
 				context.state.loose ? context.state.analysis.errors : undefined,

--- a/packages/tsrx-solid/src/transform.js
+++ b/packages/tsrx-solid/src/transform.js
@@ -73,9 +73,11 @@ export function transform(ast, source, filename) {
 			const await_expression = find_first_top_level_await_in_component_body(as_any.body || []);
 
 			if (await_expression) {
+				const await_start = get_await_keyword_start(await_expression, source);
 				const adjusted_node = /** @type {any} */ ({
 					...await_expression,
-					end: (await_expression.start ?? 0) + 'await'.length,
+					start: await_start,
+					end: await_start + 'await'.length,
 				});
 
 				throw create_compile_error(
@@ -174,6 +176,30 @@ export function transform(ast, source, filename) {
 		map: result.map,
 		css,
 	};
+}
+
+/**
+ * @param {any} await_node
+ * @param {string} source
+ * @returns {number}
+ */
+function get_await_keyword_start(await_node, source) {
+	if (await_node?.type === 'AwaitExpression') {
+		return await_node.start ?? 0;
+	}
+
+	if (await_node?.type === 'ForOfStatement' && await_node.await === true) {
+		const statement_start = await_node.start ?? 0;
+		const statement_end = await_node.end ?? statement_start;
+		const statement_source = source.slice(statement_start, statement_end);
+		const await_offset = statement_source.search(/\bawait\b/);
+
+		if (await_offset !== -1) {
+			return statement_start + await_offset;
+		}
+	}
+
+	return await_node?.start ?? 0;
 }
 // =====================================================================
 // Component → FunctionDeclaration

--- a/packages/tsrx-solid/src/transform.js
+++ b/packages/tsrx-solid/src/transform.js
@@ -69,6 +69,20 @@ export function transform(ast, source, filename) {
 	walk(/** @type {any} */ (ast), transform_context, {
 		Component(node, { next, state }) {
 			const as_any = /** @type {any} */ (node);
+			const await_expression = find_first_top_level_await_in_component_body(as_any.body || []);
+
+			if (await_expression) {
+				const adjusted_node = /** @type {any} */ ({
+					...await_expression,
+					end: (await_expression.start ?? 0) + 'await'.length,
+				});
+
+				throw create_compile_error(
+					adjusted_node,
+					'`await` is not allowed inside Solid components.',
+				);
+			}
+
 			const css = as_any.css;
 			if (css) {
 				stylesheets.push(css);
@@ -159,6 +173,66 @@ export function transform(ast, source, filename) {
 		map: result.map,
 		css,
 	};
+}
+
+/**
+ * @param {any[]} body_nodes
+ * @returns {any | null}
+ */
+function find_first_top_level_await_in_component_body(body_nodes) {
+	for (const node of body_nodes) {
+		const found = find_first_top_level_await(node, false);
+		if (found) return found;
+	}
+
+	return null;
+}
+
+/**
+ * @param {any} node
+ * @param {boolean} inside_nested_function
+ * @returns {any | null}
+ */
+function find_first_top_level_await(node, inside_nested_function) {
+	if (!node || typeof node !== 'object') {
+		return null;
+	}
+
+	if (Array.isArray(node)) {
+		for (const child of node) {
+			const found = find_first_top_level_await(child, inside_nested_function);
+			if (found) return found;
+		}
+
+		return null;
+	}
+
+	if (
+		node.type === 'FunctionDeclaration' ||
+		node.type === 'FunctionExpression' ||
+		node.type === 'ArrowFunctionExpression'
+	) {
+		return inside_nested_function ? null : find_first_top_level_await(node.body, true);
+	}
+
+	if (inside_nested_function) {
+		return null;
+	}
+
+	if (node.type === 'AwaitExpression') {
+		return node;
+	}
+
+	for (const key of Object.keys(node)) {
+		if (key === 'loc' || key === 'start' || key === 'end' || key === 'metadata') {
+			continue;
+		}
+
+		const found = find_first_top_level_await(node[key], false);
+		if (found) return found;
+	}
+
+	return null;
 }
 
 // =====================================================================

--- a/packages/tsrx-solid/src/transform.js
+++ b/packages/tsrx-solid/src/transform.js
@@ -8,6 +8,7 @@ import {
 	renderStylesheets,
 	setLocation,
 	applyLazyTransforms as apply_lazy_transforms,
+	findFirstTopLevelAwaitInComponentBody as find_first_top_level_await_in_component_body,
 	collectLazyBindingsFromComponent as collect_lazy_bindings_from_component,
 	preallocateLazyIds as preallocate_lazy_ids,
 	replaceLazyParams as replace_lazy_params,
@@ -174,67 +175,6 @@ export function transform(ast, source, filename) {
 		css,
 	};
 }
-
-/**
- * @param {any[]} body_nodes
- * @returns {any | null}
- */
-function find_first_top_level_await_in_component_body(body_nodes) {
-	for (const node of body_nodes) {
-		const found = find_first_top_level_await(node, false);
-		if (found) return found;
-	}
-
-	return null;
-}
-
-/**
- * @param {any} node
- * @param {boolean} inside_nested_function
- * @returns {any | null}
- */
-function find_first_top_level_await(node, inside_nested_function) {
-	if (!node || typeof node !== 'object') {
-		return null;
-	}
-
-	if (Array.isArray(node)) {
-		for (const child of node) {
-			const found = find_first_top_level_await(child, inside_nested_function);
-			if (found) return found;
-		}
-
-		return null;
-	}
-
-	if (
-		node.type === 'FunctionDeclaration' ||
-		node.type === 'FunctionExpression' ||
-		node.type === 'ArrowFunctionExpression'
-	) {
-		return inside_nested_function ? null : find_first_top_level_await(node.body, true);
-	}
-
-	if (inside_nested_function) {
-		return null;
-	}
-
-	if (node.type === 'AwaitExpression') {
-		return node;
-	}
-
-	for (const key of Object.keys(node)) {
-		if (key === 'loc' || key === 'start' || key === 'end' || key === 'metadata') {
-			continue;
-		}
-
-		const found = find_first_top_level_await(node[key], false);
-		if (found) return found;
-	}
-
-	return null;
-}
-
 // =====================================================================
 // Component → FunctionDeclaration
 // =====================================================================

--- a/packages/tsrx-solid/tests/basic.test.js
+++ b/packages/tsrx-solid/tests/basic.test.js
@@ -72,6 +72,25 @@ describe('@tsrx/solid basic', () => {
 			).toThrow(/`await` is not allowed inside Solid components/);
 		});
 
+		it('reports for await...of errors at the await keyword', () => {
+			const source = `component App({ items }: { items: AsyncIterable<string> }) {
+				for await (const item of items) {
+					<div>{item}</div>
+				}
+			}`;
+
+			try {
+				compile(source, 'App.tsrx');
+				expect.unreachable('Expected compile() to throw for top-level for await...of');
+			} catch (error) {
+				const compile_error = /** @type {Error & { pos?: number, end?: number }} */ (error);
+				const await_start = source.indexOf('await');
+
+				expect(compile_error.pos).toBe(await_start);
+				expect(compile_error.end).toBe(await_start + 'await'.length);
+			}
+		});
+
 		it('allows await in nested async functions inside component body', () => {
 			expect(() =>
 				compile(

--- a/packages/tsrx-solid/tests/basic.test.js
+++ b/packages/tsrx-solid/tests/basic.test.js
@@ -59,6 +59,19 @@ describe('@tsrx/solid basic', () => {
 			).toThrow(/`await` is not allowed inside Solid components/);
 		});
 
+		it('rejects for await...of in component body', () => {
+			expect(() =>
+				compile(
+					`component App({ items }: { items: AsyncIterable<string> }) {
+						for await (const item of items) {
+							<div>{item}</div>
+						}
+					}`,
+					'App.tsrx',
+				),
+			).toThrow(/`await` is not allowed inside Solid components/);
+		});
+
 		it('allows await in nested async functions inside component body', () => {
 			expect(() =>
 				compile(

--- a/packages/tsrx-solid/tests/basic.test.js
+++ b/packages/tsrx-solid/tests/basic.test.js
@@ -46,6 +46,30 @@ describe('@tsrx/solid basic', () => {
 			expect(code).toContain('return <><h1>');
 			expect(code).toContain('</h2></>;');
 		});
+
+		it('rejects await in component body', () => {
+			expect(() =>
+				compile(
+					`component App() {
+						const data = await fetchData();
+						<div>{data}</div>
+					}`,
+					'App.tsrx',
+				),
+			).toThrow(/`await` is not allowed inside Solid components/);
+		});
+
+		it('allows await in nested async functions inside component body', () => {
+			expect(() =>
+				compile(
+					`component App() {
+						const load = async () => await fetchData();
+						<button onClick={load}>{'Load'}</button>
+					}`,
+					'App.tsrx',
+				),
+			).not.toThrow();
+		});
 	});
 
 	describe('attributes', () => {

--- a/packages/tsrx/src/index.js
+++ b/packages/tsrx/src/index.js
@@ -155,6 +155,10 @@ export {
 	apply_lazy_transforms as applyLazyTransforms,
 	replace_lazy_params as replaceLazyParams,
 } from './transform/lazy.js';
+export {
+	find_first_top_level_await as findFirstTopLevelAwait,
+	find_first_top_level_await_in_component_body as findFirstTopLevelAwaitInComponentBody,
+} from './transform/await.js';
 
 // Analyze
 export { analyze_css as analyzeCss } from './analyze/css-analyze.js';

--- a/packages/tsrx/src/transform/await.js
+++ b/packages/tsrx/src/transform/await.js
@@ -1,0 +1,59 @@
+/**
+ * @param {any[]} body_nodes
+ * @returns {any | null}
+ */
+export function find_first_top_level_await_in_component_body(body_nodes) {
+	for (const node of body_nodes) {
+		const found = find_first_top_level_await(node, false);
+		if (found) return found;
+	}
+
+	return null;
+}
+
+/**
+ * @param {any} node
+ * @param {boolean} inside_nested_function
+ * @returns {any | null}
+ */
+export function find_first_top_level_await(node, inside_nested_function) {
+	if (!node || typeof node !== 'object') {
+		return null;
+	}
+
+	if (Array.isArray(node)) {
+		for (const child of node) {
+			const found = find_first_top_level_await(child, inside_nested_function);
+			if (found) return found;
+		}
+
+		return null;
+	}
+
+	if (
+		node.type === 'FunctionDeclaration' ||
+		node.type === 'FunctionExpression' ||
+		node.type === 'ArrowFunctionExpression'
+	) {
+		return inside_nested_function ? null : find_first_top_level_await(node.body, true);
+	}
+
+	if (inside_nested_function) {
+		return null;
+	}
+
+	if (node.type === 'AwaitExpression' || (node.type === 'ForOfStatement' && node.await === true)) {
+		return node;
+	}
+
+	for (const key of Object.keys(node)) {
+		if (key === 'loc' || key === 'start' || key === 'end' || key === 'metadata') {
+			continue;
+		}
+
+		const found = find_first_top_level_await(node[key], false);
+		if (found) return found;
+	}
+
+	return null;
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core TSRX transform/analyzer logic around `await` handling in React/Solid components; incorrect detection could change emitted async functions or error behavior across targets.
> 
> **Overview**
> Adds shared `@tsrx/core` utilities (`findFirstTopLevelAwait*`) to detect *top-level* `await`/`for await...of` in component bodies while ignoring nested async functions.
> 
> **React transform:** disallows top-level `await` unless the module starts with a top-level `'use server'` directive, marks such components as async and emits `async function` output, and explicitly rejects `for await...of` in template control-flow.
> 
> **Solid transform:** improves detection and error location reporting for `await` (including `for await...of`) in component bodies and blocks it with a clearer compiler error.
> 
> Updates Ripple analyzer/test expectations to align error messaging (`client components` → generic `components`) and adds targeted unit tests for the new `await`/`use server` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87484fc7508b75d69ca181471091432ccabdfb34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->