### PR TITLE
Support double quoted static string

### DIFF
--- a/.changeset/double-quoted-text-children.md
+++ b/.changeset/double-quoted-text-children.md
@@ -1,0 +1,5 @@
+---
+"@tsrx/core": minor
+---
+
+Allow direct double-quoted static text children in TSRX templates.

--- a/README.md
+++ b/README.md
@@ -131,8 +131,8 @@ export component App() {
   let &[count] = track(0);
 
   <div>
-    <p>{"Count: "}{count}</p>
-    <button onClick={() => count++}>{"Increment"}</button>
+    <p>"Count: "{count}</p>
+    <button onClick={() => count++}>"Increment"</button>
   </div>
 }
 ```
@@ -160,7 +160,7 @@ export component App() {
   const count = track(0);
 
   <div>{count.value}</div>
-  <button onClick={() => count.value++}>{"Increment"}</button>
+  <button onClick={() => count.value++}>"Increment"</button>
 }
 ```
 
@@ -179,10 +179,10 @@ export component App() {
   let &[quadruple] = track(() => double * 2);
 
   <div>
-    <p>{"Count: "}{count}</p>
-    <p>{"Double: "}{double}</p>
-    <p>{"Quadruple: "}{quadruple}</p>
-    <button onClick={() => count++}>{"Increment"}</button>
+    <p>"Count: "{count}</p>
+    <p>"Double: "{double}</p>
+    <p>"Quadruple: "{quadruple}</p>
+    <button onClick={() => count++}>"Increment"</button>
   </div>
 }
 ```
@@ -199,10 +199,10 @@ export component App() {
   const set = new RippleSet([1, 2, 3]);             // RippleSet
 
   <div>
-    <p>{"Items: "}{items.join(', ')}</p>
-    <p>{"Object: a="}{obj.a}{", b="}{obj.b}{", c="}{obj.c}</p>
-    <button onClick={() => items.push(items.length + 1)}>{"Add Item"}</button>
-    <button onClick={() => obj.c = (obj.c ?? 0) + 1}>{"Increment c"}</button>
+    <p>"Items: "{items.join(', ')}</p>
+    <p>"Object: a="{obj.a}", b="{obj.b}", c="{obj.c}</p>
+    <button onClick={() => items.push(items.length + 1)}>"Add Item"</button>
+    <button onClick={() => obj.c = (obj.c ?? 0) + 1}>"Increment c"</button>
   </div>
 }
 ```
@@ -225,8 +225,8 @@ export component App() {
   const &[double] = createDouble(countTracked);
 
   <div>
-    <p>{"Double: "}{double}</p>
-    <button onClick={() => count++}>{"Increment"}</button>
+    <p>"Double: "{double}</p>
+    <button onClick={() => count++}>"Increment"</button>
   </div>
 }
 ```
@@ -245,7 +245,7 @@ export component App() {
     console.log('Count changed:', count);
   });
 
-  <button onClick={() => count++}>{'Increment'}</button>
+  <button onClick={() => count++}>"Increment"</button>
 }
 ```
 
@@ -263,11 +263,11 @@ export component App() {
 
   <div>
     if (condition) {
-      <div>{'True'}</div>
+      <div>"True"</div>
     } else {
-      <div>{'False'}</div>
+      <div>"False"</div>
     }
-    <button onClick={() => condition = !condition}>{"Toggle"}</button>
+    <button onClick={() => condition = !condition}>"Toggle"</button>
   </div>
 }
 ```
@@ -286,9 +286,9 @@ export component App() {
 
   <div>
     for (const item of items; index i; key item.id) {
-      <div>{item.name}{" (index: "}{i}{")"}</div>
+      <div>{item.name}" (index: "{i}")"</div>
     }
-    <button onClick={() => items.push({id: items.length + 1, name: `Item ${items.length + 1}`})}>{"Add Item"}</button>
+    <button onClick={() => items.push({id: items.length + 1, name: `Item ${items.length + 1}`})}>"Add Item"</button>
   </div>
 }
 ```
@@ -299,10 +299,10 @@ export component App() {
 component ComponentThatMayFail(props: { shouldFail: boolean }) {
   if (props.shouldFail) {
     throw new Error('Component failed!');
-    {'This will never render'}
+    "This will never render"
   }
 
-  <div>{"Component working fine"}</div>
+  <div>"Component working fine"</div>
 }
 
 import { track } from 'ripple';
@@ -316,7 +316,7 @@ export component App() {
     } catch (e) {
       <div>{'Error: ' + e.message}</div>
     }
-    <button onClick={() => shouldFail = !shouldFail}>{"Toggle Error"}</button>
+    <button onClick={() => shouldFail = !shouldFail}>"Toggle Error"</button>
   </div>
 }
 ```
@@ -329,7 +329,7 @@ Capture DOM elements with the `{ref fn}` syntax:
 
 ```jsx
 export component App() {
-  <div {ref (node) => console.log(node)}>{"Hello"}</div>
+  <div {ref (node) => console.log(node)}>"Hello"</div>
 }
 ```
 
@@ -346,9 +346,9 @@ export component App() {
   let &[value] = track('');
 
   <div>
-    <button onClick={() => console.log('Clicked')}>{'Click'}</button>
+    <button onClick={() => console.log('Clicked')}>"Click"</button>
     <input onInput={(e) => value = e.target.value} />
-    <p>{"You typed: "}{value}</p>
+    <p>"You typed: "{value}</p>
   </div>
 }
 ```
@@ -361,7 +361,7 @@ export component App() {
 
 ```jsx
 export component App() {
-  <div class="container">{"Content"}</div>
+  <div class="container">"Content"</div>
 
   <style>
     .container {
@@ -382,8 +382,8 @@ export component App() {
   let &[color] = track('red');
 
   <div>
-    <div style={{ color, fontWeight: 'bold' }}>{"Styled text"}</div>
-    <button onClick={() => color = color === 'red' ? 'blue' : 'red'}>{"Toggle Color"}</button>
+    <div style={{ color, fontWeight: 'bold' }}>"Styled text"</div>
+    <button onClick={() => color = color === 'red' ? 'blue' : 'red'}>"Toggle Color"</button>
   </div>
 }
 ```
@@ -413,7 +413,7 @@ export component App() {
 
   <div>
     <Child />
-    <button onClick={() => theme = theme === 'light' ? 'dark' : 'light'}>{"Toggle Theme"}</button>
+    <button onClick={() => theme = theme === 'light' ? 'dark' : 'light'}>"Toggle Theme"</button>
   </div>
 }
 ```
@@ -431,13 +431,13 @@ export component App() {
   let &[showModal] = track(false);
 
   <div>
-    <button onClick={() => showModal = !showModal}>{"Toggle Modal"}</button>
+    <button onClick={() => showModal = !showModal}>"Toggle Modal"</button>
 
     if (showModal) {
       <Portal target={document.body}>
         <div class="modal">
-          <p>{'Modal content'}</p>
-          <button onClick={() => showModal = false}>{"Close"}</button>
+          <p>"Modal content"</p>
+          <button onClick={() => showModal = false}>"Close"</button>
         </div>
       </Portal>
     }

--- a/packages/tsrx/README.md
+++ b/packages/tsrx/README.md
@@ -61,14 +61,19 @@ component Button(props: Props) {
 ### 2. JSX-as-statements
 
 Inside a `component` body, JSX elements are valid _statement_ forms. They describe
-rendered output and are not expressions — they have no value.
+rendered output and are not expressions — they have no value. Static text may be
+written as a direct double-quoted child; dynamic values and other JavaScript
+expressions stay inside `{}`.
 
 ```tsx
 component Greeting() {
-  <h1>{'Hello'}</h1>
-  <p>{'Welcome'}</p>
+  <h1>"Hello"</h1>
+  <p>"Welcome"</p>
 }
 ```
+
+Only double quotes have direct-child text meaning. Single-quoted strings and
+template literals remain JavaScript expressions and must be written inside `{}`.
 
 Elsewhere (outside a `component` body), JSX remains an expression, as in standard
 JSX.
@@ -84,9 +89,9 @@ introduced — but framework compilers treat them as _reactive_ boundaries.
 ```tsx
 component List(props: { items: Item[]; showHeader: boolean }) {
   if (props.showHeader) {
-    <h1>{'Items'}</h1>
+    <h1>"Items"</h1>
   } else {
-    <h2>{'(no header)'}</h2>
+    <h2>"(no header)"</h2>
   }
 
   for (const item of props.items) {
@@ -95,10 +100,10 @@ component List(props: { items: Item[]; showHeader: boolean }) {
 
   switch (props.items.length) {
     case 0:
-      <p>{'empty'}</p>
+      <p>"empty"</p>
       break;
     default:
-      <p>{'has items'}</p>
+      <p>"has items"</p>
   }
 
   try {
@@ -169,7 +174,7 @@ children).
 
 ```tsx
 component Page() {
-  const header = <tsx><h1>{'Hello'}</h1></tsx>;
+  const header = <tsx><h1>Hello</h1></tsx>;
   renderSomewhereElse(header);
 }
 ```

--- a/packages/tsrx/src/plugin.js
+++ b/packages/tsrx/src/plugin.js
@@ -175,6 +175,7 @@ export function TSRXPlugin(config) {
 		class TSRXParser extends Parser {
 			/** @type {AST.Node[]} */
 			#path = [];
+			#allowTagStartAfterDoubleQuotedText = false;
 			#commentContextId = 0;
 			#loose = false;
 			/** @type {import('../types/index').CompileError[] | undefined} */
@@ -558,6 +559,10 @@ export function TSRXPlugin(config) {
 			 * @type {Parse.Parser['getTokenFromCode']}
 			 */
 			getTokenFromCode(code) {
+				if (code !== 60) {
+					this.#allowTagStartAfterDoubleQuotedText = false;
+				}
+
 				if (code === 60) {
 					// < character
 					const inComponent = this.#path.findLast((n) => n.type === 'Component');
@@ -634,8 +639,14 @@ export function TSRXPlugin(config) {
 						// Inside component template bodies, allow adjacent tags without requiring
 						// a newline/indentation before the next '<'. This is important for inputs
 						// like `<div />` and `</div><style>...</style>` which Prettier formats.
-						if (prevNonWhitespaceChar === 123 /* '{' */ || prevNonWhitespaceChar === 62 /* '>' */) {
+						if (
+							(prevNonWhitespaceChar === 34 /* '"' */ &&
+								this.#allowTagStartAfterDoubleQuotedText) ||
+							prevNonWhitespaceChar === 123 /* '{' */ ||
+							prevNonWhitespaceChar === 62 /* '>' */
+						) {
 							if (!isWhitespaceAfterLt) {
+								this.#allowTagStartAfterDoubleQuotedText = false;
 								++this.pos;
 								return this.finishToken(tstt.jsxTagStart);
 							}
@@ -712,6 +723,7 @@ export function TSRXPlugin(config) {
 						}
 					}
 				}
+				this.#allowTagStartAfterDoubleQuotedText = false;
 				return super.getTokenFromCode(code);
 			}
 
@@ -1298,6 +1310,26 @@ export function TSRXPlugin(config) {
 					this.expect(tt.bracketR),
 					this.finishNode(t, 'JSXExpressionContainer')
 				);
+			}
+
+			/**
+			 * @returns {AST.TextNode}
+			 */
+			parseDoubleQuotedTextChild() {
+				const node = /** @type {AST.TextNode} */ (this.startNode());
+				const expression = /** @type {AST.Literal} */ (this.startNode());
+				const raw = this.input.slice(this.start, this.end);
+				const end = this.end;
+				const endLoc = this.endLoc;
+
+				expression.value = this.value;
+				expression.raw = raw;
+				node.expression = this.finishNodeAt(expression, 'Literal', end, endLoc);
+
+				this.#allowTagStartAfterDoubleQuotedText = true;
+				this.next();
+
+				return this.finishNodeAt(node, 'Text', end, endLoc);
 			}
 
 			/**
@@ -2293,6 +2325,8 @@ export function TSRXPlugin(config) {
 						delete node.text;
 					}
 					body.push(node);
+				} else if (this.type === tt.string && this.input.charCodeAt(this.start) === 34) {
+					body.push(this.parseDoubleQuotedTextChild());
 				} else if (this.type === tt.braceR) {
 					// Leaving a component/template body. We may still be in TSX/JSX tokenization
 					// context (e.g. after parsing markup), but the closing `}` is a JS token.

--- a/packages/tsrx/src/plugin.js
+++ b/packages/tsrx/src/plugin.js
@@ -1327,7 +1327,11 @@ export function TSRXPlugin(config) {
 				node.expression = this.finishNodeAt(expression, 'Literal', end, endLoc);
 
 				this.#allowTagStartAfterDoubleQuotedText = true;
-				this.next();
+				try {
+					this.next();
+				} finally {
+					this.#allowTagStartAfterDoubleQuotedText = false;
+				}
 
 				return this.finishNodeAt(node, 'Text', end, endLoc);
 			}

--- a/packages/tsrx/tests/shared/compile.js
+++ b/packages/tsrx/tests/shared/compile.js
@@ -96,6 +96,30 @@ export function runSharedCompileTests({ compile, name, classAttrName }) {
 	});
 
 	describe(`[${name}] TypeScript output`, () => {
+		it('accepts direct double-quoted text children', () => {
+			const { code } = compile(
+				`export component App({ count }: { count: number }) {
+					<p>"clicked " {count} " times"</p>
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('"clicked "');
+			expect(code).toContain('{count}');
+			expect(code).toContain('" times"');
+		});
+
+		it('keeps compact string comparisons in expression containers parseable', () => {
+			const { code } = compile(
+				`export component App({ value }: { value: string }) {
+					<p>{"a"<value}</p>
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('{"a" < value}');
+		});
+
 		it('preserves regular function type parameters', () => {
 			const { code } = compile(
 				`type Props<Item> = {

--- a/packages/tsrx/types/parse.d.ts
+++ b/packages/tsrx/types/parse.d.ts
@@ -1174,6 +1174,8 @@ export namespace Parse {
 
 		parseElement(): AST.Element | AST.Tsx | AST.TsxCompat;
 
+		parseDoubleQuotedTextChild(): AST.TextNode;
+
 		parseTemplateBody(
 			body: (AST.Statement | AST.Node | ESTreeJSX.JSXText | ESTreeJSX.JSXElement['children'])[],
 		): void;

--- a/plans/tsrx-double-quoted-text-children.md
+++ b/plans/tsrx-double-quoted-text-children.md
@@ -1,0 +1,90 @@
+# TSRX Double-Quoted Text Children Plan
+
+## Issue
+
+GitHub issue #761 asks for less noisy static text in TSRX templates. Today static
+strings must be written as JavaScript expressions inside braces:
+
+```text
+<p>{'Hello world'}</p>
+<p>{'Clicked '}{count}{' times'}</p>
+```
+
+The requested ergonomic improvement is to allow quoted static text directly
+between template tags.
+
+## Decision
+
+Support only double-quoted static text children:
+
+```text
+<p>"Hello world"</p>
+<p>"Clicked " {count} " times"</p>
+```
+
+Keep all JavaScript expressions inside braces:
+
+```text
+<p>{value}</p>
+<p>{'single quoted JS string'}</p>
+<p>{`Count: ${count}`}</p>
+<p>{count > 0 ? 'Ready' : 'Waiting'}</p>
+```
+
+Rationale:
+
+- Double quotes match JSX attribute string syntax, so the rule feels familiar.
+- Single quotes remain ordinary JavaScript string syntax and avoid ambiguity with
+  prose apostrophes.
+- Backticks remain JavaScript template literals, which preserves interpolation as
+  expression syntax.
+- The parser can lower this shorthand to the existing `Text` node shape, so render
+  targets reuse existing text handling.
+
+## Implementation Slices
+
+1. Parser support in `packages/tsrx/src/plugin.js`.
+   - Recognize a double-quoted string literal in normal TSRX template child
+     position.
+   - Emit the existing `Text` node shape with a `Literal` expression.
+   - Preserve source location/range on both the `Text` node and inner literal.
+   - Do not apply this inside `<tsx>` or `<tsx:*>`, where JSX text semantics
+     should remain unchanged.
+
+2. Render-target verification.
+   - Ripple client/server should reuse existing `Text` lowering and child
+     normalization.
+   - React, Preact, Solid, and Vue targets should reuse shared JSX transform
+     behavior where applicable.
+   - Confirm Solid text-content optimization still sees the parsed node as `Text`.
+
+3. Formatting support.
+   - Update the Prettier plugin to round-trip the shorthand.
+   - Prefer printing eligible static text shorthand with double quotes regardless
+     of the `singleQuote` option, because the feature syntax itself is
+     double-quote-only.
+   - Keep `{text ...}` and non-static expressions in their existing forms.
+
+4. Tests.
+   - Parser coverage for `<p>"hello"</p>` and
+     `<p>"clicked " {count} " times"</p>`.
+   - Escaping coverage such as `<p>"She said \"hi\""</p>`.
+   - Negative or unchanged-behavior coverage for single quotes and backticks
+     outside braces.
+   - Ensure no behavior change inside `<tsx>` / `<tsx:*>` blocks.
+   - Target output coverage for Ripple client/server plus React, Preact, Solid,
+     and Vue where relevant.
+   - Prettier format and round-trip coverage.
+
+5. Documentation.
+   - Update `README.md` and `packages/tsrx/README.md`.
+   - Update `website/public/llms.txt` and `website-tsrx/public/llms.txt`.
+   - Update TSRX website docs/features/specification pages that currently say all
+     text must use braces.
+   - Show direct double-quoted text for static content and braces for expressions.
+
+## First Slice
+
+Proceed with parser support only. Keep formatter, render-target-specific
+assertions, docs, and changesets for follow-up slices after the syntax is accepted
+by the core parser.

--- a/website-new/docs/best-practices.md
+++ b/website-new/docs/best-practices.md
@@ -10,7 +10,8 @@ A summary:
 
 1. **Reactivity**: Use `track()` to create reactive variables and `@` to access
    them
-2. **Strings**: Wrap string literals in `{"string"}` within templates
+2. **Strings**: Use direct double-quoted text children for static text, and `{}`
+   for JavaScript expressions
 3. **Effects**: Use `effect()` for side effects, not direct reactive variable
    access
 4. **Components**: Keep components focused and use TypeScript interfaces for props

--- a/website-new/docs/examples.ts
+++ b/website-new/docs/examples.ts
@@ -242,17 +242,17 @@ export default component App() {
 export default component App() {
 	let count = track(1);
 
-	<button onClick={() => @count++}>{'Increment'}</button>
+	<button onClick={() => @count++}>"Increment"</button>
 
 	switch (@count) {
 		case 1:
-			<div>{'Count is 1'}</div>
+			<div>"Count is 1"</div>
 			break;
 		case 2:
-			<div>{'Count is 2'}</div>
+			<div>"Count is 2"</div>
 			break;
 		default:
-			<div>{'Count is other'}</div>
+			<div>"Count is other"</div>
 	}
 }
 `,
@@ -322,7 +322,7 @@ export default component SuspenseBoundary() {
 	try {
 		<AsyncComponent />
 	} pending {
-		<p>{'Loading...'}</p>
+		<p>"Loading..."</p>
 	}
 }
 `,
@@ -384,7 +384,7 @@ export default component App() {
     }
   });
 
-  <button onClick={() => @count++}>{'Increment'}</button>
+	<button onClick={() => @count++}>"Increment"</button>
 }
 `,
 	},
@@ -461,9 +461,9 @@ export default component App() {
 
   obj.a = 0;
 
-  <pre>{'obj.a is: '}{obj.a}</pre>
-  <pre>{'obj.b is: '}{obj.b}</pre>
-  <button onClick={() => { obj.a++; obj.b = obj.b ?? 5; obj.b++; }}>{'Increment'}</button>
+	<pre>"obj.a is: "{obj.a}</pre>
+	<pre>"obj.b is: "{obj.b}</pre>
+	<button onClick={() => { obj.a++; obj.b = obj.b ?? 5; obj.b++; }}>"Increment"</button>
 }
 `,
 	},
@@ -548,8 +548,8 @@ export default component App() {
 
   <div class="container">
     <p>{@count}</p>
-    <button onClick={() => @count++}>{"Increment"}</button>
-    <button onClick={() => @count = 0}>{"Reset"}</button>
+	<button onClick={() => @count++}>"Increment"</button>
+	<button onClick={() => @count = 0}>"Reset"</button>
   </div>
 
 	<style>
@@ -593,7 +593,7 @@ export default component App() {
   const { quad } = createQuad({ count }); // object
   <p>{'Quadruple: ' + @quad}</p>
 
-  <button onClick={() => { @count++; }}>{'Increment'}</button>
+	<button onClick={() => { @count++; }}>"Increment"</button>
 }
 `,
 	},

--- a/website-new/docs/examples.ts
+++ b/website-new/docs/examples.ts
@@ -2,7 +2,7 @@ export const examples: Array<{ title: string; code: string }> = [
 	{
 		title: 'Hello World',
 		code: `export default component App() {
-  <div>{"Hello World"}</div>
+  <div>"Hello World"</div>
 }`,
 	},
 	{
@@ -18,7 +18,7 @@ export const examples: Array<{ title: string; code: string }> = [
 		code: `import { track } from 'ripple';
 
 export default component App() {
-  <div class="message">{"Hello Ripple!"}</div>
+	<div class="message">"Hello Ripple!"</div>
 
   <InlineStyles />
 
@@ -37,10 +37,10 @@ component InlineStyles() {
   let color = track('#3e95ff');
 
   <p style={\`color: \${@color}; font-weight: bold; background-color: #eee\`}>
-    {'Hello Ripple!'}
+		"Hello Ripple!"
   </p>
   <p style={{ color: @color, fontWeight: 'bold', 'background-color': '#eee' }}>
-    {'Hello Ripple!'}
+		"Hello Ripple!"
   </p>
 
   const style = {
@@ -50,25 +50,25 @@ component InlineStyles() {
   };
 
   // using object spread
-  <p style={{...style}}>{'Hello Ripple!'}</p>
+	<p style={{...style}}>"Hello Ripple!"</p>
 
   // using object directly
-  <p style={style}>{'Hello Ripple!'}</p>
+	<p style={style}>"Hello Ripple!"</p>
 }
 
 component DynamicClasses() {
   let includeBaz = track(true);
   <p class={{ foo: true, bar: false, baz: @includeBaz }}> // becomes: class="foo baz"
-    {'Hello Ripple!'}
+		"Hello Ripple!"
   </p>
 
   <p class={['foo', {baz: false}, 0 && 'bar', [true && 'bat'] ]}> // becomes: class="foo bat"
-    {'Hello Ripple!'}
+		"Hello Ripple!"
   </p>
 
   let count = track(3);
   <p class={['foo', {bar: @count > 2}, @count > 3 && 'bat']}> // becomes: class="foo bar"
-    {'Hello Ripple!'}
+		"Hello Ripple!"
   </p>
 }
 `,
@@ -77,7 +77,7 @@ component DynamicClasses() {
 		title: 'Components',
 		code: `component Card() {
 	<div class="card">
-		<p>{"Card content here"}</p>
+		<p>"Card content here"</p>
 	</div>
 	<style>
 		.card {
@@ -146,7 +146,7 @@ component Card(props: { children: Children }) {
 // Usage
 export default component App() {
 	<Card>
-		<p>{"Card content here"}</p>
+		<p>"Card content here"</p>
 	</Card>
 }
 `,
@@ -184,16 +184,16 @@ export default component App() {
 }
 
 component CustomHeader() {
-	<h1>{'Card Title'}</h1>
+	<h1>"Card Title"</h1>
 }
 
 export default component App() {
 	component Footer() {
-		<p>{'Card footer'}</p>
+		<p>"Card footer"</p>
 	}
 
 	<Card Header={CustomHeader} {Footer}> // <- Header and Footer passed in as props
-		<p>{'Card content here'}</p>
+		<p>"Card content here"</p>
 	</Card>
 }
 `,
@@ -204,13 +204,13 @@ export default component App() {
 
 export default component App() {
 	<div class="app">
-		<h1>{'My App'}</h1>
+		<h1>"My App"</h1>
 
 		{/* This will render inside document.body, not inside the .app div */}
 		<Portal target={document.body}>
 			<div class="modal">
-				<h2>{'I am rendered in document.body!'}</h2>
-				<p>{'This content escapes the normal component tree.'}</p>
+				<h2>"I am rendered in document.body!"</h2>
+				<p>"This content escapes the normal component tree."</p>
 			</div>
 		</Portal>
 	</div>
@@ -351,11 +351,11 @@ export default component Counter() {
 	let quadruple = track(() => @double * 2);
 
 	<div class="container">
-		<p>{"Count: "}{@count}</p>
-		<p>{"Double: "}{@double}</p>
-		<p>{"Quadruple: "}{@quadruple}</p>
-		<button onClick={() => @count++}>{"Increment"}</button>
-		<button onClick={() => @count = 0}>{"Reset"}</button>
+		<p>"Count: "{@count}</p>
+		<p>"Double: "{@double}</p>
+		<p>"Quadruple: "{@quadruple}</p>
+		<button onClick={() => @count++}>"Increment"</button>
+		<button onClick={() => @count = 0}>"Reset"</button>
 	</div>
 
 	<style>
@@ -720,7 +720,7 @@ export default component App() {
     };
   };
 
-  <div {ref divRef}>{"Hello world"}</div>
+	<div {ref divRef}>"Hello world"</div>
 }
 `,
 	},

--- a/website-new/docs/guide/bindings.md
+++ b/website-new/docs/guide/bindings.md
@@ -64,7 +64,7 @@ export component App() {
       {age}
       {' years old'}
     </p>
-    <button onClick={() => (age = age + 1)}>{'Increment'}</button>
+    <button onClick={() => (age = age + 1)}>"Increment"</button>
   </div>
 }
 ```
@@ -260,7 +260,7 @@ export component App() {
     </p>
   </div>
 
-  <button onClick={() => (hobbies = ['reading'])}>{'Reset'}</button>
+  <button onClick={() => (hobbies = ['reading'])}>"Reset"</button>
 }
 ```
 

--- a/website-new/docs/guide/components.md
+++ b/website-new/docs/guide/components.md
@@ -39,12 +39,12 @@ component Card(props: { children: Children }) {
 export component App() {
   // Use implicitly...
   <Card>
-    <p>{'Card content here'}</p>
+    <p>"Card content here"</p>
   </Card>
 
   // or pass children explicitly as a prop.
   component children() {
-    <p>{'Card content here'}</p>
+    <p>"Card content here"</p>
   }
 
   <Card {children} />
@@ -120,17 +120,17 @@ component Card({
 }
 
 component CustomHeader() {
-  <h1>{'Card Title'}</h1>
+  <h1>"Card Title"</h1>
 }
 
 component CustomFooter() {
-  <button>{'Cancel'}</button>
-  <button>{'OK'}</button>
+  <button>"Cancel"</button>
+  <button>"OK"</button>
 }
 
 export component App() {
   <Card Header={CustomHeader} Footer={CustomFooter}>
-    <p>{'Card content here'}</p>
+    <p>"Card content here"</p>
   </Card>
 }
 ```
@@ -240,13 +240,13 @@ import { Portal } from 'ripple';
 
 export component App() {
   <div class="app">
-    <h1>{'My App'}</h1>
+    <h1>"My App"</h1>
 
     {/* This will render inside document.body, not inside the .app div */}
     <Portal target={document.body}>
       <div class="modal">
-        <h2>{'I am rendered in document.body!'}</h2>
-        <p>{'This content escapes the normal component tree.'}</p>
+        <h2>"I am rendered in document.body!"</h2>
+        <p>"This content escapes the normal component tree."</p>
       </div>
     </Portal>
   </div>

--- a/website-new/docs/guide/components.md
+++ b/website-new/docs/guide/components.md
@@ -220,13 +220,13 @@ See [Reactivity](/docs/guide/reactivity#Props-and-Attributes).
 
 ```ripple
 // Object spread
-<div {...properties}>{'Content'}</div>
+<div {...properties}>"Content"</div>
 
 // Shorthand props (when variable name matches prop name)
-<div {onClick} {className}>{'Content'}</div>
+<div {onClick} {className}>"Content"</div>
 
 // Equivalent to:
-<div {onClick} {className}>{'Content'}</div>
+<div {onClick} {className}>"Content"</div>
 ```
 
 ## Portal Component

--- a/website-new/docs/guide/control-flow.md
+++ b/website-new/docs/guide/control-flow.md
@@ -68,16 +68,16 @@ export component StatusIndicator({ status }) {
       case: 'init':
         // fall-through to the next
       case 'loading':
-        <p>{'Loading...'}</p>
+        <p>"Loading..."</p>
         break;
       case 'success':
-        <p>{'Success!'}</p>
+        <p>"Success!"</p>
         break;
       case 'error':
-        <p>{'Error!'}</p>
+        <p>"Error!"</p>
         break;
       default:
-        <p>{'Unknown status'}</p>
+        <p>"Unknown status"</p>
     }
   </div>
 }
@@ -95,22 +95,22 @@ import { track } from 'ripple';
 export component InteractiveStatus() {
   let &[status] = track('loading');
 
-  <button onClick={() => (status = 'success')}>{'Success'}</button>
-  <button onClick={() => (status = 'error')}>{'Error'}</button>
+  <button onClick={() => (status = 'success')}>"Success"</button>
+  <button onClick={() => (status = 'error')}>"Error"</button>
 
   <div>
     switch (status) {
       case 'init':
-        <p>{'Init'}</p>
+        <p>"Init"</p>
       // fall-through to the next
       case 'loading':
-        <p>{'Loading...'}</p>
+        <p>"Loading..."</p>
         break;
       case 'success':
-        <p>{'Success!'}</p>
+        <p>"Success!"</p>
         break;
       case 'error':
-        <p>{'Error!'}</p>
+        <p>"Error!"</p>
         break;
       default:
         <p>{'Unknown status'}</p>
@@ -283,7 +283,7 @@ export component App() {
   try {
     <UserProfile id={1} />
   } pending {
-    <p>{'Loading...'}</p>
+    <p>"Loading..."</p>
   } catch (e) {
     <p>
       {'Error: '}

--- a/website-new/docs/guide/control-flow.md
+++ b/website-new/docs/guide/control-flow.md
@@ -249,9 +249,9 @@ import { track } from 'ripple';
 export component App() {
   let &[tag] = track('div');
 
-  <@tag class="dynamic">{'Hello World'}</@tag>
+  <@tag class="dynamic">"Hello World"</@tag>
   <button onClick={() => (tag = tag === 'div' ? 'span' : 'div')}>
-    {'Toggle Element'}
+    "Toggle Element"
   </button>
 }
 ```

--- a/website-new/docs/guide/dom-refs.md
+++ b/website-new/docs/guide/dom-refs.md
@@ -28,7 +28,7 @@ export default component App() {
     };
   };
 
-  <div {ref divRef}>{'Hello world'}</div>
+  <div {ref divRef}>"Hello world"</div>
 }
 ```
 
@@ -51,7 +51,7 @@ export component App() {
       return () => (div = undefined);
     }}
   >
-    {'Hello world'}
+    "Hello world"
   </div>
 }
 ```
@@ -66,7 +66,7 @@ reactive properties.
 import { fadeIn } from 'some-library';
 
 export component App({ ms }) {
-  <div {ref fadeIn({ ms })}>{'Hello world'}</div>
+  <div {ref fadeIn({ ms })}>"Hello world"</div>
 }
 ```
 

--- a/website-new/docs/guide/reactivity.md
+++ b/website-new/docs/guide/reactivity.md
@@ -250,7 +250,7 @@ export component App() {
       count++;
     }}
   >
-    {'Increment'}
+    "Increment"
   </button>
 }
 ```
@@ -318,7 +318,7 @@ export component App() {
     console.log(count);
   });
 
-  <button onClick={() => count++}>{'Increment'}</button>
+  <button onClick={() => count++}>"Increment"</button>
 }
 ```
 
@@ -352,7 +352,7 @@ export component App() {
     });
   });
 
-  <button onClick={() => count++}>{'Increment'}</button>
+  <button onClick={() => count++}>"Increment"</button>
 }
 ```
 
@@ -500,7 +500,7 @@ export component App() {
       obj.b++;
     }}
   >
-    {'Increment'}
+    "Increment"
   </button>
 }
 ```

--- a/website-new/docs/guide/styling.md
+++ b/website-new/docs/guide/styling.md
@@ -10,7 +10,7 @@ component using the `<style>` element.
 ```ripple
 component MyComponent() {
   <div class="container">
-    <h1>{'Hello World'}</h1>
+    <h1>"Hello World"</h1>
   </div>
 
   <style>

--- a/website-new/docs/guide/syntax.md
+++ b/website-new/docs/guide/syntax.md
@@ -19,7 +19,7 @@ transform that into a function that it can call.
 
 ```ripple
 component Hello() {
-  <span>{'Hello World!'}</span>
+  <span>"Hello World!"</span>
 }
 ```
 
@@ -56,7 +56,7 @@ const myTemplate = <div>
 // ✅ Correct - Templates only inside components
 component MyComponent() {
   // Template syntax is valid here
-  <div>{'Hello World'}</div>
+  <div>"Hello World"</div>
 
   // You can have JavaScript code mixed with templates
   const message = 'Dynamic content';
@@ -173,14 +173,19 @@ then be converted to a string (if it is not already) to be inserted into the DOM
 ## Example: Displaying Text
 
 This is the first place we can notice the difference between Ripple and JSX.
-You'll need to place your text inside {braces} to start an expression. Again, this
-is because Ripple templates are statements rather than expressions, so we cannot
-have text in the middle of the template, as it would be akin to writing text in
-the middle of your code.
+Static text can be written directly as a double-quoted child. Unquoted text is
+still invalid because Ripple templates are statements rather than expressions, so
+bare words in a template would be like writing text in the middle of your code.
+Variables, single-quoted strings, template literals, and other JavaScript
+expressions still use {braces}.
 
 ```ripple
-// ✅ Correct - Text is an expression
+// ✅ Correct - Static text is a direct double-quoted child
+<span>"Hello World!"</span>
+
+// ✅ Correct - JavaScript expressions use braces
 <span>{'Hello World!'}</span>
+<span>{message}</span>
 
 // ❌ Wrong - Compilation error
 <span>Hello World!</span>
@@ -196,11 +201,12 @@ let greet_text = Hello World!;
 ## Example: Text Interpolation
 
 The most basic form of data-binding is text interpolation. In the example below,
-we'll declare a `<span>` element as a statement, then use a pair of {braces} to
-declare an expression, inside which we put our string expression, like we would in
-plain JavaScript.
+we'll declare a `<span>` element as a statement. Direct double-quoted text can sit
+next to dynamic {braces}; JavaScript string and template expressions still go
+inside braces.
 
 ```ripple
+<span>"Message: "{msg}</span>
 <span>{`Message: ${msg}`}</span>
 <span>{'Message: ' + msg}</span>
 ```
@@ -226,12 +232,12 @@ component TemplateScope() {
 
     <h1>{message}</h1>
     <p>
-      {'Count is: '}
+      "Count is: "
       {count}
     </p>
 
     if (isEven) {
-      <span>{'Count is even'}</span>
+      <span>"Count is even"</span>
     }
 
     // Nested scopes work too
@@ -269,7 +275,7 @@ but instead of quotes, we use {braces}, within which, we can write a JS expressi
 that evaluates to our desired value.
 
 ```ripple
-<span data-my-attr={attr_val}>{'Hi there!'}</span>
+<span data-my-attr={attr_val}>"Hi there!"</span>
 ```
 
 ::: info Plain attributes can still be used.
@@ -314,9 +320,10 @@ raw content, refer to [Styling](/docs/guide/styling#Global-Styles).
 
 ## Explicit Text
 
-By default, a `{expression}` in a template can render either text or a fragment.
-If you know the expression will always be text, you can use the `{text}` directive
-to make that explicit:
+Direct double-quoted children are static escaped text. By default, a
+`{expression}` in a template can render either text or a fragment. If you know
+the expression will always be text, you can use the `{text}` directive to make
+that explicit:
 
 ```ripple
 export component Frame({ children }) {

--- a/website-new/docs/troubleshooting.md
+++ b/website-new/docs/troubleshooting.md
@@ -7,12 +7,13 @@ title: Troubleshooting in Ripple
 ## Unterminated regular expression
 
 While this may be caused by an actual unterminated regular expression, most of the
-time, it's caused by not putting your DOM text nodes within expression {braces}.
+time, it's caused by unquoted text in a template. Static text should be written
+as a direct double-quoted child; JavaScript expressions should use {braces}.
 
 ```ripple
 export component TextBrace() {
   // ✔️ valid
-  <p>{'Hello world!'}</p>
+  <p>"Hello world!"</p>
 
   // ❌ invalid
   // <p>Hello world!</p>

--- a/website-new/public/llms.txt
+++ b/website-new/public/llms.txt
@@ -43,16 +43,23 @@ export component App() {
 }
 ```
 
-### ⚠️ Critical: Text Content Must Be in Expressions
+### ⚠️ Critical: Text Content Must Be Explicit
 
-**IMPORTANT**: Unlike HTML or JSX, Ripple elements cannot contain raw text content. All text must be wrapped in JavaScript expressions using curly braces `{}`.
+**IMPORTANT**: Unlike HTML or JSX, Ripple elements cannot contain raw unquoted
+text content. Static text may be written as a direct double-quoted text child.
+Variables, single-quoted strings, template literals, and other JavaScript
+expressions must be wrapped in curly braces `{}`.
 
 ```ripple
-// ❌ WRONG - Raw text not allowed
+// ❌ WRONG - Raw unquoted text not allowed
 <div>Hello World</div>
 <p>This will cause a compilation error</p>
 
-// ✅ CORRECT - Text in expressions
+// ✅ CORRECT - Static text as direct double-quoted children
+<div>"Hello World"</div>
+<p>"This works correctly"</p>
+
+// ✅ CORRECT - JavaScript strings in expressions
 <div>{"Hello World"}</div>
 <p>{"This works correctly"}</p>
 
@@ -61,7 +68,10 @@ export component App() {
 <p>{`Dynamic content: ${value}`}</p>
 ```
 
-This is because Ripple needs to distinguish between JavaScript code and literal strings within the template syntax. The parser cannot determine if `Hello` is meant to be a string literal or a JavaScript identifier without explicit expression syntax.
+This is because Ripple needs to distinguish between JavaScript code and literal
+strings within the template syntax. The parser cannot determine if `Hello` is
+meant to be a string literal or a JavaScript identifier unless static text is
+explicitly double-quoted or dynamic content is wrapped in `{}`.
 
 ### ⚠️ Critical: Templates Only Inside Component Bodies
 
@@ -82,7 +92,7 @@ const myTemplate = (
 // ✅ CORRECT - Templates only inside components
 component MyComponent() {
   // Template syntax is valid here
-  <div>{"Hello World"}</div>
+  <div>"Hello World"</div>
 
   // You can have JavaScript code mixed with templates
   const message = "Dynamic content";
@@ -539,8 +549,8 @@ import { track } from 'ripple';
 export component App() {
   let &[tag] = track('div');
 
-  <@tag class="dynamic">{'Hello World'}</@tag>
-  <button onClick={() => tag = tag === 'div' ? 'span' : 'div'}>{'Toggle Element'}</button>
+  <@tag class="dynamic">"Hello World"</@tag>
+  <button onClick={() => tag = tag === 'div' ? 'span' : 'div'}>"Toggle Element"</button>
 }
 ```
 
@@ -764,13 +774,13 @@ export component App() {
     };
   };
 
-  <div {ref divRef}>{"Hello world"}</div>
+  <div {ref divRef}>"Hello world"</div>
 }
 ```
 
 Inline refs:
 ```ripple
-<div {ref (node) => console.log(node)}>{"Content"}</div>
+<div {ref (node) => console.log(node)}>"Content"</div>
 ```
 
 ## Built-in APIs
@@ -1391,13 +1401,13 @@ effect(() => {
 ### Prop Shortcuts
 ```ripple
 // Object spread
-<div {...properties}>{"Content"}</div>
+<div {...properties}>"Content"</div>
 
 // Shorthand props (when variable name matches prop name)
-<div {onClick} {className}>{"Content"}</div>
+<div {onClick} {className}>"Content"</div>
 
 // Equivalent to:
-<div onClick={onClick} className={className}>{"Content"}</div>
+<div onClick={onClick} className={className}>"Content"</div>
 ```
 
 ### Raw HTML

--- a/website-new/public/llms.txt
+++ b/website-new/public/llms.txt
@@ -276,9 +276,9 @@ export component Counter() {
   let &[double] = track(() => count * 2);  // Derived reactive value
 
   <div>
-    <p>{"Count: "}{count}</p>
-    <p>{"Double: "}{double}</p>
-    <button onClick={() => count++}>{"Increment"}</button>
+    <p>"Count: "{count}</p>
+    <p>"Double: "{double}</p>
+    <button onClick={() => count++}>"Increment"</button>
   </div>
 }
 ```
@@ -384,8 +384,8 @@ export component App() {
 
   const &[double] = createDouble(countTracked);
 
-  <div>{'Double: ' + double}</div>
-  <button onClick={() => { count++; }}>{'Increment'}</button>
+  <div>"Double: "{double}</div>
+  <button onClick={() => { count++; }}>"Increment"</button>
 }
 ```
 
@@ -457,10 +457,10 @@ component StatusIndicator({ status }) {
 		case: 'init':
 			// fall-through to the next
     case 'loading':
-      <p>{'Loading...'}</p>
+      <p>"Loading..."</p>
       break; // break is mandatory
     case 'success':
-      <p>{'Success!'}</p>
+      <p>"Success!"</p>
       break;
     case 'error':
       <p>{'Error!'}</p>
@@ -582,7 +582,7 @@ component Card(props: { children: Children }) {
 
 // Usage
 <Card>
-  <p>{"Card content here"}</p>
+  <p>"Card content here"</p>
 </Card>
 ```
 
@@ -853,7 +853,7 @@ export component App() {
     console.log("Count changed:", count);
   });
 
-  <button onClick={() => count++}>{"Increment"}</button>
+  <button onClick={() => count++}>"Increment"</button>
 }
 ```
 
@@ -880,7 +880,7 @@ export component App() {
     });
   });
 
-  <button onClick={() => count++}>{'Increment'}</button>
+  <button onClick={() => count++}>"Increment"</button>
 }
 ```
 
@@ -1035,9 +1035,9 @@ export component App() {
 
   obj.a = 0;
 
-  <pre>{'obj.a is: '}{obj.a}</pre>
-  <pre>{'obj.b is: '}{obj.b}</pre>
-  <button onClick={() => { obj.a++; obj.b = obj.b ?? 5; obj.b++; }}>{'Increment'}</button>
+  <pre>"obj.a is: "{obj.a}</pre>
+  <pre>"obj.b is: "{obj.b}</pre>
+  <button onClick={() => { obj.a++; obj.b = obj.b ?? 5; obj.b++; }}>"Increment"</button>
 }
 ```
 
@@ -1371,13 +1371,13 @@ import { Portal } from 'ripple';
 
 export component App() {
   <div class="app">
-    <h1>{'My App'}</h1>
+    <h1>"My App"</h1>
 
     {/* This will render inside document.body, not inside the .app div */}
     <Portal target={document.body}>
       <div class="modal">
-        <h2>{'I am rendered in document.body!'}</h2>
-        <p>{'This content escapes the normal component tree.'}</p>
+        <h2>"I am rendered in document.body!"</h2>
+        <p>"This content escapes the normal component tree."</p>
       </div>
     </Portal>
   </div>
@@ -1512,7 +1512,7 @@ export default defineConfig({
 ## Best Practices
 
 1. **Reactivity**: Use `track()` (imported from `'ripple'`) to create reactive variables and `&[]` lazy destructuring to access them
-2. **Strings**: Wrap string literals in `{"string"}` within templates
+2. **Strings**: Use direct double-quoted children for static text, and `{}` for JavaScript expressions
 3. **Effects**: Use `effect()` (imported from `'ripple'`) for side effects, not direct reactive variable access
 4. **Components**: Keep components focused and use TypeScript interfaces for props
 5. **Styling**: Use scoped `<style>` elements for component-specific styles

--- a/website-new/src/components/editor.tsrx
+++ b/website-new/src/components/editor.tsrx
@@ -70,7 +70,7 @@ export component Editor() {
 		<div class="editor-content">
 			<pre class="editor-code" {ref bindNode(nodeRef)}>
 				if (loading) {
-					<span class="editor-loader">{'Loading...'}</span>
+					<span class="editor-loader">{text 'Loading...'}</span>
 				}
 			</pre>
 		</div>

--- a/website-tsrx/public/llms.txt
+++ b/website-tsrx/public/llms.txt
@@ -365,11 +365,11 @@ not helper components.
 component StatusBadge({ status }: { status: string }) {
   <div>
     if (status === 'active') {
-      <span class="badge active">{'Online'}</span>
+      <span class="badge active">"Online"</span>
     } else if (status === 'idle') {
-      <span class="badge idle">{'Away'}</span>
+      <span class="badge idle">"Away"</span>
     } else {
-      <span class="badge">{'Offline'}</span>
+      <span class="badge">"Offline"</span>
     }
   </div>
 }
@@ -403,13 +403,13 @@ fall-through works.
 component StatusMessage({ status }: { status: string }) {
   switch (status) {
     case 'loading':
-      <p>{'Loading...'}</p>
+      <p>"Loading..."</p>
       break;
     case 'success':
-      <p class="success">{'Done!'}</p>
+      <p class="success">"Done!"</p>
       break;
     default:
-      <p>{'Unknown status.'}</p>
+      <p>"Unknown status."</p>
   }
 }
 ```
@@ -426,7 +426,7 @@ component SafeProfile({ userId }: { userId: string }) {
     <UserProfile id={userId} />
   } catch (error) {
     <div class="error">
-      <p>{'Something went wrong.'}</p>
+      <p>"Something went wrong."</p>
     </div>
   }
 }
@@ -453,9 +453,9 @@ export component App() {
   try {
     <UserProfile id={1} />
   } pending {
-    <p>{'Loading...'}</p>
+    <p>"Loading..."</p>
   } catch (e) {
-    <p>{'Something went wrong.'}</p>
+    <p>"Something went wrong."</p>
   }
 }
 ```

--- a/website-tsrx/public/llms.txt
+++ b/website-tsrx/public/llms.txt
@@ -128,27 +128,33 @@ export component Button({ label, onClick }: {
 ### Statement-based JSX
 
 JSX elements are **statements**, not expressions — they appear directly in
-the component body. All text content lives in expression containers `{...}`.
+the component body. Static text can be written as direct double-quoted text
+children. Dynamic values and JavaScript string/template expressions still live
+in expression containers `{...}`.
 
 ```tsrx
 component Greeting() {
-  <h1>{'Hello World'}</h1>
-  <p>{'Welcome to TSRX.'}</p>
+  <h1>"Hello World"</h1>
+  <p>"Welcome to TSRX."</p>
 }
 ```
 
 ```tsrx
-// ❌ WRONG — bare text is not allowed
+// ❌ WRONG — bare unquoted text is not allowed
 <div>Hello World</div>
 
-// ✅ CORRECT — text must be in an expression container
+// ✅ CORRECT — static text may be a double-quoted child
+<div>"Hello World"</div>
+
+// ✅ CORRECT — JS expressions still use braces
 <div>{'Hello World'}</div>
 <div>{`Count: ${count}`}</div>
 <div>{user.name}</div>
 ```
 
-**Why:** the parser cannot tell whether `Hello` is a string literal or a JS
-identifier without explicit `{}`.
+**Why:** unquoted text is ambiguous with JavaScript identifiers. A direct text
+child must be a double-quoted static string; all other values stay explicit with
+`{}`.
 
 ### Using `<>` or `<tsx>` for JSX values
 
@@ -185,19 +191,22 @@ function badge(label: string) {
 - Do not write `const el = <div />;` at the top level of a component.
 - Do not return bare JSX from regular functions without `<>...</>` or `<tsx>...</tsx>`.
 
-### Text expressions: `{ ... }`, `{text ...}`, `{html ...}`
+### Text children and expressions: `"..."`, `{ ... }`, `{text ...}`, `{html ...}`
 
-Every expression container holds a single JS/TS expression — string, template
-literal, variable, ternary, function call. Adjacent `{...}` containers
-concatenate:
+Double-quoted static text may appear directly as a child. Every expression
+container holds a single JS/TS expression — string, template literal, variable,
+ternary, function call. Adjacent text and `{...}` containers concatenate:
 
 ```tsrx
 component Inbox({ name, count }: { name: string; count: number }) {
-  <p>{'Hello, '}{name}{'!'}</p>
+  <p>"Hello, "{name}"!"</p>
   <p>{`You have ${count} unread messages`}</p>
   <p>{count > 0 ? 'Check your inbox.' : 'All caught up.'}</p>
 }
 ```
+
+Only double quotes have this direct-child meaning. Single-quoted strings and
+template literals are JavaScript expressions and must stay inside `{}`.
 
 #### `{text expr}` — forced escaped text (all targets)
 
@@ -690,7 +699,7 @@ component List<T>({ items, render }: Props<T>) {
 | Component declaration    | `component Name(props: T) { ... }`               |
 | Exported component       | `export component Name(...) { ... }`             |
 | JSX as value             | `const v = <tsx><span /></tsx>;`                 |
-| Text content             | `<p>{'literal'}</p>`, `<p>{expr}</p>`            |
+| Text content             | `<p>"literal"</p>`, `<p>{expr}</p>`             |
 | Forced escaped text      | `<span>{text expr}</span>`                       |
 | Raw HTML (Ripple only)   | `<article>{html markup}</article>`               |
 | Lazy prop destructure    | `component C(&{ x, y }: Props) { ... }`          |

--- a/website-tsrx/src/lib/demo-snippets.ts
+++ b/website-tsrx/src/lib/demo-snippets.ts
@@ -85,11 +85,11 @@ export const DEMO_SNIPPETS: DemoSnippet[] = [
 		source: `component StatusBadge({ status }: { status: 'active' | 'idle' | 'offline' }) {
   <div>
     if (status === 'active') {
-      <span class="badge active">{'Online'}</span>
+      <span class="badge active">"Online"</span>
     } else if (status === 'idle') {
-      <span class="badge idle">{'Away'}</span>
+      <span class="badge idle">"Away"</span>
     } else {
-      <span class="badge">{'Offline'}</span>
+      <span class="badge">"Offline"</span>
     }
   </div>
 }`,
@@ -111,13 +111,13 @@ export const DEMO_SNIPPETS: DemoSnippet[] = [
 		source: `component StatusMessage({ status }: { status: string }) {
   switch (status) {
     case 'loading':
-      <p>{'Loading...'}</p>
+      <p>"Loading..."</p>
       break;
     case 'success':
-      <p class="success">{'Done!'}</p>
+      <p class="success">"Done!"</p>
       break;
     default:
-      <p>{'Unknown status.'}</p>
+      <p>"Unknown status."</p>
   }
 }`,
 	},
@@ -129,7 +129,7 @@ export const DEMO_SNIPPETS: DemoSnippet[] = [
     <UserProfile id={userId} />
   } catch (error) {
     <div class="error">
-      <p>{'Something went wrong.'}</p>
+      <p>"Something went wrong."</p>
     </div>
   }
 }`,

--- a/website-tsrx/src/lib/demo-snippets.ts
+++ b/website-tsrx/src/lib/demo-snippets.ts
@@ -75,8 +75,8 @@ export const DEMO_SNIPPETS: DemoSnippet[] = [
 		value: 'statement-jsx',
 		label: 'Statement-based JSX',
 		source: `component Greeting() {
-  <h1>{'Hello World'}</h1>
-  <p>{'Welcome to TSRX.'}</p>
+  <h1>"Hello World"</h1>
+  <p>"Welcome to TSRX."</p>
 }`,
 	},
 	{

--- a/website-tsrx/src/pages/docs.tsrx
+++ b/website-tsrx/src/pages/docs.tsrx
@@ -20,8 +20,8 @@ const COMPONENT_HTML = [
 
 const STATEMENT_HTML = [
 	'<span class="ln">1</span> <span class="kw">component</span> <span class="fn">Greeting</span><span class="br">(</span><span class="br">)</span> <span class="br">{</span>',
-	'<span class="ln">2</span>   <span class="tag">&lt;</span><span class="el">h1</span><span class="tag">&gt;</span><span class="tbr">{</span><span class="str">\'Hello World\'</span><span class="tbr">}</span><span class="tag">&lt;/</span><span class="el">h1</span><span class="tag">&gt;</span>',
-	'<span class="ln">3</span>   <span class="tag">&lt;</span><span class="el">p</span><span class="tag">&gt;</span><span class="tbr">{</span><span class="str">\'Welcome to TSRX.\'</span><span class="tbr">}</span><span class="tag">&lt;/</span><span class="el">p</span><span class="tag">&gt;</span>',
+	'<span class="ln">2</span>   <span class="tag">&lt;</span><span class="el">h1</span><span class="tag">&gt;</span><span class="str">"Hello World"</span><span class="tag">&lt;/</span><span class="el">h1</span><span class="tag">&gt;</span>',
+	'<span class="ln">3</span>   <span class="tag">&lt;</span><span class="el">p</span><span class="tag">&gt;</span><span class="str">"Welcome to TSRX."</span><span class="tag">&lt;/</span><span class="el">p</span><span class="tag">&gt;</span>',
 	'<span class="ln">4</span> <span class="br">}</span>',
 ].join('\n');
 
@@ -319,9 +319,9 @@ export component DocsPage() {
 					<section class="doc-section" id="jsx">
 						<h2 class="section-heading">{'Statement-based JSX'}</h2>
 						<p class="section-body">
-							{'In TSRX, JSX elements are statements — they appear directly in the component body rather than being expressions you assign or return. All text content must be wrapped in '}
+							{'In TSRX, JSX elements are statements — they appear directly in the component body rather than being expressions you assign or return. Static text can be written as direct double-quoted children, while dynamic values and JavaScript expressions still use '}
 							<code class="inline-code">{'{}'}</code>
-							{' expression braces.'}
+							{'.'}
 						</p>
 						<pre class="code-block">
 							<code>{html STATEMENT_HTML}</code>

--- a/website-tsrx/src/pages/features.tsrx
+++ b/website-tsrx/src/pages/features.tsrx
@@ -40,8 +40,8 @@ const BAILOUT_HTML = [
 
 const STATEMENT_HTML = [
 	'<span class="ln">1</span> <span class="kw">component</span> <span class="fn">Greeting</span><span class="br">(</span><span class="br">)</span> <span class="br">{</span>',
-	'<span class="ln">2</span>   <span class="tag">&lt;</span><span class="el">h1</span><span class="tag">&gt;</span><span class="tbr">{</span><span class="str">\'Hello World\'</span><span class="tbr">}</span><span class="tag">&lt;/</span><span class="el">h1</span><span class="tag">&gt;</span>',
-	'<span class="ln">3</span>   <span class="tag">&lt;</span><span class="el">p</span><span class="tag">&gt;</span><span class="tbr">{</span><span class="str">\'Welcome to TSRX.\'</span><span class="tbr">}</span><span class="tag">&lt;/</span><span class="el">p</span><span class="tag">&gt;</span>',
+	'<span class="ln">2</span>   <span class="tag">&lt;</span><span class="el">h1</span><span class="tag">&gt;</span><span class="str">"Hello World"</span><span class="tag">&lt;/</span><span class="el">h1</span><span class="tag">&gt;</span>',
+	'<span class="ln">3</span>   <span class="tag">&lt;</span><span class="el">p</span><span class="tag">&gt;</span><span class="str">"Welcome to TSRX."</span><span class="tag">&lt;/</span><span class="el">p</span><span class="tag">&gt;</span>',
 	'<span class="ln">4</span> <span class="br">}</span>',
 ].join('\n');
 
@@ -54,7 +54,7 @@ const TSX_EXPR_HTML = [
 
 const TEXT_EXPR_HTML = [
 	'<span class="ln">1</span> <span class="kw">component</span> <span class="fn">Inbox</span><span class="br">(</span><span class="br">{</span> <span class="prop">name</span>, <span class="prop">count</span> <span class="br">}</span>: <span class="br">{</span> <span class="prop">name</span>: <span class="type">string</span>; <span class="prop">count</span>: <span class="type">number</span> <span class="br">}</span><span class="br">)</span> <span class="br">{</span>',
-	'<span class="ln">2</span>   <span class="tag">&lt;</span><span class="el">p</span><span class="tag">&gt;</span><span class="tbr">{</span><span class="str">\'Hello, \'</span><span class="tbr">}</span><span class="tbr">{</span><span class="prop">name</span><span class="tbr">}</span><span class="tbr">{</span><span class="str">\'!\'</span><span class="tbr">}</span><span class="tag">&lt;/</span><span class="el">p</span><span class="tag">&gt;</span>',
+	'<span class="ln">2</span>   <span class="tag">&lt;</span><span class="el">p</span><span class="tag">&gt;</span><span class="str">"Hello, "</span><span class="tbr">{</span><span class="prop">name</span><span class="tbr">}</span><span class="str">"!"</span><span class="tag">&lt;/</span><span class="el">p</span><span class="tag">&gt;</span>',
 	'<span class="ln">3</span>   <span class="tag">&lt;</span><span class="el">p</span><span class="tag">&gt;</span><span class="tbr">{</span><span class="str">`You have ${</span><span class="prop">count</span><span class="str">} unread messages`</span><span class="tbr">}</span><span class="tag">&lt;/</span><span class="el">p</span><span class="tag">&gt;</span>',
 	'<span class="ln">4</span>   <span class="tag">&lt;</span><span class="el">p</span><span class="tag">&gt;</span><span class="tbr">{</span><span class="prop">count</span> &gt; <span class="val">0</span> ? <span class="str">\'Check your inbox.\'</span> : <span class="str">\'All caught up.\'</span><span class="tbr">}</span><span class="tag">&lt;/</span><span class="el">p</span><span class="tag">&gt;</span>',
 	'<span class="ln">5</span> <span class="br">}</span>',
@@ -405,9 +405,9 @@ export component FeaturesPage() {
 					<section class="doc-section" id="jsx">
 						<h2 class="section-heading">{'Statement-based JSX'}</h2>
 						<p class="section-body">
-							{'In TSRX, JSX elements are statements — they appear directly in the component body rather than being expressions you assign or return. All text content must be wrapped in '}
+							{'In TSRX, JSX elements are statements — they appear directly in the component body rather than being expressions you assign or return. Static text can be written as direct double-quoted children, while dynamic values and JavaScript expressions still use '}
 							<code class="inline-code">{'{}'}</code>
-							{' expression braces.'}
+							{'.'}
 						</p>
 						<pre class="code-block">
 							<code>{html STATEMENT_HTML}</code>
@@ -427,9 +427,9 @@ export component FeaturesPage() {
 					<section class="doc-section" id="text-expressions">
 						<h2 class="section-heading">{'Text expressions'}</h2>
 						<p class="section-body">
-							{'Because JSX is statement-based, bare text can\'t sit directly inside an element the way it does in React. Every piece of text content — even literal strings — lives inside an expression container '}
+							{'Because JSX is statement-based, unquoted bare text can\'t sit directly inside an element the way it does in React. Static text may be written as a direct double-quoted child. JavaScript string literals, template literals, variables, function calls, ternaries, and other dynamic values live inside expression containers '}
 							<code class="inline-code">{'{ ... }'}</code>
-							{'. Each container holds a single JS/TS expression: a string literal, a template literal, a variable, a function call, a ternary, anything that evaluates to a value.'}
+							{'.'}
 						</p>
 						<pre class="code-block">
 							<code>{html TEXT_EXPR_HTML}</code>
@@ -437,7 +437,7 @@ export component FeaturesPage() {
 						<p class="section-body">
 							{'Adjacent '}
 							<code class="inline-code">{'{ ... }'}</code>
-							{' containers concatenate when rendered, so you can mix static strings with dynamic values without extra wrapping elements. Expressions are re-evaluated whenever their dependencies change, so dynamic text updates automatically on reactive targets like Ripple and Solid.'}
+							{' containers concatenate with adjacent double-quoted text when rendered, so you can mix static strings with dynamic values without extra wrapping elements. Expressions are re-evaluated whenever their dependencies change, so dynamic text updates automatically on reactive targets like Ripple and Solid.'}
 						</p>
 						<p class="section-body">
 							{'A bare '}

--- a/website-tsrx/src/pages/specification.tsrx
+++ b/website-tsrx/src/pages/specification.tsrx
@@ -45,6 +45,9 @@ const TSX_GRAMMAR = [
 ].join('\n');
 
 const TEMPLATE_EXPRESSION_GRAMMAR = [
+	'DoubleQuotedTextChild :',
+	'  " StringCharactersopt "',
+	'',
 	'TemplateExpression :',
 	'  { AssignmentExpression }',
 	'  { text AssignmentExpression }',
@@ -383,7 +386,7 @@ export component SpecificationPage() {
 							{'Within a component body, element forms are admitted as template statements rather than as generic expressions. This statement-oriented model is normative. A tree that contributes directly to a component body is not interchangeable with an ordinary expression value.'}
 						</p>
 						<p class="section-body">
-							{'Template position also admits braced expression forms. The ordinary form '}
+							{'Template position also admits direct double-quoted static text children and braced expression forms. The ordinary form '}
 							<code class="inline-code">{'{ AssignmentExpression }'}</code>
 							{' contributes a generic template-expression node. The keyword-prefixed forms '}
 							<code class="inline-code">{'{text AssignmentExpression}'}</code>
@@ -395,6 +398,11 @@ export component SpecificationPage() {
 							<code>{TEMPLATE_EXPRESSION_GRAMMAR}</code>
 						</pre>
 						<ul class="spec-list">
+							<li>
+								{'A direct double-quoted text child is represented by '}
+								<code class="inline-code">{'Text'}</code>
+								{' with a string literal expression and contributes escaped static text.'}
+							</li>
 							<li>
 								<code class="inline-code">{'{ AssignmentExpression }'}</code>
 								{' is the generic template-expression form and is represented by '}
@@ -638,7 +646,7 @@ export component SpecificationPage() {
 								{'TSRXExpression wraps the embedded ECMAScript expression from the ordinary {expr} template form.'}
 							</li>
 							<li>
-								{'Text wraps the embedded ECMAScript expression from the explicit {text expr} form and marks it for escaped text handling.'}
+								{'Text wraps either a direct double-quoted static string literal child or the embedded ECMAScript expression from the explicit {text expr} form, and marks it for escaped text handling.'}
 							</li>
 							<li>
 								{'Html wraps the embedded ECMAScript expression from the explicit {html expr} form and marks it for host-defined raw-markup handling.'}

--- a/website/docs/best-practices.md
+++ b/website/docs/best-practices.md
@@ -10,7 +10,8 @@ A summary:
 
 1. **Reactivity**: Use `track()` to create reactive variables and `@` to access
    them
-2. **Strings**: Wrap string literals in `{"string"}` within templates
+2. **Strings**: Use direct double-quoted text children for static text, and `{}`
+   for JavaScript expressions
 3. **Effects**: Use `effect()` for side effects, not direct reactive variable
    access
 4. **Components**: Keep components focused and use TypeScript interfaces for props

--- a/website/docs/examples.ts
+++ b/website/docs/examples.ts
@@ -250,17 +250,17 @@ export default component App() {
 export default component App() {
 	let &[count] = track(1);
 
-	<button onClick={() => count++}>{'Increment'}</button>
+	<button onClick={() => count++}>"Increment"</button>
 
 	switch (count) {
 		case 1:
-			<div>{'Count is 1'}</div>
+			<div>"Count is 1"</div>
 			break;
 		case 2:
-			<div>{'Count is 2'}</div>
+			<div>"Count is 2"</div>
 			break;
 		default:
-			<div>{'Count is other'}</div>
+			<div>"Count is other"</div>
 	}
 }
 `,
@@ -330,7 +330,7 @@ export default component SuspenseBoundary() {
 	try {
 		<AsyncComponent />
 	} pending {
-		<p>{'Loading...'}</p>
+		<p>"Loading..."</p>
 	}
 }
 `,
@@ -392,7 +392,7 @@ export default component App() {
     }
   });
 
-  <button onClick={() => count++}>{'Increment'}</button>
+	<button onClick={() => count++}>"Increment"</button>
 }
 `,
 	},
@@ -469,9 +469,9 @@ export default component App() {
 
   obj.a = 0;
 
-  <pre>{'obj.a is: '}{obj.a}</pre>
-  <pre>{'obj.b is: '}{obj.b}</pre>
-  <button onClick={() => { obj.a++; obj.b = obj.b ?? 5; obj.b++; }}>{'Increment'}</button>
+	<pre>"obj.a is: "{obj.a}</pre>
+	<pre>"obj.b is: "{obj.b}</pre>
+	<button onClick={() => { obj.a++; obj.b = obj.b ?? 5; obj.b++; }}>"Increment"</button>
 }
 `,
 	},
@@ -556,8 +556,8 @@ export default component App() {
 
   <div class="container">
     <p>{count}</p>
-    <button onClick={() => count++}>{"Increment"}</button>
-    <button onClick={() => count = 0}>{"Reset"}</button>
+	<button onClick={() => count++}>"Increment"</button>
+	<button onClick={() => count = 0}>"Reset"</button>
   </div>
 
 	<style>
@@ -601,7 +601,7 @@ export default component App() {
   const &{ quad } = createQuad({ count }); // object
   <p>{'Quadruple: ' + quad}</p>
 
-  <button onClick={() => { count++; }}>{'Increment'}</button>
+	<button onClick={() => { count++; }}>"Increment"</button>
 }
 `,
 	},

--- a/website/docs/examples.ts
+++ b/website/docs/examples.ts
@@ -2,7 +2,7 @@ export const examples: Array<{ title: string; code: string }> = [
 	{
 		title: 'Hello World',
 		code: `export default component App() {
-  <div>{"Hello World"}</div>
+  <div>"Hello World"</div>
 }`,
 	},
 	{
@@ -18,7 +18,7 @@ export const examples: Array<{ title: string; code: string }> = [
 		code: `import { track } from 'ripple';
 
 export default component App() {
-  <div class="message">{"Hello Ripple!"}</div>
+	<div class="message">"Hello Ripple!"</div>
 
   <InlineStyles />
 
@@ -37,10 +37,10 @@ component InlineStyles() {
   let &[color] = track('#3e95ff');
 
   <p style={\`color: \${color}; font-weight: bold; background-color: #eee\`}>
-    {'Hello Ripple!'}
+		"Hello Ripple!"
   </p>
   <p style={{ color: color, fontWeight: 'bold', 'background-color': '#eee' }}>
-    {'Hello Ripple!'}
+		"Hello Ripple!"
   </p>
 
   const style = {
@@ -50,25 +50,25 @@ component InlineStyles() {
   };
 
   // using object spread
-  <p style={{...style}}>{'Hello Ripple!'}</p>
+	<p style={{...style}}>"Hello Ripple!"</p>
 
   // using object directly
-  <p style={style}>{'Hello Ripple!'}</p>
+	<p style={style}>"Hello Ripple!"</p>
 }
 
 component DynamicClasses() {
   let &[includeBaz] = track(true);
   <p class={{ foo: true, bar: false, baz: includeBaz }}> // becomes: class="foo baz"
-    {'Hello Ripple!'}
+		"Hello Ripple!"
   </p>
 
   <p class={['foo', {baz: false}, 0 && 'bar', [true && 'bat'] ]}> // becomes: class="foo bat"
-    {'Hello Ripple!'}
+		"Hello Ripple!"
   </p>
 
   let &[count] = track(3);
   <p class={['foo', {bar: count > 2}, count > 3 && 'bat']}> // becomes: class="foo bar"
-    {'Hello Ripple!'}
+		"Hello Ripple!"
   </p>
 }
 `,
@@ -77,7 +77,7 @@ component DynamicClasses() {
 		title: 'Components',
 		code: `component Card() {
 	<div class="card">
-		<p>{"Card content here"}</p>
+		<p>"Card content here"</p>
 	</div>
 	<style>
 		.card {
@@ -146,7 +146,7 @@ component Card(props: { children: Children }) {
 // Usage
 export default component App() {
 	<Card>
-		<p>{"Card content here"}</p>
+		<p>"Card content here"</p>
 	</Card>
 }
 `,
@@ -192,16 +192,16 @@ component Card(&{ children, Header, Footer }) {
 }
 
 component CustomHeader() {
-	<h1>{'Card Title'}</h1>
+	<h1>"Card Title"</h1>
 }
 
 component Footer() {
-	<p>{'Card footer'}</p>
+	<p>"Card footer"</p>
 }
 
 export default component App() {
 	<Card Header={CustomHeader} Footer={Footer}>
-		<p>{'Card content here'}</p>
+		<p>"Card content here"</p>
 	</Card>
 }
 `,
@@ -212,13 +212,13 @@ export default component App() {
 
 export default component App() {
 	<div class="app">
-		<h1>{'My App'}</h1>
+		<h1>"My App"</h1>
 
 		{/* This will render inside document.body, not inside the .app div */}
 		<Portal target={document.body}>
 			<div class="modal">
-				<h2>{'I am rendered in document.body!'}</h2>
-				<p>{'This content escapes the normal component tree.'}</p>
+				<h2>"I am rendered in document.body!"</h2>
+				<p>"This content escapes the normal component tree."</p>
 			</div>
 		</Portal>
 	</div>
@@ -359,11 +359,11 @@ export default component Counter() {
 	let &[quadruple] = track(() => double * 2);
 
 	<div class="container">
-		<p>{"Count: "}{count}</p>
-		<p>{"Double: "}{double}</p>
-		<p>{"Quadruple: "}{quadruple}</p>
-		<button onClick={() => count++}>{"Increment"}</button>
-		<button onClick={() => count = 0}>{"Reset"}</button>
+		<p>"Count: "{count}</p>
+		<p>"Double: "{double}</p>
+		<p>"Quadruple: "{quadruple}</p>
+		<button onClick={() => count++}>"Increment"</button>
+		<button onClick={() => count = 0}>"Reset"</button>
 	</div>
 
 	<style>
@@ -728,7 +728,7 @@ export default component App() {
     };
   };
 
-  <div {ref divRef}>{"Hello world"}</div>
+	<div {ref divRef}>"Hello world"</div>
 }
 `,
 	},

--- a/website/docs/guide/bindings.md
+++ b/website/docs/guide/bindings.md
@@ -64,7 +64,7 @@ export component App() {
       {age}
       {' years old'}
     </p>
-    <button onClick={() => (age = age + 1)}>{'Increment'}</button>
+    <button onClick={() => (age = age + 1)}>"Increment"</button>
   </div>
 }
 ```
@@ -260,7 +260,7 @@ export component App() {
     </p>
   </div>
 
-  <button onClick={() => (hobbies = ['reading'])}>{'Reset'}</button>
+  <button onClick={() => (hobbies = ['reading'])}>"Reset"</button>
 }
 ```
 

--- a/website/docs/guide/components.md
+++ b/website/docs/guide/components.md
@@ -39,12 +39,12 @@ component Card(props: { children: Children }) {
 export component App() {
   // Use implicitly...
   <Card>
-    <p>{'Card content here'}</p>
+    <p>"Card content here"</p>
   </Card>
 
   // or pass children explicitly as a prop.
   component children() {
-    <p>{'Card content here'}</p>
+    <p>"Card content here"</p>
   }
 
   <Card {children} />
@@ -120,17 +120,17 @@ component Card({
 }
 
 component CustomHeader() {
-  <h1>{'Card Title'}</h1>
+  <h1>"Card Title"</h1>
 }
 
 component CustomFooter() {
-  <button>{'Cancel'}</button>
-  <button>{'OK'}</button>
+  <button>"Cancel"</button>
+  <button>"OK"</button>
 }
 
 export component App() {
   <Card Header={CustomHeader} Footer={CustomFooter}>
-    <p>{'Card content here'}</p>
+    <p>"Card content here"</p>
   </Card>
 }
 ```
@@ -240,13 +240,13 @@ import { Portal } from 'ripple';
 
 export component App() {
   <div class="app">
-    <h1>{'My App'}</h1>
+    <h1>"My App"</h1>
 
     {/* This will render inside document.body, not inside the .app div */}
     <Portal target={document.body}>
       <div class="modal">
-        <h2>{'I am rendered in document.body!'}</h2>
-        <p>{'This content escapes the normal component tree.'}</p>
+        <h2>"I am rendered in document.body!"</h2>
+        <p>"This content escapes the normal component tree."</p>
       </div>
     </Portal>
   </div>

--- a/website/docs/guide/components.md
+++ b/website/docs/guide/components.md
@@ -220,13 +220,13 @@ See [Reactivity](/docs/guide/reactivity#Props-and-Attributes).
 
 ```ripple
 // Object spread
-<div {...properties}>{'Content'}</div>
+<div {...properties}>"Content"</div>
 
 // Shorthand props (when variable name matches prop name)
-<div {onClick} {className}>{'Content'}</div>
+<div {onClick} {className}>"Content"</div>
 
 // Equivalent to:
-<div {onClick} {className}>{'Content'}</div>
+<div {onClick} {className}>"Content"</div>
 ```
 
 ## Portal Component

--- a/website/docs/guide/control-flow.md
+++ b/website/docs/guide/control-flow.md
@@ -68,16 +68,16 @@ export component StatusIndicator({ status }) {
       case: 'init':
         // fall-through to the next
       case 'loading':
-        <p>{'Loading...'}</p>
+        <p>"Loading..."</p>
         break;
       case 'success':
-        <p>{'Success!'}</p>
+        <p>"Success!"</p>
         break;
       case 'error':
-        <p>{'Error!'}</p>
+        <p>"Error!"</p>
         break;
       default:
-        <p>{'Unknown status'}</p>
+        <p>"Unknown status"</p>
     }
   </div>
 }
@@ -95,22 +95,22 @@ import { track } from 'ripple';
 export component InteractiveStatus() {
   let &[status] = track('loading');
 
-  <button onClick={() => (status = 'success')}>{'Success'}</button>
-  <button onClick={() => (status = 'error')}>{'Error'}</button>
+  <button onClick={() => (status = 'success')}>"Success"</button>
+  <button onClick={() => (status = 'error')}>"Error"</button>
 
   <div>
     switch (status) {
       case 'init':
-        <p>{'Init'}</p>
+        <p>"Init"</p>
       // fall-through to the next
       case 'loading':
-        <p>{'Loading...'}</p>
+        <p>"Loading..."</p>
         break;
       case 'success':
-        <p>{'Success!'}</p>
+        <p>"Success!"</p>
         break;
       case 'error':
-        <p>{'Error!'}</p>
+        <p>"Error!"</p>
         break;
       default:
         <p>{'Unknown status'}</p>
@@ -283,7 +283,7 @@ export component App() {
   try {
     <UserProfile id={1} />
   } pending {
-    <p>{'Loading...'}</p>
+    <p>"Loading..."</p>
   } catch (e) {
     <p>
       {'Error: '}

--- a/website/docs/guide/control-flow.md
+++ b/website/docs/guide/control-flow.md
@@ -249,9 +249,9 @@ import { track } from 'ripple';
 export component App() {
   let &[tag] = track('div');
 
-  <@tag class="dynamic">{'Hello World'}</@tag>
+  <@tag class="dynamic">"Hello World"</@tag>
   <button onClick={() => (tag = tag === 'div' ? 'span' : 'div')}>
-    {'Toggle Element'}
+    "Toggle Element"
   </button>
 }
 ```

--- a/website/docs/guide/dom-refs.md
+++ b/website/docs/guide/dom-refs.md
@@ -28,7 +28,7 @@ export default component App() {
     };
   };
 
-  <div {ref divRef}>{'Hello world'}</div>
+  <div {ref divRef}>"Hello world"</div>
 }
 ```
 
@@ -51,7 +51,7 @@ export component App() {
       return () => (div = undefined);
     }}
   >
-    {'Hello world'}
+    "Hello world"
   </div>
 }
 ```
@@ -66,7 +66,7 @@ reactive properties.
 import { fadeIn } from 'some-library';
 
 export component App({ ms }) {
-  <div {ref fadeIn({ ms })}>{'Hello world'}</div>
+  <div {ref fadeIn({ ms })}>"Hello world"</div>
 }
 ```
 

--- a/website/docs/guide/reactivity.md
+++ b/website/docs/guide/reactivity.md
@@ -250,7 +250,7 @@ export component App() {
       count++;
     }}
   >
-    {'Increment'}
+    "Increment"
   </button>
 }
 ```
@@ -318,7 +318,7 @@ export component App() {
     console.log(count);
   });
 
-  <button onClick={() => count++}>{'Increment'}</button>
+  <button onClick={() => count++}>"Increment"</button>
 }
 ```
 
@@ -352,7 +352,7 @@ export component App() {
     });
   });
 
-  <button onClick={() => count++}>{'Increment'}</button>
+  <button onClick={() => count++}>"Increment"</button>
 }
 ```
 
@@ -500,7 +500,7 @@ export component App() {
       obj.b++;
     }}
   >
-    {'Increment'}
+    "Increment"
   </button>
 }
 ```

--- a/website/docs/guide/styling.md
+++ b/website/docs/guide/styling.md
@@ -10,7 +10,7 @@ component using the `<style>` element.
 ```ripple
 component MyComponent() {
   <div class="container">
-    <h1>{'Hello World'}</h1>
+    <h1>"Hello World"</h1>
   </div>
 
   <style>

--- a/website/docs/guide/syntax.md
+++ b/website/docs/guide/syntax.md
@@ -19,7 +19,7 @@ transform that into a function that it can call.
 
 ```ripple
 component Hello() {
-  <span>{'Hello World!'}</span>
+  <span>"Hello World!"</span>
 }
 ```
 
@@ -52,7 +52,7 @@ const myTemplate = (
 // ✅ Correct - Templates only inside components
 component MyComponent() {
 	// Template syntax is valid here
-	<div>{"Hello World"}</div>
+  <div>"Hello World"</div>
 
 	// You can have JavaScript code mixed with templates
 	const message = "Dynamic content";
@@ -169,14 +169,19 @@ then be converted to a string (if it is not already) to be inserted into the DOM
 ## Example: Displaying Text
 
 This is the first place we can notice the difference between Ripple and JSX.
-You'll need to place your text inside {braces} to start an expression. Again, this
-is because Ripple templates are statements rather than expressions, so we cannot
-have text in the middle of the template, as it would be akin to writing text in
-the middle of your code.
+Static text can be written directly as a double-quoted child. Unquoted text is
+still invalid because Ripple templates are statements rather than expressions, so
+bare words in a template would be like writing text in the middle of your code.
+Variables, single-quoted strings, template literals, and other JavaScript
+expressions still use {braces}.
 
 ```ripple
-// ✅ Correct - Text is an expression
+// ✅ Correct - Static text is a direct double-quoted child
+<span>"Hello World!"</span>
+
+// ✅ Correct - JavaScript expressions use braces
 <span>{'Hello World!'}</span>
+<span>{message}</span>
 
 // ❌ Wrong - Compilation error
 <span>Hello World!</span>
@@ -192,11 +197,12 @@ let greet_text = Hello World!;
 ## Example: Text Interpolation
 
 The most basic form of data-binding is text interpolation. In the example below,
-we'll declare a `<span>` element as a statement, then use a pair of {braces} to
-declare an expression, inside which we put our string expression, like we would in
-plain JavaScript.
+we'll declare a `<span>` element as a statement. Direct double-quoted text can sit
+next to dynamic {braces}; JavaScript string and template expressions still go
+inside braces.
 
 ```ripple
+<span>"Message: "{msg}</span>
 <span>{`Message: ${msg}`}</span>
 <span>{'Message: ' + msg}</span>
 ```
@@ -222,12 +228,12 @@ component TemplateScope() {
 
     <h1>{message}</h1>
     <p>
-      {'Count is: '}
+      "Count is: "
       {count}
     </p>
 
     if (isEven) {
-      <span>{'Count is even'}</span>
+      <span>"Count is even"</span>
     }
 
     // Nested scopes work too
@@ -265,7 +271,7 @@ but instead of quotes, we use {braces}, within which, we can write a JS expressi
 that evaluates to our desired value.
 
 ```ripple
-<span data-my-attr={attr_val}>{'Hi there!'}</span>
+<span data-my-attr={attr_val}>"Hi there!"</span>
 ```
 
 ::: info Plain attributes can still be used.
@@ -310,9 +316,10 @@ raw content, refer to [Styling](/docs/guide/styling#Global-Styles).
 
 ## Explicit Text
 
-By default, a `{expression}` in a template can render either text or an fragment.
-If you know the expression will always be text, you can use the `{text}` directive
-to make that explicit:
+Direct double-quoted children are static escaped text. By default, a
+`{expression}` in a template can render either text or a fragment. If you know
+the expression will always be text, you can use the `{text}` directive to make
+that explicit:
 
 ```ripple
 export component Frame({ children }) {

--- a/website/docs/troubleshooting.md
+++ b/website/docs/troubleshooting.md
@@ -7,12 +7,13 @@ title: Troubleshooting in Ripple
 ## Unterminated regular expression
 
 While this may be caused by an actual unterminated regular expression, most of the
-time, it's caused by not putting your DOM text nodes within expression {braces}.
+time, it's caused by unquoted text in a template. Static text should be written
+as a direct double-quoted child; JavaScript expressions should use {braces}.
 
 ```ripple
 export component TextBrace() {
   // ✔️ valid
-  <p>{'Hello world!'}</p>
+  <p>"Hello world!"</p>
 
   // ❌ invalid
   // <p>Hello world!</p>

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -276,9 +276,9 @@ export component Counter() {
   let &[double] = track(() => count * 2);  // Derived reactive value
 
   <div>
-    <p>{"Count: "}{count}</p>
-    <p>{"Double: "}{double}</p>
-    <button onClick={() => count++}>{"Increment"}</button>
+    <p>"Count: "{count}</p>
+    <p>"Double: "{double}</p>
+    <button onClick={() => count++}>"Increment"</button>
   </div>
 }
 ```
@@ -470,8 +470,8 @@ export component App() {
 
   const &[double] = createDouble(countTracked);
 
-  <div>{'Double: ' + double}</div>
-  <button onClick={() => { count++; }}>{'Increment'}</button>
+  <div>"Double: "{double}</div>
+  <button onClick={() => { count++; }}>"Increment"</button>
 }
 ```
 
@@ -543,10 +543,10 @@ component StatusIndicator({ status }) {
 		case: 'init':
 			// fall-through to the next
     case 'loading':
-      <p>{'Loading...'}</p>
+      <p>"Loading..."</p>
       break; // break is mandatory
     case 'success':
-      <p>{'Success!'}</p>
+      <p>"Success!"</p>
       break;
     case 'error':
       <p>{'Error!'}</p>
@@ -670,12 +670,12 @@ component Card(props: { children: Children; Footer?: Component }) {
 }
 
 component Footer() {
-  <button>{'OK'}</button>
+  <button>"OK"</button>
 }
 
 // Usage
 <Card Footer={Footer}>
-  <p>{"Card content here"}</p>
+  <p>"Card content here"</p>
 </Card>
 ```
 
@@ -946,7 +946,7 @@ export component App() {
     console.log("Count changed:", count);
   });
 
-  <button onClick={() => count++}>{"Increment"}</button>
+  <button onClick={() => count++}>"Increment"</button>
 }
 ```
 
@@ -973,7 +973,7 @@ export component App() {
     });
   });
 
-  <button onClick={() => count++}>{'Increment'}</button>
+  <button onClick={() => count++}>"Increment"</button>
 }
 ```
 
@@ -1128,9 +1128,9 @@ export component App() {
 
   obj.a = 0;
 
-  <pre>{'obj.a is: '}{obj.a}</pre>
-  <pre>{'obj.b is: '}{obj.b}</pre>
-  <button onClick={() => { obj.a++; obj.b = obj.b ?? 5; obj.b++; }}>{'Increment'}</button>
+  <pre>"obj.a is: "{obj.a}</pre>
+  <pre>"obj.b is: "{obj.b}</pre>
+  <button onClick={() => { obj.a++; obj.b = obj.b ?? 5; obj.b++; }}>"Increment"</button>
 }
 ```
 
@@ -1464,13 +1464,13 @@ import { Portal } from 'ripple';
 
 export component App() {
   <div class="app">
-    <h1>{'My App'}</h1>
+    <h1>"My App"</h1>
 
     {/* This will render inside document.body, not inside the .app div */}
     <Portal target={document.body}>
       <div class="modal">
-        <h2>{'I am rendered in document.body!'}</h2>
-        <p>{'This content escapes the normal component tree.'}</p>
+        <h2>"I am rendered in document.body!"</h2>
+        <p>"This content escapes the normal component tree."</p>
       </div>
     </Portal>
   </div>
@@ -1640,7 +1640,7 @@ export default defineConfig({
 ## Best Practices
 
 1. **Reactivity**: Use `track()` (imported from `'ripple'`) with `&[]` lazy destructuring to create reactive variables
-2. **Strings**: Wrap string literals in `{"string"}` within templates
+2. **Strings**: Use direct double-quoted children for static text, and `{}` for JavaScript expressions
 3. **Effects**: Use `effect()` (imported from `'ripple'`) for side effects, not direct reactive variable access
 4. **Components**: Keep components focused and use TypeScript interfaces for props
 5. **Styling**: Use scoped `<style>` elements for component-specific styles

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -43,16 +43,23 @@ export component App() {
 }
 ```
 
-### ⚠️ Critical: Text Content Must Be in Expressions
+### ⚠️ Critical: Text Content Must Be Explicit
 
-**IMPORTANT**: Unlike HTML or JSX, Ripple elements cannot contain raw text content. All text must be wrapped in JavaScript expressions using curly braces `{}`.
+**IMPORTANT**: Unlike HTML or JSX, Ripple elements cannot contain raw unquoted
+text content. Static text may be written as a direct double-quoted text child.
+Variables, single-quoted strings, template literals, and other JavaScript
+expressions must be wrapped in curly braces `{}`.
 
 ```ripple
-// ❌ WRONG - Raw text not allowed
+// ❌ WRONG - Raw unquoted text not allowed
 <div>Hello World</div>
 <p>This will cause a compilation error</p>
 
-// ✅ CORRECT - Text in expressions
+// ✅ CORRECT - Static text as direct double-quoted children
+<div>"Hello World"</div>
+<p>"This works correctly"</p>
+
+// ✅ CORRECT - JavaScript strings in expressions
 <div>{"Hello World"}</div>
 <p>{"This works correctly"}</p>
 
@@ -61,7 +68,10 @@ export component App() {
 <p>{`Dynamic content: ${value}`}</p>
 ```
 
-This is because Ripple needs to distinguish between JavaScript code and literal strings within the template syntax. The parser cannot determine if `Hello` is meant to be a string literal or a JavaScript identifier without explicit expression syntax.
+This is because Ripple needs to distinguish between JavaScript code and literal
+strings within the template syntax. The parser cannot determine if `Hello` is
+meant to be a string literal or a JavaScript identifier unless static text is
+explicitly double-quoted or dynamic content is wrapped in `{}`.
 
 ### ⚠️ Critical: Templates Only Inside Component Bodies
 
@@ -82,7 +92,7 @@ const myTemplate = (
 // ✅ CORRECT - Templates only inside components
 component MyComponent() {
   // Template syntax is valid here
-  <div>{"Hello World"}</div>
+  <div>"Hello World"</div>
 
   // You can have JavaScript code mixed with templates
   const message = "Dynamic content";
@@ -625,8 +635,8 @@ import { track } from 'ripple';
 export component App() {
   let &[tag] = track('div');
 
-  <@tag class="dynamic">{'Hello World'}</@tag>
-  <button onClick={() => tag = tag === 'div' ? 'span' : 'div'}>{'Toggle Element'}</button>
+  <@tag class="dynamic">"Hello World"</@tag>
+  <button onClick={() => tag = tag === 'div' ? 'span' : 'div'}>"Toggle Element"</button>
 }
 ```
 
@@ -857,13 +867,13 @@ export component App() {
     };
   };
 
-  <div {ref divRef}>{"Hello world"}</div>
+  <div {ref divRef}>"Hello world"</div>
 }
 ```
 
 Inline refs:
 ```ripple
-<div {ref (node) => console.log(node)}>{"Content"}</div>
+<div {ref (node) => console.log(node)}>"Content"</div>
 ```
 
 ## Built-in APIs
@@ -1484,13 +1494,13 @@ effect(() => {
 ### Prop Shortcuts
 ```ripple
 // Object spread
-<div {...properties}>{"Content"}</div>
+<div {...properties}>"Content"</div>
 
 // Shorthand props (when variable name matches prop name)
-<div {onClick} {className}>{"Content"}</div>
+<div {onClick} {className}>"Content"</div>
 
 // Equivalent to:
-<div onClick={onClick} className={className}>{"Content"}</div>
+<div onClick={onClick} className={className}>"Content"</div>
 ```
 
 ### Raw HTML
@@ -1513,9 +1523,10 @@ export component App() {
 
 ### Explicit Text
 
-By default, a `{expression}` in a template can render either text or a
-fragment. If you know the expression will always be text, use the `{text}`
-directive to make that explicit:
+Direct double-quoted children are static escaped text. By default, a
+`{expression}` in a template can render either text or a fragment. If you know
+the expression will always be text, use the `{text}` directive to make that
+explicit:
 
 ```ripple
 export component Frame({ children }) {


### PR DESCRIPTION
Fixes https://github.com/Ripple-TS/ripple/issues/761#issue-3997427858

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new parsing/tokenization behavior inside `component` template bodies, which can subtly affect JSX/tag vs TypeScript-generic disambiguation and downstream compilation for existing `.tsrx` code.
> 
> **Overview**
> Adds support for writing **static text directly as double-quoted children** in TSRX template bodies (e.g. `<p>"Clicked " {count} " times"</p>`), lowering it to the existing `Text` node shape.
> 
> Updates the TSRX parser to recognize double-quoted string tokens in template-child position and to allow adjacent tag starts immediately after such text, adds compile tests for the new syntax (and a regression for compact string comparisons), and refreshes docs/examples across the repo to prefer the new quoting style. Also ships a changeset bumping `@tsrx/core` (minor) and includes an implementation plan doc.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bb0ceff196ac8b13a14cec28b30fa17d26cc23d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->