### PR TITLE
Proper fixes for source maps

### DIFF
--- a/packages/tsrx-ripple/src/transform/client/index.js
+++ b/packages/tsrx-ripple/src/transform/client/index.js
@@ -4877,6 +4877,10 @@ function create_tsx_with_typescript_support(comments) {
 				context.visit(node.typeArguments);
 			}
 		},
+		// esrap's ArrowFunctionExpression printer ignores `typeParameters` and
+		// `returnType`, so an annotated arrow like `(): Record<...> => ...`
+		// prints as `() => ...` and segments.js can't resolve the return-type
+		// nodes' positions in the generated output.
 		ArrowFunctionExpression(node, context) {
 			if (node.async) context.write('async ');
 

--- a/packages/tsrx/src/transform/jsx/helpers.js
+++ b/packages/tsrx/src/transform/jsx/helpers.js
@@ -123,6 +123,35 @@ export function tsx_with_ts_locations() {
 			context.write(': ');
 			context.visit(node.elementType);
 		},
+		// esrap's Property printer for method shorthand (`{ foo<T>() {} }`)
+		// does not visit `value.typeParameters`, so the `<T>` is dropped from
+		// the output and segments.js can't resolve the TSTypeParameterDeclaration's
+		// source position. Override only the method-shorthand branch.
+		Property: (node, context) => {
+			if (node.value.type !== 'FunctionExpression') {
+				base.Property(node, context);
+				return;
+			}
+			const value = node.value;
+			if (node.kind !== 'init') context.write(node.kind + ' ');
+			if (value.async) context.write('async ');
+			if (value.generator) context.write('*');
+			if (node.computed) context.write('[');
+			context.visit(node.key);
+			if (node.computed) context.write(']');
+			if (value.typeParameters) {
+				context.visit(value.typeParameters);
+			}
+			context.write('(');
+			for (let i = 0; i < value.params.length; i++) {
+				if (i > 0) context.write(', ');
+				context.visit(value.params[i]);
+			}
+			context.write(')');
+			if (value.returnType) context.visit(value.returnType);
+			context.write(' ');
+			context.visit(value.body);
+		},
 		// esrap's ArrowFunctionExpression printer ignores `typeParameters` and
 		// `returnType`, so an annotated arrow like `(): Record<...> => ...`
 		// prints as `() => ...` and segments.js can't resolve the return-type

--- a/packages/tsrx/src/transform/jsx/helpers.js
+++ b/packages/tsrx/src/transform/jsx/helpers.js
@@ -123,6 +123,39 @@ export function tsx_with_ts_locations() {
 			context.write(': ');
 			context.visit(node.elementType);
 		},
+		// esrap's ArrowFunctionExpression printer ignores `typeParameters` and
+		// `returnType`, so an annotated arrow like `(): Record<...> => ...`
+		// prints as `() => ...` and segments.js can't resolve the return-type
+		// nodes' positions in the generated output.
+		ArrowFunctionExpression: (node, context) => {
+			if (node.async) context.write('async ');
+			if (node.typeParameters) {
+				context.visit(node.typeParameters);
+			}
+			context.write('(');
+			for (let i = 0; i < node.params.length; i++) {
+				if (i > 0) context.write(', ');
+				context.visit(node.params[i]);
+			}
+			context.write(')');
+			if (node.returnType) {
+				context.visit(node.returnType);
+			}
+			context.write(' => ');
+			const body = node.body;
+			const wrap_body =
+				body.type === 'ObjectExpression' ||
+				(body.type === 'AssignmentExpression' && body.left.type === 'ObjectPattern') ||
+				(body.type === 'LogicalExpression' && body.left.type === 'ObjectExpression') ||
+				(body.type === 'ConditionalExpression' && body.test.type === 'ObjectExpression');
+			if (wrap_body) {
+				context.write('(');
+				context.visit(body);
+				context.write(')');
+			} else {
+				context.visit(body);
+			}
+		},
 	};
 	for (const type of [
 		// JS nodes whose esrap printer emits no location marker, causing
@@ -138,6 +171,7 @@ export function tsx_with_ts_locations() {
 		'ForOfStatement',
 		'TemplateLiteral',
 		'AwaitExpression',
+		'SwitchStatement',
 		'TaggedTemplateExpression',
 		// JSX wrapper nodes: esrap writes `<`, `>`, `</`, `{`, `}` without
 		// locations, so the opening/closing element's and expression

--- a/packages/tsrx/src/transform/jsx/helpers.js
+++ b/packages/tsrx/src/transform/jsx/helpers.js
@@ -126,14 +126,15 @@ export function tsx_with_ts_locations() {
 		// esrap's Property printer for method shorthand (`{ foo<T>() {} }`)
 		// does not visit `value.typeParameters`, so the `<T>` is dropped from
 		// the output and segments.js can't resolve the TSTypeParameterDeclaration's
-		// source position. Override only the method-shorthand branch.
+		// source position. Override only the actual method-shorthand branch —
+		// `{ foo: function() {} }` (`node.method === false`) and getters/setters
+		// must fall through to base.Property to preserve their printed form.
 		Property: (node, context) => {
-			if (node.value.type !== 'FunctionExpression') {
+			if (!node.method || node.value.type !== 'FunctionExpression') {
 				base.Property(node, context);
 				return;
 			}
 			const value = node.value;
-			if (node.kind !== 'init') context.write(node.kind + ' ');
 			if (value.async) context.write('async ');
 			if (value.generator) context.write('*');
 			if (node.computed) context.write('[');

--- a/packages/tsrx/src/transform/segments.js
+++ b/packages/tsrx/src/transform/segments.js
@@ -1450,6 +1450,12 @@ export function convert_source_map_to_mappings(
 					}
 				}
 
+				if (node.loc) {
+					mappings.push(
+						get_mapping_from_node(node, src_to_gen_map, gen_line_offsets, mapping_data_verify_only),
+					);
+				}
+
 				return;
 			} else if (node.type === 'SwitchCase') {
 				// Visit in source order: test, consequent
@@ -1696,25 +1702,13 @@ export function convert_source_map_to_mappings(
 				node.type === 'TSTypeParameterDeclaration'
 			) {
 				if (node.loc) {
-					// Generic spans can be emitted by downstream transforms with sparse source-map
-					// coverage around the angle-bracket delimiters. Skip missing whole-node mappings
-					// instead of crashing Volar, and rely on child type-node mappings instead.
-					try {
-						const mapping = get_mapping_from_node(
-							node,
-							src_to_gen_map,
-							gen_line_offsets,
-							mapping_data_verify_only,
-						);
-						mappings.push(mapping);
-					} catch (error) {
-						if (
-							!(error instanceof Error) ||
-							!error.message.startsWith('No source map entry for position')
-						) {
-							throw error;
-						}
-					}
+					const mapping = get_mapping_from_node(
+						node,
+						src_to_gen_map,
+						gen_line_offsets,
+						mapping_data_verify_only,
+					);
+					mappings.push(mapping);
 				}
 				// Generic type parameters - visit to collect type variable names
 				if (node.params) {

--- a/packages/tsrx/tests/shared/source-mappings.js
+++ b/packages/tsrx/tests/shared/source-mappings.js
@@ -130,6 +130,84 @@ export function runSharedSourceMappingTests({
 			expect_maps(
 				`component C() { const [s, setS]: [boolean, React.Dispatch<React.SetStateAction<boolean>>] = useState(true); }`,
 			));
+
+		// Class TS shape: type parameters, generic super class, implements clause.
+		// esrap's ClassDeclaration printer omits typeParameters/superTypeArguments/
+		// implements; without a wrapper the type-position child nodes are dropped
+		// from the generated output and segments.js can't resolve their positions.
+		it('class with type parameters', () =>
+			expect_maps(`class Foo<T> { x: T | null = null; } component C() {}`));
+		it('class with generic extends', () =>
+			expect_maps(`class Foo extends Bar<string> {} component C() {}`));
+		it('class with implements clause', () =>
+			expect_maps(`interface I { x: number } class Foo implements I { x = 1 } component C() {}`));
+		it('class with generic implements', () =>
+			expect_maps(
+				`interface I<T> { x: T } class Foo implements I<string> { x = '' as string } component C() {}`,
+			));
+		it('class expression with type parameters', () =>
+			expect_maps(`component C() { const F = class<T> { x: T | null = null; }; }`));
+
+		// Method shorthand and class methods with type parameters / return types.
+		it('class method with type parameters', () =>
+			expect_maps(
+				`class Foo { bar<T>(x: T): T { return x; } } component C() {}`,
+			));
+		it('class method with return type', () =>
+			expect_maps(`class Foo { bar(x: number): string { return ''; } } component C() {}`));
+		it('object method shorthand with type parameters', () =>
+			expect_maps(`component C() { const o = { foo<T>(x: T): T { return x; } }; }`));
+
+		// TS type operators / mapped / parenthesized types.
+		it('keyof type operator', () =>
+			expect_maps(`type K<T> = keyof T; component C() {}`));
+		it('readonly type operator', () =>
+			expect_maps(`type R = readonly string[]; component C() {}`));
+		it('parenthesized type annotation', () =>
+			expect_maps(`component C(p: { x: (string | number) }) {}`));
+		it('mapped type', () =>
+			expect_maps(`type M<T> = { [K in keyof T]: T[K] }; component C() {}`));
+		it('mapped type with as remapping', () =>
+			expect_maps(
+				`type M<T> = { [K in keyof T as \`__\${string & K}\`]: T[K] }; component C() {}`,
+			));
+		it('object type keyword', () =>
+			expect_maps(`function f(x: object): object { return x; } component C() {}`));
+
+		// import type / `{ type X }` imports.
+		it('import type declaration', () =>
+			expect_maps(`import type { ReactNode } from 'react'; component C() {}`));
+		it('inline type import specifier', () =>
+			expect_maps(`import { type ReactNode, useState } from 'react'; component C() {}`));
+
+		// JS expressions whose esrap printer emits no leading/trailing location
+		// marker, mirroring the existing IfStatement / NewExpression cases.
+		it('UpdateExpression postfix', () =>
+			expect_maps(`component C() { let x = 0; x++; }`));
+		it('UpdateExpression prefix', () =>
+			expect_maps(`component C() { let x = 0; ++x; }`));
+		it('UnaryExpression', () =>
+			expect_maps(`component C() { const x = !true; const y = -1; const z = typeof x; }`));
+		it('YieldExpression', () =>
+			expect_maps(`function* gen() { yield 1; yield* [2, 3]; } component C() {}`));
+		it('AssignmentPattern with type', () =>
+			expect_maps(`function f(x: number = 1): number { return x; } component C() {}`));
+
+		// Arrow with default parameter and return type — combines AssignmentPattern
+		// with the ArrowFunctionExpression returnType visitor.
+		it('arrow with default-typed parameter and return type', () =>
+			expect_maps(
+				`component C() { const f = (x: number = 1): number => x + 1; }`,
+			));
+
+		// TSInstantiationExpression: `identity<string>` used as a value.
+		it('TSInstantiationExpression', () =>
+			expect_maps(
+				`function identity<T>(x: T): T { return x; } const f = identity<string>; component C() {}`,
+			));
+
+		// TSExpressionWithTypeArguments shows up in generic extends/implements.
+		// (Already covered by 'class with generic extends'/'class with generic implements'.)
 	});
 
 	describe(`[${name}] raw source maps cover one-line early-return if statements`, () => {

--- a/packages/tsrx/tests/shared/source-mappings.js
+++ b/packages/tsrx/tests/shared/source-mappings.js
@@ -155,6 +155,21 @@ export function runSharedSourceMappingTests({
 			expect_maps(`class Foo { bar(x: number): string { return ''; } } component C() {}`));
 		it('object method shorthand with type parameters', () =>
 			expect_maps(`component C() { const o = { foo<T>(x: T): T { return x; } }; }`));
+		// Non-method properties whose value happens to be a FunctionExpression
+		// (`node.method === false`) must not be reprinted as method shorthand;
+		// the Property override gates on `node.method`.
+		it('property with function expression value', () =>
+			expect_maps(`component C() { const o = { foo: function() { return 1; } }; }`));
+		it('property with named function expression value', () =>
+			expect_maps(`component C() { const o = { foo: function bar() { return 1; } }; }`));
+		it('property with async function expression value', () =>
+			expect_maps(`component C() { const o = { foo: async function() { return 1; } }; }`));
+		it('object literal getter', () =>
+			expect_maps(`component C() { const o = { get x() { return 1; } }; }`));
+		it('object literal setter', () =>
+			expect_maps(`component C() { const o = { set x(v: number) {} }; }`));
+		it('object literal getter with return type', () =>
+			expect_maps(`component C() { const o = { get x(): number { return 1; } }; }`));
 
 		// TS type operators / mapped / parenthesized types.
 		it('keyof type operator', () => expect_maps(`type K<T> = keyof T; component C() {}`));

--- a/packages/tsrx/tests/shared/source-mappings.js
+++ b/packages/tsrx/tests/shared/source-mappings.js
@@ -150,23 +150,18 @@ export function runSharedSourceMappingTests({
 
 		// Method shorthand and class methods with type parameters / return types.
 		it('class method with type parameters', () =>
-			expect_maps(
-				`class Foo { bar<T>(x: T): T { return x; } } component C() {}`,
-			));
+			expect_maps(`class Foo { bar<T>(x: T): T { return x; } } component C() {}`));
 		it('class method with return type', () =>
 			expect_maps(`class Foo { bar(x: number): string { return ''; } } component C() {}`));
 		it('object method shorthand with type parameters', () =>
 			expect_maps(`component C() { const o = { foo<T>(x: T): T { return x; } }; }`));
 
 		// TS type operators / mapped / parenthesized types.
-		it('keyof type operator', () =>
-			expect_maps(`type K<T> = keyof T; component C() {}`));
-		it('readonly type operator', () =>
-			expect_maps(`type R = readonly string[]; component C() {}`));
+		it('keyof type operator', () => expect_maps(`type K<T> = keyof T; component C() {}`));
+		it('readonly type operator', () => expect_maps(`type R = readonly string[]; component C() {}`));
 		it('parenthesized type annotation', () =>
 			expect_maps(`component C(p: { x: (string | number) }) {}`));
-		it('mapped type', () =>
-			expect_maps(`type M<T> = { [K in keyof T]: T[K] }; component C() {}`));
+		it('mapped type', () => expect_maps(`type M<T> = { [K in keyof T]: T[K] }; component C() {}`));
 		it('mapped type with as remapping', () =>
 			expect_maps(
 				`type M<T> = { [K in keyof T as \`__\${string & K}\`]: T[K] }; component C() {}`,
@@ -182,10 +177,8 @@ export function runSharedSourceMappingTests({
 
 		// JS expressions whose esrap printer emits no leading/trailing location
 		// marker, mirroring the existing IfStatement / NewExpression cases.
-		it('UpdateExpression postfix', () =>
-			expect_maps(`component C() { let x = 0; x++; }`));
-		it('UpdateExpression prefix', () =>
-			expect_maps(`component C() { let x = 0; ++x; }`));
+		it('UpdateExpression postfix', () => expect_maps(`component C() { let x = 0; x++; }`));
+		it('UpdateExpression prefix', () => expect_maps(`component C() { let x = 0; ++x; }`));
 		it('UnaryExpression', () =>
 			expect_maps(`component C() { const x = !true; const y = -1; const z = typeof x; }`));
 		it('YieldExpression', () =>
@@ -196,9 +189,7 @@ export function runSharedSourceMappingTests({
 		// Arrow with default parameter and return type — combines AssignmentPattern
 		// with the ArrowFunctionExpression returnType visitor.
 		it('arrow with default-typed parameter and return type', () =>
-			expect_maps(
-				`component C() { const f = (x: number = 1): number => x + 1; }`,
-			));
+			expect_maps(`component C() { const f = (x: number = 1): number => x + 1; }`));
 
 		// TSInstantiationExpression: `identity<string>` used as a value.
 		it('TSInstantiationExpression', () =>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adjusts source-map generation and AST printing for TypeScript/JSX constructs, which can impact editor diagnostics and tooling if mappings shift unexpectedly. Changes are localized to printers/mapping logic and are covered by expanded mapping regression tests.
> 
> **Overview**
> Improves source-map stability for TS/JSX output by overriding esrap printers that were **dropping TypeScript syntax** (generic `typeParameters`, `returnType`) on `ArrowFunctionExpression` and object-literal method shorthand `Property`, and by treating `SwitchStatement` as a node that must emit location markers.
> 
> Updates `segments.js` to always emit mappings for `TSTypeParameterDeclaration`/`Instantiation` (no longer swallowing missing-map errors) and to include a whole-node mapping for `SwitchStatement` when `loc` is present. Expands source-mapping tests to cover more TS class/method shapes, type operators, imports, and JS expression forms that previously caused missing/incorrect mappings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 567309d8d2a7e9abc7eadc57d9c2184f2d4f3f0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->