### PR TITLE
fix: parser - empty fragment <tsx></tsx> <></>

### DIFF
--- a/.changeset/allow-empty-fragments.md
+++ b/.changeset/allow-empty-fragments.md
@@ -1,0 +1,5 @@
+---
+"@tsrx/core": patch
+---
+
+Allow empty `<tsx></tsx>` and `<></>` fragments. The parser previously failed with "Unterminated regular expression" because `exprAllowed` leaked out of the template-body loop and caused the closing tag's `/` to be tokenized as a regex literal.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -39,5 +39,5 @@
   "[typescriptreact]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
-  "cSpell.words": ["tsrx", "tstc"]
+  "cSpell.words": ["tsrx", "tstc", "tstt"]
 }

--- a/packages/ripple/tests/client/tsx.test.tsrx
+++ b/packages/ripple/tests/client/tsx.test.tsrx
@@ -1,6 +1,40 @@
 import { flushSync, track } from 'ripple';
 
 describe('tsx expression', () => {
+	it('renders an empty <tsx></tsx> element', () => {
+		component App() {
+			<tsx></tsx>
+		}
+		render(App);
+		expect(container.textContent).toBe('');
+	});
+
+	it('renders an empty <></> fragment shorthand', () => {
+		component App() {
+			<></>
+		}
+		render(App);
+		expect(container.textContent).toBe('');
+	});
+
+	it('renders an empty <tsx></tsx> assigned to a variable', () => {
+		component App() {
+			const el = <tsx></tsx>;
+			{el}
+		}
+		render(App);
+		expect(container.textContent).toBe('');
+	});
+
+	it('renders an empty <></> fragment assigned to a variable', () => {
+		component App() {
+			const el = <></>;
+			{el}
+		}
+		render(App);
+		expect(container.textContent).toBe('');
+	});
+
 	it('renders a basic fragment shorthand element', () => {
 		component App() {
 			const el = <tsx><div>hello world</div></tsx>;

--- a/packages/tsrx/src/plugin.js
+++ b/packages/tsrx/src/plugin.js
@@ -2056,12 +2056,16 @@ export function TSRXPlugin(config) {
 
 						if (!inside_tsx.openingElement.name) {
 							if (this.input.slice(this.pos, this.pos + 2) === '/>') {
+								// Reset exprAllowed so the trailing `/` of `</>` is tokenized
+								// as a slash rather than as the start of a regex literal.
+								this.exprAllowed = false;
 								return;
 							}
 						} else if (this.input.slice(this.pos, this.pos + 4) === '/tsx') {
 							const after = this.input.charCodeAt(this.pos + 4);
 							// Make sure it's </tsx> and not </tsx:...>
 							if (after === 62 /* > */) {
+								this.exprAllowed = false;
 								return;
 							}
 						}
@@ -2128,6 +2132,7 @@ export function TSRXPlugin(config) {
 						}
 
 						if (this.input.slice(this.pos, this.pos + 5) === '/tsx:') {
+							this.exprAllowed = false;
 							return;
 						}
 


### PR DESCRIPTION
closes #981 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches tokenizer/parser state (`exprAllowed`) around TSX closing tags; small but easy to regress other JSX/TSX edge cases. Coverage is improved via new rendering tests for empty elements/fragments.
> 
> **Overview**
> Fixes the TSX/template parser to correctly handle **empty** `<tsx></tsx>` and fragment shorthand `<></>` by resetting `exprAllowed` before closing tags so `</...>` isn’t mis-tokenized as a regex.
> 
> Adds regression tests covering empty TSX/fragment nodes (inline and assigned to variables), and includes a patch changeset for `@tsrx/core` (plus a minor editor dictionary update).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 611c1f6ba580a5f0f3cc0387a0377335b07bd8a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->