### PR TITLE
fix(zed): update `rev`

### DIFF
--- a/packages/zed-plugin/extension.toml
+++ b/packages/zed-plugin/extension.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/Ripple-TS/ripple"
 
 [grammars.ripple]
 repository = "https://github.com/Ripple-TS/ripple"
-rev = "79225213e68d68aa8b19e78adcb2f31c37bd61de"
+rev = "ba83189e5e7d4b8e63c3a523fdd808d365bf7662"
 path = "grammars/tree-sitter"
 
 [language_servers.ripple-language-server]


### PR DESCRIPTION
to get latest changes of #953 merged into `main` today. In other case installing `Zed` extension will fail because of a non-existing  `rev` for `tree-sitter`. 

See https://github.com/Ripple-TS/ripple/pull/953#discussion_r3142404714

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: updates a single pinned git revision for the Zed plugin grammar source, affecting only syntax highlighting/grammar fetch behavior.
> 
> **Overview**
> Updates the Zed plugin `extension.toml` to pin the Ripple Tree-sitter grammar to a newer upstream git `rev`, pulling in the latest grammar changes without altering any other plugin configuration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09944d4dad280e58a1ebd0bce90d6a1726d77ac6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->