### PR TITLE
fix(typescript-plugin): point main at published source

### DIFF
--- a/.changeset/fix-typescript-plugin-main.md
+++ b/.changeset/fix-typescript-plugin-main.md
@@ -1,0 +1,5 @@
+---
+"@tsrx/typescript-plugin": patch
+---
+
+Fix the package entrypoint to point at the published source file.

--- a/packages/typescript-plugin/package.json
+++ b/packages/typescript-plugin/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "author": "Dominic Gannaway",
   "version": "0.3.33",
-  "main": "dist/index.js",
+  "main": "src/index.js",
   "type": "module",
   "homepage": "https://ripple-ts.com",
   "repository": {


### PR DESCRIPTION
The typescript plugin package is published with src/index.js but no dist/index.js, so package-root resolution currently points at a missing file. This updates main to the published source entrypoint and adds a patch changeset.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only updates package metadata to resolve the plugin’s entrypoint correctly and adds a changeset for a patch release.
> 
> **Overview**
> Fixes the `@tsrx/typescript-plugin` package entrypoint by changing `package.json` `main` from `dist/index.js` to `src/index.js`, matching what is actually published.
> 
> Adds a patch changeset to ensure the corrected entrypoint is released.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9b5fbf261e2b818a271c7d78ec2c24f601b15fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->