### PR TITLE
test: cover Preact hook children prop typing

### DIFF
--- a/packages/tsrx-preact/tests/basic.test.js
+++ b/packages/tsrx-preact/tests/basic.test.js
@@ -139,4 +139,36 @@ describe('@tsrx/preact basic', () => {
 		expect(code.match(/return <div>\{Date\.now\(\)\}<\/div>;/g)).toHaveLength(2);
 		expect(code).not.toContain('return null;');
 	});
+
+	it('preserves parent prop types in hook-bearing composite children', () => {
+		const { code } = compile(
+			`import { useState } from 'preact/hooks';
+			import type { PropsWithChildren } from 'ripple';
+
+			component Wrapper(props: PropsWithChildren<{}>) {
+				<section>{props.children}</section>
+			}
+
+			component Parent(props: { title: string }) {
+				<Wrapper>
+					const [count] = useState(0);
+
+					<h1>{props.title}</h1>
+					<span>{count}</span>
+				</Wrapper>
+			}
+
+			component App() {
+				<Parent title="Hello from props" />
+			}`,
+			'App.tsrx',
+		);
+
+		expect(code).toContain('const _tsrx_StatementBodyHook1_props = props;');
+		expect(code).toContain(
+			'function StatementBodyHook1({ props }: { props: typeof _tsrx_StatementBodyHook1_props })',
+		);
+		expect(code).toContain('<h1>{props.title}</h1>');
+		expect(code).not.toContain('function StatementBodyHook1({ props })');
+	});
 });


### PR DESCRIPTION
Adds a passing Preact regression test for hook-bearing children passed through a composite component while referencing parent props. This guards the 0.3.33 behavior where the extracted `StatementBodyHook` helper destructured `{ props }` without a type annotation, causing `props` to resolve to `any`.

This was fixed by #971 (`fix: early returns with types support`), which now emits a `typeof` annotation for the captured parent props. This PR locks that behavior in with focused Preact coverage.

Example covered by the test:

```ts
import { useState } from 'preact/hooks';
import type { PropsWithChildren } from 'ripple';

component Wrapper(props: PropsWithChildren<{}>) {
	<section>{props.children}</section>
}

component Parent(props: { title: string }) {
	<Wrapper>
		const [count] = useState(0);

		<h1>{props.title}</h1>
		<span>{count}</span>
	</Wrapper>
}

component App() {
	<Parent title="Hello from props" />
}
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 0b3519dccb0f9e8170765f1282b833d1e7b35186. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
