### PR TITLE
test: add failing composite children props regression

### DIFF
--- a/packages/ripple/tests/client/basic/basic.components.test.tsrx
+++ b/packages/ripple/tests/client/basic/basic.components.test.tsrx
@@ -540,6 +540,33 @@ describe('basic client > components & composition', () => {
 		expect(container.querySelector('.wrapper .inner').textContent).toBe('inner content');
 	});
 
+	it(
+		'renders nested component declarations in composite children that reference parent props',
+		() => {
+			component Host(props: { asChild: Component }) {
+				<div class="host">
+					<@props.asChild href="/docs" />
+				</div>
+			}
+
+			component Parent(props: { label: string }) {
+				<Host>
+					component asChild({ href }: { href: string }) {
+						<a class="link" {href}>{props.label}</a>
+					}
+				</Host>
+			}
+
+			component App() {
+				<Parent label="Read docs" />
+			}
+
+			render(App);
+			expect(container.querySelector('.link')?.textContent).toBe('Read docs');
+			expect(container.querySelector('.link')?.getAttribute('href')).toBe('/docs');
+		},
+	);
+
 	it('renders nested components declared inside composite children with prop passing', () => {
 		component Wrapper(props: PropsWithChildren<{}>) {
 			<div class="wrapper">{props.children}</div>


### PR DESCRIPTION
Adds a failing client composition regression for nested component declarations in composite children that close over parent props. The current output does not pass the nested `asChild` component through to the host, so the expected link is missing.

Failing TSRX example:

```ts
import type { Component } from 'ripple';

component Host(props: { asChild: Component }) {
	<div class="host">
		<@props.asChild href="/docs" />
	</div>
}

component Parent(props: { label: string }) {
	<Host>
		component asChild({ href }: { href: string }) {
			<a class="link" {href}>{props.label}</a>
		}
	</Host>
}

export component App() {
	<Parent label="Read docs" />
}
```

Expected: the host receives and renders `asChild`, producing `<a class="link" href="/docs">Read docs</a>`. Current behavior leaves the link missing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are test-only, but it adds coverage for a previously failing composition edge case that may require runtime/compiler fixes elsewhere to make CI pass.
> 
> **Overview**
> Adds a new client composition regression test asserting that a nested component declared inside composite children can both be passed through as a component prop (via `asChild`) and *close over parent props* while still receiving its own props (e.g., `href`).
> 
> The test expects the forwarded nested `asChild` component to render an anchor with the correct label and `href`, guarding against a missing/incorrect pass-through in composite children rendering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62f49c956ea99b7308a61bee8ff4f1603e519272. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
