### PR TITLE
fix volar mappings

### DIFF
--- a/.changeset/fix-volar-early-return-mappings.md
+++ b/.changeset/fix-volar-early-return-mappings.md
@@ -1,0 +1,8 @@
+---
+'@tsrx/core': patch
+'@tsrx/react': patch
+'@tsrx/preact': patch
+'@tsrx/solid': patch
+---
+
+Fix source-map and Volar mapping coverage for one-line early-return `if` statements in shared JSX transforms, including plain functions and class-like method bodies.

--- a/packages/tsrx-preact/tests/basic.test.js
+++ b/packages/tsrx-preact/tests/basic.test.js
@@ -4,6 +4,7 @@ import { runSharedSourceMappingTests } from '@tsrx/core/test-harness/source-mapp
 import { compile, compile_to_volar_mappings } from '../src/index.js';
 
 runSharedSourceMappingTests({
+	compile,
 	compile_to_volar_mappings,
 	name: 'preact',
 	rejectsComponentAwait: true,

--- a/packages/tsrx-react/tests/basic.test.js
+++ b/packages/tsrx-react/tests/basic.test.js
@@ -4,6 +4,7 @@ import { runSharedSourceMappingTests } from '@tsrx/core/test-harness/source-mapp
 import { compile, compile_to_volar_mappings } from '../src/index.js';
 
 runSharedSourceMappingTests({
+	compile,
 	compile_to_volar_mappings,
 	name: 'react',
 	rejectsComponentAwait: false,

--- a/packages/tsrx-solid/tests/basic.test.js
+++ b/packages/tsrx-solid/tests/basic.test.js
@@ -4,6 +4,7 @@ import { runSharedSourceMappingTests } from '@tsrx/core/test-harness/source-mapp
 import { compile, compile_to_volar_mappings } from '../src/index.js';
 
 runSharedSourceMappingTests({
+	compile,
 	compile_to_volar_mappings,
 	name: 'solid',
 	rejectsComponentAwait: true,

--- a/packages/tsrx/src/transform/jsx/helpers.js
+++ b/packages/tsrx/src/transform/jsx/helpers.js
@@ -104,6 +104,7 @@ export function tsx_with_ts_locations() {
 		// JS nodes whose esrap printer emits no location marker, causing
 		// segments.js get_mapping_from_node() to throw when it asks for the
 		// generated position of the node's start (or end).
+		'IfStatement',
 		'NewExpression',
 		'MemberExpression',
 		'ObjectExpression',

--- a/packages/tsrx/tests/shared/source-mappings.js
+++ b/packages/tsrx/tests/shared/source-mappings.js
@@ -1,8 +1,14 @@
 import { describe, expect, it } from 'vitest';
 import { identifier_to_jsx_name } from '@tsrx/core';
+import {
+	build_line_offsets,
+	build_src_to_gen_map,
+	get_generated_position,
+} from '../../src/source-map-utils.js';
 
 /**
  * @typedef {{
+ *   compile: (source: string, filename?: string) => { code: string, map: any },
  *   compile_to_volar_mappings: (source: string, filename?: string, options?: any) => any,
  *   name: string,
  *   rejectsComponentAwait: boolean,
@@ -20,6 +26,7 @@ import { identifier_to_jsx_name } from '@tsrx/core';
  * @param {SourceMappingHarness} harness
  */
 export function runSharedSourceMappingTests({
+	compile,
 	compile_to_volar_mappings,
 	name,
 	rejectsComponentAwait,
@@ -104,6 +111,121 @@ export function runSharedSourceMappingTests({
 			expect_maps(`component Test() { const [foo, setFoo] = useState<string | null>(null) }`));
 	});
 
+	describe(`[${name}] raw source maps cover one-line early-return if statements`, () => {
+		it('maps the if keyword in plain functions', () => {
+			const source = `function f(x) {
+	if (x) return true
+	return false
+}`;
+			const result = compile(source, 'App.tsrx');
+			const [src_to_gen_map] = build_src_to_gen_map(
+				result.map,
+				new Map(),
+				build_line_offsets(result.code),
+				result.code,
+			);
+
+			expect(() => get_generated_position(2, 1, src_to_gen_map)).not.toThrow();
+		});
+	});
+
+	describe(`[${name}] raw source maps cover class-like early-return if statements`, () => {
+		/**
+		 * @param {string} source
+		 * @param {number} line
+		 * @param {number} column
+		 */
+		const expect_if_mapping = (source, line, column) => {
+			const result = compile(source, 'App.tsrx');
+			const [src_to_gen_map] = build_src_to_gen_map(
+				result.map,
+				new Map(),
+				build_line_offsets(result.code),
+				result.code,
+			);
+
+			expect(() => get_generated_position(line, column, src_to_gen_map)).not.toThrow();
+		};
+
+		it('maps the if keyword in class methods', () => {
+			expect_if_mapping(
+				`class Foo {
+	bar(x) {
+		if (x) return true
+		return false
+	}
+}`,
+				3,
+				2,
+			);
+		});
+
+		it('maps the if keyword in async class methods', () => {
+			expect_if_mapping(
+				`class Foo {
+	async bar(x) {
+		if (x) return true
+		return false
+	}
+}`,
+				3,
+				2,
+			);
+		});
+
+		it('maps the if keyword in static class methods', () => {
+			expect_if_mapping(
+				`class Foo {
+	static bar(x) {
+		if (x) return true
+		return false
+	}
+}`,
+				3,
+				2,
+			);
+		});
+
+		it('maps the if keyword in class getters', () => {
+			expect_if_mapping(
+				`class Foo {
+	get bar() {
+		if (cond) return true
+		return false
+	}
+}`,
+				3,
+				2,
+			);
+		});
+
+		it('maps the if keyword in class field arrows', () => {
+			expect_if_mapping(
+				`class Foo {
+	bar = (x) => {
+		if (x) return true
+		return false
+	}
+}`,
+				3,
+				2,
+			);
+		});
+
+		it('maps the if keyword in object method shorthand', () => {
+			expect_if_mapping(
+				`const foo = {
+	bar(x) {
+		if (x) return true
+		return false
+	}
+}`,
+				3,
+				2,
+			);
+		});
+	});
+
 	describe(`[${name}] member-expression element names map each side independently`, () => {
 		it('gives <Icons.Button></Icons.Button> distinct opening and closing id mappings', () => {
 			const source = `component App() {
@@ -115,6 +237,10 @@ export function runSharedSourceMappingTests({
 			const closing_button = closing_icons + 'Icons.'.length;
 
 			const result = compile_to_volar_mappings(source, 'App.tsrx');
+			/**
+			 * @param {number} offset
+			 * @param {number} length
+			 */
 			const mapping_at = (offset, length) =>
 				result.mappings.find(
 					(/** @type {{ sourceOffsets: number[], lengths: number[] }} */ m) =>

--- a/packages/typescript-plugin/tests/plugin-integration.test.js
+++ b/packages/typescript-plugin/tests/plugin-integration.test.js
@@ -1,15 +1,8 @@
-import fs from 'fs';
-import os from 'os';
 import path from 'path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { cleanup_fixture_workspaces, create_fixture_workspace } from './workspace-fixtures.js';
 import * as ts from 'typescript';
 import { getRippleLanguagePlugin, TSRXVirtualCode, _reset_for_test } from '../src/language.js';
-import { fileURLToPath } from 'url';
-
-const repo_root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
-/** @type {string[]} */
-const created_real_compiler_workspaces = [];
 
 /**
  * @param {string} source
@@ -46,48 +39,6 @@ function create_virtual_code(plugin, file_name, source) {
 	);
 }
 
-/**
- * @returns {string}
- */
-function create_real_react_workspace() {
-	const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'ts-plugin-real-react-'));
-	created_real_compiler_workspaces.push(workspace);
-	fs.mkdirSync(path.join(workspace, 'src'), { recursive: true });
-	fs.mkdirSync(path.join(workspace, 'node_modules', '@tsrx', 'react', 'src'), { recursive: true });
-	fs.writeFileSync(
-		path.join(workspace, 'package.json'),
-		JSON.stringify(
-			{
-				name: '@tsrx/fixture-real-react-project',
-				private: true,
-				devDependencies: {
-					'@tsrx/react': 'workspace:*',
-				},
-			},
-			null,
-			2,
-		) + '\n',
-	);
-	fs.writeFileSync(
-		path.join(workspace, 'node_modules', '@tsrx', 'react', 'src', 'index.js'),
-		`module.exports = require(${JSON.stringify(
-			path.join(repo_root, 'packages', 'tsrx-react', 'src', 'index.js'),
-		)});\n`,
-	);
-
-	return workspace;
-}
-
-function cleanup_real_compiler_workspaces() {
-	while (created_real_compiler_workspaces.length > 0) {
-		const workspace = created_real_compiler_workspaces.pop();
-		if (!workspace) {
-			continue;
-		}
-		fs.rmSync(workspace, { recursive: true, force: true });
-	}
-}
-
 describe('typescript-plugin language plugin integration', () => {
 	beforeEach(() => {
 		_reset_for_test();
@@ -95,7 +46,6 @@ describe('typescript-plugin language plugin integration', () => {
 
 	afterEach(() => {
 		cleanup_fixture_workspaces();
-		cleanup_real_compiler_workspaces();
 	});
 
 	it('recognizes only .tsrx through the language plugin', () => {
@@ -166,49 +116,5 @@ describe('typescript-plugin language plugin integration', () => {
 				create_snapshot('<div>Hello</div>'),
 			),
 		).toBeUndefined();
-	});
-
-	it('preserves class-related react return mappings through the plugin virtual-code path', () => {
-		const plugin = create_plugin();
-		const workspace = create_real_react_workspace();
-		const file_name = path.join(workspace, 'src', 'App.tsrx');
-		const source = `class Foo {
-	bar(x) {
-		if (x) return true
-		return false
-	}
-
-	get ready() {
-		if (cond) return true
-		return false
-	}
-
-	field = (x) => {
-		if (x) return true
-		return false
-	};
-}`;
-		const virtual_code = create_virtual_code(plugin, file_name, source);
-
-		expect(virtual_code).toBeInstanceOf(TSRXVirtualCode);
-		expect(virtual_code.fatalErrors).toEqual([]);
-		expect(virtual_code.usageErrors).toEqual([]);
-
-		for (const snippet of ['return true', 'return false']) {
-			const offsets = [];
-			let search_from = 0;
-			while (true) {
-				const offset = source.indexOf(snippet, search_from);
-				if (offset === -1) break;
-				offsets.push(offset);
-				search_from = offset + snippet.length;
-			}
-
-			for (const offset of offsets) {
-				const mapping = virtual_code.findMappingBySourceRange(offset, offset + 'return'.length);
-				expect(mapping, `missing mapping for ${snippet} at ${offset}`).toBeTruthy();
-				expect(mapping?.generatedLengths[0]).toBeGreaterThan(0);
-			}
-		}
 	});
 });

--- a/packages/typescript-plugin/tests/plugin-integration.test.js
+++ b/packages/typescript-plugin/tests/plugin-integration.test.js
@@ -1,8 +1,15 @@
+import fs from 'fs';
+import os from 'os';
 import path from 'path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { cleanup_fixture_workspaces, create_fixture_workspace } from './workspace-fixtures.js';
 import * as ts from 'typescript';
 import { getRippleLanguagePlugin, TSRXVirtualCode, _reset_for_test } from '../src/language.js';
+import { fileURLToPath } from 'url';
+
+const repo_root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+/** @type {string[]} */
+const created_real_compiler_workspaces = [];
 
 /**
  * @param {string} source
@@ -39,6 +46,48 @@ function create_virtual_code(plugin, file_name, source) {
 	);
 }
 
+/**
+ * @returns {string}
+ */
+function create_real_react_workspace() {
+	const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'ts-plugin-real-react-'));
+	created_real_compiler_workspaces.push(workspace);
+	fs.mkdirSync(path.join(workspace, 'src'), { recursive: true });
+	fs.mkdirSync(path.join(workspace, 'node_modules', '@tsrx', 'react', 'src'), { recursive: true });
+	fs.writeFileSync(
+		path.join(workspace, 'package.json'),
+		JSON.stringify(
+			{
+				name: '@tsrx/fixture-real-react-project',
+				private: true,
+				devDependencies: {
+					'@tsrx/react': 'workspace:*',
+				},
+			},
+			null,
+			2,
+		) + '\n',
+	);
+	fs.writeFileSync(
+		path.join(workspace, 'node_modules', '@tsrx', 'react', 'src', 'index.js'),
+		`module.exports = require(${JSON.stringify(
+			path.join(repo_root, 'packages', 'tsrx-react', 'src', 'index.js'),
+		)});\n`,
+	);
+
+	return workspace;
+}
+
+function cleanup_real_compiler_workspaces() {
+	while (created_real_compiler_workspaces.length > 0) {
+		const workspace = created_real_compiler_workspaces.pop();
+		if (!workspace) {
+			continue;
+		}
+		fs.rmSync(workspace, { recursive: true, force: true });
+	}
+}
+
 describe('typescript-plugin language plugin integration', () => {
 	beforeEach(() => {
 		_reset_for_test();
@@ -46,6 +95,7 @@ describe('typescript-plugin language plugin integration', () => {
 
 	afterEach(() => {
 		cleanup_fixture_workspaces();
+		cleanup_real_compiler_workspaces();
 	});
 
 	it('recognizes only .tsrx through the language plugin', () => {
@@ -116,5 +166,49 @@ describe('typescript-plugin language plugin integration', () => {
 				create_snapshot('<div>Hello</div>'),
 			),
 		).toBeUndefined();
+	});
+
+	it('preserves class-related react return mappings through the plugin virtual-code path', () => {
+		const plugin = create_plugin();
+		const workspace = create_real_react_workspace();
+		const file_name = path.join(workspace, 'src', 'App.tsrx');
+		const source = `class Foo {
+	bar(x) {
+		if (x) return true
+		return false
+	}
+
+	get ready() {
+		if (cond) return true
+		return false
+	}
+
+	field = (x) => {
+		if (x) return true
+		return false
+	};
+}`;
+		const virtual_code = create_virtual_code(plugin, file_name, source);
+
+		expect(virtual_code).toBeInstanceOf(TSRXVirtualCode);
+		expect(virtual_code.fatalErrors).toEqual([]);
+		expect(virtual_code.usageErrors).toEqual([]);
+
+		for (const snippet of ['return true', 'return false']) {
+			const offsets = [];
+			let search_from = 0;
+			while (true) {
+				const offset = source.indexOf(snippet, search_from);
+				if (offset === -1) break;
+				offsets.push(offset);
+				search_from = offset + snippet.length;
+			}
+
+			for (const offset of offsets) {
+				const mapping = virtual_code.findMappingBySourceRange(offset, offset + 'return'.length);
+				expect(mapping, `missing mapping for ${snippet} at ${offset}`).toBeTruthy();
+				expect(mapping?.generatedLengths[0]).toBeGreaterThan(0);
+			}
+		}
 	});
 });


### PR DESCRIPTION
Fixes https://github.com/Ripple-TS/ripple/issues/935

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the shared JSX printing/sourcemap layer used by React/Preact/Solid, so regressions could affect editor mappings across targets, though runtime output should be unchanged.
> 
> **Overview**
> Fixes a sourcemap/Volar mapping gap for one-line early-return `if` statements by wrapping `IfStatement` printing with explicit location markers in the shared JSX transform.
> 
> Extends the shared source-mapping test harness to accept `compile` and adds raw sourcemap assertions that the `if` keyword maps correctly in plain functions and class-like method bodies across targets, plus a changeset bump for all affected packages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edad7db8d98e68d9e8921e36be40f1da545f510f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->