### PR TITLE
fix(tsrx): handle Volar source map gaps

### DIFF
--- a/.changeset/soft-bags-learn.md
+++ b/.changeset/soft-bags-learn.md
@@ -1,0 +1,5 @@
+---
+'@tsrx/core': patch
+---
+
+Fix Volar source mappings for switch statements and sparse generic spans.

--- a/packages/tsrx/src/transform/segments.js
+++ b/packages/tsrx/src/transform/segments.js
@@ -1699,14 +1699,21 @@ export function convert_source_map_to_mappings(
 					// Generic spans can be emitted by downstream transforms with sparse source-map
 					// coverage around the angle-bracket delimiters. Skip missing whole-node mappings
 					// instead of crashing Volar, and rely on child type-node mappings instead.
-					const mapping = get_mapping_from_node(
-						node,
-						src_to_gen_map,
-						gen_line_offsets,
-						mapping_data_verify_only,
-					);
-					if (!(mapping instanceof Error)) {
+					try {
+						const mapping = get_mapping_from_node(
+							node,
+							src_to_gen_map,
+							gen_line_offsets,
+							mapping_data_verify_only,
+						);
 						mappings.push(mapping);
+					} catch (error) {
+						if (
+							!(error instanceof Error) ||
+							!error.message.startsWith('No source map entry for position')
+						) {
+							throw error;
+						}
 					}
 				}
 				// Generic type parameters - visit to collect type variable names

--- a/packages/tsrx/src/transform/segments.js
+++ b/packages/tsrx/src/transform/segments.js
@@ -1450,12 +1450,6 @@ export function convert_source_map_to_mappings(
 					}
 				}
 
-				if (node.loc) {
-					mappings.push(
-						get_mapping_from_node(node, src_to_gen_map, gen_line_offsets, mapping_data_verify_only),
-					);
-				}
-
 				return;
 			} else if (node.type === 'SwitchCase') {
 				// Visit in source order: test, consequent

--- a/packages/tsrx/tests/shared/source-mappings.js
+++ b/packages/tsrx/tests/shared/source-mappings.js
@@ -51,6 +51,17 @@ export function runSharedSourceMappingTests({
 		it('ForInStatement', () => expect_maps(`component C() { for (const x in obj) {} }`));
 		it('ForOfStatement', () =>
 			expect_maps(`const test = () => { for (const x of Object.keys({})) {}}`));
+		it('SwitchStatement', () =>
+			expect_maps(`function getStatus(status: 'active' | 'blocked') {
+  switch (status) {
+    case 'active':
+      return { label: 'Running' }
+    case 'blocked':
+      return { label: 'Blocked' }
+    default:
+      return { label: 'Idle' }
+  }
+}`));
 		it('TemplateLiteral', () => expect_maps('component C() { const x = `hello ${y}`; }'));
 		it('TaggedTemplateExpression', () => expect_maps('component C() { tag`hi`; }'));
 		// AwaitExpression inside a component body. React emits an async
@@ -82,6 +93,10 @@ export function runSharedSourceMappingTests({
 		// generics) are otherwise invisible to the source map.
 		it('generic call with type arguments', () =>
 			expect_maps(`component C() { useState<string>(''); }`));
+		it('call argument with arrow-function return type', () =>
+			expect_maps(
+				`component C() { const [itemElements] = useState((): Record<string, HTMLButtonElement | null> => ({})) }`,
+			));
 		it('component with type parameters', () => expect_maps(`component C<T extends string>() {}`));
 		it('as-expression', () => expect_maps(`component C() { const x = y as string; }`));
 		it('union type annotation', () => expect_maps(`component C(p: { x: string | null }) {}`));


### PR DESCRIPTION
- `SwitchStatement` mapping tried to use the whole statement span, but the source map has no entry for the `switch` keyword; now Volar visits the discriminant and cases without requiring that broad mapping.
- Generic type parameter spans can be missing entries around angle brackets; now those whole-span mappings are skipped when sparse while child type mappings still run.
- Added shared source-mapping repros so React, Preact, and Solid cover both cases.
- Validated with `pnpm vitest run --project tsrx-react --project tsrx-preact --project tsrx-solid packages/tsrx-react/tests/basic.test.js packages/tsrx-preact/tests/basic.test.js packages/tsrx-solid/tests/basic.test.js`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core Volar mapping walker (`segments.js`), which can affect editor diagnostics/navigation across many syntax forms. Changes are localized and guarded, but incorrect mapping behavior could regress IDE features.
> 
> **Overview**
> Fixes Volar source-mapping edge cases that could crash or mis-map positions.
> 
> `SwitchStatement` no longer emits a whole-node mapping (relying on child-node mappings instead), and generic wrapper nodes (`TSTypeParameterInstantiation`/`Declaration`) now catch and ignore missing source-map positions instead of throwing.
> 
> Adds shared no-crash repro tests for `SwitchStatement` and an arrow-function return type inside a call argument, and includes a patch changeset for `@tsrx/core`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b8bfd602fe1a42b55c22ebdbc2f0929e80ca3a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->