### PR TITLE
feat(tsrx): add marko compile target

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1372,8 +1372,8 @@ importers:
         specifier: ^6.38.6
         version: 6.41.1
       '@marko/tsrx':
-        specifier: ^0.0.1
-        version: 0.0.1
+        specifier: ^0.0.2
+        version: 0.0.2
       '@ripple-ts/adapter-node':
         specifier: workspace:*
         version: link:../packages/adapter-node
@@ -2246,8 +2246,8 @@ packages:
   '@marijn/find-cluster-break@1.0.2':
     resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
 
-  '@marko/tsrx@0.0.1':
-    resolution: {integrity: sha512-5ipbp3xkrF0tTgcPS0Q3AHbet4S42HwkzkbeGfGYgXacxKymdX3XIUspCeiWWGnUDsJePABo40wQ9Q5hbbaKdw==}
+  '@marko/tsrx@0.0.2':
+    resolution: {integrity: sha512-AicFpdN8G9OByQp3+hc9Lq9U6bYGvS3Ly6gk59nXCOzEsWftpsA8+cpFAepeIrzOkr+PwGNuc6hcBze5ZHM22Q==}
     engines: {node: '>=18.0.0'}
 
   '@modelcontextprotocol/sdk@1.27.1':
@@ -8145,7 +8145,7 @@ snapshots:
 
   '@marijn/find-cluster-break@1.0.2': {}
 
-  '@marko/tsrx@0.0.1':
+  '@marko/tsrx@0.0.2':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
       '@tsrx/core': 0.0.14

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1371,6 +1371,9 @@ importers:
       '@codemirror/view':
         specifier: ^6.38.6
         version: 6.41.1
+      '@marko/tsrx':
+        specifier: ^0.0.1
+        version: 0.0.1
       '@ripple-ts/adapter-node':
         specifier: workspace:*
         version: link:../packages/adapter-node
@@ -1395,6 +1398,9 @@ importers:
       prettier:
         specifier: 'catalog:'
         version: 3.8.3
+      prettier-plugin-marko:
+        specifier: ^4.0.9
+        version: 4.0.9
       shiki:
         specifier: 'catalog:'
         version: 4.0.1
@@ -2239,6 +2245,10 @@ packages:
 
   '@marijn/find-cluster-break@1.0.2':
     resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
+
+  '@marko/tsrx@0.0.1':
+    resolution: {integrity: sha512-5ipbp3xkrF0tTgcPS0Q3AHbet4S42HwkzkbeGfGYgXacxKymdX3XIUspCeiWWGnUDsJePABo40wQ9Q5hbbaKdw==}
+    engines: {node: '>=18.0.0'}
 
   '@modelcontextprotocol/sdk@1.27.1':
     resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
@@ -3191,6 +3201,9 @@ packages:
 
   '@toon-format/toon@2.1.0':
     resolution: {integrity: sha512-JwWptdF5eOA0HaQxbKAzkpQtR4wSWTEfDlEy/y3/4okmOAX1qwnpLZMmtEWr+ncAhTTY1raCKH0kteHhSXnQqg==}
+
+  '@tsrx/core@0.0.14':
+    resolution: {integrity: sha512-YCt0WqQ6VMUzED8DmqglFP/kkSZGiiNAxACmiKBtdobbWM76PDw6LS2QoKiSJHbE+20lgUM/MZJrEm5uDT3aDg==}
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
@@ -4895,6 +4908,9 @@ packages:
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
+  htmljs-parser@5.10.2:
+    resolution: {integrity: sha512-Db/pHZehPxGD8Cy0NvACoMfnVQqfgEiK7z+7cuEDOeJdnzuomyaw3I31A+1uoZmS6IjvTD5iuFA+XL2LE+SieA==}
+
   htmlparser2@10.1.0:
     resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
 
@@ -5885,6 +5901,9 @@ packages:
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
+
+  prettier-plugin-marko@4.0.9:
+    resolution: {integrity: sha512-njqNk0oF6jolUMXNUOSlvRe6Dd50DN4NvQk3EY/6hUrU4tJw/HSwvhDF1uTYVs5KjOY5lH+x5C13C1Av9jajWA==}
 
   prettier@2.8.8:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
@@ -8126,6 +8145,11 @@ snapshots:
 
   '@marijn/find-cluster-break@1.0.2': {}
 
+  '@marko/tsrx@0.0.1':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@tsrx/core': 0.0.14
+
   '@modelcontextprotocol/sdk@1.27.1(zod@4.3.6)':
     dependencies:
       '@hono/node-server': 1.19.10(hono@4.12.4)
@@ -8931,6 +8955,19 @@ snapshots:
   '@tokenizer/token@0.3.0': {}
 
   '@toon-format/toon@2.1.0': {}
+
+  '@tsrx/core@0.0.14':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@noble/hashes': 2.2.0
+      '@sveltejs/acorn-typescript': 1.0.9(acorn@8.16.0)
+      '@types/estree': 1.0.8
+      '@types/estree-jsx': 1.0.5
+      acorn: 8.16.0
+      esrap: 2.2.3
+      is-reference: 3.0.3
+      magic-string: 0.30.21
+      zimmerframe: 1.1.4
 
   '@tybys/wasm-util@0.10.1':
     dependencies:
@@ -10826,6 +10863,8 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
+  htmljs-parser@5.10.2: {}
+
   htmlparser2@10.1.0:
     dependencies:
       domelementtype: 2.3.0
@@ -11780,6 +11819,10 @@ snapshots:
       tar-fs: 2.1.4
 
   prelude-ls@1.2.1: {}
+
+  prettier-plugin-marko@4.0.9:
+    dependencies:
+      htmljs-parser: 5.10.2
 
   prettier@2.8.8: {}
 

--- a/website-tsrx/package.json
+++ b/website-tsrx/package.json
@@ -26,7 +26,7 @@
     "@tsrx/react": "workspace:*",
     "@tsrx/ripple": "workspace:*",
     "@tsrx/solid": "workspace:*",
-    "@marko/tsrx": "^0.0.1",
+    "@marko/tsrx": "^0.0.2",
     "prettier-plugin-marko": "^4.0.9",
     "@tsrx/vue": "workspace:*",
     "prettier": "catalog:",

--- a/website-tsrx/package.json
+++ b/website-tsrx/package.json
@@ -26,6 +26,8 @@
     "@tsrx/react": "workspace:*",
     "@tsrx/ripple": "workspace:*",
     "@tsrx/solid": "workspace:*",
+    "@marko/tsrx": "^0.0.1",
+    "prettier-plugin-marko": "^4.0.9",
     "@tsrx/vue": "workspace:*",
     "prettier": "catalog:",
     "shiki": "catalog:"

--- a/website-tsrx/src/components/compiler-demo.tsrx
+++ b/website-tsrx/src/components/compiler-demo.tsrx
@@ -15,6 +15,7 @@ const TARGET_OPTIONS = [
 	{ value: 'ripple', label: 'Ripple' },
 	{ value: 'solid', label: 'Solid' },
 	{ value: 'vue', label: 'Vue' },
+	{ value: 'marko', label: 'Marko' },
 ];
 const TARGET_LABELS: Record<string, string> = {
 	react: 'React output',
@@ -22,6 +23,11 @@ const TARGET_LABELS: Record<string, string> = {
 	vue: 'Vue output',
 	ripple: 'Ripple output',
 	solid: 'Solid output',
+	marko: 'Marko output',
+};
+
+const TARGET_OUTPUT_LANG: Record<string, string> = {
+	marko: 'marko',
 };
 
 const VALID_TARGETS = new Set(TARGET_OPTIONS.map((o) => o.value));
@@ -122,7 +128,7 @@ export component CompilerDemo() {
 		};
 
 		(async () => {
-			const [{ EditorState }, { oneDark }, {
+			const [{ EditorState, Compartment }, { oneDark }, {
 				history,
 				defaultKeymap,
 				historyKeymap,
@@ -141,6 +147,8 @@ export component CompilerDemo() {
 
 			const { EditorView, keymap, lineNumbers, highlightActiveLine, drawSelection } = view_mod;
 			const { shiki_highlight } = shiki_mod;
+
+			const output_lang_compartment = new Compartment();
 
 			const shared_theme = EditorView.theme(
 				{
@@ -192,7 +200,7 @@ export component CompilerDemo() {
 				EditorView.editable.of(false),
 				EditorView.lineWrapping,
 				EditorState.tabSize.of(2),
-				shiki_highlight('tsx'),
+				output_lang_compartment.of(shiki_highlight('tsx')),
 				shared_theme,
 			];
 
@@ -249,6 +257,8 @@ export component CompilerDemo() {
 						return;
 					}
 
+					const output_lang = TARGET_OUTPUT_LANG[selected_target.value] ?? 'tsx';
+					output_view.dispatch({ effects: output_lang_compartment.reconfigure(shiki_highlight(output_lang)) });
 					replace_doc(output_view, join_compiled_output(payload.output.code, payload.output.css));
 					status = `${TARGET_LABELS[payload.target] ?? 'Selected output'} ready`;
 					last_updated = new Date().toLocaleTimeString([], {

--- a/website-tsrx/src/lib/shiki-codemirror.ts
+++ b/website-tsrx/src/lib/shiki-codemirror.ts
@@ -26,6 +26,7 @@ function get_highlighter(): Promise<Highlighter> {
 				'jsx',
 				'tsx',
 				'css',
+				'marko',
 				modified_grammar as any,
 				{ ...(modified_grammar as any), name: 'ripple' },
 			],

--- a/website-tsrx/src/routes.ts
+++ b/website-tsrx/src/routes.ts
@@ -4,11 +4,13 @@ import * as ripple_prettier_plugin from '@tsrx/prettier-plugin';
 import { compile as compile_react } from '@tsrx/react';
 import { compile as compile_ripple } from '@tsrx/ripple';
 import { compile as compile_solid } from '@tsrx/solid';
+import { compile as compile_marko } from '@marko/tsrx';
+import * as marko_prettier_plugin from 'prettier-plugin-marko';
 import { compile as compile_vue } from '@tsrx/vue';
 import { format } from 'prettier';
 
 const MAX_SOURCE_LENGTH = 12000;
-const VALID_TARGETS = ['react', 'preact', 'ripple', 'solid', 'vue'] as const;
+const VALID_TARGETS = ['react', 'preact', 'ripple', 'solid', 'vue', 'marko'] as const;
 
 type CompileTarget = (typeof VALID_TARGETS)[number];
 
@@ -56,6 +58,20 @@ async function format_css(css: string) {
 		return await format(css, { parser: 'css', useTabs: false, tabWidth: 2, printWidth: 80 });
 	} catch {
 		return css;
+	}
+}
+
+async function format_marko(code: string) {
+	try {
+		return await format(code, {
+			parser: 'marko',
+			plugins: [marko_prettier_plugin as any],
+			useTabs: false,
+			tabWidth: 2,
+			printWidth: 80,
+		});
+	} catch {
+		return code;
 	}
 }
 
@@ -108,6 +124,17 @@ async function compile_target(target: CompileTarget, source: string) {
 			output: {
 				code: await format_js(vue_result.code),
 				css: await format_css(vue_result.css?.code ?? ''),
+			},
+		};
+	}
+
+	if (target === 'marko') {
+		const marko_result = compile_marko(source, 'LiveDemo.tsrx');
+
+		return {
+			target,
+			output: {
+				code: await format_marko(marko_result.code),
 			},
 		};
 	}
@@ -195,7 +222,7 @@ export const routes = [
 
 			if (!is_valid_target(target)) {
 				return Response.json(
-					{ error: 'Target must be one of: react, preact, ripple, solid, vue.' },
+					{ error: 'Target must be one of: react, preact, ripple, solid, vue, marko.' },
 					{ status: 400 },
 				);
 			}


### PR DESCRIPTION
I added a [compile target](https://www.npmjs.com/package/@marko/tsrx) & [vite plugin](https://www.npmjs.com/package/@marko/vite-plugin-tsrx) that enables TSRX syntax to be used in Marko in [this repo](https://github.com/marko-js/tsrx). This PR adds Marko to the list in the dropdown, for demonstration.

No pressure to merge, and I'd also be happy to deprecate `@marko/tsrx` in favor of `@tsrx/marko` if you would rather have ownership. Just wanted to show what's possible!


<img width="1078" height="381" alt="screenshot of the tsrx.dev playground, with Ripple on the left and Marko on the right. The component is a basic counter" src="https://github.com/user-attachments/assets/b3c2e059-2dcd-4b77-9db4-acf4f5fa2899" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new compile/format path and third-party dependencies (`@marko/tsrx`, `prettier-plugin-marko`) to the playground’s server-side `/api/compile` flow, which could introduce runtime/formatting regressions for the new target.
> 
> **Overview**
> Adds **Marko** as a new TSRX playground compile target end-to-end.
> 
> The playground UI now includes `marko` in the target dropdown and dynamically switches output syntax highlighting to `marko` (via a CodeMirror `Compartment`) when that target is selected; Shiki is updated to load the `marko` language.
> 
> The server `/api/compile` endpoint now accepts `marko`, compiles via `@marko/tsrx`, and formats the emitted code with `prettier-plugin-marko`; dependencies and lockfile are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17abba2bd6e7adad46cbf9f6cfee6d14680f4145. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->