### PR TITLE
fix: optional markers on tuple members and prettier for the same

### DIFF
--- a/.changeset/preserve-named-tuple-members.md
+++ b/.changeset/preserve-named-tuple-members.md
@@ -1,0 +1,5 @@
+---
+'@tsrx/prettier-plugin': patch
+---
+
+Preserve named and optional TypeScript tuple members when formatting.

--- a/.changeset/preserve-optional-ts-params.md
+++ b/.changeset/preserve-optional-ts-params.md
@@ -1,0 +1,6 @@
+---
+'@tsrx/core': patch
+'@tsrx/ripple': patch
+---
+
+Preserve optional markers on tuple members and TypeScript function parameters in generated TSX output.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -38,5 +38,6 @@
   },
   "[typescriptreact]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
-  }
+  },
+  "cSpell.words": ["tsrx"]
 }

--- a/packages/prettier-plugin/src/index.js
+++ b/packages/prettier-plugin/src/index.js
@@ -2117,6 +2117,18 @@ function printRippleNode(node, path, options, print, args) {
 			nodeContent = printTSTupleType(node, path, options, print);
 			break;
 
+		case 'TSNamedTupleMember':
+			nodeContent = printTSNamedTupleMember(node, path, options, print);
+			break;
+
+		case 'TSRestType':
+			nodeContent = ['...', path.call(print, 'typeAnnotation')];
+			break;
+
+		case 'TSOptionalType':
+			nodeContent = [path.call(print, 'typeAnnotation'), '?'];
+			break;
+
 		case 'TSIndexSignature':
 			nodeContent = printTSIndexSignature(node, path, options, print);
 			break;
@@ -5260,6 +5272,23 @@ function printTSTupleType(node, path, options, print) {
 	}
 	parts.push(']');
 	return parts;
+}
+
+/**
+ * Print a TypeScript named tuple member
+ * @param {AST.TSNamedTupleMember} node - The named tuple member node
+ * @param {AstPath<AST.TSNamedTupleMember>} path - The AST path
+ * @param {RippleFormatOptions} options - Prettier options
+ * @param {PrintFn} print - Print callback
+ * @returns {Doc[]}
+ */
+function printTSNamedTupleMember(node, path, options, print) {
+	return [
+		path.call(print, 'label'),
+		node.optional ? '?' : '',
+		': ',
+		path.call(print, 'elementType'),
+	];
 }
 
 /**

--- a/packages/prettier-plugin/src/index.test.js
+++ b/packages/prettier-plugin/src/index.test.js
@@ -3298,6 +3298,13 @@ const items = [] as unknown[];`;
 			expect(result).toBeWithNewline(expected);
 		});
 
+		it('should preserve named optional TypeScript tuple members', async () => {
+			const input = `export type OptionalTuple = [bar: string, baz?: string];`;
+			const expected = `export type OptionalTuple = [bar: string, baz?: string];`;
+			const result = await format(input);
+			expect(result).toBeWithNewline(expected);
+		});
+
 		it('should format TypeScript index signatures (TSIndexSignature)', async () => {
 			const input = `interface Dict { [key: string]: number; readonly [id: number]: string }`;
 			const expected = `interface Dict {\n  [key: string]: number;\n  readonly [id: number]: string;\n}`;

--- a/packages/ripple/tests/client/compiler/compiler.basic.test.tsrx
+++ b/packages/ripple/tests/client/compiler/compiler.basic.test.tsrx
@@ -391,6 +391,61 @@ component App() {
 		expect(track_result).not.toContain('lazy0');
 	});
 
+	it('preserves optional markers in to_ts TypeScript output', () => {
+		const source = `
+export type OptionalTuple = [bar: string, baz?: string];
+export type OptionalFn = (bar: string, baz?: string) => void;
+export interface OptionalInterfaceFn {
+	(bar: string, baz?: string): void;
+}
+export function optionalFn(bar: string, baz?: string) {
+	todo(bar, baz);
+}
+`;
+		const result = compile_to_volar_mappings(source, 'test.tsrx').code;
+
+		expect(result).toContain('export type OptionalTuple = [bar: string, baz?: string];');
+		expect(result).toContain('export type OptionalFn = (bar: string, baz?: string) => void;');
+		expect(result).toContain('(bar: string, baz?: string): void');
+		expect(result).toContain('export function optionalFn(bar: string, baz?: string)');
+	});
+
+	it('maps optional TypeScript identifiers in to_ts output', () => {
+		const source = `
+export type OptionalTuple = [tupleRequired: string, tupleMaybe?: string];
+export type OptionalFn = (fnRequired: string, fnMaybe?: string) => void;
+export function optionalFn(declRequired: string, declMaybe?: string) {
+	todo(declRequired, declMaybe);
+}
+`;
+		const result = compile_to_volar_mappings(source, 'test.tsrx');
+
+		function expect_identifier_mapping(identifier: string, sourceNeedle: string) {
+			const source_offset = source.indexOf(sourceNeedle);
+			const generated_offset = result.code.indexOf(sourceNeedle);
+			const mapping = result.mappings.find(
+				(mapping: {
+					sourceOffsets: number[];
+					generatedOffsets: number[];
+					lengths: number[];
+					generatedLengths: number[];
+				}) => mapping.sourceOffsets[0] === source_offset &&
+					mapping.generatedOffsets[0] === generated_offset &&
+					mapping.lengths[0] === identifier.length &&
+					mapping.generatedLengths[0] === identifier.length,
+			);
+
+			expect(source_offset).toBeGreaterThan(-1);
+			expect(generated_offset).toBeGreaterThan(-1);
+			expect(mapping).toBeDefined();
+		}
+
+		expect(result.errors).toEqual([]);
+		expect_identifier_mapping('tupleMaybe', 'tupleMaybe?: string');
+		expect_identifier_mapping('fnMaybe', 'fnMaybe?: string');
+		expect_identifier_mapping('declMaybe', 'declMaybe?: string');
+	});
+
 	it('uses tracked fast path for nested lazy params typed as Tracked', () => {
 		const source = `
 import type { Tracked } from 'ripple';

--- a/packages/tsrx-ripple/src/transform/client/index.js
+++ b/packages/tsrx-ripple/src/transform/client/index.js
@@ -4510,6 +4510,15 @@ function create_tsx_with_typescript_support(comments) {
 			context.write(node.name);
 			context.location(loc.end.line, loc.end.column);
 		},
+		Identifier(node, context) {
+			context.write(node.name, node);
+			if (node.optional) {
+				context.write('?');
+			}
+			if (node.typeAnnotation) {
+				context.visit(node.typeAnnotation);
+			}
+		},
 		JSXExpressionContainer(node, context) {
 			const loc = /** @type {AST.SourceLocation} */ (node.loc);
 			if (!loc) {
@@ -4802,6 +4811,14 @@ function create_tsx_with_typescript_support(comments) {
 			context.write('(');
 			context.visit(/** @type {AST.TSTypeAnnotation} */ (node.typeAnnotation));
 			context.write(')');
+		},
+		TSNamedTupleMember(node, context) {
+			context.visit(node.label);
+			if (node.optional) {
+				context.write('?');
+			}
+			context.write(': ');
+			context.visit(node.elementType);
 		},
 		TSMappedType(node, context) {
 			context.write('{ ');

--- a/packages/tsrx/src/transform/jsx/helpers.js
+++ b/packages/tsrx/src/transform/jsx/helpers.js
@@ -106,6 +106,23 @@ export function tsx_with_ts_locations() {
 				context.visit(node.typeAnnotation);
 			}
 		},
+		Identifier: (node, context) => {
+			context.write(node.name, node);
+			if (node.optional) {
+				context.write('?');
+			}
+			if (node.typeAnnotation) {
+				context.visit(node.typeAnnotation);
+			}
+		},
+		TSNamedTupleMember: (node, context) => {
+			context.visit(node.label);
+			if (node.optional) {
+				context.write('?');
+			}
+			context.write(': ');
+			context.visit(node.elementType);
+		},
 	};
 	for (const type of [
 		// JS nodes whose esrap printer emits no location marker, causing

--- a/packages/tsrx/tests/shared/compile.js
+++ b/packages/tsrx/tests/shared/compile.js
@@ -80,6 +80,27 @@ export function runSharedCompileTests({ compile, name, classAttrName }) {
 		});
 	});
 
+	describe(`[${name}] TypeScript output`, () => {
+		it('preserves optional markers in tuple members and function parameters', () => {
+			const { code } = compile(
+				`export type OptionalTuple = [bar: string, baz?: string];
+export type OptionalFn = (bar: string, baz?: string) => void;
+export interface OptionalInterfaceFn {
+	(bar: string, baz?: string): void;
+}
+export function optionalFn(bar: string, baz?: string) {
+	todo(bar, baz);
+}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('export type OptionalTuple = [bar: string, baz?: string];');
+			expect(code).toContain('export type OptionalFn = (bar: string, baz?: string) => void;');
+			expect(code).toContain('(bar: string, baz?: string): void');
+			expect(code).toContain('export function optionalFn(bar: string, baz?: string)');
+		});
+	});
+
 	describe(`[${name}] walker transforms survive element lowering`, () => {
 		it('rewrites #style member expressions inside element child expressions', () => {
 			const { code } = compile(

--- a/packages/tsrx/tests/shared/source-mappings.js
+++ b/packages/tsrx/tests/shared/source-mappings.js
@@ -260,6 +260,48 @@ export function runSharedSourceMappingTests({
 		});
 	});
 
+	describe(`[${name}] optional TypeScript identifiers keep mappings`, () => {
+		it('maps manually printed optional tuple labels and function parameters', () => {
+			const source = `export type OptionalTuple = [tupleRequired: string, tupleMaybe?: string];
+export type OptionalFn = (fnRequired: string, fnMaybe?: string) => void;
+export function optionalFn(declRequired: string, declMaybe?: string) {
+	todo(declRequired, declMaybe);
+}`;
+			const result = compile_to_volar_mappings(source, 'App.tsrx');
+
+			/**
+			 * @param {string} identifier
+			 * @param {string} sourceNeedle
+			 */
+			const expect_identifier_mapping = (identifier, sourceNeedle) => {
+				const generated_needle = sourceNeedle;
+				const source_offset = source.indexOf(sourceNeedle);
+				const generated_offset = result.code.indexOf(generated_needle);
+				const mapping = result.mappings.find(
+					(
+						/** @type {{ sourceOffsets: number[], generatedOffsets: number[], lengths: number[], generatedLengths: number[] }} */ m,
+					) =>
+						m.sourceOffsets[0] === source_offset &&
+						m.generatedOffsets[0] === generated_offset &&
+						m.lengths[0] === identifier.length &&
+						m.generatedLengths[0] === identifier.length,
+				);
+
+				expect(source_offset).toBeGreaterThan(-1);
+				expect(generated_offset).toBeGreaterThan(-1);
+				expect(mapping).toBeDefined();
+			};
+
+			expect(result.errors).toEqual([]);
+			expect(result.code).toContain('tupleMaybe?: string');
+			expect(result.code).toContain('fnMaybe?: string');
+			expect(result.code).toContain('declMaybe?: string');
+			expect_identifier_mapping('tupleMaybe', 'tupleMaybe?: string');
+			expect_identifier_mapping('fnMaybe', 'fnMaybe?: string');
+			expect_identifier_mapping('declMaybe', 'declMaybe?: string');
+		});
+	});
+
 	describe(`[${name}] component return mappings`, () => {
 		it('maps generated bare returns back to source returns', () => {
 			const source = `component App() {


### PR DESCRIPTION
closes #972

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches code generation and Prettier printing paths for TypeScript nodes, which could subtly affect emitted TS/TSX and source-map mappings outside the covered cases.
> 
> **Overview**
> Preserves TypeScript `?` optional markers and labels in more places: the Prettier plugin now prints `TSNamedTupleMember` (and related `TSOptionalType`/`TSRestType`) so formatting keeps named/optional tuple members intact.
> 
> Updates the TSX/`to_ts` printers to emit optional identifiers/parameters and named tuple members correctly, and adds regression tests ensuring both generated code and Volar mappings still line up for optional tuple labels and function params. Changesets bump `@tsrx/prettier-plugin`, `@tsrx/core`, and `@tsrx/ripple` patch versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1bb602975fbb454dd05497a27905e6c70774b14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->