### PR TITLE
add preact to targets, mark peers as optional

### DIFF
--- a/.changeset/add-preact-typescript-plugin.md
+++ b/.changeset/add-preact-typescript-plugin.md
@@ -1,0 +1,5 @@
+---
+'@tsrx/typescript-plugin': patch
+---
+
+Add Preact compiler resolution for `.tsrx` language service support.

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ coverage
 # Local settings
 *.local.json
 
+.claude/settings.json
+
 packages/vscode-plugin/*.vsix
 playground/src
 playground/ripple/src

--- a/packages/typescript-plugin/package.json
+++ b/packages/typescript-plugin/package.json
@@ -29,7 +29,23 @@
   "peerDependencies": {
     "typescript": "catalog:peer",
     "@tsrx/react": "workspace:*",
-    "@tsrx/ripple": "workspace:*"
+    "@tsrx/ripple": "workspace:*",
+    "@tsrx/solid": "workspace:*",
+    "@tsrx/preact": "workspace:*"
+  },
+  "peerDependenciesMeta": {
+    "@tsrx/react": {
+      "optional": true
+    },
+    "@tsrx/solid": {
+      "optional": true
+    },
+    "@tsrx/ripple": {
+      "optional": true
+    },
+    "@tsrx/preact": {
+      "optional": true
+    }
   },
   "publishConfig": {
     "access": "public"

--- a/packages/typescript-plugin/package.json
+++ b/packages/typescript-plugin/package.json
@@ -28,10 +28,10 @@
   },
   "peerDependencies": {
     "typescript": "catalog:peer",
-    "@tsrx/react": "latest",
-    "@tsrx/ripple": "latest",
-    "@tsrx/solid": "latest",
-    "@tsrx/preact": "latest"
+    "@tsrx/react": "workspace:*",
+    "@tsrx/ripple": "workspace:*",
+    "@tsrx/solid": "workspace:*",
+    "@tsrx/preact": "workspace:*"
   },
   "peerDependenciesMeta": {
     "@tsrx/react": {

--- a/packages/typescript-plugin/package.json
+++ b/packages/typescript-plugin/package.json
@@ -28,10 +28,10 @@
   },
   "peerDependencies": {
     "typescript": "catalog:peer",
-    "@tsrx/react": "workspace:*",
-    "@tsrx/ripple": "workspace:*",
-    "@tsrx/solid": "workspace:*",
-    "@tsrx/preact": "workspace:*"
+    "@tsrx/react": "latest",
+    "@tsrx/ripple": "latest",
+    "@tsrx/solid": "latest",
+    "@tsrx/preact": "latest"
   },
   "peerDependenciesMeta": {
     "@tsrx/react": {

--- a/packages/typescript-plugin/src/language.js
+++ b/packages/typescript-plugin/src/language.js
@@ -48,6 +48,12 @@ export const COMPILER_CANDIDATES = [
 		['.tsrx'],
 		['@tsrx/solid', '@tsrx/vite-plugin-solid'],
 	],
+	[
+		'@tsrx/preact',
+		['node_modules', '@tsrx', 'preact'],
+		['.tsrx'],
+		['@tsrx/preact', '@tsrx/vite-plugin-preact'],
+	],
 ];
 
 /**

--- a/packages/typescript-plugin/tests/compiler-resolution.test.js
+++ b/packages/typescript-plugin/tests/compiler-resolution.test.js
@@ -27,20 +27,28 @@ describe('typescript-plugin compiler resolution', () => {
 			expect(RIPPLE_EXTENSIONS).toEqual(['.tsrx']);
 		});
 
-		it('maps both compilers to .tsrx', () => {
+		it('maps all compiler candidates to .tsrx', () => {
 			const ripple_candidate = COMPILER_CANDIDATES.find(
 				([package_name]) => package_name === '@tsrx/ripple',
 			);
 			const react_candidate = COMPILER_CANDIDATES.find(
 				([package_name]) => package_name === '@tsrx/react',
 			);
+			const solid_candidate = COMPILER_CANDIDATES.find(
+				([package_name]) => package_name === '@tsrx/solid',
+			);
+			const preact_candidate = COMPILER_CANDIDATES.find(
+				([package_name]) => package_name === '@tsrx/preact',
+			);
 
-			if (!ripple_candidate || !react_candidate) {
+			if (!ripple_candidate || !react_candidate || !solid_candidate || !preact_candidate) {
 				throw new Error('Missing compiler candidates');
 			}
 
 			expect(ripple_candidate[2]).toEqual(['.tsrx']);
 			expect(react_candidate[2]).toEqual(['.tsrx']);
+			expect(solid_candidate[2]).toEqual(['.tsrx']);
+			expect(preact_candidate[2]).toEqual(['.tsrx']);
 		});
 	});
 
@@ -81,6 +89,16 @@ describe('typescript-plugin compiler resolution', () => {
 			);
 		});
 
+		it('selects the preact compiler in a preact-only project', () => {
+			const workspace = create_fixture_workspace('preact-only');
+			const file_name = path.join(workspace, 'src', 'App.tsrx');
+			const expected = path.join(workspace, 'node_modules', '@tsrx', 'preact', 'src', 'index.js');
+
+			expect(find_workspace_compiler_entry_for_file(file_name, fs.existsSync, new Map())).toBe(
+				expected,
+			);
+		});
+
 		it('prefers the ripple compiler when both compilers exist in a ripple project', () => {
 			const workspace = create_fixture_workspace('both');
 			const file_name = path.join(workspace, 'src', 'App.tsrx');
@@ -95,6 +113,16 @@ describe('typescript-plugin compiler resolution', () => {
 			const workspace = create_fixture_workspace('both-react');
 			const file_name = path.join(workspace, 'src', 'App.tsrx');
 			const expected = path.join(workspace, 'node_modules', '@tsrx', 'react', 'src', 'index.js');
+
+			expect(find_workspace_compiler_entry_for_file(file_name, fs.existsSync, new Map())).toBe(
+				expected,
+			);
+		});
+
+		it('prefers the preact compiler when multiple compilers exist in a preact project', () => {
+			const workspace = create_fixture_workspace('both-preact');
+			const file_name = path.join(workspace, 'src', 'App.tsrx');
+			const expected = path.join(workspace, 'node_modules', '@tsrx', 'preact', 'src', 'index.js');
 
 			expect(find_workspace_compiler_entry_for_file(file_name, fs.existsSync, new Map())).toBe(
 				expected,
@@ -154,8 +182,11 @@ describe('typescript-plugin compiler resolution', () => {
 		const cases = [
 			{ name: 'ripple-only', expected: ['@tsrx', 'ripple'] },
 			{ name: 'react-only', expected: ['@tsrx', 'react'] },
+			{ name: 'solid-only', expected: ['@tsrx', 'solid'] },
+			{ name: 'preact-only', expected: ['@tsrx', 'preact'] },
 			{ name: 'both', expected: ['@tsrx', 'ripple'] },
 			{ name: 'both-react', expected: ['@tsrx', 'react'] },
+			{ name: 'both-preact', expected: ['@tsrx', 'preact'] },
 		];
 
 		for (const test_case of cases) {

--- a/packages/typescript-plugin/tests/workspace-fixtures.js
+++ b/packages/typescript-plugin/tests/workspace-fixtures.js
@@ -59,6 +59,62 @@ const COMPILER_STUBS = {
 	},
 };
 `,
+	solid: `module.exports = {
+	compile_to_volar_mappings(source, filename) {
+		const code = \`/* compiler:solid */\\nexport const filename = \${JSON.stringify(filename)};\\nexport default \${JSON.stringify(source)};\`;
+		return {
+			code,
+			mappings: [
+				{
+					sourceOffsets: [0],
+					generatedOffsets: [0],
+					lengths: [source.length],
+					generatedLengths: [source.length],
+					data: {
+						verification: false,
+						completion: true,
+						semantic: true,
+						navigation: true,
+						structure: true,
+						format: true,
+						customData: {},
+					},
+				},
+			],
+			cssMappings: [],
+			errors: [],
+		};
+	},
+};
+`,
+	preact: `module.exports = {
+	compile_to_volar_mappings(source, filename) {
+		const code = \`/* compiler:preact */\\nexport const filename = \${JSON.stringify(filename)};\\nexport default \${JSON.stringify(source)};\`;
+		return {
+			code,
+			mappings: [
+				{
+					sourceOffsets: [0],
+					generatedOffsets: [0],
+					lengths: [source.length],
+					generatedLengths: [source.length],
+					data: {
+						verification: false,
+						completion: true,
+						semantic: true,
+						navigation: true,
+						structure: true,
+						format: true,
+						customData: {},
+					},
+				},
+			],
+			cssMappings: [],
+			errors: [],
+		};
+	},
+};
+`,
 };
 
 export const WORKSPACE_CONFIGS = {
@@ -85,6 +141,28 @@ export const WORKSPACE_CONFIGS = {
 		},
 		compilers: ['react'],
 	},
+	'solid-only': {
+		package_json: {
+			name: '@tsrx/fixture-solid-only-project',
+			private: true,
+			devDependencies: {
+				'@tsrx/solid': 'workspace:*',
+				'@tsrx/vite-plugin-solid': 'workspace:*',
+			},
+		},
+		compilers: ['solid'],
+	},
+	'preact-only': {
+		package_json: {
+			name: '@tsrx/fixture-preact-only-project',
+			private: true,
+			devDependencies: {
+				'@tsrx/preact': 'workspace:*',
+				'@tsrx/vite-plugin-preact': 'workspace:*',
+			},
+		},
+		compilers: ['preact'],
+	},
 	both: {
 		package_json: {
 			name: '@ripple-ts/fixture-ripple-project',
@@ -107,6 +185,17 @@ export const WORKSPACE_CONFIGS = {
 			},
 		},
 		compilers: ['ripple', 'react'],
+	},
+	'both-preact': {
+		package_json: {
+			name: '@tsrx/fixture-preact-project',
+			private: true,
+			devDependencies: {
+				'@tsrx/preact': 'workspace:*',
+				'@tsrx/vite-plugin-preact': 'workspace:*',
+			},
+		},
+		compilers: ['ripple', 'react', 'solid', 'preact'],
 	},
 };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -843,12 +843,18 @@ importers:
 
   packages/typescript-plugin:
     dependencies:
+      '@tsrx/preact':
+        specifier: workspace:*
+        version: link:../tsrx-preact
       '@tsrx/react':
         specifier: workspace:*
         version: link:../tsrx-react
       '@tsrx/ripple':
         specifier: workspace:*
         version: link:../tsrx-ripple
+      '@tsrx/solid':
+        specifier: workspace:*
+        version: link:../tsrx-solid
       '@volar/language-core':
         specifier: catalog:default
         version: 2.4.28


### PR DESCRIPTION
- Adds preact to compile targets for ts
- We don't want these peers to be installed automatically since people may not be using them, thus optional

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk: changes compiler resolution candidates and dependency metadata, which could alter which TSRX compiler is picked in multi-compiler workspaces and affect consumers’ install/peer-dep behavior.
> 
> **Overview**
> Adds `@tsrx/preact` (and explicitly includes `@tsrx/solid`) as supported compiler candidates for `.tsrx` in the TypeScript language service plugin, allowing the plugin to resolve the correct compiler in Preact projects.
> 
> Updates `@tsrx/typescript-plugin` peer deps so framework compilers (`@tsrx/react`, `@tsrx/ripple`, `@tsrx/solid`, `@tsrx/preact`) are *optional* peers, and extends the compiler-resolution test fixtures/matrix to cover Solid and Preact selection/preference cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21ede8dafcd3e9c2dfaea5f987052049e9e99c93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->