### PR TITLE
Fixes ForOfStatement source maps, closes #944

### DIFF
--- a/.changeset/famous-hoops-sin.md
+++ b/.changeset/famous-hoops-sin.md
@@ -1,0 +1,5 @@
+---
+'@tsrx/core': patch
+---
+
+Fixes ForOfStatement source maps

--- a/packages/tsrx/src/transform/jsx/helpers.js
+++ b/packages/tsrx/src/transform/jsx/helpers.js
@@ -111,6 +111,7 @@ export function tsx_with_ts_locations() {
 		'ReturnStatement',
 		'ForStatement',
 		'ForInStatement',
+		'ForOfStatement',
 		'TemplateLiteral',
 		'AwaitExpression',
 		'TaggedTemplateExpression',

--- a/packages/tsrx/tests/shared/source-mappings.js
+++ b/packages/tsrx/tests/shared/source-mappings.js
@@ -49,6 +49,8 @@ export function runSharedSourceMappingTests({
 		it('ReturnStatement', () => expect_maps(`function f() { return 1; } component C() {}`));
 		it('ForStatement', () => expect_maps(`component C() { for (let i = 0; i < 10; i++) {} }`));
 		it('ForInStatement', () => expect_maps(`component C() { for (const x in obj) {} }`));
+		it('ForOfStatement', () =>
+			expect_maps(`const test = () => { for (const x of Object.keys({})) {}}`));
 		it('TemplateLiteral', () => expect_maps('component C() { const x = `hello ${y}`; }'));
 		it('TaggedTemplateExpression', () => expect_maps('component C() { tag`hi`; }'));
 		// AwaitExpression inside a component body. React emits an async


### PR DESCRIPTION
Closes #944 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk change limited to source-map location wrapping and a regression test; main risk is unintended source-map differences around `for...of` printing.
> 
> **Overview**
> Fixes Volar/source-map generation for `for...of` loops by adding `ForOfStatement` to the set of AST node types wrapped with explicit start/end location markers in `tsx_with_ts_locations()`.
> 
> Adds a shared source-mapping regression test to ensure `compile_to_volar_mappings` does not throw for `ForOfStatement`, and includes a changeset bumping `@tsrx/core` as a patch release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79eff5ca8685be7691553edfbdb5de98085119b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->