### PR TITLE
fix: ArrayPattern sourcemap, types for tests

### DIFF
--- a/.changeset/late-rules-rush.md
+++ b/.changeset/late-rules-rush.md
@@ -1,0 +1,9 @@
+---
+'@tsrx/vite-plugin-react': patch
+'@tsrx/vite-plugin-solid': patch
+'ripple': patch
+'@tsrx/core': patch
+---
+
+Fix ArrayPattern source map visitor, various type fixes for tests: ripple,
+vite-plugin-react, vite-plugin-solid

--- a/.cursor/rules/project.mdc
+++ b/.cursor/rules/project.mdc
@@ -6,10 +6,10 @@ globs: **/*
 # Ripple Project Guide for AI Agents
 
 Ripple is a TypeScript-first UI framework and monorepo maintained by Dominic
-Gannaway. The current authoring format is centered on `.tsrx` files and the
-shared TSRX compiler stack. Older `.ripple`-specific docs and compiler details
-still exist in repo history and changelogs, but they are not the right default
-source of truth for current work.
+Gannaway. The current authoring format is centered on `.tsrx` files and the shared
+TSRX compiler stack. Older `.ripple`-specific docs and compiler details still
+exist in repo history and changelogs, but they are not the right default source of
+truth for current work.
 
 ## Start From Current Sources
 
@@ -61,9 +61,9 @@ This is a pnpm monorepo. The current high-level layout is:
 - `packages/adapter/`, `packages/adapter-node/`, `packages/adapter-bun/`,
   `packages/adapter-vercel/`: deployment and platform adapters
 - `packages/language-server/`, `packages/typescript-plugin/`,
-  `packages/vscode-plugin/`, `packages/intellij-plugin/`,
-  `packages/nvim-plugin/`, `packages/sublime-text-plugin/`,
-  `packages/zed-plugin/`: editor and language tooling
+  `packages/vscode-plugin/`, `packages/intellij-plugin/`, `packages/nvim-plugin/`,
+  `packages/sublime-text-plugin/`, `packages/zed-plugin/`: editor and language
+  tooling
 - `packages/eslint-parser/`, `packages/eslint-plugin/`,
   `packages/prettier-plugin/`, `packages/prettier-plugin-ripple/`: linting and
   formatting
@@ -78,8 +78,8 @@ than editing generated output, tests, or editor integrations first.
 
 - Default component files are `.tsrx`. Do not describe the project as primarily
   using `.ripple` files unless the local file you are editing actually does.
-- Some packages still preserve compatibility or historical references. Treat
-  them as compatibility context, not the default architecture description.
+- Some packages still preserve compatibility or historical references. Treat them
+  as compatibility context, not the default architecture description.
 - Use `pnpm` for all package management and workspace scripts.
 - Follow the conventions of the package you are changing. This repo mixes plain
   JavaScript, JSDoc-typed JavaScript, and TypeScript depending on package.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,10 +1,10 @@
 # Ripple Project Guide for AI Agents
 
 Ripple is a TypeScript-first UI framework and monorepo maintained by Dominic
-Gannaway. The current authoring format is centered on `.tsrx` files and the
-shared TSRX compiler stack. Older `.ripple`-specific docs and compiler details
-still exist in repo history and changelogs, but they are not the right default
-source of truth for current work.
+Gannaway. The current authoring format is centered on `.tsrx` files and the shared
+TSRX compiler stack. Older `.ripple`-specific docs and compiler details still
+exist in repo history and changelogs, but they are not the right default source of
+truth for current work.
 
 ## Start From Current Sources
 
@@ -56,9 +56,9 @@ This is a pnpm monorepo. The current high-level layout is:
 - `packages/adapter/`, `packages/adapter-node/`, `packages/adapter-bun/`,
   `packages/adapter-vercel/`: deployment and platform adapters
 - `packages/language-server/`, `packages/typescript-plugin/`,
-  `packages/vscode-plugin/`, `packages/intellij-plugin/`,
-  `packages/nvim-plugin/`, `packages/sublime-text-plugin/`,
-  `packages/zed-plugin/`: editor and language tooling
+  `packages/vscode-plugin/`, `packages/intellij-plugin/`, `packages/nvim-plugin/`,
+  `packages/sublime-text-plugin/`, `packages/zed-plugin/`: editor and language
+  tooling
 - `packages/eslint-parser/`, `packages/eslint-plugin/`,
   `packages/prettier-plugin/`, `packages/prettier-plugin-ripple/`: linting and
   formatting
@@ -73,8 +73,8 @@ than editing generated output, tests, or editor integrations first.
 
 - Default component files are `.tsrx`. Do not describe the project as primarily
   using `.ripple` files unless the local file you are editing actually does.
-- Some packages still preserve compatibility or historical references. Treat
-  them as compatibility context, not the default architecture description.
+- Some packages still preserve compatibility or historical references. Treat them
+  as compatibility context, not the default architecture description.
 - Use `pnpm` for all package management and workspace scripts.
 - Follow the conventions of the package you are changing. This repo mixes plain
   JavaScript, JSDoc-typed JavaScript, and TypeScript depending on package.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,10 +5,10 @@ As this project's AI coding tool, you must follow the additional conventions bel
 # Ripple Project Guide for AI Agents
 
 Ripple is a TypeScript-first UI framework and monorepo maintained by Dominic
-Gannaway. The current authoring format is centered on `.tsrx` files and the
-shared TSRX compiler stack. Older `.ripple`-specific docs and compiler details
-still exist in repo history and changelogs, but they are not the right default
-source of truth for current work.
+Gannaway. The current authoring format is centered on `.tsrx` files and the shared
+TSRX compiler stack. Older `.ripple`-specific docs and compiler details still
+exist in repo history and changelogs, but they are not the right default source of
+truth for current work.
 
 ## Start From Current Sources
 
@@ -60,9 +60,9 @@ This is a pnpm monorepo. The current high-level layout is:
 - `packages/adapter/`, `packages/adapter-node/`, `packages/adapter-bun/`,
   `packages/adapter-vercel/`: deployment and platform adapters
 - `packages/language-server/`, `packages/typescript-plugin/`,
-  `packages/vscode-plugin/`, `packages/intellij-plugin/`,
-  `packages/nvim-plugin/`, `packages/sublime-text-plugin/`,
-  `packages/zed-plugin/`: editor and language tooling
+  `packages/vscode-plugin/`, `packages/intellij-plugin/`, `packages/nvim-plugin/`,
+  `packages/sublime-text-plugin/`, `packages/zed-plugin/`: editor and language
+  tooling
 - `packages/eslint-parser/`, `packages/eslint-plugin/`,
   `packages/prettier-plugin/`, `packages/prettier-plugin-ripple/`: linting and
   formatting
@@ -77,8 +77,8 @@ than editing generated output, tests, or editor integrations first.
 
 - Default component files are `.tsrx`. Do not describe the project as primarily
   using `.ripple` files unless the local file you are editing actually does.
-- Some packages still preserve compatibility or historical references. Treat
-  them as compatibility context, not the default architecture description.
+- Some packages still preserve compatibility or historical references. Treat them
+  as compatibility context, not the default architecture description.
 - Use `pnpm` for all package management and workspace scripts.
 - Follow the conventions of the package you are changing. This repo mixes plain
   JavaScript, JSDoc-typed JavaScript, and TypeScript depending on package.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,10 @@
 # Ripple Project Guide for AI Agents
 
 Ripple is a TypeScript-first UI framework and monorepo maintained by Dominic
-Gannaway. The current authoring format is centered on `.tsrx` files and the
-shared TSRX compiler stack. Older `.ripple`-specific docs and compiler details
-still exist in repo history and changelogs, but they are not the right default
-source of truth for current work.
+Gannaway. The current authoring format is centered on `.tsrx` files and the shared
+TSRX compiler stack. Older `.ripple`-specific docs and compiler details still
+exist in repo history and changelogs, but they are not the right default source of
+truth for current work.
 
 ## Start From Current Sources
 
@@ -56,9 +56,9 @@ This is a pnpm monorepo. The current high-level layout is:
 - `packages/adapter/`, `packages/adapter-node/`, `packages/adapter-bun/`,
   `packages/adapter-vercel/`: deployment and platform adapters
 - `packages/language-server/`, `packages/typescript-plugin/`,
-  `packages/vscode-plugin/`, `packages/intellij-plugin/`,
-  `packages/nvim-plugin/`, `packages/sublime-text-plugin/`,
-  `packages/zed-plugin/`: editor and language tooling
+  `packages/vscode-plugin/`, `packages/intellij-plugin/`, `packages/nvim-plugin/`,
+  `packages/sublime-text-plugin/`, `packages/zed-plugin/`: editor and language
+  tooling
 - `packages/eslint-parser/`, `packages/eslint-plugin/`,
   `packages/prettier-plugin/`, `packages/prettier-plugin-ripple/`: linting and
   formatting
@@ -73,8 +73,8 @@ than editing generated output, tests, or editor integrations first.
 
 - Default component files are `.tsrx`. Do not describe the project as primarily
   using `.ripple` files unless the local file you are editing actually does.
-- Some packages still preserve compatibility or historical references. Treat
-  them as compatibility context, not the default architecture description.
+- Some packages still preserve compatibility or historical references. Treat them
+  as compatibility context, not the default architecture description.
 - Use `pnpm` for all package management and workspace scripts.
 - Follow the conventions of the package you are changing. This repo mixes plain
   JavaScript, JSDoc-typed JavaScript, and TypeScript depending on package.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -5,10 +5,10 @@ As this project's AI coding tool, you must follow the additional conventions bel
 # Ripple Project Guide for AI Agents
 
 Ripple is a TypeScript-first UI framework and monorepo maintained by Dominic
-Gannaway. The current authoring format is centered on `.tsrx` files and the
-shared TSRX compiler stack. Older `.ripple`-specific docs and compiler details
-still exist in repo history and changelogs, but they are not the right default
-source of truth for current work.
+Gannaway. The current authoring format is centered on `.tsrx` files and the shared
+TSRX compiler stack. Older `.ripple`-specific docs and compiler details still
+exist in repo history and changelogs, but they are not the right default source of
+truth for current work.
 
 ## Start From Current Sources
 
@@ -60,9 +60,9 @@ This is a pnpm monorepo. The current high-level layout is:
 - `packages/adapter/`, `packages/adapter-node/`, `packages/adapter-bun/`,
   `packages/adapter-vercel/`: deployment and platform adapters
 - `packages/language-server/`, `packages/typescript-plugin/`,
-  `packages/vscode-plugin/`, `packages/intellij-plugin/`,
-  `packages/nvim-plugin/`, `packages/sublime-text-plugin/`,
-  `packages/zed-plugin/`: editor and language tooling
+  `packages/vscode-plugin/`, `packages/intellij-plugin/`, `packages/nvim-plugin/`,
+  `packages/sublime-text-plugin/`, `packages/zed-plugin/`: editor and language
+  tooling
 - `packages/eslint-parser/`, `packages/eslint-plugin/`,
   `packages/prettier-plugin/`, `packages/prettier-plugin-ripple/`: linting and
   formatting
@@ -77,8 +77,8 @@ than editing generated output, tests, or editor integrations first.
 
 - Default component files are `.tsrx`. Do not describe the project as primarily
   using `.ripple` files unless the local file you are editing actually does.
-- Some packages still preserve compatibility or historical references. Treat
-  them as compatibility context, not the default architecture description.
+- Some packages still preserve compatibility or historical references. Treat them
+  as compatibility context, not the default architecture description.
 - Use `pnpm` for all package management and workspace scripts.
 - Follow the conventions of the package you are changing. This repo mixes plain
   JavaScript, JSDoc-typed JavaScript, and TypeScript depending on package.

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@tsrx/solid": "workspace:*",
     "@ripple-ts/vite-plugin": "workspace:*",
     "@types/node": "catalog:default",
-    "@typescript/native-preview": "7.0.0-dev.20260423.1",
+    "@typescript/native-preview": "7.0.0-dev.20260425.1",
     "eslint": "catalog:default",
     "jsdom": "catalog:default",
     "linkedom": "catalog:default",

--- a/packages/ripple/tests/client/tsconfig.json
+++ b/packages/ripple/tests/client/tsconfig.json
@@ -1,5 +1,12 @@
 {
   "extends": "../../tsconfig.json",
   "include": ["../../src/**/*", "../**/*"],
-  "exclude": ["../server", "../setup-server.js", "../hydration", "../setup-hydration.js"]
+  "exclude": [
+    "../server",
+    "../hydration",
+    "../setup-server.js",
+    "../setup-hydration.js",
+    "../server.d.ts",
+    "../hydration.d.ts"
+  ]
 }

--- a/packages/ripple/tests/hydration/tsconfig.json
+++ b/packages/ripple/tests/hydration/tsconfig.json
@@ -1,5 +1,12 @@
 {
   "extends": "../../tsconfig.json",
   "include": ["../../src/**/*", "../**/*"],
-  "exclude": ["../client", "../setup-client.js", "../server", "../setup-server.js"]
+  "exclude": [
+    "../client",
+    "../server",
+    "../setup-client.js",
+    "../setup-server.js",
+    "../client.d.ts",
+    "../server.d.ts"
+  ]
 }

--- a/packages/ripple/tests/server/tsconfig.json
+++ b/packages/ripple/tests/server/tsconfig.json
@@ -1,5 +1,12 @@
 {
   "extends": "../../tsconfig.json",
   "include": ["../../src/**/*", "../**/*"],
-  "exclude": ["../client", "../setup-client.js", "../hydration", "../setup-hydration.js"]
+  "exclude": [
+    "../client",
+    "../hydration",
+    "../setup-client.js",
+    "../setup-hydration.js",
+    "../client.d.ts",
+    "../hydration.d.ts"
+  ]
 }

--- a/packages/tsrx/src/transform/jsx/helpers.js
+++ b/packages/tsrx/src/transform/jsx/helpers.js
@@ -99,7 +99,14 @@ export function tsx_with_ts_locations() {
 	};
 
 	/** @type {Record<string, (node: any, context: any) => void>} */
-	const wrappers = {};
+	const wrappers = {
+		ArrayPattern: (node, context) => {
+			base.ArrayPattern(node, context);
+			if (node.typeAnnotation) {
+				context.visit(node.typeAnnotation);
+			}
+		},
+	};
 	for (const type of [
 		// JS nodes whose esrap printer emits no location marker, causing
 		// segments.js get_mapping_from_node() to throw when it asks for the

--- a/packages/tsrx/tests/shared/source-mappings.js
+++ b/packages/tsrx/tests/shared/source-mappings.js
@@ -111,6 +111,10 @@ export function runSharedSourceMappingTests({
 		// whole line of investigation — kept as an end-to-end shape check.
 		it('calls with explicit type arguments', () =>
 			expect_maps(`component Test() { const [foo, setFoo] = useState<string | null>(null) }`));
+		it('type annotation on array destructuring pattern', () =>
+			expect_maps(
+				`component C() { const [s, setS]: [boolean, React.Dispatch<React.SetStateAction<boolean>>] = useState(true); }`,
+			));
 	});
 
 	describe(`[${name}] raw source maps cover one-line early-return if statements`, () => {

--- a/packages/vite-plugin-react/src/index.js
+++ b/packages/vite-plugin-react/src/index.js
@@ -1,5 +1,26 @@
 /** @import { Plugin } from 'vite' */
 
+/**
+ * @typedef {{ code: string, map: unknown }} TsrxReactTransformResult
+ * @typedef {{
+ *   (code: string, id: `${string}.tsrx`): Promise<TsrxReactTransformResult>,
+ *   (code: string, id: string): Promise<TsrxReactTransformResult | null>,
+ * }} TsrxReactTransform
+ * @typedef {{
+ *   (source: `${string}?tsrx-css&lang.css`): `\0${string}?tsrx-css&lang.css`,
+ *   (source: string): string | null,
+ * }} TsrxReactResolveId
+ * @typedef {{
+ *   (id: `\0${string}?tsrx-css&lang.css`): string,
+ *   (id: string): string | null,
+ * }} TsrxReactLoad
+ * @typedef {Omit<Plugin, 'transform' | 'resolveId' | 'load'> & {
+ *   transform: TsrxReactTransform,
+ *   resolveId: TsrxReactResolveId,
+ *   load: TsrxReactLoad,
+ * }} TsrxReactPlugin
+ */
+
 import { transformWithOxc } from 'vite';
 import { compile } from '@tsrx/react';
 
@@ -13,7 +34,7 @@ const CSS_QUERY = '?tsrx-css&lang.css';
  * modules that are imported by the compiled JS output.
  *
  * @param {{ jsxImportSource?: string }} [options]
- * @returns {Plugin}
+ * @returns {TsrxReactPlugin}
  */
 export function tsrxReact(options = {}) {
 	const jsxImportSource = options.jsxImportSource ?? 'react';
@@ -21,24 +42,24 @@ export function tsrxReact(options = {}) {
 	/** @type {Map<string, string>} */
 	const css_cache = new Map();
 
-	return {
+	return /** @type {TsrxReactPlugin} */ ({
 		name: '@tsrx/vite-plugin-react',
 		enforce: 'pre',
 
-		resolveId(source) {
+		resolveId(/** @type {string} */ source) {
 			if (!source.includes(CSS_QUERY)) return null;
 			if (source.startsWith('\0')) return source;
 			return '\0' + source;
 		},
 
-		load(id) {
+		load(/** @type {string} */ id) {
 			if (!id.startsWith('\0') || !id.includes(CSS_QUERY)) return null;
 			const key = id.slice(1).split('?')[0];
 			const css = css_cache.get(key);
 			return css ?? '';
 		},
 
-		async transform(code, id) {
+		async transform(/** @type {string} */ code, /** @type {string} */ id) {
 			if (!TSRX_EXTENSION_PATTERN.test(id)) return null;
 
 			const { code: tsx_code, css } = compile(code, id);
@@ -63,7 +84,7 @@ export function tsrxReact(options = {}) {
 
 			return { code: result.code, map: result.map };
 		},
-	};
+	});
 }
 
 export default tsrxReact;

--- a/packages/vite-plugin-react/tests/basic.test.js
+++ b/packages/vite-plugin-react/tests/basic.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, it } from 'vitest';
 import { tsrxReact } from '../src/index.js';
 
 describe('@tsrx/vite-plugin-react basic', () => {

--- a/packages/vite-plugin-react/tests/runtime.test.tsrx
+++ b/packages/vite-plugin-react/tests/runtime.test.tsrx
@@ -1,4 +1,4 @@
-import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import type { MockInstance } from 'vitest';
 import { useState, use } from 'react';
 
 const EXPECTED_ERROR_LOG_SNIPPETS = [
@@ -11,8 +11,7 @@ const EXPECTED_ERROR_LOG_SNIPPETS = [
 	'React will try to recreate this component tree from scratch using the error boundary you provided',
 ];
 
-/** @type {import('vitest').MockInstance | undefined} */
-let console_error_spy;
+let console_error_spy: MockInstance | undefined;
 
 function is_expected_error_log(args: unknown[]) {
 	const message = args.map((arg) => {
@@ -243,8 +242,8 @@ component ThrowingChild() {
 component ErrorBoundaryApp() {
 	try {
 		<ThrowingChild />
-	} catch (err) {
-		<p class="caught">{(err as Error).message}</p>
+	} catch (err: Error) {
+		<p class="caught">{err.message}</p>
 	}
 }
 
@@ -262,8 +261,8 @@ component ErrorToggleApp() {
 
 	try {
 		<MaybeThrow shouldThrow={fail} />
-	} catch (err, reset) {
-		<p class="caught">{(err as Error).message}</p>
+	} catch (err: Error, reset: () => void) {
+		<p class="caught">{err.message}</p>
 		<button
 			class="reset"
 			onClick={() => {
@@ -300,8 +299,8 @@ component SuspenseErrorApp(props: { promise: Promise<string> }) {
 		<AsyncChild promise={props.promise} />
 	} pending {
 		<p class="pending">{'loading...'}</p>
-	} catch (err) {
-		<p class="caught">{(err as Error).message}</p>
+	} catch (err: Error) {
+		<p class="caught">{err.message}</p>
 	}
 }
 
@@ -312,8 +311,8 @@ component ErrorResetApp(props: { promise: Promise<string> }) {
 		<AsyncChild promise={props.promise} />
 	} pending {
 		<p class="pending">{'loading...'}</p>
-	} catch (err, reset) {
-		<p class="caught">{(err as Error).message}</p>
+	} catch (err: Error, reset: () => void) {
+		<p class="caught">{err.message}</p>
 		<button class="retry" onClick={() => reset()}>{'retry'}</button>
 	}
 }
@@ -330,12 +329,12 @@ component NestedTryApp() {
 		<div class="outer">
 			try {
 				<InnerThrow />
-			} catch (err) {
-				<p class="inner-caught">{(err as Error).message}</p>
+			} catch (err: Error) {
+				<p class="inner-caught">{err.message}</p>
 			}
 		</div>
-	} catch (err) {
-		<p class="outer-caught">{(err as Error).message}</p>
+	} catch (err: Error) {
+		<p class="outer-caught">{err.message}</p>
 	}
 }
 
@@ -364,7 +363,7 @@ component IfInsideTryApp() {
 		} else {
 			<p class="branch-b">{'alternate'}</p>
 		}
-	} catch (err) {
+	} catch (err: Error) {
 		<p class="caught">{'error'}</p>
 	}
 
@@ -380,7 +379,7 @@ component ForInsideTryApp() {
 		for (const item of items) {
 			<span class="try-item" key={item}>{item}</span>
 		}
-	} catch (err) {
+	} catch (err: Error) {
 		<p class="caught">{'error'}</p>
 	}
 
@@ -390,7 +389,7 @@ component ForInsideTryApp() {
 // ── Hook inside if-branch ──
 
 component HookInIfApp() {
-	const [show, setShow] = useState(true);
+	const [show, setShow]: [boolean, React.Dispatch<React.SetStateAction<boolean>>] = useState(true);
 
 	if (show) {
 		const [count, setCount] = useState(0);

--- a/packages/vite-plugin-react/tests/setup.js
+++ b/packages/vite-plugin-react/tests/setup.js
@@ -11,17 +11,10 @@ let container;
 /** @type {import('react-dom/client').Root | null} */
 let root;
 
-/**
- * Render a React component into the test container.
- *
- * @param {import('react').ComponentType} Component
- * @param {Record<string, unknown>} [props]
- * @returns {Promise<void>}
- */
 globalThis.render = async function render(Component, props) {
 	root = createRoot(container);
 	await act(async () => {
-		root.render(createElement(Component, props ?? {}));
+		/** @type {import('react-dom/client').Root} */ (root).render(createElement(Component, props));
 	});
 };
 
@@ -34,10 +27,12 @@ beforeEach(() => {
 afterEach(() => {
 	if (root) {
 		act(() => {
-			root.unmount();
+			/** @type {import('react-dom/client').Root} */ (root).unmount();
 		});
 		root = null;
 	}
+	// cleanup but these are guaranteed to be present during tests
+	// so tests can safely references container as a global
 	document.body.removeChild(container);
-	globalThis.container = undefined;
+	globalThis.container = /** @type {HTMLDivElement} */ (/** @type {unknown} */ (undefined));
 });

--- a/packages/vite-plugin-react/tests/tsconfig.json
+++ b/packages/vite-plugin-react/tests/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["**/*.d.ts", "**/*.test.tsrx", "**/*.test.js", "setup.js"],
+  // override parent exclusion of this folder
+  "exclude": []
+}

--- a/packages/vite-plugin-react/tests/types.d.ts
+++ b/packages/vite-plugin-react/tests/types.d.ts
@@ -1,0 +1,13 @@
+import type { JSXElementConstructor, act as reactAct } from 'react';
+
+declare global {
+	var IS_REACT_ACT_ENVIRONMENT: boolean;
+
+	var render: <Props extends object>(
+		component: JSXElementConstructor<{}>,
+		props?: Props,
+	) => Promise<void>;
+
+	var act: typeof reactAct;
+	var container: HTMLDivElement;
+}

--- a/packages/vite-plugin-react/tsconfig.json
+++ b/packages/vite-plugin-react/tsconfig.json
@@ -1,4 +1,5 @@
 {
   "extends": "../tsrx/tsconfig.json",
-  "include": ["src/**/*", "types/**/*"]
+  "include": ["src/**/*", "types/**/*"],
+  "exclude": ["tests/**/*"]
 }

--- a/packages/vite-plugin-react/types/index.d.ts
+++ b/packages/vite-plugin-react/types/index.d.ts
@@ -4,5 +4,25 @@ export interface TsrxReactPluginOptions {
 	jsxImportSource?: string;
 }
 
-export function tsrxReact(options?: TsrxReactPluginOptions): Plugin;
+export interface TsrxReactTransformResult {
+	code: string;
+	map: unknown;
+}
+
+export interface TsrxReactPlugin extends Omit<Plugin, 'transform' | 'resolveId' | 'load'> {
+	transform: {
+		(code: string, id: `${string}.tsrx`): Promise<TsrxReactTransformResult>;
+		(code: string, id: string): Promise<TsrxReactTransformResult | null>;
+	};
+	resolveId: {
+		(source: `${string}?tsrx-css&lang.css`): `\0${string}?tsrx-css&lang.css`;
+		(source: string): string | null;
+	};
+	load: {
+		(id: `\0${string}?tsrx-css&lang.css`): string;
+		(id: string): string | null;
+	};
+}
+
+export function tsrxReact(options?: TsrxReactPluginOptions): TsrxReactPlugin;
 export default tsrxReact;

--- a/packages/vite-plugin-solid/tests/plugin.test.js
+++ b/packages/vite-plugin-solid/tests/plugin.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, it } from 'vitest';
 import { tsrxSolid } from '../src/index.js';
 
 /**
@@ -7,10 +6,10 @@ import { tsrxSolid } from '../src/index.js';
  * the "rewrite to virtual id" path.
  *
  * @param {string} source
- * @returns {Promise<{ id: string } | null>}
+ * @returns {Promise<{ id: string, external: false, moduleSideEffects: true, meta: {} }>}
  */
 async function fake_plugin_resolve(source) {
-	return { id: source };
+	return { id: source, external: false, moduleSideEffects: true, meta: {} };
 }
 
 /**
@@ -21,7 +20,18 @@ function call_resolve_id(plugin, source) {
 	const hook =
 		typeof plugin.resolveId === 'function' ? plugin.resolveId : plugin.resolveId?.handler;
 	if (!hook) throw new Error('plugin has no resolveId hook');
-	return hook.call({ resolve: fake_plugin_resolve }, source, undefined, {});
+	const context = /** @type {ThisParameterType<typeof hook>} */ ({ resolve: fake_plugin_resolve });
+	return hook.call(context, source, undefined, { isEntry: false });
+}
+
+/**
+ * @param {unknown} result
+ * @returns {string | undefined}
+ */
+function resolved_id(result) {
+	return typeof result === 'object' && result !== null && 'id' in result
+		? String(result.id)
+		: undefined;
 }
 
 describe('@tsrx/vite-plugin-solid routing', () => {
@@ -30,7 +40,7 @@ describe('@tsrx/vite-plugin-solid routing', () => {
 
 		it('rewrites `.tsrx` imports to a virtual `.tsx` id', async () => {
 			const result = await call_resolve_id(plugin, '/abs/path/App.tsrx');
-			expect(result).toEqual({ id: '/abs/path/App.tsrx.tsx' });
+			expect(resolved_id(result)).toBe('/abs/path/App.tsrx.tsx');
 		});
 
 		it('leaves unrelated extensions alone', async () => {
@@ -45,8 +55,8 @@ describe('@tsrx/vite-plugin-solid routing', () => {
 			const plugin = tsrxSolid({ include: /\.(tsrx|foo)$/ });
 			const tsrx = await call_resolve_id(plugin, '/abs/path/App.tsrx');
 			const foo = await call_resolve_id(plugin, '/abs/path/Other.foo');
-			expect(tsrx).toEqual({ id: '/abs/path/App.tsrx.tsx' });
-			expect(foo).toEqual({ id: '/abs/path/Other.foo.tsx' });
+			expect(resolved_id(tsrx)).toBe('/abs/path/App.tsrx.tsx');
+			expect(resolved_id(foo)).toBe('/abs/path/Other.foo.tsx');
 		});
 
 		it('narrows routing when the pattern is stricter than the default', async () => {
@@ -54,7 +64,7 @@ describe('@tsrx/vite-plugin-solid routing', () => {
 			const plugin = tsrxSolid({ include: /\/src\/.*\.tsrx$/ });
 			const matched = await call_resolve_id(plugin, '/proj/src/App.tsrx');
 			const skipped = await call_resolve_id(plugin, '/proj/tests/App.tsrx');
-			expect(matched).toEqual({ id: '/proj/src/App.tsrx.tsx' });
+			expect(resolved_id(matched)).toBe('/proj/src/App.tsrx.tsx');
 			expect(skipped).toBeNull();
 		});
 	});

--- a/packages/vite-plugin-solid/tests/runtime.test.tsrx
+++ b/packages/vite-plugin-solid/tests/runtime.test.tsrx
@@ -1,4 +1,4 @@
-import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import type { MockInstance } from 'vitest';
 import { createSignal, lazy } from 'solid-js';
 
 const EXPECTED_ERROR_LOG_SNIPPETS = [
@@ -9,8 +9,7 @@ const EXPECTED_ERROR_LOG_SNIPPETS = [
 	'inner error',
 ];
 
-/** @type {import('vitest').MockInstance | undefined} */
-let console_error_spy;
+let console_error_spy: MockInstance | undefined;
 
 function is_expected_error_log(args: unknown[]) {
 	const message = args.map((arg) => {
@@ -207,7 +206,7 @@ component ForReactiveApp() {
 	const [items, setItems] = createSignal(['a', 'b', 'c']);
 
 	for (const item of items(); index i) {
-		<li class="item">{item}</li>
+		<li class="item">{item()}</li>
 	}
 
 	<button class="add" onClick={() => setItems([...items(), 'd'])}>{'add'}</button>
@@ -394,7 +393,7 @@ component ForInsideTryApp() {
 
 	try {
 		for (const item of items(); index i) {
-			<span class="try-item">{item}</span>
+			<span class="try-item">{item()}</span>
 		}
 	} catch (err) {
 		<p class="caught">{'error'}</p>
@@ -572,7 +571,7 @@ component MidTemplateLocalsApp() {
 		const [count, setCount] = createSignal(0);
 
 		for (const item of ['a', 'b']; index i) {
-			<span class="mid-template-item">{item}</span>
+			<span class="mid-template-item">{item()}</span>
 		}
 
 		<p class="mid-template-count">{count()}</p>

--- a/packages/vite-plugin-solid/tests/setup.js
+++ b/packages/vite-plugin-solid/tests/setup.js
@@ -24,13 +24,6 @@ let container;
 /** @type {(() => void) | null} */
 let dispose = null;
 
-/**
- * Render a Solid component into the test container.
- *
- * @param {import('solid-js').Component<any>} Component
- * @param {Record<string, unknown>} [props]
- * @returns {Promise<void>}
- */
 globalThis.render = async function render(Component, props) {
 	dispose = solidRender(() => createComponent(Component, props ?? {}), container);
 	// Let Solid finish initial effects / microtasks.
@@ -41,8 +34,6 @@ globalThis.render = async function render(Component, props) {
 /**
  * Yield to Solid: flush pending microtasks so that signal updates and
  * promise-backed resources settle before assertions run.
- *
- * @returns {Promise<void>}
  */
 globalThis.flush = async function flush() {
 	for (let i = 0; i < 4; i++) {
@@ -62,5 +53,5 @@ afterEach(() => {
 		dispose = null;
 	}
 	document.body.removeChild(container);
-	globalThis.container = undefined;
+	globalThis.container = /** @type {HTMLDivElement} */ (/** @type {unknown} */ (undefined));
 });

--- a/packages/vite-plugin-solid/tests/tsconfig.json
+++ b/packages/vite-plugin-solid/tests/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "preserve",
+    "jsxImportSource": "solid-js",
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["**/*.d.ts", "**/*.test.tsrx", "**/*.test.js", "setup.js"],
+  // override parent exclusion of this folder
+  "exclude": []
+}

--- a/packages/vite-plugin-solid/tests/types.d.ts
+++ b/packages/vite-plugin-solid/tests/types.d.ts
@@ -1,0 +1,9 @@
+import type { Component } from 'solid-js';
+
+declare global {
+	var render: <Props extends object>(component: Component<{}>, props?: Props) => Promise<void>;
+
+	var flush: () => Promise<void>;
+
+	var container: HTMLDivElement;
+}

--- a/packages/vite-plugin-solid/tsconfig.json
+++ b/packages/vite-plugin-solid/tsconfig.json
@@ -1,4 +1,5 @@
 {
   "extends": "../tsrx/tsconfig.json",
-  "include": ["src/**/*", "types/**/*"]
+  "include": ["src/**/*", "types/**/*"],
+  "exclude": ["tests/**/*"]
 }

--- a/playground/ripple/package.json
+++ b/playground/ripple/package.json
@@ -20,7 +20,6 @@
     "@tsrx/eslint-plugin": "workspace:*",
     "@tsrx/typescript-plugin": "workspace:*",
     "@ripple-ts/vite-plugin": "workspace:*",
-    "@tsrx/ripple": "workspace:*",
     "@typescript-eslint/parser": "catalog:default",
     "@tailwindcss/vite": "catalog:default",
     "eslint": "catalog:default",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -276,8 +276,8 @@ importers:
         specifier: catalog:default
         version: 24.11.0
       '@typescript/native-preview':
-        specifier: 7.0.0-dev.20260423.1
-        version: 7.0.0-dev.20260423.1
+        specifier: 7.0.0-dev.20260425.1
+        version: 7.0.0-dev.20260425.1
       eslint:
         specifier: catalog:default
         version: 10.2.1(jiti@2.6.1)
@@ -404,7 +404,7 @@ importers:
         version: 2.4.2
       tsdown:
         specifier: catalog:default
-        version: 0.20.3(@typescript/native-preview@7.0.0-dev.20260423.1)(typescript@5.9.3)
+        version: 0.20.3(@typescript/native-preview@7.0.0-dev.20260425.1)(typescript@5.9.3)
       type-fest:
         specifier: catalog:default
         version: 5.6.0
@@ -445,7 +445,7 @@ importers:
     devDependencies:
       tsdown:
         specifier: catalog:default
-        version: 0.20.3(@typescript/native-preview@7.0.0-dev.20260423.1)(typescript@5.9.3)
+        version: 0.20.3(@typescript/native-preview@7.0.0-dev.20260425.1)(typescript@5.9.3)
 
   packages/eslint-parser:
     dependencies:
@@ -470,7 +470,7 @@ importers:
         version: 24.11.0
       tsdown:
         specifier: catalog:default
-        version: 0.20.3(@typescript/native-preview@7.0.0-dev.20260423.1)(typescript@5.9.3)
+        version: 0.20.3(@typescript/native-preview@7.0.0-dev.20260425.1)(typescript@5.9.3)
       typescript:
         specifier: catalog:default
         version: 5.9.3
@@ -497,7 +497,7 @@ importers:
         version: 10.2.1(jiti@2.6.1)
       tsdown:
         specifier: catalog:default
-        version: 0.20.3(@typescript/native-preview@7.0.0-dev.20260423.1)(typescript@5.9.3)
+        version: 0.20.3(@typescript/native-preview@7.0.0-dev.20260425.1)(typescript@5.9.3)
       typescript:
         specifier: catalog:default
         version: 5.9.3
@@ -539,7 +539,7 @@ importers:
         version: link:../tsrx-ripple
       tsdown:
         specifier: catalog:default
-        version: 0.20.3(@typescript/native-preview@7.0.0-dev.20260423.1)(typescript@5.9.3)
+        version: 0.20.3(@typescript/native-preview@7.0.0-dev.20260425.1)(typescript@5.9.3)
 
   packages/nvim-plugin: {}
 
@@ -870,7 +870,7 @@ importers:
         version: 24.11.0
       tsdown:
         specifier: catalog:default
-        version: 0.20.3(@typescript/native-preview@7.0.0-dev.20260423.1)(typescript@5.9.3)
+        version: 0.20.3(@typescript/native-preview@7.0.0-dev.20260425.1)(typescript@5.9.3)
 
   packages/vite-plugin:
     dependencies:
@@ -1007,7 +1007,7 @@ importers:
         version: 0.5.17
       tsdown:
         specifier: catalog:default
-        version: 0.20.3(@typescript/native-preview@7.0.0-dev.20260423.1)(typescript@5.9.3)
+        version: 0.20.3(@typescript/native-preview@7.0.0-dev.20260425.1)(typescript@5.9.3)
 
   packages/zed-plugin: {}
 
@@ -1060,9 +1060,6 @@ importers:
       '@tsrx/eslint-plugin':
         specifier: workspace:*
         version: link:../../packages/eslint-plugin
-      '@tsrx/ripple':
-        specifier: workspace:*
-        version: link:../../packages/tsrx-ripple
       '@tsrx/typescript-plugin':
         specifier: workspace:*
         version: link:../../packages/typescript-plugin
@@ -3077,50 +3074,50 @@ packages:
     resolution: {integrity: sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260423.1':
-    resolution: {integrity: sha512-wbLr6o5fROaCYt6cOpFhbe92FJAOdhAHwm/s8I/IyN5HbL1ULgel/wHaZiR+ws+27rgruNUiCENzTUg9vSz2bA==}
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260425.1':
+    resolution: {integrity: sha512-vM7O+PlxHRUT4Dv0VkxEmU3N2uyWeSFrhu57O7s3SE9TX1ENljwQlCFG0oQdBGLBRo+SZSoedxKL5jOGlD1eiw==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [darwin]
 
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260423.1':
-    resolution: {integrity: sha512-13MpNT+4MgkgrfiW2u03rnER5aB3yz9fA0bWEYh6IH3rIqA2AR3Dntp3QXW4sQrZf0SriXqHe2R7X3HCT5xmqA==}
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260425.1':
+    resolution: {integrity: sha512-EiikklZSuEvMhZEeN0VRb0vmedhLgtKwz5p4Oz9e8hlJ4lLrslgvX7Z7JWb2YSKlhm14dUlRMvdoe+6t+56rSA==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [darwin]
 
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260423.1':
-    resolution: {integrity: sha512-ICIkJDTqmn0R4Vs811+Ht2RYTk1OCrAhHCu0JthmhR216T1Tqgi5DWRoCprp3RL1qU6fLnxxrIpEbNlNN7XFYA==}
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260425.1':
+    resolution: {integrity: sha512-5KJ++prl1dscJtxnkE7Cb6rjud4T3nO4mcnKhkCfYcQaFtFrvcZhBtDobwcpSzHbfsW0MeM+QCy1UfWoK4gjUQ==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [linux]
 
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260423.1':
-    resolution: {integrity: sha512-CxUA15qbPQRvz2nanBpiv1h4tgXTCJJwqOtgKMSdIuPkow8dyYW3ba5oLoH/jZhS4792XislX659hlFrfiU6CQ==}
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260425.1':
+    resolution: {integrity: sha512-9eWInaHqhfTu1Mt/1M85p5M+HlSStahAQkqYaW9rJzUWRe+AcVUKsN6I7U7iwxbkCT8gFZsMCRqABcwBUWw3kg==}
     engines: {node: '>=16.20.0'}
     cpu: [arm]
     os: [linux]
 
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260423.1':
-    resolution: {integrity: sha512-cWLFS4R8dOU1YuUJ/2VLeGMVIjgI3GGb/f9rRY5MbWHq5l3NNZh8y1QwAOrTh3+g3q6+znArfxVnD2hZHUz8Mw==}
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260425.1':
+    resolution: {integrity: sha512-a/E/8UL2x6nWmIJwrrbEvLz938RMcrFfm5hLRKaPMjCE32bgwesBZEG5jRn8fzQes+4HICRXKEaL544jtb/Syg==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [linux]
 
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260423.1':
-    resolution: {integrity: sha512-OWaGUI4+dHqYZv+k6sITx9Y27FNy3XzNFk4OrOiYtBkIO/xrb9TPMP4A5XI4n5zwRLIv3xne9g039xgRbaeyoQ==}
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260425.1':
+    resolution: {integrity: sha512-BZ7jEnaNZHkHbq9LWuqqIgYMmMb2E2NReMybjOyl3ASFmJHYekDnytXIT3Zbp4dyPLJV55faGzLqMw2MMS81NA==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [win32]
 
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260423.1':
-    resolution: {integrity: sha512-5MQjO/qdLwXpjW7Dy/1lNv7Vtpvo6bhCkbjan4PoRN5/eeyqEqDWxdf8AGE4btLmHqyIjEHRuYf7kp2tlAr6lQ==}
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260425.1':
+    resolution: {integrity: sha512-/iwK50mO31lKr1KVDRCqW5xGyKArZuq9jQr2b/PJ3e0xEuV6hoJ4Kok11LA1lhx1uctqr3UXKmfwQF3HWqcZTQ==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [win32]
 
-  '@typescript/native-preview@7.0.0-dev.20260423.1':
-    resolution: {integrity: sha512-9WD7TJJlGvt9PQqJI/+44dVP4oqGQFIkYrpXt7nlQ0WgNIErN52x/XhxmJ4nWft06qejgPiUbPo4aYRNOmIHXg==}
+  '@typescript/native-preview@7.0.0-dev.20260425.1':
+    resolution: {integrity: sha512-qhSVDT9DsoKPBeEm777eUUkiCDjBFlF7wwjfMvcPctZFVHfD6b1O1icpfCdQHPqzjrSXWu2YaNiY0DXbljTmgw==}
     engines: {node: '>=16.20.0'}
     hasBin: true
 
@@ -8369,36 +8366,36 @@ snapshots:
       '@typescript-eslint/types': 8.56.1
       eslint-visitor-keys: 5.0.1
 
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260423.1':
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260425.1':
     optional: true
 
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260423.1':
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260425.1':
     optional: true
 
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260423.1':
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260425.1':
     optional: true
 
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260423.1':
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260425.1':
     optional: true
 
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260423.1':
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260425.1':
     optional: true
 
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260423.1':
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260425.1':
     optional: true
 
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260423.1':
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260425.1':
     optional: true
 
-  '@typescript/native-preview@7.0.0-dev.20260423.1':
+  '@typescript/native-preview@7.0.0-dev.20260425.1':
     optionalDependencies:
-      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260423.1
-      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260423.1
-      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260423.1
-      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260423.1
-      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260423.1
-      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260423.1
-      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260423.1
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260425.1
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260425.1
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260425.1
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260425.1
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260425.1
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260425.1
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260425.1
 
   '@typespec/ts-http-runtime@0.3.3':
     dependencies:
@@ -10916,7 +10913,7 @@ snapshots:
       devalue: 5.6.3
       esm-env: 1.2.2
 
-  rolldown-plugin-dts@0.22.3(@typescript/native-preview@7.0.0-dev.20260423.1)(rolldown@1.0.0-rc.3)(typescript@5.9.3):
+  rolldown-plugin-dts@0.22.3(@typescript/native-preview@7.0.0-dev.20260425.1)(rolldown@1.0.0-rc.3)(typescript@5.9.3):
     dependencies:
       '@babel/generator': 8.0.0-rc.2
       '@babel/helper-validator-identifier': 8.0.0-rc.2
@@ -10929,7 +10926,7 @@ snapshots:
       obug: 2.1.1
       rolldown: 1.0.0-rc.3
     optionalDependencies:
-      '@typescript/native-preview': 7.0.0-dev.20260423.1
+      '@typescript/native-preview': 7.0.0-dev.20260425.1
       typescript: 5.9.3
     transitivePeerDependencies:
       - oxc-resolver
@@ -11516,7 +11513,7 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  tsdown@0.20.3(@typescript/native-preview@7.0.0-dev.20260423.1)(typescript@5.9.3):
+  tsdown@0.20.3(@typescript/native-preview@7.0.0-dev.20260425.1)(typescript@5.9.3):
     dependencies:
       ansis: 4.2.0
       cac: 6.7.14
@@ -11527,7 +11524,7 @@ snapshots:
       obug: 2.1.1
       picomatch: 4.0.3
       rolldown: 1.0.0-rc.3
-      rolldown-plugin-dts: 0.22.3(@typescript/native-preview@7.0.0-dev.20260423.1)(rolldown@1.0.0-rc.3)(typescript@5.9.3)
+      rolldown-plugin-dts: 0.22.3(@typescript/native-preview@7.0.0-dev.20260425.1)(rolldown@1.0.0-rc.3)(typescript@5.9.3)
       semver: 7.7.4
       tinyexec: 1.0.2
       tinyglobby: 0.2.15


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches the JSX printer/source-map visitor used across targets, so regressions could impact Volar/source-map generation even though the change is small and covered by new mapping tests.
> 
> **Overview**
> Fixes a source-map crash by teaching the shared `tsx_with_ts_locations()` printer to also visit `ArrayPattern` `typeAnnotation`s, and adds a regression mapping test for typed array destructuring.
> 
> Improves type-safety around plugin/test code: adds stronger public typings for `@tsrx/vite-plugin-react` hook signatures, introduces per-plugin `tests/tsconfig.json` + global `types.d.ts` for React/Solid test helpers, and tweaks various test/tsconfig exclusions and runtime test typings.
> 
> Bumps `@typescript/native-preview` and removes an unused `@tsrx/ripple` devDependency from the Ripple playground; includes a changeset for patch releases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 578892d0940f0479f33d7f280d81e37704c1c72a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->