### PR TITLE
test(preact): reproduce generic prop alias diagnostic

### DIFF
--- a/packages/tsrx-preact/tests/basic.test.js
+++ b/packages/tsrx-preact/tests/basic.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { runSharedCompileTests } from '@tsrx/core/test-harness/compile';
 import { runSharedSourceMappingTests } from '@tsrx/core/test-harness/source-mappings';
+import { getTypeDiagnostics } from '@tsrx/core/test-harness/typescript-diagnostics';
 import { compile, compile_to_volar_mappings } from '../src/index.js';
 
 runSharedSourceMappingTests({
@@ -80,6 +81,26 @@ describe('@tsrx/preact basic', () => {
 		);
 
 		expect(code).toContain("{'preact tsx'}");
+	});
+
+	it('preserves component type parameters used by prop aliases', () => {
+		const { code } = compile(
+			`type Props<Item> = {
+				items: readonly Item[];
+			}
+
+			export component MyComponent<Item>(props: Props<Item>) {
+				<div />
+			}`,
+			'MyComponent.tsrx',
+		);
+
+		expect(
+			getTypeDiagnostics(code, {
+				fileName: new URL('./generated.tsx', import.meta.url),
+				jsxImportSource: 'preact',
+			}),
+		).toEqual([]);
 	});
 
 	it('rejects unsupported tsx compat kinds with Preact-branded message', () => {

--- a/packages/tsrx/package.json
+++ b/packages/tsrx/package.json
@@ -28,7 +28,8 @@
       "types": "./types/acorn.d.ts"
     },
     "./test-harness/source-mappings": "./tests/shared/source-mappings.js",
-    "./test-harness/compile": "./tests/shared/compile.js"
+    "./test-harness/compile": "./tests/shared/compile.js",
+    "./test-harness/typescript-diagnostics": "./tests/shared/typescript-diagnostics.js"
   },
   "dependencies": {
     "@jridgewell/sourcemap-codec": "catalog:default",

--- a/packages/tsrx/tests/shared/typescript-diagnostics.js
+++ b/packages/tsrx/tests/shared/typescript-diagnostics.js
@@ -1,0 +1,85 @@
+import { fileURLToPath } from 'url';
+import ts from 'typescript';
+
+/**
+ * @typedef {{
+ *   code: number,
+ *   message: string,
+ *   text?: string,
+ * }} TypeDiagnostic
+ */
+
+/**
+ * @typedef {{
+ *   fileName: string | URL,
+ *   jsxImportSource?: string,
+ *   compilerOptions?: ts.CompilerOptions,
+ * }} TypeDiagnosticOptions
+ */
+
+/**
+ * @param {string | URL} file_name
+ * @returns {string}
+ */
+function normalize_file_name(file_name) {
+	return file_name instanceof URL ? fileURLToPath(file_name) : file_name;
+}
+
+/**
+ * Runs TypeScript diagnostics against an in-memory TSX module.
+ *
+ * Keep `fileName` near the package under test so TypeScript resolves that
+ * package's JSX runtime and ambient types.
+ *
+ * @param {string} code
+ * @param {TypeDiagnosticOptions} options
+ * @returns {TypeDiagnostic[]}
+ */
+export function getTypeDiagnostics(code, { fileName, jsxImportSource, compilerOptions = {} }) {
+	const file_name = normalize_file_name(fileName);
+	/** @type {ts.CompilerOptions} */
+	const compiler_options = {
+		noEmit: true,
+		strict: true,
+		jsx: ts.JsxEmit.ReactJSX,
+		module: ts.ModuleKind.ESNext,
+		moduleResolution: ts.ModuleResolutionKind.Bundler,
+		target: ts.ScriptTarget.ESNext,
+		lib: ['lib.esnext.d.ts', 'lib.dom.d.ts'],
+		skipLibCheck: true,
+		types: [],
+		...compilerOptions,
+	};
+
+	if (jsxImportSource !== undefined) {
+		compiler_options.jsxImportSource = jsxImportSource;
+	}
+
+	const host = ts.createCompilerHost(compiler_options);
+	const get_source_file = host.getSourceFile.bind(host);
+	const file_exists = host.fileExists.bind(host);
+	const read_file = host.readFile.bind(host);
+
+	host.getSourceFile = (name, language_version, on_error, should_create_new_source_file) => {
+		if (name === file_name) {
+			return ts.createSourceFile(name, code, language_version, true, ts.ScriptKind.TSX);
+		}
+		return get_source_file(name, language_version, on_error, should_create_new_source_file);
+	};
+	host.fileExists = (name) => name === file_name || file_exists(name);
+	host.readFile = (name) => (name === file_name ? code : read_file(name));
+
+	return ts
+		.getPreEmitDiagnostics(ts.createProgram([file_name], compiler_options, host))
+		.map((diagnostic) => ({
+			code: diagnostic.code,
+			message: ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n'),
+			text:
+				diagnostic.file && diagnostic.start !== undefined
+					? diagnostic.file.text.slice(
+							diagnostic.start,
+							diagnostic.start + (diagnostic.length ?? 0),
+						)
+					: undefined,
+		}));
+}


### PR DESCRIPTION
Adds a failing Preact compiler regression for:

```ts
type Props<Item> = {
  items: readonly Item[];
}

export component MyComponent<Item>(props: Props<Item>) {
  <div />
}
```

The Preact transform currently emits a function without the `Item` type parameter while preserving `Props<Item>` on `props`, so TypeScript reports `TS2304: Cannot find name 'Item'`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes: adds a new shared TypeScript-diagnostics helper and a Preact regression that type-checks generated TSX for missing generic parameters. Low risk aside from potential CI/test environment sensitivity to TypeScript config/resolution.
> 
> **Overview**
> Adds a new shared test-harness utility, `getTypeDiagnostics`, that runs TypeScript pre-emit diagnostics against an in-memory TSX module, and exports it from `@tsrx/core`.
> 
> Extends `@tsrx/preact` basic tests with a regression that compiles a generic component using a generic `Props<Item>` alias and asserts the generated output type-checks with zero diagnostics (catching the missing type parameter emission bug).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2904325d968eafb9e44778548988919c034a656d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->