### PR TITLE
fix: early returns with types support

### DIFF
--- a/.changeset/guard-render-continuations.md
+++ b/.changeset/guard-render-continuations.md
@@ -1,0 +1,7 @@
+---
+'@tsrx/core': patch
+'@tsrx/react': patch
+'@tsrx/preact': patch
+---
+
+Extract early-return continuations into typed cached helpers and type generated hook-helper props from branch-local aliases.

--- a/packages/tsrx-react/tests/basic.test.js
+++ b/packages/tsrx-react/tests/basic.test.js
@@ -285,6 +285,28 @@ describe('@tsrx/react basic', () => {
 		expect(code).toContain('<button>{count}</button>');
 	});
 
+	it('keeps transforming unreachable component body statements after bare returns', () => {
+		const { code } = compile(
+			`export component App() {
+				const foo = 'string';
+
+				return;
+
+				const bar = foo.trim();
+				<div>{bar}</div>
+			}`,
+			'App.tsrx',
+		);
+
+		const return_pos = code.indexOf('return null;');
+		const bar_pos = code.indexOf('const bar = foo.trim();');
+		const tail_return_pos = code.indexOf('return <div>{bar}</div>;');
+
+		expect(return_pos).toBeGreaterThan(-1);
+		expect(bar_pos).toBeGreaterThan(return_pos);
+		expect(tail_return_pos).toBeGreaterThan(bar_pos);
+	});
+
 	it('extracts typed cached continuation helpers after early-return if statements', () => {
 		const source = `import { useState, useEffect } from 'react';
 

--- a/packages/tsrx-react/tests/basic.test.js
+++ b/packages/tsrx-react/tests/basic.test.js
@@ -285,7 +285,7 @@ describe('@tsrx/react basic', () => {
 		expect(code).toContain('<button>{count}</button>');
 	});
 
-	it('extracts hook-bearing continuations after lone early-return if statements', () => {
+	it('extracts typed cached continuation helpers after early-return if statements', () => {
 		const source = `import { useState, useEffect } from 'react';
 
 			export component App() {
@@ -305,12 +305,58 @@ describe('@tsrx/react basic', () => {
 		const { code } = compile(source, 'App.tsrx');
 		const mappings = compile_to_volar_mappings(source, 'App.tsrx');
 
-		expect(code).toContain('function App__Continue1({ count, setCount }) {');
 		expect(code).toContain('useEffect(');
 		expect(code).toContain('count > 2');
-		expect(code).toContain('<App__Continue1 count={count} setCount={setCount} />');
+		expect(code).toContain('let App__StatementBodyHook1;');
+		expect(code).toContain('let App__StatementBodyHook2;');
+		expect(code).toContain('const _tsrx_StatementBodyHook2_count = count;');
+		expect(code).toContain('const StatementBodyHook2 = App__StatementBodyHook2 ??');
+		expect(code).toContain('<button onClick={() => setCount(count + 1)}>{count}</button>');
+		expect(code).not.toContain('App__Continue');
 		expect(mappings.errors).toEqual([]);
 		expect(mappings.mappings.length).toBeGreaterThan(0);
+	});
+
+	it('extracts rendered early-return branches while preserving source local names', () => {
+		const source = `import { useEffect } from 'react';
+
+			declare function getFoo(): string | null;
+
+			export component App() {
+				const foo = getFoo();
+
+				if (!foo) {
+					<div>{'Foo not found'}</div>
+					return;
+				}
+
+				useEffect(() => {
+					console.log(foo);
+				}, [foo]);
+
+				<div>{foo.trim()}</div>
+			}`;
+
+		const { code } = compile(source, 'App.tsrx');
+		const mappings = compile_to_volar_mappings(source, 'App.tsrx');
+		const source_if_foo = source.indexOf('foo', source.indexOf('if (!foo'));
+		const generated_if_foo = mappings.code.indexOf('foo', mappings.code.indexOf('if (!foo'));
+		const if_foo_mapping = mappings.mappings.find(
+			(mapping) =>
+				mapping.sourceOffsets[0] === source_if_foo &&
+				mapping.generatedOffsets[0] === generated_if_foo &&
+				mapping.lengths[0] === 'foo'.length,
+		);
+
+		expect(code).toContain('let App__StatementBodyHook1;');
+		expect(code).toContain('let App__StatementBodyHook2;');
+		expect(code).toContain('const _tsrx_StatementBodyHook1_foo = foo;');
+		expect(code).toContain('const _tsrx_StatementBodyHook2_foo = foo;');
+		expect(code).toContain('return App__static1;');
+		expect(code).toContain('useEffect(');
+		expect(code).toContain('return <div>{foo.trim()}</div>;');
+		expect(code).not.toContain('App__Continue');
+		expect(if_foo_mapping?.data.completion).toBe(true);
 	});
 
 	it('does not emit duplicate Volar mappings for helper-extracted React output', () => {
@@ -911,6 +957,31 @@ describe('@tsrx/react basic', () => {
 		expect(hook_pos).toBeGreaterThan(helper_pos);
 	});
 
+	it('types hook helper props from branch-local aliases', () => {
+		const { code } = compile(
+			`import { useState } from 'react';
+
+			declare function getFoo(): string | null;
+
+			export component App() {
+				const foo = getFoo();
+				if (foo) {
+					const [count] = useState(0);
+					<div>{foo.trim()}{count}</div>
+				}
+			}`,
+			'App.tsrx',
+		);
+
+		expect(code).toContain('let App__StatementBodyHook1;');
+		expect(code).toContain('const _tsrx_StatementBodyHook1_foo = foo;');
+		expect(code).toContain('const StatementBodyHook1 = App__StatementBodyHook1 ??');
+		expect(code).toContain(
+			'function StatementBodyHook1({ foo }: { foo: typeof _tsrx_StatementBodyHook1_foo })',
+		);
+		expect(code).toContain('<StatementBodyHook1 foo={foo} />');
+	});
+
 	it('extracts hooks from if-else branches into separate local components', () => {
 		const { code } = compile(
 			`import { useState } from 'react';
@@ -1466,7 +1537,7 @@ describe('lazy destructuring', () => {
 		expect(code).not.toContain('localVar={localVar}');
 	});
 
-	it('does not pass post-split bindings as helper component props', () => {
+	it('keeps post-split bindings local inside typed cached continuation helpers', () => {
 		const { code } = compile(
 			`import { useState, useEffect } from 'react';
 
@@ -1488,12 +1559,12 @@ describe('lazy destructuring', () => {
 			'App.tsrx',
 		);
 
-		// The continuation helper should receive count/setCount from before the split
-		expect(code).toContain('App__Continue');
-		expect(code).toContain('count={count}');
-
-		// laterVar is declared AFTER the split — it must NOT appear as a prop
-		// on the helper element at the call site (it's not in scope there)
-		expect(code).not.toContain('laterVar={laterVar}');
+		expect(code).toContain("const laterVar = 'after split';");
+		expect(code).toContain('useEffect(');
+		expect(code).toContain('let App__StatementBodyHook1;');
+		expect(code).toContain('let App__StatementBodyHook2;');
+		expect(code).toContain('const _tsrx_StatementBodyHook2_count = count;');
+		expect(code).toContain('return <div>{laterVar}</div>;');
+		expect(code).not.toContain('App__Continue');
 	});
 });

--- a/packages/tsrx-react/tests/basic.test.js
+++ b/packages/tsrx-react/tests/basic.test.js
@@ -1615,6 +1615,34 @@ describe('lazy destructuring', () => {
 		expect(code).not.toContain('later={later}');
 	});
 
+	it('does not pass helper-local declarations as hook-safe element helper props', () => {
+		const { code } = compile(
+			`import { useEffect } from 'react';
+
+			export component App() {
+				<div>
+					const later = 'inner';
+
+					useEffect(() => {
+						console.log(later);
+					}, [later]);
+
+					<span>{later}</span>
+				</div>
+
+				const later = 'outer';
+			}`,
+			'App.tsrx',
+		);
+
+		expect(code).toContain("const later = 'inner';");
+		expect(code).toContain("const later = 'outer';");
+		expect(code).toContain('function StatementBodyHook1(');
+		expect(code).not.toContain('_tsrx_StatementBodyHook1_later');
+		expect(code).not.toContain('later: typeof _tsrx_StatementBodyHook1_later');
+		expect(code).not.toContain('later={later}');
+	});
+
 	it('keeps post-split bindings local inside typed cached continuation helpers', () => {
 		const { code } = compile(
 			`import { useState, useEffect } from 'react';
@@ -1642,6 +1670,9 @@ describe('lazy destructuring', () => {
 		expect(code).toContain('let App__StatementBodyHook1;');
 		expect(code).toContain('let App__StatementBodyHook2;');
 		expect(code).not.toContain('const _tsrx_StatementBodyHook2_count = count;');
+		expect(code).not.toContain('const _tsrx_StatementBodyHook2_laterVar = laterVar;');
+		expect(code).not.toContain('laterVar: typeof _tsrx_StatementBodyHook2_laterVar');
+		expect(code).not.toContain('<StatementBodyHook2 laterVar={laterVar} />');
 		expect(code).toContain('return <div>{laterVar}</div>;');
 		expect(code).not.toContain('App__Continue');
 	});

--- a/packages/tsrx-react/tests/basic.test.js
+++ b/packages/tsrx-react/tests/basic.test.js
@@ -381,6 +381,38 @@ describe('@tsrx/react basic', () => {
 		expect(if_foo_mapping?.data.completion).toBe(true);
 	});
 
+	it('declares helper prop type aliases before typed cached helpers', () => {
+		const { code } = compile(
+			`import { useEffect } from 'react';
+
+			declare function getFoo(): string | null;
+
+			export component App() {
+				const foo = getFoo();
+
+				if (!foo) {
+					<div>{'Foo not found'}</div>
+					return;
+				}
+
+				useEffect(() => {
+					console.log(foo);
+				}, [foo]);
+
+				<div>{foo.trim()}</div>
+			}`,
+			'App.tsrx',
+		);
+
+		const alias_pos = code.indexOf('const _tsrx_StatementBodyHook2_foo = foo;');
+		const helper_pos = code.indexOf('const StatementBodyHook2 = App__StatementBodyHook2 ??');
+		const type_ref_pos = code.indexOf('foo: typeof _tsrx_StatementBodyHook2_foo');
+
+		expect(alias_pos).toBeGreaterThan(-1);
+		expect(helper_pos).toBeGreaterThan(alias_pos);
+		expect(type_ref_pos).toBeGreaterThan(helper_pos);
+	});
+
 	it('does not emit duplicate Volar mappings for helper-extracted React output', () => {
 		const source = `import { useState, useEffect } from 'react';
 

--- a/packages/tsrx-react/tests/basic.test.js
+++ b/packages/tsrx-react/tests/basic.test.js
@@ -332,6 +332,7 @@ describe('@tsrx/react basic', () => {
 		expect(code).toContain('let App__StatementBodyHook1;');
 		expect(code).toContain('let App__StatementBodyHook2;');
 		expect(code).toContain('const _tsrx_StatementBodyHook2_count = count;');
+		expect(code).toContain('const _tsrx_StatementBodyHook2_setCount = setCount;');
 		expect(code).toContain('const StatementBodyHook2 = App__StatementBodyHook2 ??');
 		expect(code).toContain('<button onClick={() => setCount(count + 1)}>{count}</button>');
 		expect(code).not.toContain('App__Continue');
@@ -372,7 +373,7 @@ describe('@tsrx/react basic', () => {
 
 		expect(code).toContain('let App__StatementBodyHook1;');
 		expect(code).toContain('let App__StatementBodyHook2;');
-		expect(code).toContain('const _tsrx_StatementBodyHook1_foo = foo;');
+		expect(code).not.toContain('const _tsrx_StatementBodyHook1_foo = foo;');
 		expect(code).toContain('const _tsrx_StatementBodyHook2_foo = foo;');
 		expect(code).toContain('return App__static1;');
 		expect(code).toContain('useEffect(');
@@ -1176,7 +1177,8 @@ describe('@tsrx/react basic', () => {
 
 		expect(code).toContain('function StatementBodyHook');
 		// Key should appear on both the inner element and wrapper component
-		expect(code).toContain('<StatementBodyHook1 items={items} item={item} key={item} />');
+		expect(code).toContain('<StatementBodyHook1 item={item} key={item} />');
+		expect(code).not.toContain('items={items}');
 	});
 
 	it('adds index key to hook wrapper component when loop has index and no explicit key', () => {
@@ -1196,9 +1198,8 @@ describe('@tsrx/react basic', () => {
 
 		expect(code).toContain('function StatementBodyHook');
 		expect(code).toContain('items.map((item, index) =>');
-		expect(code).toContain(
-			'<StatementBodyHook1 items={items} item={item} index={index} key={index} />',
-		);
+		expect(code).toContain('<StatementBodyHook1 item={item} key={index} />');
+		expect(code).not.toContain('index={index} />');
 	});
 
 	it('applies for-of key clauses to hook wrapper components', () => {
@@ -1215,7 +1216,8 @@ describe('@tsrx/react basic', () => {
 		);
 
 		expect(code).toContain('function StatementBodyHook');
-		expect(code).toContain('<StatementBodyHook1 items={items} item={item} key={item.id} />');
+		expect(code).toContain('<StatementBodyHook1 item={item} key={item.id} />');
+		expect(code).not.toContain('items={items}');
 	});
 
 	it('prefers inline JSX keys over for-of key clauses for hook wrapper components', () => {
@@ -1232,8 +1234,9 @@ describe('@tsrx/react basic', () => {
 		);
 
 		expect(code).toContain('function StatementBodyHook');
-		expect(code).toContain('<StatementBodyHook1 items={items} item={item} key={item.inner} />');
-		expect(code).not.toContain('<StatementBodyHook1 items={items} item={item} key={item.id} />');
+		expect(code).toContain('<StatementBodyHook1 item={item} key={item.inner} />');
+		expect(code).not.toContain('<StatementBodyHook1 item={item} key={item.id} />');
+		expect(code).not.toContain('items={items}');
 	});
 
 	it('adds index key to non-hook loop items in conditional branches', () => {
@@ -1591,6 +1594,27 @@ describe('lazy destructuring', () => {
 		expect(code).not.toContain('localVar={localVar}');
 	});
 
+	it('does not pass unrelated future bindings into hook-safe element helpers', () => {
+		const { code } = compile(
+			`import { useEffect } from 'react';
+
+			export component App() {
+				<div>
+					useEffect(() => {}, []);
+					<span>{'ok'}</span>
+				</div>
+
+				const later = 'later';
+			}`,
+			'App.tsrx',
+		);
+
+		expect(code).toContain("const later = 'later';");
+		expect(code).toContain('function StatementBodyHook1(');
+		expect(code).not.toContain('_tsrx_StatementBodyHook1_later');
+		expect(code).not.toContain('later={later}');
+	});
+
 	it('keeps post-split bindings local inside typed cached continuation helpers', () => {
 		const { code } = compile(
 			`import { useState, useEffect } from 'react';
@@ -1617,7 +1641,7 @@ describe('lazy destructuring', () => {
 		expect(code).toContain('useEffect(');
 		expect(code).toContain('let App__StatementBodyHook1;');
 		expect(code).toContain('let App__StatementBodyHook2;');
-		expect(code).toContain('const _tsrx_StatementBodyHook2_count = count;');
+		expect(code).not.toContain('const _tsrx_StatementBodyHook2_count = count;');
 		expect(code).toContain('return <div>{laterVar}</div>;');
 		expect(code).not.toContain('App__Continue');
 	});

--- a/packages/tsrx/src/transform/jsx/index.js
+++ b/packages/tsrx/src/transform/jsx/index.js
@@ -48,7 +48,7 @@ import { is_hoist_safe_jsx_node } from '../jsx-hoist.js';
  *   local_statement_component_index: number,
  *   needs_error_boundary: boolean,
  *   needs_suspense: boolean,
- *   helper_state: { base_name: string, next_id: number, helpers: AST.FunctionDeclaration[], statics: any[] } | null,
+ *   helper_state: { base_name: string, next_id: number, helpers: any[], statics: any[] } | null,
  *   available_bindings: Map<string, AST.Identifier>,
  *   lazy_next_id: number,
  *   current_css_hash: string | null,
@@ -173,14 +173,12 @@ export function createJsxTransform(platform) {
 				// so that Element children processed during the bottom-up walk can see
 				// the full scope. Without this, hoisted helpers would miss body-level
 				// variables like `const [x] = useState(...)` and produce ReferenceErrors.
-				// Only collect up to the split point — bindings declared after a
-				// hook-safe split aren't in scope at the return statement and would
-				// cause ReferenceErrors if passed as helper props.
+				// Collect the whole top-level component scope so bottom-up element
+				// children can see body-level declarations while building typed helper
+				// props.
 				const body_bindings = collect_param_bindings(as_any.params || []);
 				const body = as_any.body || [];
-				const split_index = find_hook_safe_split_index(body);
-				const collect_end = split_index === -1 ? body.length : split_index;
-				for (let i = 0; i < collect_end; i += 1) {
+				for (let i = 0; i < body.length; i += 1) {
 					collect_statement_bindings(body[i], body_bindings);
 				}
 				state.available_bindings = body_bindings;
@@ -347,12 +345,7 @@ function component_to_function_declaration(component, transform_context, walk_he
 	transform_context.helper_state = helper_state;
 	transform_context.available_bindings = new Map(param_bindings);
 
-	const body_statements = build_component_statements(
-		body,
-		helper_state,
-		param_bindings,
-		transform_context,
-	);
+	const body_statements = build_component_statements(body, transform_context);
 
 	// Replace lazy param patterns with generated identifiers
 	const final_params = lazy_bindings.size > 0 ? replace_lazy_params(params) : params;
@@ -401,107 +394,11 @@ function component_to_function_declaration(component, transform_context, walk_he
 
 /**
  * @param {any[]} body_nodes
- * @param {{ base_name: string, next_id: number, helpers: AST.FunctionDeclaration[], statics: any[] }} helper_state
- * @param {Map<string, AST.Identifier>} available_bindings
  * @param {TransformContext} transform_context
  * @returns {any[]}
  */
-function build_component_statements(
-	body_nodes,
-	helper_state,
-	available_bindings,
-	transform_context,
-) {
-	const split_index = find_hook_safe_split_index(body_nodes);
-	if (split_index === -1) {
-		return build_render_statements(body_nodes, false, transform_context);
-	}
-
-	const statements = [];
-	const render_nodes = [];
-	const bindings = new Map(available_bindings);
-
-	const pre_split_body = body_nodes.slice(0, split_index);
-	const interleaved = is_interleaved_body(pre_split_body);
-	let capture_index = 0;
-
-	for (let i = 0; i < split_index; i += 1) {
-		const child = body_nodes[i];
-
-		if (is_bare_return_statement(child)) {
-			statements.push(create_component_return_statement(render_nodes, child));
-			return statements;
-		}
-
-		if (is_lone_return_if_statement(child)) {
-			statements.push(create_component_lone_return_if_statement(child, render_nodes));
-			continue;
-		}
-
-		if (is_jsx_child(child)) {
-			const jsx = to_jsx_child(child, transform_context);
-			if (interleaved && is_capturable_jsx_child(jsx)) {
-				const { declaration, reference } = captureJsxChild(jsx, capture_index++);
-				statements.push(declaration);
-				render_nodes.push(reference);
-			} else {
-				render_nodes.push(jsx);
-			}
-		} else {
-			statements.push(child);
-			collect_statement_bindings(child, bindings);
-			transform_context.available_bindings = bindings;
-		}
-	}
-
-	if (!interleaved) {
-		hoist_static_render_nodes(render_nodes, transform_context);
-	}
-
-	const split_node = body_nodes[split_index];
-	const consequent_body =
-		split_node.consequent.type === 'BlockStatement'
-			? split_node.consequent.body
-			: [split_node.consequent];
-	const short_branch_body = consequent_body.filter(
-		(/** @type {any} */ child) => !is_bare_return_statement(child),
-	);
-	const continuation_body = body_nodes.slice(split_index + 1);
-	const short_branch = create_helper_component_expression(
-		short_branch_body,
-		helper_state,
-		bindings,
-		split_node.consequent,
-		'Exit',
-		transform_context,
-	);
-	const continuation = create_helper_component_expression(
-		continuation_body,
-		helper_state,
-		bindings,
-		split_node,
-		'Continue',
-		transform_context,
-	);
-
-	render_nodes.push(
-		to_jsx_expression_container(
-			set_loc(
-				/** @type {any} */ ({
-					type: 'ConditionalExpression',
-					test: split_node.test,
-					consequent: short_branch,
-					alternate: continuation,
-					metadata: { path: [] },
-				}),
-				split_node,
-			),
-			split_node,
-		),
-	);
-
-	statements.push(create_component_return_statement(render_nodes, split_node));
-	return statements;
+function build_component_statements(body_nodes, transform_context) {
+	return build_render_statements(body_nodes, false, transform_context);
 }
 
 /**
@@ -527,11 +424,41 @@ function build_render_statements(body_nodes, return_null_when_empty, transform_c
 	const interleaved = is_interleaved_body(body_nodes);
 	let capture_index = 0;
 
-	for (const child of body_nodes) {
+	for (let i = 0; i < body_nodes.length; i += 1) {
+		const child = body_nodes[i];
+
 		if (is_bare_return_statement(child)) {
 			statements.push(create_component_return_statement(render_nodes, child));
 			transform_context.available_bindings = saved_bindings;
 			return statements;
+		}
+
+		if (is_returning_if_statement(child)) {
+			const branch_has_hooks = body_contains_top_level_hook_call(get_if_consequent_body(child));
+			const continuation_has_hooks = body_contains_top_level_hook_call(body_nodes.slice(i + 1));
+
+			if (branch_has_hooks || continuation_has_hooks) {
+				statements.push(
+					...create_component_helper_split_returning_if_statements(
+						child,
+						body_nodes.slice(i + 1),
+						render_nodes,
+						transform_context,
+					),
+				);
+				transform_context.available_bindings = saved_bindings;
+				return statements;
+			}
+
+			if (is_lone_return_if_statement(child)) {
+				statements.push(create_component_lone_return_if_statement(child, render_nodes));
+				continue;
+			}
+
+			statements.push(
+				create_component_returning_if_statement(child, render_nodes, transform_context),
+			);
+			continue;
 		}
 
 		if (is_lone_return_if_statement(child)) {
@@ -584,24 +511,6 @@ function is_interleaved_body(body_nodes) {
 		(child) => !is_bare_return_statement(child) && !is_lone_return_if_statement(child),
 	);
 	return is_interleaved_body_core(filtered, is_jsx_child);
-}
-
-/**
- * @param {any[]} body_nodes
- * @returns {number}
- */
-function find_hook_safe_split_index(body_nodes) {
-	for (let i = 0; i < body_nodes.length; i += 1) {
-		if (!is_lone_return_if_statement(body_nodes[i])) {
-			continue;
-		}
-
-		if (body_contains_top_level_hook_call(body_nodes.slice(i + 1))) {
-			return i;
-		}
-	}
-
-	return -1;
 }
 
 /**
@@ -699,96 +608,6 @@ function is_hook_callee(callee) {
 }
 
 /**
- * @param {any[]} body_nodes
- * @param {{ base_name: string, next_id: number, helpers: AST.FunctionDeclaration[], statics: any[] }} helper_state
- * @param {Map<string, AST.Identifier>} available_bindings
- * @param {any} source_node
- * @param {string} suffix
- * @param {TransformContext} transform_context
- * @returns {any}
- */
-function create_helper_component_expression(
-	body_nodes,
-	helper_state,
-	available_bindings,
-	source_node,
-	suffix,
-	transform_context,
-) {
-	if (body_nodes.length === 0) {
-		return create_null_literal();
-	}
-
-	const helper_name = create_helper_name(helper_state, suffix);
-	const helper_id = set_loc(create_generated_identifier(helper_name), source_node);
-	const helper_bindings = Array.from(available_bindings.values());
-	const helper_fn = create_helper_function_declaration(
-		helper_id,
-		body_nodes,
-		helper_state,
-		available_bindings,
-		helper_bindings,
-		source_node,
-		transform_context,
-	);
-
-	helper_state.helpers.push(helper_fn);
-
-	return create_helper_component_element(helper_id, helper_bindings, source_node);
-}
-
-/**
- * @param {AST.Identifier} helper_id
- * @param {any[]} body_nodes
- * @param {{ base_name: string, next_id: number, helpers: AST.FunctionDeclaration[], statics: any[] }} helper_state
- * @param {Map<string, AST.Identifier>} available_bindings
- * @param {AST.Identifier[]} helper_bindings
- * @param {any} source_node
- * @param {TransformContext} transform_context
- * @returns {AST.FunctionDeclaration}
- */
-function create_helper_function_declaration(
-	helper_id,
-	body_nodes,
-	helper_state,
-	available_bindings,
-	helper_bindings,
-	source_node,
-	transform_context,
-) {
-	const fn = /** @type {any} */ ({
-		type: 'FunctionDeclaration',
-		id: helper_id,
-		params: helper_bindings.length > 0 ? [create_helper_props_pattern(helper_bindings)] : [],
-		body: {
-			type: 'BlockStatement',
-			body: build_component_statements(
-				body_nodes,
-				helper_state,
-				new Map(available_bindings),
-				transform_context,
-			),
-			metadata: { path: [] },
-		},
-		async: false,
-		generator: false,
-		metadata: {
-			path: [],
-			is_component: true,
-		},
-	});
-
-	if (fn.id) {
-		fn.id.metadata = /** @type {AST.Identifier['metadata']} */ ({
-			...fn.id.metadata,
-			is_component: true,
-		});
-	}
-
-	return set_loc(fn, source_node);
-}
-
-/**
  * @param {AST.Identifier[]} bindings
  * @returns {AST.ObjectPattern}
  */
@@ -867,7 +686,7 @@ function create_helper_component_element(helper_id, bindings, source_node, mappi
 }
 
 /**
- * @param {{ base_name: string, next_id: number, helpers: AST.FunctionDeclaration[], statics: any[] }} helper_state
+ * @param {{ base_name: string, next_id: number, helpers: any[], statics: any[] }} helper_state
  * @param {string} suffix
  * @returns {string}
  */
@@ -878,7 +697,7 @@ function create_helper_name(helper_state, suffix) {
 
 /**
  * @param {string} base_name
- * @returns {{ base_name: string, next_id: number, helpers: AST.FunctionDeclaration[], statics: any[] }}
+ * @returns {{ base_name: string, next_id: number, helpers: any[], statics: any[] }}
  */
 function create_helper_state(base_name) {
 	return {
@@ -1116,10 +935,42 @@ function is_lone_return_if_statement(node) {
 		return false;
 	}
 
-	const consequent_body =
-		node.consequent.type === 'BlockStatement' ? node.consequent.body : [node.consequent];
+	const consequent_body = get_if_consequent_body(node);
 
 	return consequent_body.length === 1 && is_bare_return_statement(consequent_body[0]);
+}
+
+/**
+ * @param {any} node
+ * @returns {boolean}
+ */
+function is_returning_if_statement(node) {
+	if (node?.type !== 'IfStatement' || node.alternate) {
+		return false;
+	}
+
+	return get_if_consequent_body(node).some(is_bare_return_statement);
+}
+
+/**
+ * @param {any} node
+ * @returns {any[]}
+ */
+function get_if_consequent_body(node) {
+	return node.consequent.type === 'BlockStatement' ? node.consequent.body : [node.consequent];
+}
+
+/**
+ * @param {any} node
+ * @returns {boolean}
+ */
+function returning_if_statement_needs_child(node) {
+	const consequent_body = get_if_consequent_body(node);
+	const return_index = consequent_body.findIndex(is_bare_return_statement);
+	const rendered_body =
+		return_index === -1 ? consequent_body : consequent_body.slice(0, return_index);
+
+	return rendered_body.some(is_jsx_child) || body_contains_top_level_hook_call(rendered_body);
 }
 
 /**
@@ -1157,8 +1008,7 @@ function create_component_return_statement(
  * @returns {any}
  */
 function create_component_lone_return_if_statement(node, render_nodes) {
-	const consequent_body =
-		node.consequent.type === 'BlockStatement' ? node.consequent.body : [node.consequent];
+	const consequent_body = get_if_consequent_body(node);
 
 	return set_loc(
 		/** @type {any} */ ({
@@ -1177,6 +1027,196 @@ function create_component_lone_return_if_statement(node, render_nodes) {
 		}),
 		node,
 	);
+}
+
+/**
+ * @param {any} node
+ * @param {any[]} render_nodes
+ * @param {TransformContext} transform_context
+ * @returns {any}
+ */
+function create_component_returning_if_statement(node, render_nodes, transform_context) {
+	const consequent_body = get_if_consequent_body(node);
+	const branch_statements = build_render_statements(consequent_body, true, transform_context);
+	prepend_render_nodes_to_return_statements(branch_statements, render_nodes);
+
+	return set_loc(
+		/** @type {any} */ ({
+			type: 'IfStatement',
+			test: node.test,
+			consequent: set_loc(
+				/** @type {any} */ ({
+					type: 'BlockStatement',
+					body: branch_statements,
+					metadata: { path: [] },
+				}),
+				node.consequent,
+			),
+			alternate: null,
+			metadata: { path: [] },
+		}),
+		node,
+	);
+}
+
+/**
+ * @param {any} node
+ * @param {any[]} continuation_body
+ * @param {any[]} render_nodes
+ * @param {TransformContext} transform_context
+ * @returns {any[]}
+ */
+function create_component_helper_split_returning_if_statements(
+	node,
+	continuation_body,
+	render_nodes,
+	transform_context,
+) {
+	const consequent_body = get_if_consequent_body(node);
+	const return_index = consequent_body.findIndex(is_bare_return_statement);
+	const branch_body =
+		return_index === -1 ? consequent_body : consequent_body.slice(0, return_index);
+	const branch_helper = create_hook_safe_helper(
+		branch_body,
+		undefined,
+		node.consequent,
+		transform_context,
+	);
+	const continuation_helper = create_hook_safe_helper(
+		continuation_body,
+		undefined,
+		node,
+		transform_context,
+	);
+
+	return [
+		set_loc(
+			/** @type {any} */ ({
+				type: 'IfStatement',
+				test: node.test,
+				consequent: set_loc(
+					/** @type {any} */ ({
+						type: 'BlockStatement',
+						body: [
+							...branch_helper.setup_statements,
+							{
+								type: 'ReturnStatement',
+								argument: combine_render_return_argument(
+									render_nodes,
+									branch_helper.component_element,
+								),
+								metadata: { path: [] },
+							},
+						],
+						metadata: { path: [] },
+					}),
+					node.consequent,
+				),
+				alternate: null,
+				metadata: { path: [] },
+			}),
+			node,
+		),
+		...continuation_helper.setup_statements,
+		{
+			type: 'ReturnStatement',
+			argument: combine_render_return_argument(render_nodes, continuation_helper.component_element),
+			metadata: { path: [] },
+		},
+	];
+}
+
+/**
+ * @param {any[]} statements
+ * @param {any[]} render_nodes
+ * @returns {void}
+ */
+function prepend_render_nodes_to_return_statements(statements, render_nodes) {
+	if (render_nodes.length === 0) {
+		return;
+	}
+
+	for (const statement of statements) {
+		prepend_render_nodes_to_return_statement(statement, render_nodes, false);
+	}
+}
+
+/**
+ * @param {any} node
+ * @param {any[]} render_nodes
+ * @param {boolean} inside_nested_function
+ * @returns {void}
+ */
+function prepend_render_nodes_to_return_statement(node, render_nodes, inside_nested_function) {
+	if (!node || typeof node !== 'object') {
+		return;
+	}
+
+	if (
+		node.type === 'FunctionDeclaration' ||
+		node.type === 'FunctionExpression' ||
+		node.type === 'ArrowFunctionExpression'
+	) {
+		inside_nested_function = true;
+	}
+
+	if (!inside_nested_function && node.type === 'ReturnStatement') {
+		node.argument = combine_render_return_argument(render_nodes, node.argument);
+		return;
+	}
+
+	if (Array.isArray(node)) {
+		for (const child of node) {
+			prepend_render_nodes_to_return_statement(child, render_nodes, inside_nested_function);
+		}
+		return;
+	}
+
+	for (const key of Object.keys(node)) {
+		if (key === 'loc' || key === 'start' || key === 'end' || key === 'metadata') {
+			continue;
+		}
+		prepend_render_nodes_to_return_statement(node[key], render_nodes, inside_nested_function);
+	}
+}
+
+/**
+ * @param {any[]} render_nodes
+ * @param {any} return_argument
+ * @returns {any}
+ */
+function combine_render_return_argument(render_nodes, return_argument) {
+	const combined = render_nodes.map((node) => clone_expression_node_without_locations(node));
+
+	if (!is_null_literal(return_argument)) {
+		combined.push(return_argument_to_render_node(return_argument));
+	}
+
+	return build_return_expression(combined) || create_null_literal();
+}
+
+/**
+ * @param {any} argument
+ * @returns {any}
+ */
+function return_argument_to_render_node(argument) {
+	if (
+		argument?.type === 'JSXElement' ||
+		argument?.type === 'JSXFragment' ||
+		argument?.type === 'JSXExpressionContainer'
+	) {
+		return argument;
+	}
+
+	return to_jsx_expression_container(argument);
+}
+
+/**
+ * @param {any} node
+ * @returns {boolean}
+ */
+function is_null_literal(node) {
+	return node?.type === 'Literal' && node.value == null;
 }
 
 /**
@@ -1392,48 +1432,11 @@ function statement_body_to_jsx_child(body_nodes, transform_context) {
  */
 function hook_safe_statement_body_to_jsx_child(body_nodes, transform_context) {
 	const source_node = get_body_source_node(body_nodes);
-	const helper_id = create_generated_identifier(
-		create_local_statement_component_name(transform_context),
-	);
-	const helper_bindings = Array.from(transform_context.available_bindings.values());
+	const helper = create_hook_safe_helper(body_nodes, undefined, source_node, transform_context);
 
-	// Save and isolate bindings for the helper body
-	const saved_bindings = transform_context.available_bindings;
-	transform_context.available_bindings = new Map(saved_bindings);
-
-	const helper_fn = /** @type {any} */ ({
-		type: 'FunctionDeclaration',
-		id: helper_id,
-		params: helper_bindings.length > 0 ? [create_helper_props_pattern(helper_bindings)] : [],
-		body: {
-			type: 'BlockStatement',
-			body: build_render_statements(body_nodes, true, transform_context),
-			metadata: { path: [] },
-		},
-		async: false,
-		generator: false,
-		metadata: {
-			path: [],
-			is_component: true,
-			is_method: false,
-		},
-	});
-
-	// Restore bindings
-	transform_context.available_bindings = saved_bindings;
-
-	// Register helper for hoisting to module level
 	if (transform_context.helper_state) {
-		transform_context.helper_state.helpers.push(helper_fn);
-
 		return to_jsx_expression_container(
-			/** @type {any} */ (
-				create_helper_component_element(helper_id, helper_bindings, source_node, {
-					mapWrapper: false,
-					mapBindingNames: false,
-					mapBindingValues: false,
-				})
-			),
+			create_hook_safe_helper_iife(helper.setup_statements, helper.component_element),
 			source_node,
 		);
 	}
@@ -1447,14 +1450,10 @@ function hook_safe_statement_body_to_jsx_child(body_nodes, transform_context) {
 				body: /** @type {any} */ ({
 					type: 'BlockStatement',
 					body: [
-						helper_fn,
+						...helper.setup_statements,
 						{
 							type: 'ReturnStatement',
-							argument: create_helper_component_element(helper_id, helper_bindings, source_node, {
-								mapWrapper: false,
-								mapBindingNames: false,
-								mapBindingValues: false,
-							}),
+							argument: helper.component_element,
 							metadata: { path: [] },
 						},
 					],
@@ -1497,19 +1496,51 @@ function create_local_statement_component_name(transform_context) {
  */
 function hook_safe_render_statements(body_nodes, key_expression, transform_context) {
 	const source_node = get_body_source_node(body_nodes);
+	const helper = create_hook_safe_helper(
+		body_nodes,
+		key_expression,
+		source_node,
+		transform_context,
+	);
+	const statements = [...helper.setup_statements];
+
+	statements.push({
+		type: 'ReturnStatement',
+		argument: helper.component_element,
+		metadata: { path: [] },
+	});
+
+	return statements;
+}
+
+/**
+ * @param {any[]} body_nodes
+ * @param {any} key_expression
+ * @param {any} source_node
+ * @param {TransformContext} transform_context
+ * @returns {{ setup_statements: any[], component_element: ESTreeJSX.JSXElement }}
+ */
+function create_hook_safe_helper(body_nodes, key_expression, source_node, transform_context) {
 	const helper_id = create_generated_identifier(
 		create_local_statement_component_name(transform_context),
 	);
 	const helper_bindings = Array.from(transform_context.available_bindings.values());
+	const aliases = helper_bindings.map((binding) =>
+		create_helper_type_alias_declaration(helper_id, binding),
+	);
+	const props_type = () => create_helper_props_type_literal(helper_bindings, aliases);
+	const params =
+		helper_bindings.length > 0
+			? [create_typed_helper_props_pattern(helper_bindings, props_type())]
+			: [];
 
-	// Save and isolate bindings for the helper body
 	const saved_bindings = transform_context.available_bindings;
 	transform_context.available_bindings = new Map(saved_bindings);
 
 	const helper_fn = /** @type {any} */ ({
-		type: 'FunctionDeclaration',
-		id: helper_id,
-		params: helper_bindings.length > 0 ? [create_helper_props_pattern(helper_bindings)] : [],
+		type: 'FunctionExpression',
+		id: clone_identifier(helper_id),
+		params,
 		body: {
 			type: 'BlockStatement',
 			body: build_render_statements(body_nodes, true, transform_context),
@@ -1524,13 +1555,7 @@ function hook_safe_render_statements(body_nodes, key_expression, transform_conte
 		},
 	});
 
-	// Restore bindings
 	transform_context.available_bindings = saved_bindings;
-
-	// Register helper for hoisting to module level
-	if (transform_context.helper_state) {
-		transform_context.helper_state.helpers.push(helper_fn);
-	}
 
 	const component_element = create_helper_component_element(
 		helper_id,
@@ -1554,26 +1579,203 @@ function hook_safe_render_statements(body_nodes, key_expression, transform_conte
 		);
 	}
 
-	// When helper_state is null (no enclosing component context), inline the
-	// helper via an IIFE so the function declaration isn't silently dropped.
 	if (!transform_context.helper_state) {
-		return [
-			helper_fn,
-			{
-				type: 'ReturnStatement',
-				argument: component_element,
-				metadata: { path: [] },
-			},
-		];
+		return {
+			setup_statements: [create_helper_function_declaration_from_expression(helper_id, helper_fn)],
+			component_element,
+		};
 	}
 
-	return [
-		{
-			type: 'ReturnStatement',
-			argument: component_element,
+	const cache_id = create_generated_identifier(
+		`${transform_context.helper_state.base_name}__${helper_id.name}`,
+	);
+	transform_context.helper_state.helpers.push(create_helper_cache_declaration(cache_id));
+
+	return {
+		setup_statements: [
+			...aliases.map((alias) => alias.declaration),
+			create_cached_helper_declaration(helper_id, cache_id, helper_fn, props_type()),
+		],
+		component_element,
+	};
+}
+
+/**
+ * @param {any[]} setup_statements
+ * @param {ESTreeJSX.JSXElement} component_element
+ * @returns {any}
+ */
+function create_hook_safe_helper_iife(setup_statements, component_element) {
+	return /** @type {any} */ ({
+		type: 'CallExpression',
+		callee: {
+			type: 'ArrowFunctionExpression',
+			params: [],
+			body: /** @type {any} */ ({
+				type: 'BlockStatement',
+				body: [
+					...setup_statements,
+					{
+						type: 'ReturnStatement',
+						argument: component_element,
+						metadata: { path: [] },
+					},
+				],
+				metadata: { path: [] },
+			}),
+			async: false,
+			generator: false,
+			expression: false,
 			metadata: { path: [] },
 		},
-	];
+		arguments: [],
+		optional: false,
+		metadata: { path: [] },
+	});
+}
+
+/**
+ * @param {AST.Identifier} helper_id
+ * @param {AST.Identifier} binding
+ * @returns {{ id: AST.Identifier, declaration: any }}
+ */
+function create_helper_type_alias_declaration(helper_id, binding) {
+	const alias_id = create_generated_identifier(`_tsrx_${helper_id.name}_${binding.name}`);
+
+	return {
+		id: alias_id,
+		declaration: /** @type {any} */ ({
+			type: 'VariableDeclaration',
+			kind: 'const',
+			declarations: [
+				{
+					type: 'VariableDeclarator',
+					id: clone_identifier(alias_id),
+					init: create_generated_identifier(binding.name),
+					metadata: { path: [] },
+				},
+			],
+			metadata: { path: [] },
+		}),
+	};
+}
+
+/**
+ * @param {AST.Identifier[]} bindings
+ * @param {{ id: AST.Identifier }[]} aliases
+ * @returns {any}
+ */
+function create_helper_props_type_literal(bindings, aliases) {
+	return /** @type {any} */ ({
+		type: 'TSTypeLiteral',
+		members: bindings.map(
+			(binding, i) =>
+				/** @type {any} */ ({
+					type: 'TSPropertySignature',
+					key: create_generated_identifier(binding.name),
+					computed: false,
+					optional: false,
+					readonly: false,
+					static: false,
+					kind: 'init',
+					typeAnnotation: {
+						type: 'TSTypeAnnotation',
+						typeAnnotation: {
+							type: 'TSTypeQuery',
+							exprName: clone_identifier(aliases[i].id),
+							typeArguments: null,
+							metadata: { path: [] },
+						},
+						metadata: { path: [] },
+					},
+					metadata: { path: [] },
+				}),
+		),
+		metadata: { path: [] },
+	});
+}
+
+/**
+ * @param {AST.Identifier[]} bindings
+ * @param {any} props_type
+ * @returns {AST.ObjectPattern}
+ */
+function create_typed_helper_props_pattern(bindings, props_type) {
+	const pattern = create_helper_props_pattern(bindings);
+	/** @type {any} */ (pattern).typeAnnotation = {
+		type: 'TSTypeAnnotation',
+		typeAnnotation: props_type,
+		metadata: { path: [] },
+	};
+	return pattern;
+}
+
+/**
+ * @param {AST.Identifier} cache_id
+ * @returns {any}
+ */
+function create_helper_cache_declaration(cache_id) {
+	return /** @type {any} */ ({
+		type: 'VariableDeclaration',
+		kind: 'let',
+		declarations: [
+			{
+				type: 'VariableDeclarator',
+				id: clone_identifier(cache_id),
+				init: null,
+				metadata: { path: [] },
+			},
+		],
+		metadata: { path: [] },
+	});
+}
+
+/**
+ * @param {AST.Identifier} helper_id
+ * @param {AST.Identifier} cache_id
+ * @param {any} helper_fn
+ * @param {any} props_type
+ * @returns {any}
+ */
+function create_cached_helper_declaration(helper_id, cache_id, helper_fn, props_type) {
+	return /** @type {any} */ ({
+		type: 'VariableDeclaration',
+		kind: 'const',
+		declarations: [
+			{
+				type: 'VariableDeclarator',
+				id: clone_identifier(helper_id),
+				init: {
+					type: 'LogicalExpression',
+					operator: '??',
+					left: clone_identifier(cache_id),
+					right: {
+						type: 'AssignmentExpression',
+						operator: '=',
+						left: clone_identifier(cache_id),
+						right: helper_fn,
+						metadata: { path: [] },
+					},
+					metadata: { path: [] },
+				},
+				metadata: { path: [] },
+			},
+		],
+		metadata: { path: [] },
+	});
+}
+
+/**
+ * @param {AST.Identifier} helper_id
+ * @param {any} helper_fn
+ * @returns {AST.FunctionDeclaration}
+ */
+function create_helper_function_declaration_from_expression(helper_id, helper_fn) {
+	return /** @type {any} */ ({
+		...helper_fn,
+		type: 'FunctionDeclaration',
+		id: clone_identifier(helper_id),
+	});
 }
 
 /**

--- a/packages/tsrx/src/transform/jsx/index.js
+++ b/packages/tsrx/src/transform/jsx/index.js
@@ -1532,7 +1532,10 @@ function create_hook_safe_helper(body_nodes, key_expression, source_node, transf
 
 	if (!transform_context.helper_state) {
 		return {
-			setup_statements: [create_helper_function_declaration_from_expression(helper_id, helper_fn)],
+			setup_statements: [
+				...aliases.map((alias) => alias.declaration),
+				create_helper_function_declaration_from_expression(helper_id, helper_fn),
+			],
 			component_element,
 		};
 	}

--- a/packages/tsrx/src/transform/jsx/index.js
+++ b/packages/tsrx/src/transform/jsx/index.js
@@ -1418,40 +1418,8 @@ function hook_safe_statement_body_to_jsx_child(body_nodes, transform_context) {
 	const source_node = get_body_source_node(body_nodes);
 	const helper = create_hook_safe_helper(body_nodes, undefined, source_node, transform_context);
 
-	if (transform_context.helper_state) {
-		return to_jsx_expression_container(
-			create_hook_safe_helper_iife(helper.setup_statements, helper.component_element),
-			source_node,
-		);
-	}
-
 	return to_jsx_expression_container(
-		/** @type {any} */ ({
-			type: 'CallExpression',
-			callee: {
-				type: 'ArrowFunctionExpression',
-				params: [],
-				body: /** @type {any} */ ({
-					type: 'BlockStatement',
-					body: [
-						...helper.setup_statements,
-						{
-							type: 'ReturnStatement',
-							argument: helper.component_element,
-							metadata: { path: [] },
-						},
-					],
-					metadata: { path: [] },
-				}),
-				async: false,
-				generator: false,
-				expression: false,
-				metadata: { path: [] },
-			},
-			arguments: [],
-			optional: false,
-			metadata: { path: [] },
-		}),
+		create_hook_safe_helper_iife(helper.setup_statements, helper.component_element),
 		source_node,
 	);
 }

--- a/packages/tsrx/src/transform/jsx/index.js
+++ b/packages/tsrx/src/transform/jsx/index.js
@@ -429,8 +429,8 @@ function build_render_statements(body_nodes, return_null_when_empty, transform_c
 
 		if (is_bare_return_statement(child)) {
 			statements.push(create_component_return_statement(render_nodes, child));
-			transform_context.available_bindings = saved_bindings;
-			return statements;
+			render_nodes.length = 0;
+			continue;
 		}
 
 		if (is_returning_if_statement(child)) {
@@ -984,22 +984,25 @@ function create_component_return_statement(
 	source_node,
 	map_render_node_locations = true,
 ) {
-	return /** @type {any} */ ({
-		type: 'ReturnStatement',
-		argument: build_return_expression(
-			render_nodes.map((node) =>
-				map_render_node_locations
-					? clone_expression_node(node)
-					: clone_expression_node_without_locations(node),
-			),
-		) || {
-			type: 'Literal',
-			value: null,
-			raw: 'null',
+	return set_loc(
+		/** @type {any} */ ({
+			type: 'ReturnStatement',
+			argument: build_return_expression(
+				render_nodes.map((node) =>
+					map_render_node_locations
+						? clone_expression_node(node)
+						: clone_expression_node_without_locations(node),
+				),
+			) || {
+				type: 'Literal',
+				value: null,
+				raw: 'null',
+				metadata: { path: [] },
+			},
 			metadata: { path: [] },
-		},
-		metadata: { path: [] },
-	});
+		}),
+		source_node,
+	);
 }
 
 /**
@@ -1088,7 +1091,6 @@ function create_component_helper_split_returning_if_statements(
 		node,
 		transform_context,
 	);
-
 	return [
 		set_loc(
 			/** @type {any} */ ({

--- a/packages/tsrx/src/transform/jsx/index.js
+++ b/packages/tsrx/src/transform/jsx/index.js
@@ -170,12 +170,9 @@ export function createJsxTransform(platform) {
 				state.current_css_hash = as_any.css ? as_any.css.hash : null;
 
 				// Pre-collect component body bindings (params + top-level statements)
-				// so that Element children processed during the bottom-up walk can see
-				// the full scope. Without this, hoisted helpers would miss body-level
-				// variables like `const [x] = useState(...)` and produce ReferenceErrors.
-				// Collect the whole top-level component scope so bottom-up element
-				// children can see body-level declarations while building typed helper
-				// props.
+				// so Element children processed during the bottom-up walk can see
+				// component-scope names. Hook-safe helpers filter this set down to
+				// the names their body actually references before generating props.
 				const body_bindings = collect_param_bindings(as_any.params || []);
 				const body = as_any.body || [];
 				for (let i = 0; i < body.length; i += 1) {
@@ -1467,6 +1464,23 @@ function hook_safe_render_statements(body_nodes, key_expression, transform_conte
 
 /**
  * @param {any[]} body_nodes
+ * @param {Map<string, AST.Identifier>} available_bindings
+ * @returns {AST.Identifier[]}
+ */
+function get_referenced_helper_bindings(body_nodes, available_bindings) {
+	const helper_bindings = [];
+
+	for (const [name, binding] of available_bindings) {
+		if (references_scope_bindings(body_nodes, new Map([[name, binding]]))) {
+			helper_bindings.push(binding);
+		}
+	}
+
+	return helper_bindings;
+}
+
+/**
+ * @param {any[]} body_nodes
  * @param {any} key_expression
  * @param {any} source_node
  * @param {TransformContext} transform_context
@@ -1476,7 +1490,10 @@ function create_hook_safe_helper(body_nodes, key_expression, source_node, transf
 	const helper_id = create_generated_identifier(
 		create_local_statement_component_name(transform_context),
 	);
-	const helper_bindings = Array.from(transform_context.available_bindings.values());
+	const helper_bindings = get_referenced_helper_bindings(
+		body_nodes,
+		transform_context.available_bindings,
+	);
 	const aliases = helper_bindings.map((binding) =>
 		create_helper_type_alias_declaration(helper_id, binding),
 	);

--- a/packages/tsrx/src/transform/jsx/index.js
+++ b/packages/tsrx/src/transform/jsx/index.js
@@ -461,11 +461,6 @@ function build_render_statements(body_nodes, return_null_when_empty, transform_c
 			continue;
 		}
 
-		if (is_lone_return_if_statement(child)) {
-			statements.push(create_component_lone_return_if_statement(child, render_nodes));
-			continue;
-		}
-
 		if (is_jsx_child(child)) {
 			const jsx = to_jsx_child(child, transform_context);
 			if (interleaved && is_capturable_jsx_child(jsx)) {
@@ -958,19 +953,6 @@ function is_returning_if_statement(node) {
  */
 function get_if_consequent_body(node) {
 	return node.consequent.type === 'BlockStatement' ? node.consequent.body : [node.consequent];
-}
-
-/**
- * @param {any} node
- * @returns {boolean}
- */
-function returning_if_statement_needs_child(node) {
-	const consequent_body = get_if_consequent_body(node);
-	const return_index = consequent_body.findIndex(is_bare_return_statement);
-	const rendered_body =
-		return_index === -1 ? consequent_body : consequent_body.slice(0, return_index);
-
-	return rendered_body.some(is_jsx_child) || body_contains_top_level_hook_call(rendered_body);
 }
 
 /**
@@ -1530,11 +1512,10 @@ function create_hook_safe_helper(body_nodes, key_expression, source_node, transf
 	const aliases = helper_bindings.map((binding) =>
 		create_helper_type_alias_declaration(helper_id, binding),
 	);
-	const props_type = () => create_helper_props_type_literal(helper_bindings, aliases);
+	const props_type =
+		helper_bindings.length > 0 ? create_helper_props_type_literal(helper_bindings, aliases) : null;
 	const params =
-		helper_bindings.length > 0
-			? [create_typed_helper_props_pattern(helper_bindings, props_type())]
-			: [];
+		props_type !== null ? [create_typed_helper_props_pattern(helper_bindings, props_type)] : [];
 
 	const saved_bindings = transform_context.available_bindings;
 	transform_context.available_bindings = new Map(saved_bindings);
@@ -1596,7 +1577,7 @@ function create_hook_safe_helper(body_nodes, key_expression, source_node, transf
 	return {
 		setup_statements: [
 			...aliases.map((alias) => alias.declaration),
-			create_cached_helper_declaration(helper_id, cache_id, helper_fn, props_type()),
+			create_cached_helper_declaration(helper_id, cache_id, helper_fn),
 		],
 		component_element,
 	};
@@ -1736,10 +1717,9 @@ function create_helper_cache_declaration(cache_id) {
  * @param {AST.Identifier} helper_id
  * @param {AST.Identifier} cache_id
  * @param {any} helper_fn
- * @param {any} props_type
  * @returns {any}
  */
-function create_cached_helper_declaration(helper_id, cache_id, helper_fn, props_type) {
+function create_cached_helper_declaration(helper_id, cache_id, helper_fn) {
 	return /** @type {any} */ ({
 		type: 'VariableDeclaration',
 		kind: 'const',

--- a/packages/tsrx/src/transform/jsx/index.js
+++ b/packages/tsrx/src/transform/jsx/index.js
@@ -1469,8 +1469,15 @@ function hook_safe_render_statements(body_nodes, key_expression, transform_conte
  */
 function get_referenced_helper_bindings(body_nodes, available_bindings) {
 	const helper_bindings = [];
+	const local_bindings = new Map();
+
+	for (const node of body_nodes) {
+		collect_statement_bindings(node, local_bindings);
+	}
 
 	for (const [name, binding] of available_bindings) {
+		if (local_bindings.has(name)) continue;
+
 		if (references_scope_bindings(body_nodes, new Map([[name, binding]]))) {
 			helper_bindings.push(binding);
 		}

--- a/packages/tsrx/tests/shared/compile.js
+++ b/packages/tsrx/tests/shared/compile.js
@@ -311,11 +311,10 @@ export function runSharedCompileTests({ compile, name, classAttrName }) {
 			expect(second_capture).toBeGreaterThan(assign_two);
 		});
 
-		it('preserves source order for interleaved JSX across a hook-safe split', () => {
-			// React/Preact track a hook-safe split for top-level hook calls;
-			// Solid has no such concept but still goes through the same
-			// capture path for interleaved mutations, so the assertion holds
-			// cross-platform.
+		it('preserves source order for interleaved JSX across early-return splits', () => {
+			// React/Preact extract typed continuation helpers after early returns
+			// when top-level hooks follow; Solid has no hook-order rule but still
+			// goes through the same capture path for interleaved mutations.
 			const { code } = compile(
 				`component Card() {
 					var a = "one"

--- a/packages/tsrx/tests/shared/source-mappings.js
+++ b/packages/tsrx/tests/shared/source-mappings.js
@@ -260,6 +260,31 @@ export function runSharedSourceMappingTests({
 		});
 	});
 
+	describe(`[${name}] component return mappings`, () => {
+		it('maps generated bare returns back to source returns', () => {
+			const source = `component App() {
+	return;
+	const value = 'after';
+	<div>{value}</div>
+}`;
+			const result = compile_to_volar_mappings(source, 'App.tsrx');
+			const source_return_offset = source.indexOf('return');
+			const generated_return_offset = result.code.indexOf('return');
+			const return_mapping = result.mappings.find(
+				(
+					/** @type {{ sourceOffsets: number[], lengths: number[], generatedOffsets: number[], generatedLengths: number[] }} */ mapping,
+				) =>
+					mapping.sourceOffsets[0] === source_return_offset &&
+					mapping.lengths[0] === 'return'.length &&
+					mapping.generatedOffsets[0] === generated_return_offset &&
+					mapping.generatedLengths[0] === 'return'.length,
+			);
+
+			expect(generated_return_offset).toBeGreaterThan(-1);
+			expect(return_mapping).toBeDefined();
+		});
+	});
+
 	describe(`[${name}] identifier_to_jsx_name preserves component metadata`, () => {
 		it('flags capitalized identifier names as components', () => {
 			const jsx = identifier_to_jsx_name({


### PR DESCRIPTION
closes #959 and potential other type issues with early returns.

NOTE: Explored adding diagnostics for greying out code after early returns that are directly in the component body but it's too cumbersome as we'd need to map all elements that we usually don't: if statements, variable declarations, etc.  Didn't think it's worth doing it as it's not such a big deal.  If it does become necessary we can address it by doing just what I just outlined: mapping everything.

after lots of experimentation arrived at a cached component helper with types on local vars via typeof and wrapping the continuation after the block with a return also in the same structures to make sure we're 100% legit with the hooks usage.

```jsx
export component App() {
	const foo = 'string';
	const bar = 'string';

	if (foo) {
		useEffect(() => {
			console.log(bar);
		}, [bar]);
		<div>{'Foo not found'}</div>
		return;
	}

	useEffect(() => {
		console.log(foo);
	}, [foo]);

	<div>{foo.trim()}</div>

	if (!bar) {
		<div>{'Bar not found'}</div>
		return;
	}

	useEffect(() => {
		console.log(bar);
	}, [bar]);

	<div>{bar.trim()}</div>
}
```

becomes:

```jsx
const App__static1 = <div>{'Foo not found'}</div>;
const App__static2 = <div>{'Bar not found'}</div>;
let App__StatementBodyHook1;
let App__StatementBodyHook3;
let App__StatementBodyHook4;
let App__StatementBodyHook2;

export function App() {
	const foo = 'string';
	const bar = 'string';

	if (foo) {
		const _tsrx_StatementBodyHook1_bar = bar;

		const StatementBodyHook1 = App__StatementBodyHook1 ?? (App__StatementBodyHook1 = function StatementBodyHook1({ bar }: { bar: typeof _tsrx_StatementBodyHook1_bar }) {
			useEffect(
				() => {
					console.log(bar);
				},
				[bar]
			);

			return App__static1;
		});

		return <StatementBodyHook1 bar={bar} />;
	}

	const _tsrx_StatementBodyHook2_foo = foo;
	const _tsrx_StatementBodyHook2_bar = bar;

	const StatementBodyHook2 = App__StatementBodyHook2 ?? (App__StatementBodyHook2 = function StatementBodyHook2(
		{ foo, bar }: { 
			foo: typeof _tsrx_StatementBodyHook2_foo;
			bar: typeof _tsrx_StatementBodyHook2_bar
		 }
	) {
		useEffect(
			() => {
				console.log(foo);
			},
			[foo]
		);

		const _tsrx_child_0 = <div>{foo.trim()}</div>;

		if (!bar) {
			const StatementBodyHook3 = App__StatementBodyHook3 ?? (App__StatementBodyHook3 = function StatementBodyHook3() {
				return App__static2;
			});

			return <>{_tsrx_child_0}<StatementBodyHook3 /></>;
		}

		const _tsrx_StatementBodyHook4_bar = bar;

		const StatementBodyHook4 = App__StatementBodyHook4 ?? (App__StatementBodyHook4 = function StatementBodyHook4({ bar }: { bar: typeof _tsrx_StatementBodyHook4_bar }) {
			useEffect(
				() => {
					console.log(bar);
				},
				[bar]
			);

			return <div>{bar.trim()}</div>;
		});

		return <>{_tsrx_child_0}<StatementBodyHook4 bar={bar} /></>;
	});

	return <StatementBodyHook2 foo={foo} bar={bar} />;
}
```


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core JSX transform control-flow rewriting around early returns and hook extraction, which can affect generated runtime behavior and source maps across React/Preact/Solid. Risk is mitigated by expanded unit tests covering typing, prop capture, key handling, and Volar mappings.
> 
> **Overview**
> Fixes early-return + hooks codegen by replacing the previous `Continue/Exit` helper split with **cached `StatementBodyHook*` helpers** that are **typed via `typeof` aliases** and only capture **actually-referenced, in-scope bindings**.
> 
> Updates component-body rendering to treat *any* returning `if` as a split point when hooks exist in either branch or the continuation, correctly combining pre-return render nodes with branch/continuation returns and continuing transformation after bare `return;` statements.
> 
> Adjusts loop hook-wrapper props/keys to avoid passing unrelated outer bindings (e.g., no longer forwarding `items`/`index` when unused), and adds/updates tests for Volar mapping correctness (including mapping generated `return null;` back to source `return;`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34437c20c3b844b0632f436414d782449f66b3fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->