### PR TITLE
revert use server

### DIFF
--- a/.changeset/real-kiwis-smell.md
+++ b/.changeset/real-kiwis-smell.md
@@ -1,0 +1,5 @@
+---
+'@tsrx/react': minor
+---
+
+Allow top-level component-body `await` in React components without requiring a module-level `"use server"` directive.

--- a/packages/tsrx-react/src/transform.js
+++ b/packages/tsrx-react/src/transform.js
@@ -51,7 +51,6 @@ import {
 export function transform(ast, source, filename) {
 	/** @type {any[]} */
 	const stylesheets = [];
-	const module_uses_server_directive = has_use_server_directive(ast);
 
 	/** @type {TransformContext} */
 	const transform_context = {
@@ -70,13 +69,6 @@ export function transform(ast, source, filename) {
 		Component(node, { next, state }) {
 			const as_any = /** @type {any} */ (node);
 			const await_expression = find_first_top_level_await_in_component_body(as_any.body || []);
-
-			if (await_expression && !module_uses_server_directive) {
-				throw create_compile_error(
-					await_expression,
-					'React components can only use `await` when the module has a top-level "use server" directive.',
-				);
-			}
 
 			if (await_expression) {
 				as_any.metadata = /** @type {any} */ ({
@@ -530,34 +522,6 @@ function is_hook_callee(callee) {
 		callee.property?.type === 'Identifier'
 	) {
 		return /^use[A-Z0-9]/.test(callee.property.name);
-	}
-
-	return false;
-}
-
-/**
- * @param {AST.Program} program
- * @returns {boolean}
- */
-function has_use_server_directive(program) {
-	for (const statement of program.body || []) {
-		const directive = /** @type {any} */ (statement).directive;
-
-		if (directive === 'use server') {
-			return true;
-		}
-
-		if (
-			statement.type === 'ExpressionStatement' &&
-			statement.expression?.type === 'Literal' &&
-			statement.expression.value === 'use server'
-		) {
-			return true;
-		}
-
-		if (directive == null) {
-			break;
-		}
 	}
 
 	return false;

--- a/packages/tsrx-react/tests/basic.test.js
+++ b/packages/tsrx-react/tests/basic.test.js
@@ -68,19 +68,20 @@ describe('@tsrx/react basic', () => {
 		expect(code).toContain("{'Hello world'}");
 	});
 
-	it('rejects await in components without top-level use server directive', () => {
-		expect(() =>
-			compile(
-				`export component App() {
-					const data = await fetchData();
-					<div>{data}</div>
-				}`,
-				'App.tsrx',
-			),
-		).toThrow(/use server/);
+	it('emits async component functions for top-level await without requiring use server', () => {
+		const { code } = compile(
+			`export component App() {
+				const data = await fetchData();
+				<div>{data}</div>
+			}`,
+			'App.tsrx',
+		);
+
+		expect(code).toContain('export async function App()');
+		expect(code).toContain('const data = await fetchData()');
 	});
 
-	it('emits async component functions for await when use server directive is present', () => {
+	it('still emits async component functions for await when use server is present', () => {
 		const { code } = compile(
 			`'use server';
 
@@ -93,9 +94,10 @@ describe('@tsrx/react basic', () => {
 
 		expect(code).toContain('export async function App()');
 		expect(code).toContain('const data = await fetchData()');
+		expect(code).toContain("'use server';");
 	});
 
-	it('treats for await...of as top-level await and requires use server', () => {
+	it('rejects for await...of in templates without requiring use server', () => {
 		expect(() =>
 			compile(
 				`export component App({ items }: { items: AsyncIterable<string> }) {
@@ -105,7 +107,7 @@ describe('@tsrx/react basic', () => {
 				}`,
 				'App.tsrx',
 			),
-		).toThrow(/use server/);
+		).toThrow(/does not support `for await\.\.\.of`/);
 	});
 
 	it('rejects for await...of in templates even when use server is present', () => {

--- a/website-tsrx/public/llms.txt
+++ b/website-tsrx/public/llms.txt
@@ -409,8 +409,7 @@ target) and suspended via `try` / `pending` / `catch`.
 
 - **Solid + Ripple**: component bodies are synchronous; top-level
   component-body `await` is a compile-time error.
-- **React**: top-level component-body `await` is supported only when the
-  module has a top-level `'use server'` directive. In that mode TSRX emits
+- **React**: top-level component-body `await` is supported and TSRX emits
   an async component function.
 - **React**: `for await...of` is not supported inside component templates.
   Resolve async iterables in an upstream helper and render plain data in the
@@ -432,8 +431,6 @@ export component App() {
 
 **LLM DON'T:**
 - Do not write top-level component-body `await` in Solid or Ripple targets.
-- Do not use top-level component-body `await` in React modules without
-  `'use server'`.
 - Do not use `for await...of` inside React component templates.
 - Do not mark components `async`.
 
@@ -526,17 +523,15 @@ compound/descendant selectors cannot be passed.
 
 ## Target-specific behavior
 
-### React (`@tsrx/react`) — hooks + server await
+### React (`@tsrx/react`) — hooks + await
 
 The compiler **lifts all hook calls** to the top of the generated function
 regardless of where they appear in the TSRX source. That means hooks can
 sit after early returns, inside conditional branches, or inside loops, and
 the compiled output still satisfies the Rules of Hooks.
 
-React additionally supports top-level component-body `await` in server
-modules. Add a module-level `'use server'` directive and TSRX will emit an
-async component function. Without `'use server'`, top-level component-body
-`await` throws a compile error.
+React additionally supports top-level component-body `await` and TSRX emits
+an async component function when it appears in the component body.
 
 ```tsrx
 import { useState, useEffect } from 'react';

--- a/website-tsrx/src/pages/features.tsrx
+++ b/website-tsrx/src/pages/features.tsrx
@@ -695,9 +695,7 @@ export component FeaturesPage() {
 							<code class="inline-code">{'await'}</code>
 							{'. On React, top-level component-body '}
 							<code class="inline-code">{'await'}</code>
-							{' is supported only in modules with a top-level '}
-							<code class="inline-code">{'\'use server\''}</code>
-							{' directive.'}
+							{' is supported and TSRX emits an async component function.'}
 						</p>
 						<p class="section-body muted">
 							{'React note: '}
@@ -779,11 +777,7 @@ export component FeaturesPage() {
 						<p class="section-body">
 							{'React also supports top-level component-body '}
 							<code class="inline-code">{'await'}</code>
-							{' for server modules only. Add a module-level '}
-							<code class="inline-code">{'\'use server\''}</code>
-							{' directive and TSRX will emit an async component function. Without that directive, top-level '}
-							<code class="inline-code">{'await'}</code>
-							{' is a compile error.'}
+							{' and TSRX will emit an async component function when it appears in the component body.'}
 						</p>
 						<pre class="code-block">
 							<code>{html REACT_HOOKS_HTML}</code>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes generated React component function signatures (sync → async) based on `await` detection, which can affect runtime behavior and integration expectations; scope is limited to the React transform + docs/tests.
> 
> **Overview**
> React target compilation now **allows top-level component-body `await` without requiring a module-level `'use server'` directive**; the transform simply marks components containing top-level awaits and emits them as `async` functions.
> 
> Tests were updated to assert async output in the no-directive case and to adjust the `for await...of` failure to a dedicated “not supported” error message, and the website/docs were revised to remove the `'use server'` guidance. A changeset bumps `@tsrx/react` with a minor release for this behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7affcf44d30afc6a1b1e29d622cc8f884e2d33d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->