### PR TITLE
Add lazy destructuring tests to Preact package

### DIFF
--- a/packages/tsrx-preact/tests/basic.test.js
+++ b/packages/tsrx-preact/tests/basic.test.js
@@ -202,7 +202,7 @@ describe('@tsrx/preact basic', () => {
 			const { code } = compile(
 				`export component App(&{name}: Props) {
 					const obj = {name};
-					<div>{obj}</div>
+					<div>{obj.name}</div>
 				}`,
 				'App.tsrx',
 			);

--- a/packages/tsrx-preact/tests/basic.test.js
+++ b/packages/tsrx-preact/tests/basic.test.js
@@ -139,4 +139,199 @@ describe('@tsrx/preact basic', () => {
 		expect(code.match(/return <div>\{Date\.now\(\)\}<\/div>;/g)).toHaveLength(2);
 		expect(code).not.toContain('return null;');
 	});
+
+	describe('lazy destructuring', () => {
+		it('transforms lazy object destructuring in component params', () => {
+			const { code } = compile(
+				`export component App(&{name, age}: Props) {
+					<div>{name}{age}</div>
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('function App(__lazy0: Props)');
+			expect(code).toContain('__lazy0.name');
+			expect(code).toContain('__lazy0.age');
+		});
+
+		it('uses regular array destructuring for useState', () => {
+			const { code } = compile(
+				`export component App() {
+					const [count, setCount] = useState(0);
+					<div>{count}</div>
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('const [count, setCount] = useState(0)');
+			expect(code).toContain('{count}');
+		});
+
+		it('transforms lazy object destructuring in variable declarations', () => {
+			const { code } = compile(
+				`export component App() {
+					const &{data, error} = useSWR("/api");
+					<div>{data}{error}</div>
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('const __lazy0 = useSWR("/api")');
+			expect(code).toContain('__lazy0.data');
+			expect(code).toContain('__lazy0.error');
+		});
+
+		it('handles assignment to lazy array bindings', () => {
+			const { code } = compile(
+				`export component App() {
+					let &[val] = getState();
+					val = 10;
+					val++;
+					++val;
+					<div>{val}</div>
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('__lazy0[0] = 10');
+			expect(code).toContain('__lazy0[0]++');
+			expect(code).toContain('++__lazy0[0]');
+		});
+
+		it('handles shorthand object properties with lazy bindings', () => {
+			const { code } = compile(
+				`export component App(&{name}: Props) {
+					const obj = {name};
+					<div>{obj}</div>
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('name: __lazy0.name');
+		});
+
+		it('handles shadowing in inner functions', () => {
+			const { code } = compile(
+				`export component App(&{name}: Props) {
+					const fn = (name: string) => name.toUpperCase();
+					<div>{fn(name)}</div>
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('(name: string) => name.toUpperCase()');
+			expect(code).toContain('fn(__lazy0.name)');
+		});
+
+		it('combines lazy params and regular destructuring', () => {
+			const { code } = compile(
+				`export component App(&{name}: Props) {
+					const [count, setCount] = useState(0);
+					<div>{name}{count}</div>
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('function App(__lazy0: Props)');
+			expect(code).toContain('const [count, setCount] = useState(0)');
+			expect(code).toContain('__lazy0.name');
+			expect(code).toContain('{count}');
+		});
+
+		it('uses regular destructuring inside callbacks', () => {
+			const { code } = compile(
+				`export component App() {
+					const [count, setCount] = useState(0);
+					const handler = () => setCount(count + 1);
+					<div>{count}</div>
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('const [count, setCount] = useState(0)');
+			expect(code).toContain('() => setCount(count + 1)');
+		});
+
+		it('transforms lazy params on plain function declarations', () => {
+			const { code } = compile(
+				`export function greet(&{ name }: { name: string }) {
+					return 'hello ' + name;
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('function greet(__lazy0: { name: string })');
+			expect(code).toContain("'hello ' + __lazy0.name");
+			expect(code).not.toContain('{ name }');
+		});
+
+		it('transforms lazy params on function expressions', () => {
+			const { code } = compile(
+				`const add = function (&{ a, b }: { a: number; b: number }) {
+					return a + b;
+				};`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('function (__lazy0: { a: number; b: number })');
+			expect(code).toContain('__lazy0.a + __lazy0.b');
+		});
+
+		it('transforms lazy params in nested functions inside components', () => {
+			const { code } = compile(
+				`export component App(&{ outer }: { outer: string }) {
+					function greet(&{ name }: { name: string }) {
+						return 'hi ' + name + ' from ' + outer;
+					}
+					<div>{greet}</div>
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('function App(__lazy0: { outer: string })');
+			expect(code).toContain('function greet(__lazy1: { name: string })');
+			expect(code).toContain("'hi ' + __lazy1.name + ' from ' + __lazy0.outer");
+		});
+
+		it('uses regular destructuring for useState at statement level', () => {
+			const { code } = compile(
+				`export component App() {
+					const [count] = useState(0);
+					<div>{count}</div>
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('const [count] = useState(0)');
+			expect(code).toContain('{count}');
+		});
+
+		it('does not hoist elements referencing useState bindings', () => {
+			const { code } = compile(
+				`export component App() {
+					const [count] = useState(0);
+					<p>{count}</p>
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).not.toContain('App__static');
+			expect(code).toContain('{count}');
+		});
+
+		it('uses regular destructuring with default parameter values', () => {
+			const { code } = compile(
+				`export component App() {
+					const [count] = useState(0);
+					const handler = (step = count) => step + 1;
+					<div>{count}</div>
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('const [count] = useState(0)');
+			expect(code).toContain('step = count');
+			expect(code).toContain('step + 1');
+		});
+	});
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds lazy destructuring compiler tests to `tsrx-preact`, mirroring the tests in `tsrx-react`. This is a follow-up to PR #952 which fixed incorrect `&[]` lazy destructuring usage with `createSignal`/`useState` in the Solid and React packages.

The Preact package was missing these tests entirely. All new tests use regular `[]` destructuring for `useState` (not `&[]`), consistent with the corrected React/Solid tests.

## Tests Added (14 new tests)

- `transforms lazy object destructuring in component params` — `&{name, age}` rewrites to `__lazy0.name`/`__lazy0.age`
- `uses regular array destructuring for useState` — `const [count, setCount] = useState(0)` stays as-is
- `transforms lazy object destructuring in variable declarations` — `&{data, error}` rewrites to `__lazy0.data`/`__lazy0.error`
- `handles assignment to lazy array bindings` — `&[val]` with mutations rewrites to `__lazy0[0]`
- `handles shorthand object properties with lazy bindings` — `{name}` expands to `{name: __lazy0.name}`
- `handles shadowing in inner functions` — inner params shadow lazy bindings correctly
- `combines lazy params and regular destructuring` — `&{name}` + `useState` coexist
- `uses regular destructuring inside callbacks` — `useState` destructuring preserved in closures
- `transforms lazy params on plain function declarations`
- `transforms lazy params on function expressions`
- `transforms lazy params in nested functions inside components`
- `uses regular destructuring for useState at statement level`
- `does not hoist elements referencing useState bindings`
- `uses regular destructuring with default parameter values`

## Files Changed
- `packages/tsrx-preact/tests/basic.test.js`

## Testing
All 2473 tests pass (14 new). The only failing tests (6 eslint-plugin tests) are pre-existing failures unrelated to this change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0064ac3c-ff7d-4509-a628-041b83957200"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0064ac3c-ff7d-4509-a628-041b83957200"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

