### PR TITLE
Another parser fix

### DIFF
--- a/.changeset/dirty-plants-smell.md
+++ b/.changeset/dirty-plants-smell.md
@@ -1,0 +1,5 @@
+---
+'@tsrx/core': patch
+---
+
+Fix parser handling of line-start `<` comparisons inside statement-based element children so they are not misparsed as JSX tags.

--- a/packages/ripple/tests/client/compiler/compiler.basic.test.tsrx
+++ b/packages/ripple/tests/client/compiler/compiler.basic.test.tsrx
@@ -726,10 +726,10 @@ export component App() {
 		expect(result).toContain('_$_.spread_props(');
 	});
 
-	it('parses less-than comparisons at line start in element children', () => {
+	it('parses less-than comparisons at line start in element children without whitespace', () => {
 		const source = `component TodoList({ items }: { items: { text: string }[] }) {
 	<ul>var a = 3
-	< 4;</ul>
+	<4;</ul>
 }`;
 
 		const ast = parse(source);

--- a/packages/ripple/tests/client/compiler/compiler.basic.test.tsrx
+++ b/packages/ripple/tests/client/compiler/compiler.basic.test.tsrx
@@ -725,4 +725,19 @@ export component App() {
 
 		expect(result).toContain('_$_.spread_props(');
 	});
+
+	it('parses less-than comparisons at line start in element children', () => {
+		const source = `component TodoList({ items }: { items: { text: string }[] }) {
+	<ul>var a = 3
+	< 4;</ul>
+}`;
+
+		const ast = parse(source);
+		const comp = ast.body[0] as unknown as AST.Component;
+		const ul = comp.body.find((n) => n.type === 'Element') as AST.Element;
+		expect(ul.id.name).toBe('ul');
+		expect(ul.children.length).toBeGreaterThanOrEqual(1);
+		const decl = ul.children[0] as unknown as AST.VariableDeclaration;
+		expect(decl.type).toBe('VariableDeclaration');
+	});
 });

--- a/packages/tsrx-react/src/transform.js
+++ b/packages/tsrx-react/src/transform.js
@@ -1203,6 +1203,19 @@ function to_jsx_element(node, transform_context) {
 		return dynamic_element_to_jsx_child(node, transform_context);
 	}
 
+	if (!node.id) {
+		const children = create_element_children(node.children || [], transform_context);
+		return set_loc(
+			/** @type {any} */ ({
+				type: 'JSXFragment',
+				openingFragment: { type: 'JSXOpeningFragment' },
+				closingFragment: { type: 'JSXClosingFragment' },
+				children,
+			}),
+			node,
+		);
+	}
+
 	const name = identifier_to_jsx_name(node.id);
 	const attributes = (node.attributes || []).map(to_jsx_attribute);
 	const selfClosing = !!node.selfClosing;

--- a/packages/tsrx-react/tests/basic.test.js
+++ b/packages/tsrx-react/tests/basic.test.js
@@ -593,6 +593,56 @@ describe('@tsrx/react basic', () => {
 		expect(code).toContain('return null;');
 	});
 
+	it('supports JSX fragments at line start in component bodies', () => {
+		const { code } = compile(
+			`export component App() {
+				<>
+					<div>{'hello'}</div>
+				</>
+			}`,
+			'App.tsrx',
+		);
+
+		expect(code).toContain('function App()');
+		expect(code).toContain('<>');
+		expect(code).toContain('</>');
+		expect(code).toContain("{'hello'}");
+	});
+
+	it('supports JSX fragments at line start inside element children', () => {
+		const { code } = compile(
+			`component App() {
+				<div>
+					<>
+						<span>{'inner'}</span>
+					</>
+				</div>
+			}`,
+			'App.tsrx',
+		);
+
+		expect(code).toContain('function App()');
+		expect(code).toContain('<>');
+		expect(code).toContain('</>');
+		expect(code).toContain("{'inner'}");
+	});
+
+	it('supports JSX fragments alongside other elements in component bodies', () => {
+		const { code } = compile(
+			`export component App() {
+				<h1>{'title'}</h1>
+				<>
+					<p>{'content'}</p>
+				</>
+			}`,
+			'App.tsrx',
+		);
+
+		expect(code).toContain('function App()');
+		expect(code).toContain("{'title'}");
+		expect(code).toContain("{'content'}");
+	});
+
 	it('supports early returns inside element child statement bodies', () => {
 		const { code } = compile(
 			`component App() {

--- a/packages/tsrx-react/tests/basic.test.js
+++ b/packages/tsrx-react/tests/basic.test.js
@@ -578,6 +578,21 @@ describe('@tsrx/react basic', () => {
 		expect(code).toContain('return null;');
 	});
 
+	it('supports less-than comparisons in statement-based element children', () => {
+		const { code } = compile(
+			`component TodoList({ items }: { items: { text: string }[] }) {
+				<ul>var a = 3
+				< 4;</ul>
+			}`,
+			'TodoList.tsrx',
+		);
+
+		expect(code).toContain('function TodoList');
+		expect(code).toContain('return <ul>{(() => {');
+		expect(code).toContain('var a = 3 < 4;');
+		expect(code).toContain('return null;');
+	});
+
 	it('supports early returns inside element child statement bodies', () => {
 		const { code } = compile(
 			`component App() {

--- a/packages/tsrx-react/tests/basic.test.js
+++ b/packages/tsrx-react/tests/basic.test.js
@@ -578,11 +578,11 @@ describe('@tsrx/react basic', () => {
 		expect(code).toContain('return null;');
 	});
 
-	it('supports less-than comparisons in statement-based element children', () => {
+	it('supports less-than comparisons in statement-based element children without whitespace', () => {
 		const { code } = compile(
 			`component TodoList({ items }: { items: { text: string }[] }) {
 				<ul>var a = 3
-				< 4;</ul>
+				<4;</ul>
 			}`,
 			'TodoList.tsrx',
 		);

--- a/packages/tsrx/src/plugin.js
+++ b/packages/tsrx/src/plugin.js
@@ -1572,7 +1572,9 @@ export function TSRXPlugin(config) {
 						this.next();
 					}
 				} else if (is_fragment) {
+					this.enterScope(0);
 					this.parseTemplateBody(/** @type {AST.Element} */ (element).children);
+					this.exitScope();
 				} else {
 					if (/** @type {ESTreeJSX.JSXIdentifier} */ (open.name).name === 'script') {
 						let content = '';

--- a/packages/tsrx/src/plugin.js
+++ b/packages/tsrx/src/plugin.js
@@ -436,14 +436,15 @@ export function TSRXPlugin(config) {
 						this.pos + 1 < this.input.length ? this.input.charCodeAt(this.pos + 1) : -1;
 					const isWhitespaceAfterLt =
 						nextChar === 32 || nextChar === 9 || nextChar === 10 || nextChar === 13;
-					const isTagLikeAfterLt =
-						!isWhitespaceAfterLt &&
-						(nextChar === 47 || // '/'
-							nextChar === 64 || // '@'
-							nextChar === 36 || // '$'
-							nextChar === 95 || // '_'
-							(nextChar >= 65 && nextChar <= 90) || // A-Z
-							(nextChar >= 97 && nextChar <= 122)); // a-z
+				const isTagLikeAfterLt =
+					!isWhitespaceAfterLt &&
+					(nextChar === 47 || // '/'
+						nextChar === 62 || // '>' (fragments: <>)
+						nextChar === 64 || // '@'
+						nextChar === 36 || // '$'
+						nextChar === 95 || // '_'
+						(nextChar >= 65 && nextChar <= 90) || // A-Z
+						(nextChar >= 97 && nextChar <= 122)); // a-z
 					const prevAllowsTagStart =
 						prevNonWhitespaceChar === null ||
 						prevNonWhitespaceChar === 10 || // '\n'
@@ -1474,7 +1475,11 @@ export function TSRXPlugin(config) {
 			 */
 			parseElement() {
 				const inside_head = this.#path.findLast(
-					(n) => n.type === 'Element' && n.id.type === 'Identifier' && n.id.name === 'head',
+					(n) =>
+						n.type === 'Element' &&
+						n.id &&
+						n.id.type === 'Identifier' &&
+						n.id.name === 'head',
 				);
 				// Adjust the start so we capture the `<` as part of the element
 				const start = this.start - 1;
@@ -1493,10 +1498,14 @@ export function TSRXPlugin(config) {
 				// Always attach the concrete opening element node for accurate source mapping
 				element.openingElement = open;
 
-				// Check if this is a namespaced element (tsx:react)
-				const is_tsx_compat = open.name.type === 'JSXNamespacedName';
+				// Fragments (<>) produce JSXOpeningFragment with no `name` property
+				const is_fragment = !open.name;
+				const is_tsx_compat = !is_fragment && open.name.type === 'JSXNamespacedName';
 				const is_tsx =
-					!is_tsx_compat && open.name.type === 'JSXIdentifier' && open.name.name === 'tsx';
+					!is_fragment &&
+					!is_tsx_compat &&
+					open.name.type === 'JSXIdentifier' &&
+					open.name.name === 'tsx';
 
 				if (is_tsx_compat) {
 					const namespace_node = /** @type {ESTreeJSX.JSXNamespacedName} */ (open.name);
@@ -1546,11 +1555,13 @@ export function TSRXPlugin(config) {
 					}
 				}
 
-				if (!is_tsx_compat && !is_tsx) {
+				if (!is_tsx_compat && !is_tsx && !is_fragment) {
 					/** @type {AST.Element} */ (element).id = /** @type {AST.Identifier} */ (
 						convert_from_jsx(/** @type {ESTreeJSX.JSXIdentifier} */ (open.name))
 					);
 					element.selfClosing = open.selfClosing;
+				} else if (is_fragment) {
+					element.selfClosing = false;
 				}
 
 				element.attributes = open.attributes;
@@ -1564,6 +1575,8 @@ export function TSRXPlugin(config) {
 						this.pos--;
 						this.next();
 					}
+				} else if (is_fragment) {
+					this.parseTemplateBody(element.children);
 				} else {
 					if (/** @type {ESTreeJSX.JSXIdentifier} */ (open.name).name === 'script') {
 						let content = '';
@@ -1816,7 +1829,7 @@ export function TSRXPlugin(config) {
 					}
 				}
 
-				if (element.closingElement && !is_tsx_compat && !is_tsx) {
+				if (element.closingElement && !is_tsx_compat && !is_tsx && element.closingElement.name) {
 					/** @type {unknown} */ (element.closingElement.name) = convert_from_jsx(
 						element.closingElement.name,
 					);
@@ -2041,12 +2054,17 @@ export function TSRXPlugin(config) {
 									? closingElement.name.namespace.name + ':' + closingElement.name.name.name
 									: this.getElementName(closingElement.name);
 						} else {
-							// Regular Element node
-							openingTagName = this.getElementName(currentElement.id);
-							closingTagName =
-								closingElement.name?.type === 'JSXNamespacedName'
-									? closingElement.name.namespace.name + ':' + closingElement.name.name.name
-									: this.getElementName(closingElement.name);
+							// Regular Element node (or fragment)
+							openingTagName = currentElement.id
+								? this.getElementName(currentElement.id)
+								: null;
+							closingTagName = closingElement.name
+								? closingElement.name?.type === 'JSXNamespacedName'
+									? closingElement.name.namespace.name +
+										':' +
+										closingElement.name.name.name
+									: this.getElementName(closingElement.name)
+								: null;
 						}
 
 						if (openingTagName !== closingTagName) {
@@ -2070,7 +2088,9 @@ export function TSRXPlugin(config) {
 											? 'tsx:' + elem.kind
 											: elem.type === 'Tsx'
 												? 'tsx'
-												: this.getElementName(elem.id);
+												: elem.id
+													? this.getElementName(elem.id)
+													: null;
 
 									// Found matching opening tag
 									if (elemName === closingTagName) {
@@ -2091,9 +2111,9 @@ export function TSRXPlugin(config) {
 
 						const elementToClose = this.#path[this.#path.length - 1];
 						if (elementToClose && elementToClose.type === 'Element') {
-							const elementToCloseName = this.getElementName(
-								/** @type {AST.Element} */ (elementToClose).id,
-							);
+							const elementToCloseName = /** @type {AST.Element} */ (elementToClose).id
+								? this.getElementName(/** @type {AST.Element} */ (elementToClose).id)
+								: null;
 							if (elementToCloseName === closingTagName) {
 								/** @type {AST.Element} */ (elementToClose).closingElement = closingElement;
 							}

--- a/packages/tsrx/src/plugin.js
+++ b/packages/tsrx/src/plugin.js
@@ -1572,7 +1572,7 @@ export function TSRXPlugin(config) {
 						this.next();
 					}
 				} else if (is_fragment) {
-					this.parseTemplateBody(element.children);
+					this.parseTemplateBody(/** @type {AST.Element} */ (element).children);
 				} else {
 					if (/** @type {ESTreeJSX.JSXIdentifier} */ (open.name).name === 'script') {
 						let content = '';

--- a/packages/tsrx/src/plugin.js
+++ b/packages/tsrx/src/plugin.js
@@ -439,6 +439,9 @@ export function TSRXPlugin(config) {
 					const isTagLikeAfterLt =
 						!isWhitespaceAfterLt &&
 						(nextChar === 47 || // '/'
+							nextChar === 64 || // '@'
+							nextChar === 36 || // '$'
+							nextChar === 95 || // '_'
 							(nextChar >= 65 && nextChar <= 90) || // A-Z
 							(nextChar >= 97 && nextChar <= 122)); // a-z
 					const prevAllowsTagStart =
@@ -503,13 +506,11 @@ export function TSRXPlugin(config) {
 							}
 						}
 
-						// Check if the character after < is not whitespace
-						if (allWhitespace && this.pos + 1 < this.input.length) {
-							const nextChar = this.input.charCodeAt(this.pos + 1);
-							if (nextChar !== 32 && nextChar !== 9 && nextChar !== 10 && nextChar !== 13) {
-								++this.pos;
-								return this.finishToken(tstt.jsxTagStart);
-							}
+						// At the start of a line inside template bodies, only treat `<` as
+						// a tag start when the following character can actually begin a tag.
+						if (allWhitespace && isTagLikeAfterLt) {
+							++this.pos;
+							return this.finishToken(tstt.jsxTagStart);
 						}
 					}
 				}

--- a/packages/tsrx/src/plugin.js
+++ b/packages/tsrx/src/plugin.js
@@ -436,15 +436,15 @@ export function TSRXPlugin(config) {
 						this.pos + 1 < this.input.length ? this.input.charCodeAt(this.pos + 1) : -1;
 					const isWhitespaceAfterLt =
 						nextChar === 32 || nextChar === 9 || nextChar === 10 || nextChar === 13;
-				const isTagLikeAfterLt =
-					!isWhitespaceAfterLt &&
-					(nextChar === 47 || // '/'
-						nextChar === 62 || // '>' (fragments: <>)
-						nextChar === 64 || // '@'
-						nextChar === 36 || // '$'
-						nextChar === 95 || // '_'
-						(nextChar >= 65 && nextChar <= 90) || // A-Z
-						(nextChar >= 97 && nextChar <= 122)); // a-z
+					const isTagLikeAfterLt =
+						!isWhitespaceAfterLt &&
+						(nextChar === 47 || // '/'
+							nextChar === 62 || // '>' (fragments: <>)
+							nextChar === 64 || // '@'
+							nextChar === 36 || // '$'
+							nextChar === 95 || // '_'
+							(nextChar >= 65 && nextChar <= 90) || // A-Z
+							(nextChar >= 97 && nextChar <= 122)); // a-z
 					const prevAllowsTagStart =
 						prevNonWhitespaceChar === null ||
 						prevNonWhitespaceChar === 10 || // '\n'
@@ -1475,11 +1475,7 @@ export function TSRXPlugin(config) {
 			 */
 			parseElement() {
 				const inside_head = this.#path.findLast(
-					(n) =>
-						n.type === 'Element' &&
-						n.id &&
-						n.id.type === 'Identifier' &&
-						n.id.name === 'head',
+					(n) => n.type === 'Element' && n.id && n.id.type === 'Identifier' && n.id.name === 'head',
 				);
 				// Adjust the start so we capture the `<` as part of the element
 				const start = this.start - 1;
@@ -2055,14 +2051,10 @@ export function TSRXPlugin(config) {
 									: this.getElementName(closingElement.name);
 						} else {
 							// Regular Element node (or fragment)
-							openingTagName = currentElement.id
-								? this.getElementName(currentElement.id)
-								: null;
+							openingTagName = currentElement.id ? this.getElementName(currentElement.id) : null;
 							closingTagName = closingElement.name
 								? closingElement.name?.type === 'JSXNamespacedName'
-									? closingElement.name.namespace.name +
-										':' +
-										closingElement.name.name.name
+									? closingElement.name.namespace.name + ':' + closingElement.name.name.name
 									: this.getElementName(closingElement.name)
 								: null;
 						}


### PR DESCRIPTION
Follow up to https://github.com/Ripple-TS/ripple/issues/891

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core tokenization and element parsing logic around `<`, which can have broad syntax-disambiguation impact, but changes are narrowly scoped and covered by new regression tests.
> 
> **Overview**
> Fixes a parser ambiguity where a line-start `<` inside statement-based element children could be mis-tokenized as a JSX tag start, ensuring expressions like `var a = 3\n<4;` parse/compile as `3 < 4`.
> 
> Extends the parser and React transform to support JSX fragments (`<>...</>`) in templates by treating `<>` as tag-like, representing fragments as `Element` nodes with no `id`, and emitting `JSXFragment` in the React target; adds regression tests for both the `<` comparison case and fragment parsing/compilation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21f7a39f1c54323d575400f67986af805367d499. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->