### PR TITLE
Add React fixture tests

### DIFF
--- a/packages/vite-plugin-react/package.json
+++ b/packages/vite-plugin-react/package.json
@@ -26,6 +26,7 @@
     "vite": "*"
   },
   "devDependencies": {
+    "@tanstack/react-query": "^5.100.6",
     "@types/react": "catalog:default",
     "@types/react-dom": "catalog:default",
     "react": "catalog:default",

--- a/packages/vite-plugin-react/package.json
+++ b/packages/vite-plugin-react/package.json
@@ -29,7 +29,9 @@
     "@types/react": "catalog:default",
     "@types/react-dom": "catalog:default",
     "react": "catalog:default",
+    "react-aria-components": "^1.17.0",
     "react-dom": "catalog:default",
+    "react-router": "^7.14.2",
     "typescript": "catalog:default",
     "vite": "catalog:default"
   },

--- a/packages/vite-plugin-react/tests/fixtures/react-aria/App.tsrx
+++ b/packages/vite-plugin-react/tests/fixtures/react-aria/App.tsrx
@@ -21,7 +21,7 @@ export component ReactAriaFixture() {
 	function recordAction(id: ActionId, pointerType: ActionPointerType) {
 		const action =
 			id === saveAction.id ? saveAction : deleteAction;
-		setEntries([...entries, { id, label: action.label, pointerType }]);
+		setEntries((prev) => [...prev, { id, label: action.label, pointerType }]);
 	}
 
 	<section aria-label="React Aria TSRX fixture">

--- a/packages/vite-plugin-react/tests/fixtures/react-aria/App.tsrx
+++ b/packages/vite-plugin-react/tests/fixtures/react-aria/App.tsrx
@@ -1,0 +1,38 @@
+import { useState } from 'react';
+import { AriaActionButton } from './AriaActionButton.tsx';
+import type { ActionDetails, ActionId, ActionLogEntry, ActionPointerType } from './types';
+
+const saveAction: ActionDetails = {
+	id: 'save',
+	label: 'Save draft',
+	description: 'Stores changes through a React Aria button',
+};
+
+const deleteAction: ActionDetails = {
+	id: 'delete',
+	label: 'Delete draft',
+	description: 'Disabled destructive action',
+};
+
+export component ReactAriaFixture() {
+	const [entries, setEntries] = useState<ActionLogEntry[]>([]);
+	const lastEntry = entries.at(-1);
+
+	function recordAction(id: ActionId, pointerType: ActionPointerType) {
+		const action =
+			id === saveAction.id ? saveAction : deleteAction;
+		setEntries([...entries, { id, label: action.label, pointerType }]);
+	}
+
+	<section aria-label="React Aria TSRX fixture">
+		<AriaActionButton
+			action={saveAction}
+			aria-label="Save draft with React Aria"
+			onAction={recordAction}
+		/>
+		<AriaActionButton action={deleteAction} isDisabled={true} onAction={recordAction} />
+		<output class="last-action">{lastEntry ? lastEntry.id : 'none'}</output>
+		<output class="last-pointer">{lastEntry ? lastEntry.pointerType : 'none'}</output>
+		<output class="action-count">{entries.length}</output>
+	</section>
+}

--- a/packages/vite-plugin-react/tests/fixtures/react-aria/AriaActionButton.tsx
+++ b/packages/vite-plugin-react/tests/fixtures/react-aria/AriaActionButton.tsx
@@ -1,0 +1,25 @@
+import { Button, type ButtonProps } from 'react-aria-components';
+import type { ActionDetails, ActionId, ActionPointerType } from './types';
+
+export type AriaActionButtonProps = Pick<ButtonProps, 'aria-label' | 'isDisabled'> & {
+	action: ActionDetails;
+	onAction: (id: ActionId, pointerType: ActionPointerType) => void;
+};
+
+export function AriaActionButton(props: AriaActionButtonProps) {
+	return (
+		<Button
+			aria-label={props['aria-label'] ?? props.action.label}
+			data-action-id={props.action.id}
+			isDisabled={props.isDisabled}
+			onPress={(event) => props.onAction(props.action.id, event.pointerType)}
+		>
+			{({ isPressed }) => (
+				<span data-pressed={isPressed ? 'yes' : 'no'}>
+					{props.action.label}
+					<span className="description">{props.action.description}</span>
+				</span>
+			)}
+		</Button>
+	);
+}

--- a/packages/vite-plugin-react/tests/fixtures/react-aria/runtime.test.tsrx
+++ b/packages/vite-plugin-react/tests/fixtures/react-aria/runtime.test.tsrx
@@ -1,0 +1,34 @@
+import { ReactAriaFixture } from './App.tsrx';
+
+function text(selector: string): string | null {
+	return container.querySelector(selector)?.textContent ?? null;
+}
+
+describe('tsrx-react fixtures: react-aria runtime', () => {
+	it('renders and updates a TSRX component through TSX React Aria modules', async () => {
+		await render(ReactAriaFixture);
+
+		const saveButton = container.querySelector(
+			'[data-action-id="save"]',
+		) as HTMLButtonElement | null;
+		const deleteButton = container.querySelector(
+			'[data-action-id="delete"]',
+		) as HTMLButtonElement | null;
+
+		expect(saveButton).not.toBeNull();
+		expect(deleteButton).not.toBeNull();
+		expect(saveButton?.tagName).toBe('BUTTON');
+		expect(saveButton?.getAttribute('aria-label')).toBe('Save draft with React Aria');
+		expect(deleteButton?.disabled).toBe(true);
+		expect(text('.last-action')).toBe('none');
+		expect(text('.action-count')).toBe('0');
+
+		await act(async () => {
+			saveButton?.click();
+		});
+
+		expect(text('.last-action')).toBe('save');
+		expect(text('.last-pointer')).not.toBe('none');
+		expect(text('.action-count')).toBe('1');
+	});
+});

--- a/packages/vite-plugin-react/tests/fixtures/react-aria/tsconfig.json
+++ b/packages/vite-plugin-react/tests/fixtures/react-aria/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "noEmit": true
+  },
+  "include": ["../../types.d.ts", "*.ts", "*.tsx", "*.tsrx"],
+  "exclude": []
+}

--- a/packages/vite-plugin-react/tests/fixtures/react-aria/typecheck.test.js
+++ b/packages/vite-plugin-react/tests/fixtures/react-aria/typecheck.test.js
@@ -1,0 +1,43 @@
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const fixture_dir = fileURLToPath(new URL('.', import.meta.url));
+const tsconfig_path = fileURLToPath(new URL('./tsconfig.json', import.meta.url));
+const tsrx_tsc_path = fileURLToPath(
+	new URL('../../../../typescript-plugin/dist/tsc.js', import.meta.url),
+);
+
+/**
+ * @returns {Promise<{ code: number | null, stdout: string, stderr: string }>}
+ */
+function run_tsrx_tsc() {
+	return new Promise((resolve, reject) => {
+		const child = spawn(process.execPath, [tsrx_tsc_path, '--noEmit', '-p', tsconfig_path], {
+			cwd: fixture_dir,
+			stdio: 'pipe',
+		});
+
+		let stdout = '';
+		let stderr = '';
+
+		child.stdout.on('data', (chunk) => {
+			stdout += String(chunk);
+		});
+		child.stderr.on('data', (chunk) => {
+			stderr += String(chunk);
+		});
+		child.on('error', reject);
+		child.on('close', (code) => {
+			resolve({ code, stdout, stderr });
+		});
+	});
+}
+
+describe('tsrx-react fixtures: react-aria typecheck', () => {
+	it('typechecks TSX, TSRX, and third-party React Aria types together', async () => {
+		const result = await run_tsrx_tsc();
+
+		expect(result, result.stdout + result.stderr).toMatchObject({ code: 0 });
+	}, 30000);
+});

--- a/packages/vite-plugin-react/tests/fixtures/react-aria/types.ts
+++ b/packages/vite-plugin-react/tests/fixtures/react-aria/types.ts
@@ -1,0 +1,16 @@
+import type { PressEvent } from 'react-aria-components';
+
+export type ActionId = 'save' | 'delete';
+export type ActionPointerType = PressEvent['pointerType'];
+
+export interface ActionDetails {
+	id: ActionId;
+	label: string;
+	description: string;
+}
+
+export interface ActionLogEntry {
+	id: ActionId;
+	label: string;
+	pointerType: ActionPointerType;
+}

--- a/packages/vite-plugin-react/tests/fixtures/react-query/App.tsrx
+++ b/packages/vite-plugin-react/tests/fixtures/react-query/App.tsrx
@@ -1,0 +1,51 @@
+import { useState } from 'react';
+import { QueryFixtureShell } from './QueryFixtureShell.tsx';
+import type { Project, ProjectId, ProjectSummary } from './types';
+
+const projects: Record<ProjectId, Project> = {
+	alpha: {
+		id: 'alpha',
+		name: 'Alpha Query',
+		stars: 42,
+		tags: ['cache', 'client'],
+	},
+	beta: {
+		id: 'beta',
+		name: 'Beta Query',
+		stars: 7,
+		tags: ['router', 'forms', 'async'],
+	},
+};
+
+function delay() {
+	return new Promise<void>((resolve) => {
+		setTimeout(resolve, 5);
+	});
+}
+
+export component ReactQueryFixture() {
+	const [fetchCount, setFetchCount] = useState(0);
+
+	async function fetchProject(id: ProjectId): Promise<Project> {
+		setFetchCount((count) => count + 1);
+		await delay();
+		return projects[id];
+	}
+
+	function selectSummary(project: Project): ProjectSummary {
+		return {
+			id: project.id,
+			name: project.name,
+			stars: project.stars,
+			tagCount: project.tags.length,
+		};
+	}
+
+	<QueryFixtureShell
+		initialProjectId="alpha"
+		alternateProjectId="beta"
+		{fetchProject}
+		{selectSummary}
+	/>
+	<output class="query-fetch-count">{fetchCount}</output>
+}

--- a/packages/vite-plugin-react/tests/fixtures/react-query/QueryFixtureShell.tsx
+++ b/packages/vite-plugin-react/tests/fixtures/react-query/QueryFixtureShell.tsx
@@ -1,0 +1,97 @@
+import { useState } from 'react';
+import {
+	QueryClient,
+	QueryClientProvider,
+	useIsFetching,
+	useQuery,
+	type QueryClientConfig,
+} from '@tanstack/react-query';
+import type { ProjectFetcher, ProjectId, ProjectQueryStatus, ProjectSelector } from './types';
+import { project_query_key } from './types';
+
+export interface QueryFixtureShellProps {
+	initialProjectId: ProjectId;
+	alternateProjectId: ProjectId;
+	fetchProject: ProjectFetcher;
+	selectSummary: ProjectSelector;
+}
+
+const query_client_config: QueryClientConfig = {
+	defaultOptions: {
+		queries: {
+			gcTime: Infinity,
+			retry: false,
+			staleTime: Infinity,
+		},
+	},
+};
+
+function ProjectPanel(props: {
+	projectId: ProjectId;
+	fetchProject: ProjectFetcher;
+	selectSummary: ProjectSelector;
+}) {
+	const query = useQuery({
+		queryKey: project_query_key(props.projectId),
+		queryFn: () => props.fetchProject(props.projectId),
+		select: props.selectSummary,
+	});
+	const status: ProjectQueryStatus = query.status;
+
+	return (
+		<section aria-label="Project query">
+			<p className="query-status">{status}</p>
+			<p className="query-project-id">{query.data?.id ?? 'none'}</p>
+			<p className="query-name">{query.data?.name ?? 'Loading project'}</p>
+			<p className="query-stars">{query.data?.stars ?? 0}</p>
+			<p className="query-tag-count">{query.data?.tagCount ?? 0}</p>
+			<button className="refetch-project" onClick={() => query.refetch()}>
+				Refetch
+			</button>
+		</section>
+	);
+}
+
+function CachedProjectMirror(props: { projectId: ProjectId; fetchProject: ProjectFetcher }) {
+	const query = useQuery({
+		queryKey: project_query_key(props.projectId),
+		queryFn: () => props.fetchProject(props.projectId),
+		select: (project) => project.name.toUpperCase(),
+	});
+
+	return <p className="query-mirror">{query.data ?? 'NO PROJECT'}</p>;
+}
+
+function QueryFixtureInner(props: QueryFixtureShellProps) {
+	const [projectId, setProjectId] = useState<ProjectId>(props.initialProjectId);
+	const fetchingCount = useIsFetching({ queryKey: ['project'] });
+
+	return (
+		<>
+			<button className="show-initial" onClick={() => setProjectId(props.initialProjectId)}>
+				Show initial
+			</button>
+			<button className="show-alternate" onClick={() => setProjectId(props.alternateProjectId)}>
+				Show alternate
+			</button>
+			<p className="query-active-id">{projectId}</p>
+			<p className="query-fetching-count">{fetchingCount}</p>
+			<ProjectPanel
+				projectId={projectId}
+				fetchProject={props.fetchProject}
+				selectSummary={props.selectSummary}
+			/>
+			<CachedProjectMirror projectId={projectId} fetchProject={props.fetchProject} />
+		</>
+	);
+}
+
+export function QueryFixtureShell(props: QueryFixtureShellProps) {
+	const [queryClient] = useState(() => new QueryClient(query_client_config));
+
+	return (
+		<QueryClientProvider client={queryClient}>
+			<QueryFixtureInner {...props} />
+		</QueryClientProvider>
+	);
+}

--- a/packages/vite-plugin-react/tests/fixtures/react-query/runtime.test.tsrx
+++ b/packages/vite-plugin-react/tests/fixtures/react-query/runtime.test.tsrx
@@ -1,0 +1,105 @@
+import { ReactQueryFixture } from './App.tsrx';
+
+function text(selector: string): string | null {
+	return container.querySelector(selector)?.textContent ?? null;
+}
+
+async function wait_for(assertion: () => void) {
+	let last_error: unknown;
+
+	for (let i = 0; i < 50; i++) {
+		try {
+			assertion();
+			return;
+		} catch (error) {
+			last_error = error;
+		}
+
+		await act(async () => {
+			await new Promise((resolve) => setTimeout(resolve, 10));
+		});
+	}
+
+	throw last_error;
+}
+
+describe('tsrx-react fixtures: react-query runtime', () => {
+	it('loads TSRX-provided async data through TSX TanStack Query components', async () => {
+		await render(ReactQueryFixture);
+
+		expect(text('.query-status')).toBe('pending');
+		expect(text('.query-name')).toBe('Loading project');
+
+		await wait_for(() => {
+			expect(text('.query-status')).toBe('success');
+			expect(text('.query-project-id')).toBe('alpha');
+			expect(text('.query-name')).toBe('Alpha Query');
+			expect(text('.query-stars')).toBe('42');
+			expect(text('.query-tag-count')).toBe('2');
+			expect(text('.query-mirror')).toBe('ALPHA QUERY');
+			expect(text('.query-fetch-count')).toBe('1');
+			expect(text('.query-fetching-count')).toBe('0');
+		});
+	});
+
+	it('shares one cached query result across multiple TSX consumers', async () => {
+		await render(ReactQueryFixture);
+
+		await wait_for(() => {
+			expect(text('.query-name')).toBe('Alpha Query');
+			expect(text('.query-mirror')).toBe('ALPHA QUERY');
+			expect(text('.query-fetch-count')).toBe('1');
+		});
+	});
+
+	it('switches query keys from TSRX props and reuses cached results', async () => {
+		await render(ReactQueryFixture);
+
+		await wait_for(() => {
+			expect(text('.query-name')).toBe('Alpha Query');
+			expect(text('.query-fetch-count')).toBe('1');
+		});
+
+		await act(async () => {
+			(container.querySelector('.show-alternate') as HTMLButtonElement).click();
+		});
+
+		await wait_for(() => {
+			expect(text('.query-active-id')).toBe('beta');
+			expect(text('.query-name')).toBe('Beta Query');
+			expect(text('.query-tag-count')).toBe('3');
+			expect(text('.query-mirror')).toBe('BETA QUERY');
+			expect(text('.query-fetch-count')).toBe('2');
+		});
+
+		await act(async () => {
+			(container.querySelector('.show-initial') as HTMLButtonElement).click();
+		});
+
+		await wait_for(() => {
+			expect(text('.query-active-id')).toBe('alpha');
+			expect(text('.query-name')).toBe('Alpha Query');
+			expect(text('.query-fetch-count')).toBe('2');
+		});
+	});
+
+	it('refetches the active query through a TSX callback without losing selected data', async () => {
+		await render(ReactQueryFixture);
+
+		await wait_for(() => {
+			expect(text('.query-name')).toBe('Alpha Query');
+			expect(text('.query-fetch-count')).toBe('1');
+		});
+
+		await act(async () => {
+			(container.querySelector('.refetch-project') as HTMLButtonElement).click();
+		});
+
+		await wait_for(() => {
+			expect(text('.query-status')).toBe('success');
+			expect(text('.query-name')).toBe('Alpha Query');
+			expect(text('.query-fetch-count')).toBe('2');
+			expect(text('.query-fetching-count')).toBe('0');
+		});
+	});
+});

--- a/packages/vite-plugin-react/tests/fixtures/react-query/tsconfig.json
+++ b/packages/vite-plugin-react/tests/fixtures/react-query/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "noEmit": true
+  },
+  "include": ["../../types.d.ts", "*.ts", "*.tsx", "*.tsrx"],
+  "exclude": []
+}

--- a/packages/vite-plugin-react/tests/fixtures/react-query/typecheck.test.js
+++ b/packages/vite-plugin-react/tests/fixtures/react-query/typecheck.test.js
@@ -1,0 +1,43 @@
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const fixture_dir = fileURLToPath(new URL('.', import.meta.url));
+const tsconfig_path = fileURLToPath(new URL('./tsconfig.json', import.meta.url));
+const tsrx_tsc_path = fileURLToPath(
+	new URL('../../../../typescript-plugin/dist/tsc.js', import.meta.url),
+);
+
+/**
+ * @returns {Promise<{ code: number | null, stdout: string, stderr: string }>}
+ */
+function run_tsrx_tsc() {
+	return new Promise((resolve, reject) => {
+		const child = spawn(process.execPath, [tsrx_tsc_path, '--noEmit', '-p', tsconfig_path], {
+			cwd: fixture_dir,
+			stdio: 'pipe',
+		});
+
+		let stdout = '';
+		let stderr = '';
+
+		child.stdout.on('data', (chunk) => {
+			stdout += String(chunk);
+		});
+		child.stderr.on('data', (chunk) => {
+			stderr += String(chunk);
+		});
+		child.on('error', reject);
+		child.on('close', (code) => {
+			resolve({ code, stdout, stderr });
+		});
+	});
+}
+
+describe('tsrx-react fixtures: react-query typecheck', () => {
+	it('typechecks TSX, TSRX, and third-party TanStack Query types together', async () => {
+		const result = await run_tsrx_tsc();
+
+		expect(result, result.stdout + result.stderr).toMatchObject({ code: 0 });
+	}, 30000);
+});

--- a/packages/vite-plugin-react/tests/fixtures/react-query/types.ts
+++ b/packages/vite-plugin-react/tests/fixtures/react-query/types.ts
@@ -1,0 +1,26 @@
+import type { QueryKey, UseQueryResult } from '@tanstack/react-query';
+
+export type ProjectId = 'alpha' | 'beta';
+
+export interface Project {
+	id: ProjectId;
+	name: string;
+	stars: number;
+	tags: readonly string[];
+}
+
+export interface ProjectSummary {
+	id: ProjectId;
+	name: string;
+	stars: number;
+	tagCount: number;
+}
+
+export type ProjectQueryKey = readonly ['project', ProjectId];
+export type ProjectFetcher = (id: ProjectId) => Promise<Project>;
+export type ProjectSelector = (project: Project) => ProjectSummary;
+export type ProjectQueryStatus = UseQueryResult<ProjectSummary, Error>['status'];
+
+export function project_query_key(id: ProjectId): QueryKey {
+	return ['project', id] satisfies ProjectQueryKey;
+}

--- a/packages/vite-plugin-react/tests/fixtures/react-router/App.tsrx
+++ b/packages/vite-plugin-react/tests/fixtures/react-router/App.tsrx
@@ -1,0 +1,29 @@
+import { RouterFixtureShell } from './RouterFixtureShell.tsx';
+import type { ProjectRoute } from './types';
+
+const projectRoutes: readonly ProjectRoute[] = [
+	{
+		id: 'alpha',
+		name: 'Alpha project',
+		to: '/projects/alpha?tab=activity',
+		searchLabel(location) {
+			return location.search || 'no search';
+		},
+	},
+	{
+		id: 'beta',
+		name: 'Beta project',
+		to: { pathname: '/projects/beta', search: '?tab=settings' },
+		searchLabel(location) {
+			return location.search.replace('?', 'query:');
+		},
+	},
+];
+
+export component ReactRouterFixture() {
+	<RouterFixtureShell
+		routes={projectRoutes}
+		initialEntry="/projects/alpha?tab=activity"
+		fallbackLabel="No matching route"
+	/>
+}

--- a/packages/vite-plugin-react/tests/fixtures/react-router/RouterFixtureShell.tsx
+++ b/packages/vite-plugin-react/tests/fixtures/react-router/RouterFixtureShell.tsx
@@ -1,0 +1,60 @@
+import {
+	Link,
+	MemoryRouter,
+	Route,
+	Routes,
+	useLocation,
+	useParams,
+	useSearchParams,
+} from 'react-router';
+import type { ProjectId, ProjectRoute } from './types';
+
+export interface RouterFixtureShellProps {
+	routes: readonly ProjectRoute[];
+	initialEntry: string;
+	fallbackLabel: string;
+}
+
+function ProjectLink(props: { route: ProjectRoute }) {
+	return (
+		<Link data-route-id={props.route.id} to={props.route.to}>
+			{props.route.name}
+		</Link>
+	);
+}
+
+function ProjectDetails(props: { routes: readonly ProjectRoute[] }) {
+	const params = useParams<{ projectId: ProjectId }>();
+	const [searchParams] = useSearchParams();
+	const location = useLocation();
+	const route = props.routes.find((candidate) => candidate.id === params.projectId);
+
+	if (!route) {
+		return <p className="route-missing">Missing project</p>;
+	}
+
+	return (
+		<section aria-label="Project route">
+			<h2 className="route-title">{route.name}</h2>
+			<p className="route-id">{route.id}</p>
+			<p className="route-tab">{searchParams.get('tab') ?? 'overview'}</p>
+			<p className="route-search-label">{route.searchLabel(location)}</p>
+		</section>
+	);
+}
+
+export function RouterFixtureShell(props: RouterFixtureShellProps) {
+	return (
+		<MemoryRouter initialEntries={[props.initialEntry]}>
+			<nav aria-label="Projects">
+				{props.routes.map((route) => (
+					<ProjectLink key={route.id} route={route} />
+				))}
+			</nav>
+			<Routes>
+				<Route path="/projects/:projectId" element={<ProjectDetails routes={props.routes} />} />
+				<Route path="*" element={<p className="route-fallback">{props.fallbackLabel}</p>} />
+			</Routes>
+		</MemoryRouter>
+	);
+}

--- a/packages/vite-plugin-react/tests/fixtures/react-router/runtime.test.tsrx
+++ b/packages/vite-plugin-react/tests/fixtures/react-router/runtime.test.tsrx
@@ -1,0 +1,32 @@
+import { ReactRouterFixture } from './App.tsrx';
+
+function text(selector: string): string | null {
+	return container.querySelector(selector)?.textContent ?? null;
+}
+
+describe('tsrx-react fixtures: react-router runtime', () => {
+	it('renders and navigates through TSRX data passed into TSX React Router modules', async () => {
+		await render(ReactRouterFixture);
+
+		const alphaLink = container.querySelector(
+			'[data-route-id="alpha"]',
+		) as HTMLAnchorElement | null;
+		const betaLink = container.querySelector('[data-route-id="beta"]') as HTMLAnchorElement | null;
+
+		expect(alphaLink?.getAttribute('href')).toBe('/projects/alpha?tab=activity');
+		expect(betaLink?.getAttribute('href')).toBe('/projects/beta?tab=settings');
+		expect(text('.route-title')).toBe('Alpha project');
+		expect(text('.route-id')).toBe('alpha');
+		expect(text('.route-tab')).toBe('activity');
+		expect(text('.route-search-label')).toBe('?tab=activity');
+
+		await act(async () => {
+			betaLink?.click();
+		});
+
+		expect(text('.route-title')).toBe('Beta project');
+		expect(text('.route-id')).toBe('beta');
+		expect(text('.route-tab')).toBe('settings');
+		expect(text('.route-search-label')).toBe('query:tab=settings');
+	});
+});

--- a/packages/vite-plugin-react/tests/fixtures/react-router/tsconfig.json
+++ b/packages/vite-plugin-react/tests/fixtures/react-router/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "noEmit": true
+  },
+  "include": ["../../types.d.ts", "*.ts", "*.tsx", "*.tsrx"],
+  "exclude": []
+}

--- a/packages/vite-plugin-react/tests/fixtures/react-router/typecheck.test.js
+++ b/packages/vite-plugin-react/tests/fixtures/react-router/typecheck.test.js
@@ -1,0 +1,43 @@
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const fixture_dir = fileURLToPath(new URL('.', import.meta.url));
+const tsconfig_path = fileURLToPath(new URL('./tsconfig.json', import.meta.url));
+const tsrx_tsc_path = fileURLToPath(
+	new URL('../../../../typescript-plugin/dist/tsc.js', import.meta.url),
+);
+
+/**
+ * @returns {Promise<{ code: number | null, stdout: string, stderr: string }>}
+ */
+function run_tsrx_tsc() {
+	return new Promise((resolve, reject) => {
+		const child = spawn(process.execPath, [tsrx_tsc_path, '--noEmit', '-p', tsconfig_path], {
+			cwd: fixture_dir,
+			stdio: 'pipe',
+		});
+
+		let stdout = '';
+		let stderr = '';
+
+		child.stdout.on('data', (chunk) => {
+			stdout += String(chunk);
+		});
+		child.stderr.on('data', (chunk) => {
+			stderr += String(chunk);
+		});
+		child.on('error', reject);
+		child.on('close', (code) => {
+			resolve({ code, stdout, stderr });
+		});
+	});
+}
+
+describe('tsrx-react fixtures: react-router typecheck', () => {
+	it('typechecks TSX, TSRX, and third-party React Router types together', async () => {
+		const result = await run_tsrx_tsc();
+
+		expect(result, result.stdout + result.stderr).toMatchObject({ code: 0 });
+	}, 30000);
+});

--- a/packages/vite-plugin-react/tests/fixtures/react-router/types.ts
+++ b/packages/vite-plugin-react/tests/fixtures/react-router/types.ts
@@ -1,0 +1,10 @@
+import type { Location, To } from 'react-router';
+
+export type ProjectId = 'alpha' | 'beta';
+
+export interface ProjectRoute {
+	id: ProjectId;
+	name: string;
+	to: To;
+	searchLabel: (location: Pick<Location, 'search'>) => string;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -361,6 +361,24 @@ importers:
         specifier: catalog:default
         version: 1.3.10
 
+  packages/adapter-node:
+    dependencies:
+      '@ripple-ts/adapter':
+        specifier: workspace:*
+        version: link:../adapter
+
+  packages/adapter-vercel:
+    dependencies:
+      '@ripple-ts/adapter':
+        specifier: workspace:*
+        version: link:../adapter
+      '@ripple-ts/adapter-node':
+        specifier: workspace:*
+        version: link:../adapter-node
+      '@vercel/nft':
+        specifier: catalog:default
+        version: 1.3.2(encoding@0.1.13)(rollup@4.59.0)
+
   packages/bun-plugin-preact:
     dependencies:
       '@tsrx/preact':
@@ -379,24 +397,6 @@ importers:
       typescript:
         specifier: catalog:default
         version: 5.9.3
-
-  packages/adapter-node:
-    dependencies:
-      '@ripple-ts/adapter':
-        specifier: workspace:*
-        version: link:../adapter
-
-  packages/adapter-vercel:
-    dependencies:
-      '@ripple-ts/adapter':
-        specifier: workspace:*
-        version: link:../adapter
-      '@ripple-ts/adapter-node':
-        specifier: workspace:*
-        version: link:../adapter-node
-      '@vercel/nft':
-        specifier: catalog:default
-        version: 1.3.2(encoding@0.1.13)(rollup@4.59.0)
 
   packages/cli:
     devDependencies:
@@ -1025,9 +1025,15 @@ importers:
       react:
         specifier: catalog:default
         version: 19.2.4
+      react-aria-components:
+        specifier: ^1.17.0
+        version: 1.17.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react-dom:
         specifier: catalog:default
         version: 19.2.4(react@19.2.4)
+      react-router:
+        specifier: ^7.14.2
+        version: 7.14.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       typescript:
         specifier: catalog:default
         version: 5.9.3
@@ -2131,6 +2137,15 @@ packages:
       '@types/node':
         optional: true
 
+  '@internationalized/date@3.12.1':
+    resolution: {integrity: sha512-6IedsVWXyq4P9Tj+TxuU8WGWM70hYLl12nbYU8jkikVpa6WXapFazPUcHUMDMoWftIDE2ILDkFFte6W2nFCkRQ==}
+
+  '@internationalized/number@3.6.6':
+    resolution: {integrity: sha512-iFgmQaXHE0vytNfpLZWOC2mEJCBRzcUxt53Xf/yCXG93lRvqas237i3r7X4RKMwO3txiyZD4mQjKAByFv6UGSQ==}
+
+  '@internationalized/string@3.2.8':
+    resolution: {integrity: sha512-NdbMQUSfXLYIQol5VyMtinm9pZDciiMfN7RtmSuSB78io1hqwJ0naYfxyW6vgxWBkzWymQa/3uLDlbfmshtCaA==}
+
   '@isaacs/cliui@9.0.0':
     resolution: {integrity: sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==}
     engines: {node: '>=18'}
@@ -2423,6 +2438,11 @@ packages:
 
   '@quansync/fs@1.0.0':
     resolution: {integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==}
+
+  '@react-types/shared@3.34.0':
+    resolution: {integrity: sha512-gp6xo/s2lX54AlTjOiqwDnxA7UW79BNvI9dB9pr3LZTzRKCd1ZA+ZbgKw/ReIiWuvvVw/8QFJpnqeeFyLocMcQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
   '@rolldown/binding-android-arm64@1.0.0-rc.3':
     resolution: {integrity: sha512-0T1k9FinuBZ/t7rZ8jN6OpUKPnUjNdYHoj/cESWrQ3ZraAJ4OMm6z7QjSfCxqj8mOp9kTKc1zHK3kGz5vMu+nQ==}
@@ -3896,6 +3916,10 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  aria-hidden@1.2.6:
+    resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
+    engines: {node: '>=10'}
+
   array-union@2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
@@ -4174,6 +4198,10 @@ packages:
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
+
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
 
   cookies@0.9.1:
     resolution: {integrity: sha512-TG2hpqe4ELx54QER/S3HQ9SRVnQnGBtKUz5bLQWtYAQ+o6GpgMs6sYUvaiJjVxb+UXwhRhAEP3m7LbsIZ77Hmw==}
@@ -5881,10 +5909,37 @@ packages:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
 
+  react-aria-components@1.17.0:
+    resolution: {integrity: sha512-0EyisMgvsFJ2aML3crDYv2tW5vT2Ryf8PGzY/g63JjDdCbLshlwazhS8JNtPF1vkTkungJJ6sVJbKyX+YKSoFA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  react-aria@3.48.0:
+    resolution: {integrity: sha512-jQjd4rBEIMqecBaAKYJbVGK6EqIHLa5znVQ7jwFyK5vCyljoj6KhgtiahmcIPsG5vG5vEDLw+ba+bEWn6A2P4w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
   react-dom@19.2.4:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
     peerDependencies:
       react: ^19.2.4
+
+  react-router@7.14.2:
+    resolution: {integrity: sha512-yCqNne6I8IB6rVCH7XUvlBK7/QKyqypBFGv+8dj4QBFJiiRX+FG7/nkdAvGElyvVZ/HQP5N19wzteuTARXi5Gw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
+  react-stately@3.46.0:
+    resolution: {integrity: sha512-OdxhWvHgs2L4OJGIs7hnuTr5WjjMM6enhNEAMRqiekhF8+ITvA2LRwNftOZwcogaoCslGYq5S2VQTQwnm0GbCA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
   react@19.2.4:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
@@ -6058,6 +6113,9 @@ packages:
   serve-static@2.2.1:
     resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
     engines: {node: '>= 18'}
+
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
@@ -6586,6 +6644,11 @@ packages:
 
   url-join@4.0.1:
     resolution: {integrity: sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==}
+
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -7927,6 +7990,18 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.11.0
 
+  '@internationalized/date@3.12.1':
+    dependencies:
+      '@swc/helpers': 0.5.15
+
+  '@internationalized/number@3.6.6':
+    dependencies:
+      '@swc/helpers': 0.5.15
+
+  '@internationalized/string@3.2.8':
+    dependencies:
+      '@swc/helpers': 0.5.15
+
   '@isaacs/cliui@9.0.0': {}
 
   '@isaacs/fs-minipass@4.0.1':
@@ -8226,6 +8301,10 @@ snapshots:
   '@quansync/fs@1.0.0':
     dependencies:
       quansync: 1.0.0
+
+  '@react-types/shared@3.34.0(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
 
   '@rolldown/binding-android-arm64@1.0.0-rc.3':
     optional: true
@@ -9678,6 +9757,10 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  aria-hidden@1.2.6:
+    dependencies:
+      tslib: 2.8.1
+
   array-union@2.1.0: {}
 
   assertion-error@2.0.1: {}
@@ -9963,6 +10046,8 @@ snapshots:
   cookie-signature@1.2.2: {}
 
   cookie@0.7.2: {}
+
+  cookie@1.1.1: {}
 
   cookies@0.9.1:
     dependencies:
@@ -11708,10 +11793,53 @@ snapshots:
       strip-json-comments: 2.0.1
     optional: true
 
+  react-aria-components@1.17.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      '@internationalized/date': 3.12.1
+      '@react-types/shared': 3.34.0(react@19.2.4)
+      '@swc/helpers': 0.5.15
+      client-only: 0.0.1
+      react: 19.2.4
+      react-aria: 3.48.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react-dom: 19.2.4(react@19.2.4)
+      react-stately: 3.46.0(react@19.2.4)
+
+  react-aria@3.48.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      '@internationalized/date': 3.12.1
+      '@internationalized/number': 3.6.6
+      '@internationalized/string': 3.2.8
+      '@react-types/shared': 3.34.0(react@19.2.4)
+      '@swc/helpers': 0.5.15
+      aria-hidden: 1.2.6
+      clsx: 2.1.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-stately: 3.46.0(react@19.2.4)
+      use-sync-external-store: 1.6.0(react@19.2.4)
+
   react-dom@19.2.4(react@19.2.4):
     dependencies:
       react: 19.2.4
       scheduler: 0.27.0
+
+  react-router@7.14.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      cookie: 1.1.1
+      react: 19.2.4
+      set-cookie-parser: 2.7.2
+    optionalDependencies:
+      react-dom: 19.2.4(react@19.2.4)
+
+  react-stately@3.46.0(react@19.2.4):
+    dependencies:
+      '@internationalized/date': 3.12.1
+      '@internationalized/number': 3.6.6
+      '@internationalized/string': 3.2.8
+      '@react-types/shared': 3.34.0(react@19.2.4)
+      '@swc/helpers': 0.5.15
+      react: 19.2.4
+      use-sync-external-store: 1.6.0(react@19.2.4)
 
   react@19.2.4: {}
 
@@ -12006,6 +12134,8 @@ snapshots:
       send: 1.2.1
     transitivePeerDependencies:
       - supports-color
+
+  set-cookie-parser@2.7.2: {}
 
   setprototypeof@1.2.0: {}
 
@@ -12553,6 +12683,10 @@ snapshots:
   uri-templates@0.2.0: {}
 
   url-join@4.0.1: {}
+
+  use-sync-external-store@1.6.0(react@19.2.4):
+    dependencies:
+      react: 19.2.4
 
   util-deprecate@1.0.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1016,6 +1016,9 @@ importers:
         specifier: workspace:*
         version: link:../tsrx-react
     devDependencies:
+      '@tanstack/react-query':
+        specifier: ^5.100.6
+        version: 5.100.6(react@19.2.4)
       '@types/react':
         specifier: catalog:default
         version: 19.2.14
@@ -3114,6 +3117,14 @@ packages:
     resolution: {integrity: sha512-TBf2sJjYeb28jD2U/OhwdW0bbOsxkWPwQ7SrqGf9sVcoYwZj7rkXljroBO9wKBut9XnmQLXanuDUeqQK0lGg/w==}
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7
+
+  '@tanstack/query-core@5.100.6':
+    resolution: {integrity: sha512-Os2CPUr98to98RYm+D4qGqGkiffn7MGSyl2547a4MljVkHE30AMJRqTiyCqBfMwzAx/I91vCkAxp5tHSla6Twg==}
+
+  '@tanstack/react-query@5.100.6':
+    resolution: {integrity: sha512-uVSrps0PV16Cxmcn2rvL+dUhwTpTUtiRW347AEeYxMZXO2pZe9ja7E24PAMGoQ5u2g89DD8u4QhOviBk+RN8RA==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@textlint/ast-node-types@15.5.2':
     resolution: {integrity: sha512-fCaOxoup5LIyBEo7R1oYWE7V4bSX0KQeHh66twon9e9usaLE3ijgF8QjYsR6joCssdeCHVd0wHm7ppsEyTr6vg==}
@@ -8832,6 +8843,13 @@ snapshots:
       '@tailwindcss/oxide': 4.2.1
       tailwindcss: 4.2.1
       vite: 8.0.0(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)
+
+  '@tanstack/query-core@5.100.6': {}
+
+  '@tanstack/react-query@5.100.6(react@19.2.4)':
+    dependencies:
+      '@tanstack/query-core': 5.100.6
+      react: 19.2.4
 
   '@textlint/ast-node-types@15.5.2': {}
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Mostly adds new fixture tests and dev-only dependencies, but it introduces several large third-party packages (notably `react-router` with a Node >=20 engine) which could affect CI/install compatibility and test runtime stability.
> 
> **Overview**
> Adds three new `vite-plugin-react` fixture suites (`react-aria`, `react-query`, `react-router`) that exercise `.tsrx` components interacting with third-party TSX libraries, with runtime assertions for rendering, state updates, navigation, and async query caching/refetch behavior.
> 
> Each fixture also includes a dedicated `tsconfig.json` plus a `typecheck.test.js` that runs the custom `typescript-plugin/dist/tsc.js` to ensure TSX/TSRX and the third-party type definitions compose cleanly. Updates `@tsrx/vite-plugin-react` devDependencies and `pnpm-lock.yaml` to include `react-aria-components`, `@tanstack/react-query`, and `react-router`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5945a19512fd224a86681b134f987245f822b3a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->