### PR TITLE
Fix text bugs

### DIFF
--- a/.changeset/direct-quoted-expression-containers.md
+++ b/.changeset/direct-quoted-expression-containers.md
@@ -1,0 +1,10 @@
+---
+"@tsrx/core": patch
+"@tsrx/react": patch
+"@tsrx/preact": patch
+"@tsrx/solid": patch
+"@tsrx/ripple": patch
+"ripple": patch
+---
+
+Keep double-quoted JavaScript strings inside TSRX expression containers using normal JavaScript string semantics while preserving direct double-quoted text child parsing.

--- a/packages/tsrx/src/plugin.js
+++ b/packages/tsrx/src/plugin.js
@@ -176,6 +176,7 @@ export function TSRXPlugin(config) {
 			/** @type {AST.Node[]} */
 			#path = [];
 			#allowTagStartAfterDoubleQuotedText = false;
+			#allowDoubleQuotedTextChildAfterBrace = false;
 			#commentContextId = 0;
 			#loose = false;
 			/** @type {import('../types/index').CompileError[] | undefined} */
@@ -229,7 +230,7 @@ export function TSRXPlugin(config) {
 					prev === 34 || // "
 					prev === 59 || // ;
 					prev === 62 || // >
-					prev === 123 || // {
+					(prev === 123 && this.#allowDoubleQuotedTextChildAfterBrace) || // {
 					prev === 125 // }
 				);
 			}
@@ -632,8 +633,14 @@ export function TSRXPlugin(config) {
 			 * @type {Parse.Parser['getTokenFromCode']}
 			 */
 			getTokenFromCode(code) {
-				if (code === 34 && this.#isDoubleQuotedTextChildStart()) {
-					return this.#readDoubleQuotedTextChildToken();
+				if (code === 34) {
+					const is_double_quoted_text_child = this.#isDoubleQuotedTextChildStart();
+					this.#allowDoubleQuotedTextChildAfterBrace = false;
+					if (is_double_quoted_text_child) {
+						return this.#readDoubleQuotedTextChildToken();
+					}
+				} else {
+					this.#allowDoubleQuotedTextChildAfterBrace = false;
 				}
 
 				if (code !== 60) {
@@ -1058,6 +1065,9 @@ export function TSRXPlugin(config) {
 				const parent_function_body_depth = this.#functionBodyDepth;
 				this.#functionBodyDepth = 0;
 
+				if (this.type === tt.braceL) {
+					this.#allowDoubleQuotedTextChildAfterBrace = true;
+				}
 				this.eat(tt.braceL);
 				node.body = [];
 				this.#path.push(node);
@@ -2654,6 +2664,7 @@ export function TSRXPlugin(config) {
 					if (node === void 0) node = /** @type {AST.BlockStatement} */ (this.startNode());
 
 					node.body = [];
+					this.#allowDoubleQuotedTextChildAfterBrace = true;
 					this.expect(tt.braceL);
 					if (createNewLexicalScope) {
 						this.enterScope(0);

--- a/packages/tsrx/tests/shared/compile.js
+++ b/packages/tsrx/tests/shared/compile.js
@@ -109,6 +109,17 @@ export function runSharedCompileTests({ compile, name, classAttrName }) {
 			expect(code).toContain('" times"');
 		});
 
+		it('accepts direct double-quoted text at the start of template bodies', () => {
+			const { code } = compile(
+				`export component App() {
+					"hello"
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('"hello"');
+		});
+
 		it('decodes entities in direct double-quoted text children like JSX attributes', () => {
 			const { code } = compile(
 				`export component App() {
@@ -130,6 +141,30 @@ export function runSharedCompileTests({ compile, name, classAttrName }) {
 			);
 
 			expect(code).toContain('"line\\\\nbreak"');
+		});
+
+		it('keeps double-quoted strings inside expression containers as JavaScript strings', () => {
+			const { code } = compile(
+				`export component App() {
+					<p>{"line\\nbreak"} {"&amp;"}</p>
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('"line\\nbreak"');
+			expect(code).toContain('"&amp;"');
+		});
+
+		it('rejects literal newlines in double-quoted strings inside expression containers', () => {
+			expect(() =>
+				compile(
+					`export component App() {
+						<p>{"line
+break"}</p>
+					}`,
+					'App.tsrx',
+				),
+			).toThrow(/Unterminated string constant/);
 		});
 
 		it('does not use JavaScript quote escapes in direct double-quoted text children', () => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches TSRX tokenization around `"` handling inside templates/expression containers, which can subtly affect parsing of template bodies and nested blocks. Risk is moderate because it changes parser state/branching but is covered by new regression tests.
> 
> **Overview**
> Fixes TSRX parsing so **double-quoted strings inside `{...}` expression containers** are tokenized as normal JavaScript strings (including rejecting literal newlines), instead of being misread as direct template text.
> 
> Tightens when **direct double-quoted text children** are allowed by gating `"`-text-child detection behind a new brace-scoped flag, enabling cases like a template body starting with `"hello"` while avoiding interference with JS blocks. Adds a changeset for patch releases and regression tests covering the new behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f56d8f5906a0bed88503e3a59195a97c1ec9cde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->