### PR TITLE
Fix narrowing after rendered early returns

### DIFF
--- a/.changeset/early-return-narrowing.md
+++ b/.changeset/early-return-narrowing.md
@@ -1,0 +1,5 @@
+---
+"@tsrx/core": patch
+---
+
+Preserve TypeScript narrowing after early-return branches that render fallback JSX.

--- a/packages/tsrx-preact/tests/basic.test.js
+++ b/packages/tsrx-preact/tests/basic.test.js
@@ -13,6 +13,54 @@ runSharedSourceMappingTests({
 runSharedCompileTests({ compile, name: 'preact', classAttrName: 'class' });
 
 describe('@tsrx/preact basic', () => {
+	it('preserves outer early-return narrowing when the branch renders before returning', () => {
+		const { code } = compile(
+			`declare function getFoo(): string | null;
+
+			export component Test() {
+				const foo = getFoo();
+
+				if (!foo) {
+					<div>{"Foo not found"}</div>
+					return;
+				}
+
+				<div>{foo.trim()}</div>
+			}`,
+			'Test.tsrx',
+		);
+
+		expect(code).toContain('if (!foo) {');
+		expect(code).toContain('return Test__static1;');
+		expect(code).toContain('return <div>{foo.trim()}</div>;');
+		expect(code).not.toContain('return <>{(() =>');
+	});
+
+	it('does not shadow outer JSX captures in nested rendered early-return branches', () => {
+		const { code } = compile(
+			`export component App() {
+				let value = 'outer';
+				<p>{value}</p>
+				value = 'after outer';
+
+				if (value) {
+					<span>{value}</span>
+					value = 'branch';
+					<b>{value}</b>
+					return;
+				}
+
+				<i>{value}</i>
+			}`,
+			'App.tsrx',
+		);
+
+		expect(code.match(/const _tsrx_child_0/g)).toHaveLength(1);
+		expect(code).toContain('const _tsrx_child_1 = <span>{value}</span>;');
+		expect(code).toContain('const _tsrx_child_2 = <b>{value}</b>;');
+		expect(code).toContain('return <>{_tsrx_child_0}{_tsrx_child_1}{_tsrx_child_2}</>;');
+	});
+
 	it('imports Suspense from preact/compat when try/pending is used', () => {
 		const { code } = compile(
 			`export component App() {

--- a/packages/tsrx/src/transform/jsx/index.js
+++ b/packages/tsrx/src/transform/jsx/index.js
@@ -55,6 +55,8 @@ import { is_hoist_safe_jsx_node } from '../jsx-hoist.js';
  * }} TransformContext
  */
 
+/** @typedef {{ next: number }} CaptureState */
+
 /**
  * @typedef {{ source_name: string, read: () => any }} LazyBinding
  */
@@ -404,6 +406,7 @@ function component_to_function_declaration(component, transform_context, walk_he
  * @param {{ base_name: string, next_id: number, helpers: AST.FunctionDeclaration[], statics: any[] }} helper_state
  * @param {Map<string, AST.Identifier>} available_bindings
  * @param {TransformContext} transform_context
+ * @param {CaptureState} [capture_state]
  * @returns {any[]}
  */
 function build_component_statements(
@@ -411,10 +414,11 @@ function build_component_statements(
 	helper_state,
 	available_bindings,
 	transform_context,
+	capture_state = { next: 0 },
 ) {
 	const split_index = find_hook_safe_split_index(body_nodes);
 	if (split_index === -1) {
-		return build_render_statements(body_nodes, false, transform_context);
+		return build_render_statements(body_nodes, false, transform_context, [], capture_state);
 	}
 
 	const statements = [];
@@ -423,7 +427,6 @@ function build_component_statements(
 
 	const pre_split_body = body_nodes.slice(0, split_index);
 	const interleaved = is_interleaved_body(pre_split_body);
-	let capture_index = 0;
 
 	for (let i = 0; i < split_index; i += 1) {
 		const child = body_nodes[i];
@@ -433,15 +436,22 @@ function build_component_statements(
 			return statements;
 		}
 
-		if (is_lone_return_if_statement(child)) {
-			statements.push(create_component_lone_return_if_statement(child, render_nodes));
+		if (is_early_return_if_statement(child)) {
+			statements.push(
+				create_component_early_return_if_statement(
+					child,
+					render_nodes,
+					transform_context,
+					capture_state,
+				),
+			);
 			continue;
 		}
 
 		if (is_jsx_child(child)) {
 			const jsx = to_jsx_child(child, transform_context);
 			if (interleaved && is_capturable_jsx_child(jsx)) {
-				const { declaration, reference } = captureJsxChild(jsx, capture_index++);
+				const { declaration, reference } = captureJsxChild(jsx, capture_state.next++);
 				statements.push(declaration);
 				render_nodes.push(reference);
 			} else {
@@ -508,11 +518,21 @@ function build_component_statements(
  * @param {any[]} body_nodes
  * @param {boolean} return_null_when_empty
  * @param {TransformContext} transform_context
+ * @param {any[]} [initial_render_nodes]
+ * @param {CaptureState} [capture_state]
  * @returns {any[]}
  */
-function build_render_statements(body_nodes, return_null_when_empty, transform_context) {
+function build_render_statements(
+	body_nodes,
+	return_null_when_empty,
+	transform_context,
+	initial_render_nodes = [],
+	capture_state = { next: 0 },
+) {
 	const statements = [];
-	const render_nodes = [];
+	const render_nodes = initial_render_nodes.map((node) =>
+		clone_expression_node_without_locations(node),
+	);
 
 	// Create a new bindings map so inner-scope bindings from
 	// collect_statement_bindings don't leak to the caller's scope.
@@ -525,7 +545,6 @@ function build_render_statements(body_nodes, return_null_when_empty, transform_c
 	// any JSX is constructed, and every JSX child would observe the final
 	// state of mutable variables.
 	const interleaved = is_interleaved_body(body_nodes);
-	let capture_index = 0;
 
 	for (const child of body_nodes) {
 		if (is_bare_return_statement(child)) {
@@ -534,15 +553,22 @@ function build_render_statements(body_nodes, return_null_when_empty, transform_c
 			return statements;
 		}
 
-		if (is_lone_return_if_statement(child)) {
-			statements.push(create_component_lone_return_if_statement(child, render_nodes));
+		if (is_early_return_if_statement(child)) {
+			statements.push(
+				create_component_early_return_if_statement(
+					child,
+					render_nodes,
+					transform_context,
+					capture_state,
+				),
+			);
 			continue;
 		}
 
 		if (is_jsx_child(child)) {
 			const jsx = to_jsx_child(child, transform_context);
 			if (interleaved && is_capturable_jsx_child(jsx)) {
-				const { declaration, reference } = captureJsxChild(jsx, capture_index++);
+				const { declaration, reference } = captureJsxChild(jsx, capture_state.next++);
 				statements.push(declaration);
 				render_nodes.push(reference);
 			} else {
@@ -572,7 +598,7 @@ function build_render_statements(body_nodes, return_null_when_empty, transform_c
 
 /**
  * React-specific wrapper around the core `isInterleavedBody` helper that
- * ignores bare `return` / lone return-if statements. Those are rewriting
+ * ignores bare `return` / early return-if statements. Those are rewriting
  * signals rather than user-visible side effects, so JSX children around
  * them don't need capturing.
  *
@@ -581,7 +607,7 @@ function build_render_statements(body_nodes, return_null_when_empty, transform_c
  */
 function is_interleaved_body(body_nodes) {
 	const filtered = body_nodes.filter(
-		(child) => !is_bare_return_statement(child) && !is_lone_return_if_statement(child),
+		(child) => !is_bare_return_statement(child) && !is_early_return_if_statement(child),
 	);
 	return is_interleaved_body_core(filtered, is_jsx_child);
 }
@@ -592,7 +618,7 @@ function is_interleaved_body(body_nodes) {
  */
 function find_hook_safe_split_index(body_nodes) {
 	for (let i = 0; i < body_nodes.length; i += 1) {
-		if (!is_lone_return_if_statement(body_nodes[i])) {
+		if (!is_early_return_if_statement(body_nodes[i])) {
 			continue;
 		}
 
@@ -1111,7 +1137,7 @@ function is_bare_return_statement(node) {
  * @param {any} node
  * @returns {boolean}
  */
-function is_lone_return_if_statement(node) {
+function is_early_return_if_statement(node) {
 	if (node?.type !== 'IfStatement' || node.alternate) {
 		return false;
 	}
@@ -1119,7 +1145,10 @@ function is_lone_return_if_statement(node) {
 	const consequent_body =
 		node.consequent.type === 'BlockStatement' ? node.consequent.body : [node.consequent];
 
-	return consequent_body.length === 1 && is_bare_return_statement(consequent_body[0]);
+	return (
+		consequent_body.length > 0 &&
+		is_bare_return_statement(consequent_body[consequent_body.length - 1])
+	);
 }
 
 /**
@@ -1154,11 +1183,19 @@ function create_component_return_statement(
 /**
  * @param {any} node
  * @param {any[]} render_nodes
+ * @param {TransformContext} transform_context
+ * @param {CaptureState} capture_state
  * @returns {any}
  */
-function create_component_lone_return_if_statement(node, render_nodes) {
+function create_component_early_return_if_statement(
+	node,
+	render_nodes,
+	transform_context,
+	capture_state,
+) {
 	const consequent_body =
 		node.consequent.type === 'BlockStatement' ? node.consequent.body : [node.consequent];
+	const branch_body = consequent_body.slice(0, -1);
 
 	return set_loc(
 		/** @type {any} */ ({
@@ -1167,7 +1204,13 @@ function create_component_lone_return_if_statement(node, render_nodes) {
 			consequent: set_loc(
 				/** @type {any} */ ({
 					type: 'BlockStatement',
-					body: [create_component_return_statement(render_nodes, consequent_body[0], false)],
+					body: build_render_statements(
+						branch_body,
+						true,
+						transform_context,
+						render_nodes,
+						capture_state,
+					),
 					metadata: { path: [] },
 				}),
 				node.consequent,
@@ -1315,7 +1358,7 @@ function child_contains_return_semantics(node) {
 		return false;
 	}
 
-	if (node.type === 'ReturnStatement' || is_lone_return_if_statement(node)) {
+	if (node.type === 'ReturnStatement' || is_early_return_if_statement(node)) {
 		return true;
 	}
 


### PR DESCRIPTION
When an early-return branch rendered JSX before returning, the shared JSX transform treated the whole if statement as render control flow and generated an inner IIFE return, so TypeScript could not narrow values after the branch. This broadens the early-return detection to branches ending in bare return and reuses the existing render-statement builder for the branch body, preserving rendered fallback output while emitting an outer component return that TypeScript can narrow across.

Closes #959 

## Before
```tsx
declare function getFoo(): string | null;

export function Test() {
	const foo = getFoo();

	return <>{(() => {
			if (!foo) {
				return <div>{"Foo not found"}</div>;
			}

			return null;
		})()}<div>{foo.trim()}</div></>;
}
```

## After
```tsx
declare function getFoo(): string | null;

const Test__static1 = <div>{"Foo not found"}</div>;

export function Test() {
	const foo = getFoo();

	if (!foo) {
		return Test__static1;
	}

	return <div>{foo.trim()}</div>;
}
```


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core JSX transform control-flow rewriting for early-return `if` statements and JSX capture sequencing, which could affect generated output across platforms if edge cases regress.
> 
> **Overview**
> Preserves TypeScript narrowing across early-return `if` branches that *render fallback JSX* by broadening early-return detection to any `if` consequent that ends with a bare `return`, and by emitting the branch’s rendered output via `build_render_statements` instead of wrapping the `if` in an inner IIFE/fragment return.
> 
> Updates JSX child capture tracking to share a single counter (`CaptureState`) across outer and nested early-return branches to avoid shadowing/redeclaring captured JSX variables, and adds Preact coverage for both narrowing and capture behavior. Includes a patch changeset for `@tsrx/core`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b4448bbde1abb85cc1a9946f2b76f9630fdc400. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->