### PR TITLE
Fix lazy types

### DIFF
--- a/.changeset/lazy-destructure-editor-support.md
+++ b/.changeset/lazy-destructure-editor-support.md
@@ -1,0 +1,9 @@
+---
+"@tsrx/core": patch
+"@tsrx/react": patch
+"@tsrx/preact": patch
+"@tsrx/solid": patch
+"@ripple-ts/language-server": patch
+---
+
+Improve lazy destructuring editor support for TSX targets, including typed virtual params, hover display rewrites, and loose-mode diagnostics for duplicate lazy parameter names.

--- a/.changeset/lazy-param-editor-shape.md
+++ b/.changeset/lazy-param-editor-shape.md
@@ -1,0 +1,8 @@
+---
+"@tsrx/core": patch
+"@tsrx/react": patch
+"@tsrx/preact": patch
+"@tsrx/solid": patch
+---
+
+Improve editor support for lazy object params by emitting object-shaped virtual TSX annotations for untyped params and preserving source mappings for lazy property reads.

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@tsrx/solid": "workspace:*",
     "@ripple-ts/vite-plugin": "workspace:*",
     "@types/node": "catalog:default",
-    "@typescript/native-preview": "7.0.0-dev.20260425.1",
+    "@typescript/native-preview": "7.0.0-dev.20260426.1",
     "eslint": "catalog:default",
     "jsdom": "catalog:default",
     "linkedom": "catalog:default",

--- a/packages/language-server/src/compileErrorDiagnosticPlugin.js
+++ b/packages/language-server/src/compileErrorDiagnosticPlugin.js
@@ -73,8 +73,8 @@ function parseCompilationErrorWithDocument(error, virtualCode, sourceMap, docume
 			severity: DiagnosticSeverity.Error,
 			range: get_error_range_from_source(error, document),
 			message: error.message,
-			source: 'Ripple',
-			code: 'ripple-compile-error',
+			source: 'TSRX',
+			code: 'tsrx-compile-error',
 		};
 	}
 
@@ -114,8 +114,8 @@ function parseCompilationErrorWithDocument(error, virtualCode, sourceMap, docume
 		severity: DiagnosticSeverity.Error,
 		range: { start, end },
 		message: error.message,
-		source: 'Ripple',
-		code: 'ripple-usage-error',
+		source: 'TSRX',
+		code: 'tsrx-usage-error',
 	};
 }
 

--- a/packages/language-server/src/typescriptDiagnosticPlugin.js
+++ b/packages/language-server/src/typescriptDiagnosticPlugin.js
@@ -45,7 +45,7 @@ function processDiagnostics(document, context, diagnostics) {
 	const result = [];
 
 	for (const diagnostic of diagnostics) {
-		if (virtualCode.fatalErrors.length > 0 && diagnostic.code !== 'ripple-compile-error') {
+		if (virtualCode.fatalErrors.length > 0 && diagnostic.code !== 'tsrx-compile-error') {
 			// skip all TS diagnostics since we're dealing directly with the source code
 			continue;
 		}

--- a/packages/tsrx-preact/src/index.js
+++ b/packages/tsrx-preact/src/index.js
@@ -42,7 +42,8 @@ export function compile(source, filename, compile_options) {
  * @returns {import('@tsrx/core/types').VolarMappingsResult}
  */
 export function compile_to_volar_mappings(source, filename, options) {
-	const ast = parseModule(source, filename, options);
+	const errors = /** @type {import('@tsrx/core/types').CompileError[]} */ ([]);
+	const ast = parseModule(source, filename, { ...options, errors });
 	const transformed = transform(ast, source, filename, options);
 	const result = createVolarMappingsResult({
 		ast: transformed.ast,
@@ -50,7 +51,7 @@ export function compile_to_volar_mappings(source, filename, options) {
 		source,
 		generated_code: transformed.code,
 		source_map: transformed.map,
-		errors: [],
+		errors,
 	});
 
 	return {

--- a/packages/tsrx-react/src/index.js
+++ b/packages/tsrx-react/src/index.js
@@ -38,7 +38,8 @@ export function compile(source, filename) {
  * @returns {import('@tsrx/core/types').VolarMappingsResult}
  */
 export function compile_to_volar_mappings(source, filename, options) {
-	const ast = parseModule(source, filename, options);
+	const errors = /** @type {import('@tsrx/core/types').CompileError[]} */ ([]);
+	const ast = parseModule(source, filename, { ...options, errors });
 	const transformed = transform(ast, source, filename);
 	const result = createVolarMappingsResult({
 		ast: transformed.ast,
@@ -46,7 +47,7 @@ export function compile_to_volar_mappings(source, filename, options) {
 		source,
 		generated_code: transformed.code,
 		source_map: transformed.map,
-		errors: [],
+		errors,
 	});
 
 	return {

--- a/packages/tsrx-solid/src/index.js
+++ b/packages/tsrx-solid/src/index.js
@@ -38,7 +38,8 @@ export function compile(source, filename) {
  * @returns {import('@tsrx/core/types').VolarMappingsResult}
  */
 export function compile_to_volar_mappings(source, filename, options) {
-	const ast = parseModule(source, filename, options);
+	const errors = /** @type {import('@tsrx/core/types').CompileError[]} */ ([]);
+	const ast = parseModule(source, filename, { ...options, errors });
 	const transformed = transform(ast, source, filename);
 	const result = createVolarMappingsResult({
 		ast: transformed.ast,
@@ -46,7 +47,7 @@ export function compile_to_volar_mappings(source, filename, options) {
 		source,
 		generated_code: transformed.code,
 		source_map: transformed.map,
-		errors: [],
+		errors,
 	});
 
 	return {

--- a/packages/tsrx/src/plugin.js
+++ b/packages/tsrx/src/plugin.js
@@ -16,6 +16,37 @@ import {
 import { regex_newline_characters } from './utils/patterns.js';
 import { error } from './errors.js';
 
+/** @type {WeakMap<Record<string, boolean>, Map<string, number>>} */
+const argument_clash_first_positions = new WeakMap();
+/** @type {WeakMap<Record<string, boolean>, Set<string>>} */
+const argument_clash_reported_names = new WeakMap();
+
+/**
+ * @param {Record<string, boolean>} check_clashes
+ * @returns {Map<string, number>}
+ */
+function get_argument_clash_first_positions(check_clashes) {
+	let first_positions = argument_clash_first_positions.get(check_clashes);
+	if (!first_positions) {
+		first_positions = new Map();
+		argument_clash_first_positions.set(check_clashes, first_positions);
+	}
+	return first_positions;
+}
+
+/**
+ * @param {Record<string, boolean>} check_clashes
+ * @returns {Set<string>}
+ */
+function get_argument_clash_reported_names(check_clashes) {
+	let reported_names = argument_clash_reported_names.get(check_clashes);
+	if (!reported_names) {
+		reported_names = new Set();
+		argument_clash_reported_names.set(check_clashes, reported_names);
+	}
+	return reported_names;
+}
+
 /**
  * @param {string} input
  * @param {number} i
@@ -166,20 +197,21 @@ export function TSRXPlugin(config) {
 
 			/**
 			 * @param {number} position
+			 * @param {number} end
 			 * @param {string} message
 			 */
-			#report_recoverable_error(position, message) {
+			#report_recoverable_error_range(position, end, message) {
 				const start = Math.max(0, Math.min(position, this.input.length));
-				const end = Math.min(this.input.length, start + 1);
+				const range_end = Math.max(start, Math.min(end, this.input.length));
 				const start_loc = acorn.getLineInfo(this.input, start);
-				const end_loc = acorn.getLineInfo(this.input, end);
+				const end_loc = acorn.getLineInfo(this.input, range_end);
 
 				error(
 					message,
 					this.#filename,
 					/** @type {AST.NodeWithLocation} */ ({
 						start,
-						end,
+						end: range_end,
 						loc: {
 							start: start_loc,
 							end: end_loc,
@@ -187,6 +219,14 @@ export function TSRXPlugin(config) {
 					}),
 					this.#loose ? this.#errors : undefined,
 				);
+			}
+
+			/**
+			 * @param {number} position
+			 * @param {string} message
+			 */
+			#report_recoverable_error(position, message) {
+				this.#report_recoverable_error_range(position, position + 1, message);
 			}
 
 			/**
@@ -203,7 +243,10 @@ export function TSRXPlugin(config) {
 							? message.message
 							: String(message);
 
-				if (error_message.includes('has already been declared')) {
+				if (
+					error_message.includes('has already been declared') ||
+					error_message === 'Argument name clash'
+				) {
 					this.#report_recoverable_error(position, error_message);
 					return;
 				}
@@ -715,6 +758,67 @@ export function TSRXPlugin(config) {
 			}
 
 			/**
+			 * Acorn reports only the second duplicate function parameter. In loose
+			 * mode, report the first one too so editor diagnostics can underline both
+			 * binding sites. Keep strict mode on Acorn's normal fatal path.
+			 *
+			 * @type {Parse.Parser['checkLValSimple']}
+			 */
+			checkLValSimple(expr, bindingType = BINDING_TYPES.BIND_NONE, checkClashes) {
+				if (
+					this.#loose &&
+					expr.type === 'Identifier' &&
+					bindingType !== BINDING_TYPES.BIND_NONE &&
+					checkClashes
+				) {
+					const first_positions = get_argument_clash_first_positions(checkClashes);
+					const reported_names = get_argument_clash_reported_names(checkClashes);
+					const first_position = first_positions.get(expr.name);
+
+					if (Object.prototype.hasOwnProperty.call(checkClashes, expr.name)) {
+						if (first_position != null && !reported_names.has(expr.name)) {
+							this.#report_recoverable_error_range(
+								first_position,
+								first_position + expr.name.length,
+								'Argument name clash',
+							);
+							reported_names.add(expr.name);
+						}
+						const start = /** @type {number} */ (expr.start);
+						this.#report_recoverable_error_range(
+							start,
+							/** @type {number} */ (expr.end ?? start + expr.name.length),
+							'Argument name clash',
+						);
+						return;
+					}
+
+					const result = super.checkLValSimple(expr, bindingType, checkClashes);
+					first_positions.set(expr.name, /** @type {number} */ (expr.start));
+					return result;
+				}
+
+				return super.checkLValSimple(expr, bindingType, checkClashes);
+			}
+
+			/**
+			 * Components do not use Acorn's normal function-body parser, but they
+			 * should still report duplicate parameter names like functions do. Keep
+			 * this validation on `BIND_OUTSIDE` so params are checked without being
+			 * declared in the component template scope, preserving existing shadowing
+			 * behavior.
+			 *
+			 * @param {AST.Pattern[]} params
+			 */
+			checkComponentParams(params) {
+				/** @type {Record<string, boolean>} */
+				const name_hash = Object.create(null);
+				for (const param of params || []) {
+					this.checkLValInnerPattern(param, BINDING_TYPES.BIND_OUTSIDE, name_hash);
+				}
+			}
+
+			/**
 			 * Parse expression atom - handles RippleArray and RippleObject literals
 			 * @type {Parse.Parser['parseExprAtom']}
 			 */
@@ -856,6 +960,7 @@ export function TSRXPlugin(config) {
 				}
 
 				this.parseFunctionParams(node);
+				this.checkComponentParams(node.params);
 
 				// Reset before `eat(braceL)` so the lookahead `next()` it triggers reads
 				// the component body's first token as if we'd entered fresh — no

--- a/packages/tsrx/src/transform/lazy.js
+++ b/packages/tsrx/src/transform/lazy.js
@@ -26,7 +26,7 @@
  */
 
 /**
- * @typedef {{ source_name: string, read: () => any }} LazyBinding
+ * @typedef {{ source_name: string, read: (reference?: any) => any }} LazyBinding
  */
 
 /**
@@ -47,11 +47,104 @@ function generate_lazy_id(context) {
 }
 
 /**
- * @param {string} name
+ * @param {any} node
+ * @param {any} [loc_info]
  * @returns {any}
  */
-function create_generated_identifier(name) {
-	return /** @type {any} */ ({ type: 'Identifier', name, metadata: { path: [] } });
+function set_source_location(node, loc_info) {
+	if (loc_info?.loc) {
+		node.start = loc_info.start;
+		node.end = loc_info.end;
+		node.loc = loc_info.loc;
+	}
+	return node;
+}
+
+/**
+ * @param {string} name
+ * @param {any} [loc_info]
+ * @param {string} [source_name]
+ * @param {number} [source_length]
+ * @returns {any}
+ */
+function create_generated_identifier(name, loc_info, source_name, source_length) {
+	const id = /** @type {any} */ ({ type: 'Identifier', name, metadata: { path: [] } });
+	if (source_name && source_name !== name) id.metadata.source_name = source_name;
+	if (source_length != null) id.metadata.source_length = source_length;
+	return set_source_location(id, loc_info);
+}
+
+/**
+ * @param {any} pattern
+ * @returns {{ start: number, end: number, loc: any, source_length: number } | null}
+ */
+function get_lazy_pattern_mapping_range(pattern) {
+	if (!pattern.loc) return null;
+
+	const end = pattern.typeAnnotation?.start ?? pattern.end;
+	const end_loc = pattern.typeAnnotation?.loc?.start ?? pattern.loc.end;
+	return {
+		start: pattern.start,
+		end,
+		loc: {
+			start: pattern.loc.start,
+			end: end_loc,
+		},
+		source_length: end - pattern.start,
+	};
+}
+
+/**
+ * Synthesize an object-shaped annotation for untyped lazy object params so the
+ * virtual TSX can expose prop names to TypeScript completions.
+ *
+ * @param {any} pattern
+ * @returns {any | null}
+ */
+function create_lazy_object_type_annotation(pattern) {
+	if (pattern.type !== 'ObjectPattern') return null;
+
+	const members = [];
+	for (const prop of pattern.properties || []) {
+		if (prop.type === 'RestElement' || prop.computed) continue;
+
+		const key = prop.key;
+		if (key.type !== 'Identifier' && key.type !== 'Literal') continue;
+
+		members.push({
+			type: 'TSPropertySignature',
+			key:
+				key.type === 'Identifier'
+					? create_generated_identifier(key.name, key)
+					: set_source_location({ ...key, metadata: { path: [] } }, key),
+			computed: false,
+			optional: false,
+			readonly: false,
+			static: false,
+			kind: 'init',
+			typeAnnotation: {
+				type: 'TSTypeAnnotation',
+				typeAnnotation: {
+					type: 'TSAnyKeyword',
+					metadata: { path: [] },
+				},
+				metadata: { path: [] },
+			},
+			metadata: { path: [] },
+		});
+	}
+
+	if (members.length === 0) return null;
+
+	return {
+		type: 'TSTypeAnnotation',
+		typeAnnotation: {
+			type: 'TSTypeLiteral',
+			members,
+			metadata: { path: [] },
+		},
+		metadata: { path: [] },
+	};
 }
 
 /**
@@ -76,12 +169,13 @@ export function collect_lazy_bindings(pattern, source_name, lazy_bindings) {
 				const computed = prop.computed || key.type !== 'Identifier';
 				lazy_bindings.set(actual.name, {
 					source_name,
-					read: () => ({
+					read: (reference) => ({
 						type: 'MemberExpression',
 						object: create_generated_identifier(source_name),
-						property: computed
-							? { ...key }
-							: { type: 'Identifier', name: key.name, metadata: { path: [] } },
+						property:
+							computed || key.type !== 'Identifier'
+								? { ...key }
+								: create_generated_identifier(key.name, reference, reference?.name),
 						computed,
 						optional: false,
 						metadata: { path: [] },
@@ -491,7 +585,7 @@ export function apply_lazy_transforms(node, lazy_bindings) {
 		const binding = /** @type {LazyBinding} */ (lazy_bindings.get(node.left.name));
 		return {
 			...node,
-			left: binding.read(),
+			left: binding.read(node.left),
 			right: apply_lazy_transforms(node.right, lazy_bindings),
 		};
 	}
@@ -502,7 +596,7 @@ export function apply_lazy_transforms(node, lazy_bindings) {
 		lazy_bindings.has(node.argument.name)
 	) {
 		const binding = /** @type {LazyBinding} */ (lazy_bindings.get(node.argument.name));
-		return { ...node, argument: binding.read() };
+		return { ...node, argument: binding.read(node.argument) };
 	}
 
 	// Replace lazy variable declaration patterns with generated identifiers.
@@ -520,14 +614,14 @@ export function apply_lazy_transforms(node, lazy_bindings) {
 	if (node.type === 'Property' && node.shorthand && node.value?.type === 'Identifier') {
 		const binding = lazy_bindings.get(node.value.name);
 		if (binding) {
-			return { ...node, shorthand: false, value: binding.read() };
+			return { ...node, shorthand: false, value: binding.read(node.value) };
 		}
 	}
 
 	// Bare identifier reference.
 	if (node.type === 'Identifier' && lazy_bindings.has(node.name)) {
 		const binding = /** @type {LazyBinding} */ (lazy_bindings.get(node.name));
-		return binding.read();
+		return binding.read(node);
 	}
 
 	// JSXIdentifier is a label (component/element name), never a reference.
@@ -654,8 +748,21 @@ export function replace_lazy_params(params) {
 			pattern.lazy &&
 			pattern.metadata?.lazy_id
 		) {
-			const lazy_id = create_generated_identifier(pattern.metadata.lazy_id);
-			if (pattern.typeAnnotation) lazy_id.typeAnnotation = pattern.typeAnnotation;
+			const pattern_range = get_lazy_pattern_mapping_range(pattern);
+			const lazy_id = pattern_range
+				? create_generated_identifier(
+						pattern.metadata.lazy_id,
+						pattern_range,
+						undefined,
+						pattern_range.source_length,
+					)
+				: create_generated_identifier(pattern.metadata.lazy_id);
+			if (pattern.typeAnnotation) {
+				lazy_id.typeAnnotation = pattern.typeAnnotation;
+			} else {
+				const type_annotation = create_lazy_object_type_annotation(pattern);
+				if (type_annotation) lazy_id.typeAnnotation = type_annotation;
+			}
 			if (param.type === 'AssignmentPattern') return { ...param, left: lazy_id };
 			return lazy_id;
 		}

--- a/packages/tsrx/src/transform/lazy.js
+++ b/packages/tsrx/src/transform/lazy.js
@@ -148,6 +148,70 @@ function create_lazy_object_type_annotation(pattern) {
 }
 
 /**
+ * @param {any} node
+ * @returns {string | null}
+ */
+function get_static_property_name(node) {
+	if (node.type === 'Identifier') return node.name;
+	if (node.type === 'Literal') return String(node.value);
+	return null;
+}
+
+/**
+ * @param {any} type_annotation
+ * @returns {Map<string, any>}
+ */
+function get_type_property_keys(type_annotation) {
+	const keys = new Map();
+	const members = type_annotation?.typeAnnotation?.members;
+	if (!Array.isArray(members)) return keys;
+
+	for (const member of members) {
+		if (member.type !== 'TSPropertySignature' || !member.key) continue;
+		const name = get_static_property_name(member.key);
+		if (name != null && !keys.has(name)) keys.set(name, member.key);
+	}
+
+	return keys;
+}
+
+/**
+ * Store extra mappings from lazy object binding identifiers to generated type
+ * property keys. Parser diagnostics for duplicate bindings point at the binding
+ * names (`&{ a: value, value }`), while the virtual param only exposes object
+ * properties (`__lazy0: { a: ...; value: ... }`).
+ *
+ * @param {any} lazy_id
+ * @param {any} pattern
+ */
+function set_lazy_param_binding_mappings(lazy_id, pattern) {
+	if (pattern.type !== 'ObjectPattern') return;
+
+	const type_keys = get_type_property_keys(lazy_id.typeAnnotation);
+	if (type_keys.size === 0) return;
+
+	const mappings = [];
+	for (const prop of pattern.properties || []) {
+		if (prop.type === 'RestElement' || prop.computed) continue;
+
+		const value = prop.value;
+		const actual = value.type === 'AssignmentPattern' ? value.left : value;
+		if (actual.type !== 'Identifier' || !actual.loc) continue;
+
+		const key_name = get_static_property_name(prop.key);
+		const generated = key_name == null ? null : type_keys.get(key_name);
+		if (generated?.loc) {
+			generated.metadata = { ...generated.metadata, disable_verification: true };
+			mappings.push({ source: actual, generated });
+		}
+	}
+
+	if (mappings.length > 0) {
+		lazy_id.metadata.lazy_param_binding_mappings = mappings;
+	}
+}
+
+/**
  * Collect lazy bindings from a destructuring pattern.
  *
  * For `&{ name, age }` on source `S`, maps `name` → `S.name`, `age` → `S.age`.
@@ -763,6 +827,7 @@ export function replace_lazy_params(params) {
 				const type_annotation = create_lazy_object_type_annotation(pattern);
 				if (type_annotation) lazy_id.typeAnnotation = type_annotation;
 			}
+			set_lazy_param_binding_mappings(lazy_id, pattern);
 			if (param.type === 'AssignmentPattern') return { ...param, left: lazy_id };
 			return lazy_id;
 		}

--- a/packages/tsrx/src/transform/segments.js
+++ b/packages/tsrx/src/transform/segments.js
@@ -79,12 +79,16 @@ function replace_label_to_component(content) {
 
 /**
  * @param {string} lazy_id
+ * @param {(content: string) => string} [base_hover]
  * @returns {(content: string) => string}
  */
-function create_lazy_param_hover_replacement(lazy_id) {
+function create_lazy_param_hover_replacement(lazy_id, base_hover) {
 	const lazy_param_regex = new RegExp(`\\b${escape_regex(lazy_id)}\\s*:\\s*`, 'g');
 
-	return (content) => replace_label_to_component(content).replace(lazy_param_regex, '&');
+	return (content) => {
+		const next = base_hover ? base_hover(content) : content;
+		return next.replace(lazy_param_regex, '&');
+	};
 }
 
 /**
@@ -491,7 +495,10 @@ export function convert_source_map_to_mappings(
 						token.metadata.hover = replace_label_to_component;
 					}
 					if (node.metadata?.source_length != null && LAZY_PARAM_IDENTIFIER_REGEX.test(node.name)) {
-						token.metadata.hover = create_lazy_param_hover_replacement(node.name);
+						token.metadata.hover = create_lazy_param_hover_replacement(
+							node.name,
+							node.metadata?.lazy_param_is_component ? replace_label_to_component : undefined,
+						);
 					}
 					if (node.metadata?.disable_verification) {
 						token.mappingData = { ...mapping_data, verification: false };
@@ -935,6 +942,13 @@ export function convert_source_map_to_mappings(
 
 				if (node.params) {
 					for (const param of node.params) {
+						if (
+							param.type === 'Identifier' &&
+							param.metadata?.source_length != null &&
+							LAZY_PARAM_IDENTIFIER_REGEX.test(param.name)
+						) {
+							param.metadata.lazy_param_is_component = node.metadata?.is_component === true;
+						}
 						visit(param);
 						if (param.typeAnnotation) {
 							visit(param.typeAnnotation);

--- a/packages/tsrx/src/transform/segments.js
+++ b/packages/tsrx/src/transform/segments.js
@@ -56,6 +56,15 @@ import {
 } from '../source-map-utils.js';
 
 const LABEL_TO_COMPONENT_REPLACE_REGEX = /(function|\((property|method)\))/;
+const LAZY_PARAM_IDENTIFIER_REGEX = /^__lazy\d+$/;
+
+/**
+ * @param {string} value
+ * @returns {string}
+ */
+function escape_regex(value) {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
 
 /**
  * @param {string} content
@@ -66,6 +75,47 @@ function replace_label_to_component(content) {
 		if (fn === 'function') return 'component';
 		return `(component ${kind})`;
 	});
+}
+
+/**
+ * @param {string} lazy_id
+ * @returns {(content: string) => string}
+ */
+function create_lazy_param_hover_replacement(lazy_id) {
+	const lazy_param_regex = new RegExp(`\\b${escape_regex(lazy_id)}\\s*:\\s*`, 'g');
+
+	return (content) => replace_label_to_component(content).replace(lazy_param_regex, '&');
+}
+
+/**
+ * @param {AST.Parameter[] | undefined} params
+ * @param {(content: string) => string} [base_hover]
+ * @returns {((content: string) => string) | undefined}
+ */
+function create_function_hover_replacement(params, base_hover) {
+	const lazy_ids =
+		params
+			?.filter(
+				(param) =>
+					param.type === 'Identifier' &&
+					param.metadata?.source_length != null &&
+					LAZY_PARAM_IDENTIFIER_REGEX.test(param.name),
+			)
+			.map((param) => /** @type {AST.Identifier} */ (param).name) ?? [];
+
+	if (lazy_ids.length === 0) return base_hover;
+
+	const lazy_param_regexes = lazy_ids.map(
+		(lazy_id) => new RegExp(`\\b${escape_regex(lazy_id)}\\s*:\\s*`, 'g'),
+	);
+
+	return (content) => {
+		let next = base_hover ? base_hover(content) : content;
+		for (const regex of lazy_param_regexes) {
+			next = next.replace(regex, '&');
+		}
+		return next;
+	};
 }
 
 /**
@@ -440,7 +490,33 @@ export function convert_source_map_to_mappings(
 						// only if the node has a component as the parent
 						token.metadata.hover = replace_label_to_component;
 					}
+					if (node.metadata?.source_length != null && LAZY_PARAM_IDENTIFIER_REGEX.test(node.name)) {
+						token.metadata.hover = create_lazy_param_hover_replacement(node.name);
+					}
+					if (node.metadata?.disable_verification) {
+						token.mappingData = { ...mapping_data, verification: false };
+					}
 					tokens.push(token);
+
+					if (Array.isArray(node.metadata?.lazy_param_binding_mappings)) {
+						for (const binding_mapping of node.metadata.lazy_param_binding_mappings) {
+							const source_node = binding_mapping.source;
+							const generated_node = binding_mapping.generated;
+							if (!source_node?.loc || !generated_node?.loc) continue;
+
+							const mapping = get_mapping_from_node(
+								generated_node,
+								src_to_gen_map,
+								gen_line_offsets,
+								mapping_data_verify_only,
+							);
+							const source_start = /** @type {number} */ (source_node.start);
+							const source_end = /** @type {number} */ (source_node.end);
+							mapping.sourceOffsets = [source_start];
+							mapping.lengths = [source_end - source_start];
+							mappings.push(mapping);
+						}
+					}
 				}
 				return; // Leaf node, don't traverse further
 			} else if (node.type === 'JSXIdentifier') {
@@ -770,6 +846,10 @@ export function convert_source_map_to_mappings(
 					const node_fn = /** @type (typeof node) & AST.NodeWithLocation */ (node);
 					const is_component = node_fn.metadata?.is_component;
 					const source_func_keyword = is_component ? 'component' : 'function';
+					const function_hover = create_function_hover_replacement(
+						/** @type {AST.Parameter[]} */ (node.params),
+						is_component ? replace_label_to_component : undefined,
+					);
 					let start_col = node_fn.loc.start.column;
 					let start = node_fn.start;
 					const async_keyword = 'async';
@@ -785,7 +865,7 @@ export function convert_source_map_to_mappings(
 						mapping.lengths = [source_func_keyword.length];
 						mapping.generatedOffsets = [generated_keyword_start];
 						mapping.generatedLengths = ['function'.length];
-						mapping.data.customData.hover = replace_label_to_component;
+						if (function_hover) mapping.data.customData.hover = function_hover;
 						mappings.push(mapping);
 					} else {
 						if (node_fn.async) {
@@ -817,7 +897,7 @@ export function convert_source_map_to_mappings(
 									column: start_col + source_func_keyword.length,
 								},
 							},
-							metadata: is_component ? { hover: replace_label_to_component } : {},
+							metadata: function_hover ? { hover: function_hover } : {},
 						});
 					}
 				}
@@ -829,11 +909,24 @@ export function convert_source_map_to_mappings(
 					/** @type {AST.FunctionDeclaration | AST.FunctionExpression} */ (node).id &&
 					!is_method
 				) {
-					visit(
-						/** @type {AST.Node} */ (
-							/** @type {AST.FunctionDeclaration | AST.FunctionExpression} */ (node).id
-						),
+					const id = /** @type {AST.Identifier} */ (
+						/** @type {AST.FunctionDeclaration | AST.FunctionExpression} */ (node).id
 					);
+					const function_hover = create_function_hover_replacement(
+						/** @type {AST.Parameter[]} */ (node.params),
+						node.metadata?.is_component ? replace_label_to_component : undefined,
+					);
+					if (function_hover && id.loc) {
+						tokens.push({
+							source: id.metadata?.source_name ?? id.name,
+							generated: id.name,
+							loc: id.loc,
+							metadata: { hover: function_hover },
+							sourceLength: id.metadata?.source_length,
+						});
+					} else {
+						visit(/** @type {AST.Node} */ (id));
+					}
 				}
 
 				if (node.typeParameters) {

--- a/packages/tsrx/src/transform/segments.js
+++ b/packages/tsrx/src/transform/segments.js
@@ -27,6 +27,7 @@
 	loc: AST.SourceLocation;
 	metadata: PluginActionOverrides;
 	end_loc?: AST.SourceLocation;
+	sourceLength?: number;
 	mappingData?: Partial<VolarCodeMapping['data']>;
 }} Token;
 @typedef {{
@@ -423,6 +424,7 @@ export function convert_source_map_to_mappings(
 							generated: node.name,
 							loc: node.loc,
 							metadata: {},
+							sourceLength: node.metadata.source_length,
 						};
 					} else {
 						token = {
@@ -430,6 +432,7 @@ export function convert_source_map_to_mappings(
 							generated: node.name,
 							loc: node.loc,
 							metadata: {},
+							sourceLength: node.metadata?.source_length,
 						};
 					}
 
@@ -2067,7 +2070,7 @@ export function convert_source_map_to_mappings(
 			token.loc.start.column,
 			src_line_offsets,
 		);
-		const source_length = source_text.length;
+		const source_length = token.sourceLength ?? source_text.length;
 		const gen_length = gen_text.length;
 		let gen_line_col;
 		try {

--- a/packages/tsrx/tests/shared/compile.js
+++ b/packages/tsrx/tests/shared/compile.js
@@ -408,6 +408,44 @@ export function optionalFn(bar: string, baz?: string) {
 		// component scope, but locals with the same name must shadow — the
 		// shared `applyLazyTransforms` helper in @tsrx/core handles this.
 
+		it('gives untyped lazy object params an object-shaped generated type', () => {
+			const { code } = compile(
+				`export component App(&{ name, age }) {
+					<div>{name}{age}</div>
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('function App(__lazy0: { name: any; age: any })');
+			expect(code).toContain('__lazy0.name');
+			expect(code).toContain('__lazy0.age');
+		});
+
+		it('uses the source property name for aliased lazy object params', () => {
+			const { code } = compile(
+				`export component App(&{ name: displayName }) {
+					<div>{displayName}</div>
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('function App(__lazy0: { name: any })');
+			expect(code).toContain('__lazy0.name');
+			expect(code).not.toContain('__lazy0.displayName');
+		});
+
+		it('preserves provided types for aliased lazy object params', () => {
+			const { code } = compile(
+				`export component App(&{ a: b, b }: { a: string, b: string }) {
+					<div>{b}</div>
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('function App(__lazy0: { a: string; b: string })');
+			expect(code).toContain('__lazy0.b');
+		});
+
 		it('does not rewrite switch-case variables that shadow lazy bindings', () => {
 			const { code } = compile(
 				`export component App(&{ name }: { name: string }) {

--- a/packages/tsrx/tests/shared/compile.js
+++ b/packages/tsrx/tests/shared/compile.js
@@ -436,14 +436,49 @@ export function optionalFn(bar: string, baz?: string) {
 
 		it('preserves provided types for aliased lazy object params', () => {
 			const { code } = compile(
-				`export component App(&{ a: b, b }: { a: string, b: string }) {
-					<div>{b}</div>
+				`export component App(&{ a: c, b }: { a: string, b: string }) {
+					<div>{c}{b}</div>
 				}`,
 				'App.tsrx',
 			);
 
 			expect(code).toContain('function App(__lazy0: { a: string; b: string })');
+			expect(code).toContain('__lazy0.a');
 			expect(code).toContain('__lazy0.b');
+		});
+
+		it('rejects repeated local names inside lazy object params on plain functions', () => {
+			expect(() =>
+				compile(
+					`export function greet(&{ a: b, b }: { a: string, b: string }) {
+						return b;
+					}`,
+					'App.tsrx',
+				),
+			).toThrow(/Argument name clash/);
+		});
+
+		it('rejects repeated local names inside lazy object params on components', () => {
+			expect(() =>
+				compile(
+					`export component App(&{ a: b, b }: { a: string, b: string }) {
+						<div>{b}</div>
+					}`,
+					'App.tsrx',
+				),
+			).toThrow(/Argument name clash/);
+		});
+
+		it('allows distinct local names inside lazy object params on plain functions', () => {
+			const { code } = compile(
+				`export function greet(&{ a: c, b }: { a: string, b: string }) {
+					return c + b;
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('function greet(__lazy0: { a: string; b: string })');
+			expect(code).toContain('return __lazy0.a + __lazy0.b');
 		});
 
 		it('does not rewrite switch-case variables that shadow lazy bindings', () => {

--- a/packages/tsrx/tests/shared/source-mappings.js
+++ b/packages/tsrx/tests/shared/source-mappings.js
@@ -369,6 +369,168 @@ export function optionalFn(declRequired: string, declMaybe?: string) {
 			expect(result.code).toContain('function Hello(__lazy0: { a: string; b: string })');
 			expect(pattern_mapping).toBeDefined();
 		});
+
+		it('rewrites lazy object params in hover text', () => {
+			const source = `component Hello(&{ a: c, b }: { a: string, b: string }) {
+	<>{c}{b}</>
+}`;
+			const result = compile_to_volar_mappings(source, 'App.tsrx');
+			const source_pattern_offset = source.indexOf('{ a: c, b }');
+			const source_name_offset = source.indexOf('Hello');
+			const generated_lazy_offset = result.code.indexOf('__lazy0');
+			const generated_name_offset = result.code.indexOf('Hello');
+			const pattern_mapping = result.mappings.find(
+				(mapping) =>
+					mapping.sourceOffsets[0] === source_pattern_offset &&
+					mapping.generatedOffsets[0] === generated_lazy_offset,
+			);
+			const name_mapping = result.mappings.find(
+				(mapping) =>
+					mapping.sourceOffsets[0] === source_name_offset &&
+					mapping.generatedOffsets[0] === generated_name_offset,
+			);
+			const hover = pattern_mapping?.data.customData.hover;
+			const name_hover = name_mapping?.data.customData.hover;
+
+			expect(typeof hover).toBe('function');
+			if (typeof hover === 'function') {
+				expect(
+					hover(`function Hello(__lazy0: {
+    a: string;
+    b: string;
+}): void`),
+				).toBe(`component Hello(&{
+    a: string;
+    b: string;
+}): void`);
+
+				expect(
+					hover(`(parameter) __lazy0: {
+    a: string;
+    b: string;
+}`),
+				).toBe(`(parameter) &{
+    a: string;
+    b: string;
+}`);
+			}
+
+			expect(typeof name_hover).toBe('function');
+			if (typeof name_hover === 'function') {
+				expect(
+					name_hover(`function Hello(__lazy0: {
+    a: string;
+    b: string;
+}): void`),
+				).toBe(`component Hello(&{
+    a: string;
+    b: string;
+}): void`);
+			}
+		});
+
+		it('rewrites lazy object params in plain function hover text', () => {
+			const source = `function greet(&{ a: c, b }: { a: string, b: string }) {
+	return c + b;
+}`;
+			const result = compile_to_volar_mappings(source, 'App.tsrx');
+			const source_name_offset = source.indexOf('greet');
+			const generated_name_offset = result.code.indexOf('greet');
+			const name_mapping = result.mappings.find(
+				(mapping) =>
+					mapping.sourceOffsets[0] === source_name_offset &&
+					mapping.generatedOffsets[0] === generated_name_offset,
+			);
+			const hover = name_mapping?.data.customData.hover;
+
+			expect(result.code).toContain('function greet(__lazy0: { a: string; b: string })');
+			expect(typeof hover).toBe('function');
+			if (typeof hover === 'function') {
+				expect(
+					hover(`function greet(__lazy0: {
+    a: string;
+    b: string;
+}): string`),
+				).toBe(`function greet(&{
+    a: string;
+    b: string;
+}): string`);
+			}
+		});
+
+		it('reports repeated lazy param bindings in loose mode without throwing', () => {
+			const source = `function greet(&{ a: b, b }: { a: string, b: string }) {
+	return b;
+}`;
+
+			const result = compile_to_volar_mappings(source, 'App.tsrx', { loose: true });
+
+			expect(result.errors).toHaveLength(2);
+			expect(result.errors[0].message).toBe('Argument name clash');
+			expect(result.errors[0].type).toBe('usage');
+			expect(source.slice(result.errors[0].pos, result.errors[0].end)).toBe('b');
+			expect(result.errors[1].message).toBe('Argument name clash');
+			expect(result.errors[1].type).toBe('usage');
+			expect(source.slice(result.errors[1].pos, result.errors[1].end)).toBe('b');
+			expect(result.code).toContain('function greet(__lazy0: { a: string; b: string })');
+		});
+
+		it('reports repeated lazy component param bindings in loose mode without throwing', () => {
+			const source = `component App(&{ a: b, b }: { a: string, b: string }) {
+	<>{b}</>
+}`;
+
+			const result = compile_to_volar_mappings(source, 'App.tsrx', { loose: true });
+
+			expect(result.errors).toHaveLength(2);
+			expect(result.errors[0].message).toBe('Argument name clash');
+			expect(result.errors[0].type).toBe('usage');
+			expect(source.slice(result.errors[0].pos, result.errors[0].end)).toBe('b');
+			expect(result.errors[1].message).toBe('Argument name clash');
+			expect(result.errors[1].type).toBe('usage');
+			expect(source.slice(result.errors[1].pos, result.errors[1].end)).toBe('b');
+			expect(
+				result.mappings.find(
+					(mapping) =>
+						mapping.sourceOffsets[0] === result.errors[0].pos &&
+						mapping.lengths[0] === result.errors[0].end - result.errors[0].pos,
+				),
+			).toBeDefined();
+			expect(
+				result.mappings.find(
+					(mapping) =>
+						mapping.sourceOffsets[0] === result.errors[1].pos &&
+						mapping.lengths[0] === result.errors[1].end - result.errors[1].pos,
+				),
+			).toBeDefined();
+			expect(result.code).toContain('function App(__lazy0: { a: string; b: string })');
+		});
+
+		it('reports repeated lazy param bindings with full identifier ranges', () => {
+			const source = `component App(&{ a: value, value }: { a: string, value: string }) {
+	<>{value}</>
+}`;
+
+			const result = compile_to_volar_mappings(source, 'App.tsrx', { loose: true });
+
+			expect(result.errors).toHaveLength(2);
+			expect(source.slice(result.errors[0].pos, result.errors[0].end)).toBe('value');
+			expect(source.slice(result.errors[1].pos, result.errors[1].end)).toBe('value');
+			expect(
+				result.mappings.find(
+					(mapping) =>
+						mapping.sourceOffsets[0] === result.errors[0].pos &&
+						mapping.lengths[0] === result.errors[0].end - result.errors[0].pos,
+				),
+			).toBeDefined();
+			expect(
+				result.mappings.find(
+					(mapping) =>
+						mapping.sourceOffsets[0] === result.errors[1].pos &&
+						mapping.lengths[0] === result.errors[1].end - result.errors[1].pos,
+				),
+			).toBeDefined();
+		});
 	});
 
 	describe(`[${name}] component return mappings`, () => {

--- a/packages/tsrx/tests/shared/source-mappings.js
+++ b/packages/tsrx/tests/shared/source-mappings.js
@@ -434,16 +434,37 @@ export function optionalFn(declRequired: string, declMaybe?: string) {
 	return c + b;
 }`;
 			const result = compile_to_volar_mappings(source, 'App.tsrx');
+			const source_pattern_offset = source.indexOf('{ a: c, b }');
 			const source_name_offset = source.indexOf('greet');
+			const generated_lazy_offset = result.code.indexOf('__lazy0');
 			const generated_name_offset = result.code.indexOf('greet');
+			const pattern_mapping = result.mappings.find(
+				(mapping) =>
+					mapping.sourceOffsets[0] === source_pattern_offset &&
+					mapping.generatedOffsets[0] === generated_lazy_offset,
+			);
 			const name_mapping = result.mappings.find(
 				(mapping) =>
 					mapping.sourceOffsets[0] === source_name_offset &&
 					mapping.generatedOffsets[0] === generated_name_offset,
 			);
+			const param_hover = pattern_mapping?.data.customData.hover;
 			const hover = name_mapping?.data.customData.hover;
 
 			expect(result.code).toContain('function greet(__lazy0: { a: string; b: string })');
+			expect(typeof param_hover).toBe('function');
+			if (typeof param_hover === 'function') {
+				expect(
+					param_hover(`function greet(__lazy0: {
+    a: string;
+    b: string;
+}): string`),
+				).toBe(`function greet(&{
+    a: string;
+    b: string;
+}): string`);
+			}
+
 			expect(typeof hover).toBe('function');
 			if (typeof hover === 'function') {
 				expect(

--- a/packages/tsrx/tests/shared/source-mappings.js
+++ b/packages/tsrx/tests/shared/source-mappings.js
@@ -302,6 +302,75 @@ export function optionalFn(declRequired: string, declMaybe?: string) {
 		});
 	});
 
+	describe(`[${name}] lazy destructuring mappings`, () => {
+		it('maps untyped lazy object param keys and aliased reads into generated property names', () => {
+			const source = `component Hello(&{ a: value, b }) {
+	<>{value}{b}</>
+}`;
+			const result = compile_to_volar_mappings(source, 'App.tsrx');
+
+			/**
+			 * @param {number} sourceOffset
+			 * @param {number} generatedOffset
+			 * @param {number} sourceLength
+			 * @param {number} [generatedLength]
+			 */
+			const mapping_at = (
+				sourceOffset,
+				generatedOffset,
+				sourceLength,
+				generatedLength = sourceLength,
+			) =>
+				result.mappings.find(
+					(
+						/** @type {{ sourceOffsets: number[], generatedOffsets: number[], lengths: number[], generatedLengths: number[] }} */ mapping,
+					) =>
+						mapping.sourceOffsets[0] === sourceOffset &&
+						mapping.generatedOffsets[0] === generatedOffset &&
+						mapping.lengths[0] === sourceLength &&
+						mapping.generatedLengths[0] === generatedLength,
+				);
+
+			const source_key_a_offset = source.indexOf('a: value');
+			const source_key_b_offset = source.indexOf('b })');
+			const source_body_value_offset = source.lastIndexOf('value');
+			const source_body_b_offset = source.lastIndexOf('b');
+			const generated_type_a_offset = result.code.indexOf('{ a: any') + 2;
+			const generated_type_b_offset = result.code.indexOf('b: any');
+			const generated_read_a_offset = result.code.indexOf('__lazy0.a') + '__lazy0.'.length;
+			const generated_read_b_offset = result.code.indexOf('__lazy0.b') + '__lazy0.'.length;
+
+			expect(result.code).toContain('function Hello(__lazy0: { a: any; b: any })');
+			expect(mapping_at(source_key_a_offset, generated_type_a_offset, 'a'.length)).toBeDefined();
+			expect(mapping_at(source_key_b_offset, generated_type_b_offset, 'b'.length)).toBeDefined();
+			expect(
+				mapping_at(source_body_value_offset, generated_read_a_offset, 'value'.length, 'a'.length),
+			).toBeDefined();
+			expect(mapping_at(source_body_b_offset, generated_read_b_offset, 'b'.length)).toBeDefined();
+		});
+
+		it('maps annotated lazy object params to the generated lazy parameter', () => {
+			const source = `component Hello(&{ a: value, b }: { a: string, b: string }) {
+	<>{value}{b}</>
+}`;
+			const result = compile_to_volar_mappings(source, 'App.tsrx');
+			const source_pattern_offset = source.indexOf('{ a: value, b }');
+			const generated_lazy_offset = result.code.indexOf('__lazy0');
+			const pattern_mapping = result.mappings.find(
+				(
+					/** @type {{ sourceOffsets: number[], generatedOffsets: number[], lengths: number[], generatedLengths: number[] }} */ mapping,
+				) =>
+					mapping.sourceOffsets[0] === source_pattern_offset &&
+					mapping.generatedOffsets[0] === generated_lazy_offset &&
+					mapping.lengths[0] === '{ a: value, b }'.length &&
+					mapping.generatedLengths[0] === '__lazy0'.length,
+			);
+
+			expect(result.code).toContain('function Hello(__lazy0: { a: string; b: string })');
+			expect(pattern_mapping).toBeDefined();
+		});
+	});
+
 	describe(`[${name}] component return mappings`, () => {
 		it('maps generated bare returns back to source returns', () => {
 			const source = `component App() {

--- a/packages/tsrx/types/index.d.ts
+++ b/packages/tsrx/types/index.d.ts
@@ -58,6 +58,7 @@ interface BaseNodeMetaData {
 	forceMapping?: boolean;
 	lazy_id?: string;
 	disable_verification?: boolean;
+	lazy_param_is_component?: boolean;
 	lazy_param_binding_mappings?: Array<{
 		source: AST.Identifier;
 		generated: AST.Identifier | AST.Literal;

--- a/packages/tsrx/types/index.d.ts
+++ b/packages/tsrx/types/index.d.ts
@@ -45,6 +45,7 @@ interface BaseNodeMetaData {
 	path: AST.Node[];
 	has_template?: boolean;
 	source_name?: string | '#server' | '#style';
+	source_length?: number;
 	is_capitalized?: boolean;
 	commentContainerId?: number;
 	parenthesized?: boolean;

--- a/packages/tsrx/types/index.d.ts
+++ b/packages/tsrx/types/index.d.ts
@@ -57,6 +57,11 @@ interface BaseNodeMetaData {
 	lone_return?: boolean;
 	forceMapping?: boolean;
 	lazy_id?: string;
+	disable_verification?: boolean;
+	lazy_param_binding_mappings?: Array<{
+		source: AST.Identifier;
+		generated: AST.Identifier | AST.Literal;
+	}>;
 }
 
 interface FunctionMetaData extends BaseNodeMetaData {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -276,8 +276,8 @@ importers:
         specifier: catalog:default
         version: 24.11.0
       '@typescript/native-preview':
-        specifier: 7.0.0-dev.20260425.1
-        version: 7.0.0-dev.20260425.1
+        specifier: 7.0.0-dev.20260426.1
+        version: 7.0.0-dev.20260426.1
       eslint:
         specifier: catalog:default
         version: 10.2.1(jiti@2.6.1)
@@ -404,7 +404,7 @@ importers:
         version: 2.4.2
       tsdown:
         specifier: catalog:default
-        version: 0.20.3(@typescript/native-preview@7.0.0-dev.20260425.1)(typescript@5.9.3)
+        version: 0.20.3(@typescript/native-preview@7.0.0-dev.20260426.1)(typescript@5.9.3)
       type-fest:
         specifier: catalog:default
         version: 5.6.0
@@ -445,7 +445,7 @@ importers:
     devDependencies:
       tsdown:
         specifier: catalog:default
-        version: 0.20.3(@typescript/native-preview@7.0.0-dev.20260425.1)(typescript@5.9.3)
+        version: 0.20.3(@typescript/native-preview@7.0.0-dev.20260426.1)(typescript@5.9.3)
 
   packages/eslint-parser:
     dependencies:
@@ -470,7 +470,7 @@ importers:
         version: 24.11.0
       tsdown:
         specifier: catalog:default
-        version: 0.20.3(@typescript/native-preview@7.0.0-dev.20260425.1)(typescript@5.9.3)
+        version: 0.20.3(@typescript/native-preview@7.0.0-dev.20260426.1)(typescript@5.9.3)
       typescript:
         specifier: catalog:default
         version: 5.9.3
@@ -497,7 +497,7 @@ importers:
         version: 10.2.1(jiti@2.6.1)
       tsdown:
         specifier: catalog:default
-        version: 0.20.3(@typescript/native-preview@7.0.0-dev.20260425.1)(typescript@5.9.3)
+        version: 0.20.3(@typescript/native-preview@7.0.0-dev.20260426.1)(typescript@5.9.3)
       typescript:
         specifier: catalog:default
         version: 5.9.3
@@ -539,7 +539,7 @@ importers:
         version: link:../tsrx-ripple
       tsdown:
         specifier: catalog:default
-        version: 0.20.3(@typescript/native-preview@7.0.0-dev.20260425.1)(typescript@5.9.3)
+        version: 0.20.3(@typescript/native-preview@7.0.0-dev.20260426.1)(typescript@5.9.3)
 
   packages/nvim-plugin: {}
 
@@ -870,7 +870,7 @@ importers:
         version: 24.11.0
       tsdown:
         specifier: catalog:default
-        version: 0.20.3(@typescript/native-preview@7.0.0-dev.20260425.1)(typescript@5.9.3)
+        version: 0.20.3(@typescript/native-preview@7.0.0-dev.20260426.1)(typescript@5.9.3)
 
   packages/vite-plugin:
     dependencies:
@@ -1007,7 +1007,7 @@ importers:
         version: 0.5.17
       tsdown:
         specifier: catalog:default
-        version: 0.20.3(@typescript/native-preview@7.0.0-dev.20260425.1)(typescript@5.9.3)
+        version: 0.20.3(@typescript/native-preview@7.0.0-dev.20260426.1)(typescript@5.9.3)
 
   packages/zed-plugin: {}
 
@@ -3074,50 +3074,50 @@ packages:
     resolution: {integrity: sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260425.1':
-    resolution: {integrity: sha512-vM7O+PlxHRUT4Dv0VkxEmU3N2uyWeSFrhu57O7s3SE9TX1ENljwQlCFG0oQdBGLBRo+SZSoedxKL5jOGlD1eiw==}
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260426.1':
+    resolution: {integrity: sha512-HzGvERpIFO7p6pMljPN1fIOHqAv2oMeVIqYLSt27TKILkTRpe7fANW3R2OAM+/A+pLtYNNXGDbKl/wR+DHz9KA==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [darwin]
 
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260425.1':
-    resolution: {integrity: sha512-EiikklZSuEvMhZEeN0VRb0vmedhLgtKwz5p4Oz9e8hlJ4lLrslgvX7Z7JWb2YSKlhm14dUlRMvdoe+6t+56rSA==}
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260426.1':
+    resolution: {integrity: sha512-aE17wCPNQ09K4jV7TQYYRYF/Q/6nFS9jLpbyTYHtS+i+0yV1Rrs4VsqboisS1R/iSWsq3m1Yhh3uS4x3/9KUkg==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [darwin]
 
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260425.1':
-    resolution: {integrity: sha512-5KJ++prl1dscJtxnkE7Cb6rjud4T3nO4mcnKhkCfYcQaFtFrvcZhBtDobwcpSzHbfsW0MeM+QCy1UfWoK4gjUQ==}
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260426.1':
+    resolution: {integrity: sha512-6OfhODChD1N6FX+ITzA1lny3WX6uew/Nw9kN7uWhymXlM3/vE0qtaAfsMpgdHdCbTPgcdpGaNFhbcMieju9Vdg==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [linux]
 
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260425.1':
-    resolution: {integrity: sha512-9eWInaHqhfTu1Mt/1M85p5M+HlSStahAQkqYaW9rJzUWRe+AcVUKsN6I7U7iwxbkCT8gFZsMCRqABcwBUWw3kg==}
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260426.1':
+    resolution: {integrity: sha512-/XJRC8B6JeOOb2/iek/BrzW4r5Nut+fkucG7ntEOQn63IRTsfP+AfJdJodG1VIwXOleNlFgG4RtYTUsvcbDJhg==}
     engines: {node: '>=16.20.0'}
     cpu: [arm]
     os: [linux]
 
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260425.1':
-    resolution: {integrity: sha512-a/E/8UL2x6nWmIJwrrbEvLz938RMcrFfm5hLRKaPMjCE32bgwesBZEG5jRn8fzQes+4HICRXKEaL544jtb/Syg==}
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260426.1':
+    resolution: {integrity: sha512-KPDpjmLo/4xY8ugfMGFm7Ona/1igPzZveLt/C0rb6/jNPYuShumRfKYnItGDRXBlmecJY/04lrqkWqQjhtSSPg==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [linux]
 
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260425.1':
-    resolution: {integrity: sha512-BZ7jEnaNZHkHbq9LWuqqIgYMmMb2E2NReMybjOyl3ASFmJHYekDnytXIT3Zbp4dyPLJV55faGzLqMw2MMS81NA==}
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260426.1':
+    resolution: {integrity: sha512-I7ThiopxuNKX/iAcwgMwsm6L32GOwmwLOyPwQmXjh5c3VD2acq3FYyZRDJVk0aUUy1w6bTbODlo5ZHoPnlZtvw==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [win32]
 
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260425.1':
-    resolution: {integrity: sha512-/iwK50mO31lKr1KVDRCqW5xGyKArZuq9jQr2b/PJ3e0xEuV6hoJ4Kok11LA1lhx1uctqr3UXKmfwQF3HWqcZTQ==}
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260426.1':
+    resolution: {integrity: sha512-4624MJq72vN4H1msiWVBqAIyerJRi5Ni/U6eeE1A1Opqg4c4QoalYQQ+5h5RIuaZ6rY+9kvUn+SjsvbZwyLbjQ==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [win32]
 
-  '@typescript/native-preview@7.0.0-dev.20260425.1':
-    resolution: {integrity: sha512-qhSVDT9DsoKPBeEm777eUUkiCDjBFlF7wwjfMvcPctZFVHfD6b1O1icpfCdQHPqzjrSXWu2YaNiY0DXbljTmgw==}
+  '@typescript/native-preview@7.0.0-dev.20260426.1':
+    resolution: {integrity: sha512-zE7B6TIG4XDYr4Your5E2Bxm1vD2YiPyD8OFG4nD5Odt/uN6gO0Y+T4TIbtGUBmOftMRqEV2Jw1ZC4ka0my1yw==}
     engines: {node: '>=16.20.0'}
     hasBin: true
 
@@ -8366,36 +8366,36 @@ snapshots:
       '@typescript-eslint/types': 8.56.1
       eslint-visitor-keys: 5.0.1
 
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260425.1':
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260426.1':
     optional: true
 
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260425.1':
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260426.1':
     optional: true
 
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260425.1':
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260426.1':
     optional: true
 
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260425.1':
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260426.1':
     optional: true
 
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260425.1':
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260426.1':
     optional: true
 
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260425.1':
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260426.1':
     optional: true
 
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260425.1':
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260426.1':
     optional: true
 
-  '@typescript/native-preview@7.0.0-dev.20260425.1':
+  '@typescript/native-preview@7.0.0-dev.20260426.1':
     optionalDependencies:
-      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260425.1
-      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260425.1
-      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260425.1
-      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260425.1
-      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260425.1
-      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260425.1
-      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260425.1
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260426.1
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260426.1
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260426.1
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260426.1
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260426.1
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260426.1
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260426.1
 
   '@typespec/ts-http-runtime@0.3.3':
     dependencies:
@@ -10913,7 +10913,7 @@ snapshots:
       devalue: 5.6.3
       esm-env: 1.2.2
 
-  rolldown-plugin-dts@0.22.3(@typescript/native-preview@7.0.0-dev.20260425.1)(rolldown@1.0.0-rc.3)(typescript@5.9.3):
+  rolldown-plugin-dts@0.22.3(@typescript/native-preview@7.0.0-dev.20260426.1)(rolldown@1.0.0-rc.3)(typescript@5.9.3):
     dependencies:
       '@babel/generator': 8.0.0-rc.2
       '@babel/helper-validator-identifier': 8.0.0-rc.2
@@ -10926,7 +10926,7 @@ snapshots:
       obug: 2.1.1
       rolldown: 1.0.0-rc.3
     optionalDependencies:
-      '@typescript/native-preview': 7.0.0-dev.20260425.1
+      '@typescript/native-preview': 7.0.0-dev.20260426.1
       typescript: 5.9.3
     transitivePeerDependencies:
       - oxc-resolver
@@ -11513,7 +11513,7 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  tsdown@0.20.3(@typescript/native-preview@7.0.0-dev.20260425.1)(typescript@5.9.3):
+  tsdown@0.20.3(@typescript/native-preview@7.0.0-dev.20260426.1)(typescript@5.9.3):
     dependencies:
       ansis: 4.2.0
       cac: 6.7.14
@@ -11524,7 +11524,7 @@ snapshots:
       obug: 2.1.1
       picomatch: 4.0.3
       rolldown: 1.0.0-rc.3
-      rolldown-plugin-dts: 0.22.3(@typescript/native-preview@7.0.0-dev.20260425.1)(rolldown@1.0.0-rc.3)(typescript@5.9.3)
+      rolldown-plugin-dts: 0.22.3(@typescript/native-preview@7.0.0-dev.20260426.1)(rolldown@1.0.0-rc.3)(typescript@5.9.3)
       semver: 7.7.4
       tinyexec: 1.0.2
       tinyglobby: 0.2.15


### PR DESCRIPTION
closes #956

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches TSRX parsing and source-mapping logic to improve lazy destructuring diagnostics and hover/type output; regressions could impact editor errors/mappings across TSX targets but not runtime behavior.
> 
> **Overview**
> Improves *editor/tooling support* for lazy destructuring (`&{}` / `&[]`) in TSX targets by emitting **better-typed virtual parameters** (including synthesized object-shaped types for untyped lazy object params) and preserving more accurate Volar source mappings for lazy property keys/reads.
> 
> Enhances hover text rewriting so generated `__lazyN: ...` parameters display as `&...` in function/component signatures, and adds loose-mode diagnostics for **duplicate lazy parameter bindings** (reporting full identifier ranges and flagging both the first and second occurrences). Also standardizes language-server diagnostic `source`/`code` identifiers from `Ripple` to `TSRX` and threads parse errors through `compile_to_volar_mappings` for React/Preact/Solid.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbd3c27ed3b6c3c90f53004ad10f89891a3138ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->