### PR TITLE
fix: SpreadAttribute

### DIFF
--- a/.changeset/sharp-tsx-spreads.md
+++ b/.changeset/sharp-tsx-spreads.md
@@ -1,0 +1,6 @@
+---
+'@tsrx/core': patch
+'@tsrx/prettier-plugin': patch
+---
+
+Preserve JSX spread attributes inside explicit `<tsx>` blocks.

--- a/packages/prettier-plugin/src/index.js
+++ b/packages/prettier-plugin/src/index.js
@@ -5734,7 +5734,7 @@ function printJSXElement(node, path, options, print) {
 						'attributes',
 						i,
 					);
-				} else if (attr.type === 'JSXSpreadAttribute') {
+				} else if (attr.type === 'JSXSpreadAttribute' || attr.type === 'SpreadAttribute') {
 					return ['{...', path.call(print, 'openingElement', 'attributes', i, 'argument'), '}'];
 				}
 				return '';

--- a/packages/prettier-plugin/src/index.test.js
+++ b/packages/prettier-plugin/src/index.test.js
@@ -741,6 +741,17 @@ import { Something, type Props, track } from 'ripple';`;
 			expect(result).toBeWithNewline(expected);
 		});
 
+		it('should preserve JSX spread attributes inside explicit tsx blocks', async () => {
+			const input = `const props = {};
+const foo = <tsx><Bar {...props} /></tsx>;`;
+
+			const expected = `const props = {};
+const foo = <tsx><Bar {...props} /></tsx>;`;
+
+			const result = await format(input, { singleQuote: true });
+			expect(result).toBeWithNewline(expected);
+		});
+
 		it('should handle type annotations in object params', async () => {
 			const input = `interface Props {
   a: number;

--- a/packages/tsrx/src/plugin.js
+++ b/packages/tsrx/src/plugin.js
@@ -1059,9 +1059,23 @@ export function TSRXPlugin(config) {
 			 * @type {Parse.Parser['jsx_parseAttribute']}
 			 */
 			jsx_parseAttribute() {
-				let node = /** @type {AST.TSRXAttribute | ESTreeJSX.JSXAttribute} */ (this.startNode());
+				let node =
+					/** @type {AST.TSRXAttribute | ESTreeJSX.JSXAttribute | ESTreeJSX.JSXSpreadAttribute} */ (
+						this.startNode()
+					);
 
 				if (this.eat(tt.braceL)) {
+					const inside_tsx = this.#path.findLast((n) => n.type === 'TsxCompat' || n.type === 'Tsx');
+					if (inside_tsx) {
+						if (this.type === tt.ellipsis) {
+							this.expect(tt.ellipsis);
+							/** @type {ESTreeJSX.JSXSpreadAttribute} */ (node).argument = this.parseMaybeAssign();
+							this.expect(tt.braceR);
+							return this.finishNode(node, 'JSXSpreadAttribute');
+						}
+						this.unexpected();
+					}
+
 					if (this.value === 'ref') {
 						this.next();
 						if (this.type === tt.braceR) {

--- a/packages/tsrx/tests/shared/compile.js
+++ b/packages/tsrx/tests/shared/compile.js
@@ -142,6 +142,15 @@ export function runSharedCompileTests({ compile, name, classAttrName }) {
 			expect(code).not.toContain('<tsx>');
 		});
 
+		it('preserves JSX spread attributes inside tsx blocks', () => {
+			const { code } = compile(
+				`class Foo { bar() { const props = {}; return <tsx><Bar {...props} /></tsx>; } }`,
+				'App.tsrx',
+			);
+			expect(code).toContain('return <Bar {...props} />;');
+			expect(code).not.toContain('<tsx>');
+		});
+
 		it('unwraps a tsx block containing a single expression to the expression', () => {
 			// Regression: previously `<tsx>{'Hello'}</tsx>` was compiled to
 			// `return {'Hello'};`, which is a JS syntax error because `{`

--- a/packages/tsrx/types/parse.d.ts
+++ b/packages/tsrx/types/parse.d.ts
@@ -1639,7 +1639,7 @@ export namespace Parse {
 		 * Parse JSX attribute (name="value" or {spread})
 		 * @returns JSXAttribute or JSXSpreadAttribute
 		 */
-		jsx_parseAttribute(): AST.TSRXAttribute | ESTreeJSX.JSXAttribute;
+		jsx_parseAttribute(): AST.TSRXAttribute | ESTreeJSX.JSXAttribute | ESTreeJSX.JSXSpreadAttribute;
 
 		/**
 		 * Parse JSX opening element at position


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches the TSRX JSX attribute parser and the Prettier printer logic for spread attributes, which could subtly affect how JSX attributes are parsed/printed in tsx contexts.
> 
> **Overview**
> Ensures JSX spread attributes inside explicit `<tsx>...</tsx>` (and `TsxCompat`) blocks are parsed as `JSXSpreadAttribute` and printed correctly, rather than being lost or misinterpreted.
> 
> Updates the Prettier plugin’s JSX printer to handle both `JSXSpreadAttribute` and `SpreadAttribute`, and adds regression tests in both the formatter and compiler suites; includes a patch changeset for `@tsrx/core` and `@tsrx/prettier-plugin`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e475fd556f5cd6150553d99f163edd383064b12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->