### PR TITLE
test(tsrx): cover explicit component type args

### DIFF
--- a/packages/tsrx-preact/tests/basic.test.js
+++ b/packages/tsrx-preact/tests/basic.test.js
@@ -14,7 +14,7 @@ runSharedSourceMappingTests({
 });
 
 runSharedCompileTests({ compile, name: 'preact', classAttrName: 'class' });
-runSharedCompileDiagnosticsTests({ compile_to_volar_mappings, name: 'preact' });
+runSharedCompileDiagnosticsTests({ compile, compile_to_volar_mappings, name: 'preact' });
 
 describe('@tsrx/preact basic', () => {
 	it('imports Suspense from preact/compat when try/pending is used', () => {

--- a/packages/tsrx-react/tests/basic.test.js
+++ b/packages/tsrx-react/tests/basic.test.js
@@ -14,7 +14,7 @@ runSharedSourceMappingTests({
 });
 
 runSharedCompileTests({ compile, name: 'react', classAttrName: 'className' });
-runSharedCompileDiagnosticsTests({ compile_to_volar_mappings, name: 'react' });
+runSharedCompileDiagnosticsTests({ compile, compile_to_volar_mappings, name: 'react' });
 
 /**
  * @import { CodeMapping } from '@tsrx/core/types';

--- a/packages/tsrx-solid/tests/basic.test.js
+++ b/packages/tsrx-solid/tests/basic.test.js
@@ -14,7 +14,7 @@ runSharedSourceMappingTests({
 });
 
 runSharedCompileTests({ compile, name: 'solid', classAttrName: 'class' });
-runSharedCompileDiagnosticsTests({ compile_to_volar_mappings, name: 'solid' });
+runSharedCompileDiagnosticsTests({ compile, compile_to_volar_mappings, name: 'solid' });
 
 describe('@tsrx/solid basic', () => {
 	describe('component → function', () => {

--- a/packages/tsrx-vue/tests/basic.test.js
+++ b/packages/tsrx-vue/tests/basic.test.js
@@ -9,7 +9,7 @@ runSharedSourceMappingTests({
 	name: 'vue',
 	rejectsComponentAwait: true,
 });
-runSharedCompileDiagnosticsTests({ compile_to_volar_mappings, name: 'vue' });
+runSharedCompileDiagnosticsTests({ compile, compile_to_volar_mappings, name: 'vue' });
 
 describe('@tsrx/vue basic', () => {
 	it('wraps named component exports in defineVaporComponent', () => {

--- a/packages/tsrx/tests/shared/compile.js
+++ b/packages/tsrx/tests/shared/compile.js
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import ts from 'typescript';
 import { DIAGNOSTIC_CODES } from '../../src/diagnostics.js';
 
 /**
@@ -9,6 +10,7 @@ import { DIAGNOSTIC_CODES } from '../../src/diagnostics.js';
  * }} CompileHarness
  *
  * @typedef {{
+ *   compile: (source: string, filename?: string, options?: any) => { code: string },
  *   compile_to_volar_mappings: (source: string, filename?: string, options?: any) => { errors: Array<{ code?: string }> },
  *   name: string,
  * }} CompileDiagnosticsHarness
@@ -34,13 +36,75 @@ function diagnostic_codes(result) {
 	return result.errors.map((error) => error.code);
 }
 
+const virtual_jsx_types_filename = '/tsrx-shared-jsx.d.ts';
+const virtual_jsx_types = `declare namespace JSX {
+	interface Element {}
+	interface ElementChildrenAttribute {
+		children: {};
+	}
+	interface IntrinsicElements {
+		[name: string]: unknown;
+	}
+}
+declare module 'vue-jsx-vapor' {
+	export function defineVaporComponent<T>(component: T): T;
+}`;
+
+/**
+ * @param {string} code
+ */
+function get_tsx_diagnostics(code) {
+	const filename = '/App.tsx';
+	const options = {
+		jsx: ts.JsxEmit.Preserve,
+		module: ts.ModuleKind.ESNext,
+		moduleResolution: ts.ModuleResolutionKind.Bundler,
+		noEmit: true,
+		skipLibCheck: true,
+		strict: true,
+		target: ts.ScriptTarget.ESNext,
+		types: [],
+	};
+	const host = ts.createCompilerHost(options);
+	const original_get_source_file = host.getSourceFile;
+	host.getSourceFile = (file_name, language_version, on_error, should_create_new_source_file) => {
+		if (file_name === filename) {
+			return ts.createSourceFile(file_name, code, language_version, true, ts.ScriptKind.TSX);
+		}
+		if (file_name === virtual_jsx_types_filename) {
+			return ts.createSourceFile(file_name, virtual_jsx_types, language_version, true);
+		}
+		return original_get_source_file(
+			file_name,
+			language_version,
+			on_error,
+			should_create_new_source_file,
+		);
+	};
+	host.fileExists = (file_name) => {
+		return (
+			file_name === filename ||
+			file_name === virtual_jsx_types_filename ||
+			ts.sys.fileExists(file_name)
+		);
+	};
+	host.readFile = (file_name) => {
+		if (file_name === filename) return code;
+		if (file_name === virtual_jsx_types_filename) return virtual_jsx_types;
+		return ts.sys.readFile(file_name);
+	};
+
+	const program = ts.createProgram([filename, virtual_jsx_types_filename], options, host);
+	return ts.getPreEmitDiagnostics(program);
+}
+
 /**
  * Shared compile/editor diagnostics. These do not assert source-map structure;
  * they only verify that editor-facing compile entry points collect diagnostics.
  *
  * @param {CompileDiagnosticsHarness} harness
  */
-export function runSharedCompileDiagnosticsTests({ compile_to_volar_mappings, name }) {
+export function runSharedCompileDiagnosticsTests({ compile, compile_to_volar_mappings, name }) {
 	describe(`[${name}] compile diagnostics`, () => {
 		it('collects volar parser diagnostics without requiring loose mode', () => {
 			const result = compile_to_volar_mappings(
@@ -51,6 +115,30 @@ export function runSharedCompileDiagnosticsTests({ compile_to_volar_mappings, na
 			);
 
 			expect(diagnostic_codes(result)).toContain(DIAGNOSTIC_CODES.JSX_RETURN_IN_COMPONENT);
+		});
+
+		it('uses explicit component type arguments to type render-prop children', () => {
+			const { code } = compile(
+				`type User = { name: string };
+				type Renderable = JSX.Element;
+
+				component RenderProp<Item = any>({ children }: { children: (item: Item) => Renderable }) {
+					{children({} as Item)}
+				}
+
+				export component App() {
+					<RenderProp<User>>
+						{(item) => item.missing}
+					</RenderProp>
+				}`,
+				'App.tsrx',
+			);
+			const diagnostics = get_tsx_diagnostics(code);
+			const messages = diagnostics.map((diagnostic) =>
+				ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n'),
+			);
+
+			expect(messages).toContain("Property 'missing' does not exist on type 'User'.");
 		});
 	});
 }


### PR DESCRIPTION
- Adds shared diagnostics coverage for explicit type arguments on TSRX component elements with render-prop children.
- Current generated code drops the type argument: `return <RenderProp>{(item) => item.missing}</RenderProp>;`
- Expected generated code keeps it: `return <RenderProp<User>>{(item) => item.missing}</RenderProp>;`
- Current diagnostic: `'item' is of type 'unknown'.`; expected diagnostic: `Property 'missing' does not exist on type 'User'.`
- Test-only PR; no compiler fix included.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that expand the shared diagnostics harness and adjust test wiring across targets; risk is limited to potentially increasing test runtime and introducing brittle TypeScript-diagnostics assertions.
> 
> **Overview**
> Updates the shared `runSharedCompileDiagnosticsTests` harness to take `compile` (not just `compile_to_volar_mappings`) and adds a new regression that TypeScript diagnostics reflect explicit generic type arguments on component elements (render-prop children are typed correctly).
> 
> All platform `basic.test.js` files are updated to call the revised harness, and the new test compiles the emitted TSX and runs `typescript` diagnostics against a small virtual JSX typings shim.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f067cdfa6f72912da665ef3d8897277b8691324. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->