### PR TITLE
fix: preserve function and component type parameters

### DIFF
--- a/.changeset/preserve-component-type-parameters.md
+++ b/.changeset/preserve-component-type-parameters.md
@@ -1,0 +1,9 @@
+---
+"@tsrx/core": patch
+"@tsrx/react": patch
+"@tsrx/preact": patch
+"@tsrx/solid": patch
+"@tsrx/ripple": patch
+---
+
+Preserve component type parameters when lowering generic TSRX components to generated functions.

--- a/packages/ripple/tests/client/compiler/compiler.basic.test.tsrx
+++ b/packages/ripple/tests/client/compiler/compiler.basic.test.tsrx
@@ -410,6 +410,36 @@ export function optionalFn(bar: string, baz?: string) {
 		expect(result).toContain('export function optionalFn(bar: string, baz?: string)');
 	});
 
+	it('preserves component type parameters in to_ts output', () => {
+		const source = `
+type Props<Item> = {
+	items: readonly Item[];
+}
+
+export component MyComponent<Item>(props: Props<Item>) {
+	<div />
+}
+`;
+		const result = compile_to_volar_mappings(source, 'test.tsrx').code;
+
+		expect(result).toContain('export function MyComponent<Item>(props: Props<Item>)');
+	});
+
+	it('preserves regular function type parameters in to_ts output', () => {
+		const source = `
+type Props<Item> = {
+	items: readonly Item[];
+}
+
+export function getItems<Item>(props: Props<Item>) {
+	return props.items;
+}
+`;
+		const result = compile_to_volar_mappings(source, 'test.tsrx').code;
+
+		expect(result).toContain('export function getItems<Item>(props: Props<Item>)');
+	});
+
 	it('maps optional TypeScript identifiers in to_ts output', () => {
 		const source = `
 export type OptionalTuple = [tupleRequired: string, tupleMaybe?: string];

--- a/packages/tsrx-ripple/src/transform/client/index.js
+++ b/packages/tsrx-ripple/src/transform/client/index.js
@@ -1982,6 +1982,7 @@ const visitors = {
 				false,
 				/** @type {AST.NodeWithLocation} */ (node),
 			);
+			func.typeParameters = node.typeParameters;
 			// Mark that this function was originally a component
 			func.metadata = /** @type {AST.FunctionExpression['metadata']} */ ({
 				...node.metadata,

--- a/packages/tsrx-solid/src/transform.js
+++ b/packages/tsrx-solid/src/transform.js
@@ -282,6 +282,7 @@ function component_to_function_declaration(component, transform_context) {
 	const fn = /** @type {any} */ ({
 		type: 'FunctionDeclaration',
 		id: component.id,
+		typeParameters: component.typeParameters,
 		params: final_params,
 		body: final_body,
 		async: false,

--- a/packages/tsrx/src/transform/jsx/index.js
+++ b/packages/tsrx/src/transform/jsx/index.js
@@ -372,6 +372,7 @@ function component_to_function_declaration(component, transform_context, walk_he
 	const fn = /** @type {any} */ ({
 		type: 'FunctionDeclaration',
 		id: component.id,
+		typeParameters: component.typeParameters,
 		params: final_params,
 		body: final_body,
 		async: is_async_component,

--- a/packages/tsrx/tests/shared/compile.js
+++ b/packages/tsrx/tests/shared/compile.js
@@ -78,9 +78,39 @@ export function runSharedCompileTests({ compile, name, classAttrName }) {
 			expect(code).toContain('export default function App()');
 			expect(code).toContain("{'Hello world'}");
 		});
+
+		it('preserves component type parameters on the emitted function', () => {
+			const { code } = compile(
+				`type Props<Item> = {
+					items: readonly Item[];
+				}
+
+				export component MyComponent<Item>(props: Props<Item>) {
+					<div />
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('export function MyComponent<Item>(props: Props<Item>)');
+		});
 	});
 
 	describe(`[${name}] TypeScript output`, () => {
+		it('preserves regular function type parameters', () => {
+			const { code } = compile(
+				`type Props<Item> = {
+					items: readonly Item[];
+				}
+
+				export function getItems<Item>(props: Props<Item>) {
+					return props.items;
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('export function getItems<Item>(props: Props<Item>)');
+		});
+
 		it('preserves optional markers in tuple members and function parameters', () => {
 			const { code } = compile(
 				`export type OptionalTuple = [bar: string, baz?: string];


### PR DESCRIPTION
closes #977  that identified the issue.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core compiler transforms for multiple targets (`ripple`, `core/jsx`, `solid`), so a small AST change could affect TypeScript/JS output shape across projects, though the change is narrowly scoped to `typeParameters` propagation.
> 
> **Overview**
> **Preserves generics in generated output.** When lowering TSRX `component` declarations to function declarations/expressions, the transforms now carry over the component’s `typeParameters` so emitted TypeScript retains signatures like `MyComponent<Item>(props: Props<Item>)`.
> 
> Adds regression coverage in shared compile tests and Ripple’s `compile_to_volar_mappings` tests, plus a changeset bumping affected packages (`@tsrx/core`, `@tsrx/react`, `@tsrx/preact`, `@tsrx/solid`, `@tsrx/ripple`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3787cd89b7e28a9361aa96f116a9cc3a09476e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->