### PR TITLE
fix: stale outer binding when control flow block apply changes

### DIFF
--- a/.changeset/smooth-icons-shave.md
+++ b/.changeset/smooth-icons-shave.md
@@ -1,0 +1,18 @@
+---
+'@tsrx/preact': patch
+'@tsrx/react': patch
+'@tsrx/react-playground': patch
+'@tsrx/solid-playground': patch
+'@tsrx/core': patch
+---
+
+Fixes a bug where for all control statements: for, if, switch, try/pending/catch
+where using hooks inside to change values, like useState, would not be reflected
+in the subsequent code. The fix involved creating continuation hooks and calling
+them at the end of the control flow block - it's an oversimplification.
+
+Fixes the for loop by hoisting the generated statement body hooks and types to the
+outside of the loop.
+
+Refactors a bunch, but not all, manually created AST nodes into using ast builder
+functions.

--- a/packages/tsrx-preact/tests/__snapshots__/basic.test.js.snap
+++ b/packages/tsrx-preact/tests/__snapshots__/basic.test.js.snap
@@ -224,17 +224,19 @@ export function App({ kind }: { kind: 'a' | 'b' }) {
 		return null;
 	});
 
+	const _tsrx_StatementBodyHook2_x = x;
+
+	const StatementBodyHook2 = App__StatementBodyHook2 ?? (App__StatementBodyHook2 = function StatementBodyHook2({ x }: { x: typeof _tsrx_StatementBodyHook2_x }) {
+		[x] = useState(100);
+
+		return <><div>{x}</div><StatementBodyHook1 x={x} /></>;
+	});
+
 	switch (kind) {
 		case 'a':
 			return <StatementBodyHook1 x={x} />;
 
 		case 'b':
-			const _tsrx_StatementBodyHook2_x = x;
-			const StatementBodyHook2 = App__StatementBodyHook2 ?? (App__StatementBodyHook2 = function StatementBodyHook2({ x }: { x: typeof _tsrx_StatementBodyHook2_x }) {
-				[x] = useState(100);
-
-				return <><div>{x}</div><StatementBodyHook1 x={x} /></>;
-			});
 			return <StatementBodyHook2 x={x} />;
 	}
 
@@ -267,8 +269,8 @@ export function App({ kind }: { kind: 'a' | 'b' }) {
 
 exports[`[preact] continuation lift for switch-with-hook > lifts the tail of a switch whose cases contain hooks 1`] = `
 "let App__StatementBodyHook1;
-let App__StatementBodyHook2;
 let App__StatementBodyHook3;
+let App__StatementBodyHook2;
 
 export function App({ kind }: { kind: 'a' | 'b' }) {
 	let x: number | undefined;
@@ -280,23 +282,27 @@ export function App({ kind }: { kind: 'a' | 'b' }) {
 		return null;
 	});
 
+	const _tsrx_StatementBodyHook2_x = x;
+
+	const StatementBodyHook2 = App__StatementBodyHook2 ?? (App__StatementBodyHook2 = function StatementBodyHook2({ x }: { x: typeof _tsrx_StatementBodyHook2_x }) {
+		[x] = useState(100);
+
+		return <><div>{x}</div><StatementBodyHook1 x={x} /></>;
+	});
+
+	const _tsrx_StatementBodyHook3_x = x;
+
+	const StatementBodyHook3 = App__StatementBodyHook3 ?? (App__StatementBodyHook3 = function StatementBodyHook3({ x }: { x: typeof _tsrx_StatementBodyHook3_x }) {
+		[x] = useState(200);
+
+		return <><span>{x}</span><StatementBodyHook1 x={x} /></>;
+	});
+
 	switch (kind) {
 		case 'a':
-			const _tsrx_StatementBodyHook2_x = x;
-			const StatementBodyHook2 = App__StatementBodyHook2 ?? (App__StatementBodyHook2 = function StatementBodyHook2({ x }: { x: typeof _tsrx_StatementBodyHook2_x }) {
-				[x] = useState(100);
-
-				return <><div>{x}</div><StatementBodyHook1 x={x} /></>;
-			});
 			return <StatementBodyHook2 x={x} />;
 
 		case 'b':
-			const _tsrx_StatementBodyHook3_x = x;
-			const StatementBodyHook3 = App__StatementBodyHook3 ?? (App__StatementBodyHook3 = function StatementBodyHook3({ x }: { x: typeof _tsrx_StatementBodyHook3_x }) {
-				[x] = useState(200);
-
-				return <><span>{x}</span><StatementBodyHook1 x={x} /></>;
-			});
 			return <StatementBodyHook3 x={x} />;
 	}
 
@@ -307,8 +313,8 @@ export function App({ kind }: { kind: 'a' | 'b' }) {
 exports[`[preact] continuation lift for switch-with-hook > lifts the tail when a switch has a default case with a hook 1`] = `
 "const App__static1 = <div>{'a'}</div>;
 let App__StatementBodyHook1;
-let App__StatementBodyHook2;
 let App__StatementBodyHook3;
+let App__StatementBodyHook2;
 
 export function App({ kind }: { kind: string }) {
 	let x: number | undefined;
@@ -320,21 +326,25 @@ export function App({ kind }: { kind: string }) {
 		return null;
 	});
 
+	const _tsrx_StatementBodyHook2_x = x;
+
+	const StatementBodyHook2 = App__StatementBodyHook2 ?? (App__StatementBodyHook2 = function StatementBodyHook2({ x }: { x: typeof _tsrx_StatementBodyHook2_x }) {
+		return <>{App__static1}<StatementBodyHook1 x={x} /></>;
+	});
+
+	const _tsrx_StatementBodyHook3_x = x;
+
+	const StatementBodyHook3 = App__StatementBodyHook3 ?? (App__StatementBodyHook3 = function StatementBodyHook3({ x }: { x: typeof _tsrx_StatementBodyHook3_x }) {
+		[x] = useState(100);
+
+		return <><div>{x}</div><StatementBodyHook1 x={x} /></>;
+	});
+
 	switch (kind) {
 		case 'a':
-			const _tsrx_StatementBodyHook2_x = x;
-			const StatementBodyHook2 = App__StatementBodyHook2 ?? (App__StatementBodyHook2 = function StatementBodyHook2({ x }: { x: typeof _tsrx_StatementBodyHook2_x }) {
-				return <>{App__static1}<StatementBodyHook1 x={x} /></>;
-			});
 			return <StatementBodyHook2 x={x} />;
 
 		default:
-			const _tsrx_StatementBodyHook3_x = x;
-			const StatementBodyHook3 = App__StatementBodyHook3 ?? (App__StatementBodyHook3 = function StatementBodyHook3({ x }: { x: typeof _tsrx_StatementBodyHook3_x }) {
-				[x] = useState(100);
-
-				return <><div>{x}</div><StatementBodyHook1 x={x} /></>;
-			});
 			return <StatementBodyHook3 x={x} />;
 	}
 
@@ -343,12 +353,12 @@ export function App({ kind }: { kind: string }) {
 `;
 
 exports[`[preact] continuation lift for switch-with-hook > lifts the tail when only some switch cases contain hooks 1`] = `
-"const App__static1 = <span>{'static'}</span>;
-const App__static2 = <p>{'fallback'}</p>;
+"const App__static1 = <p>{'fallback'}</p>;
+const App__static2 = <span>{'static'}</span>;
 let App__StatementBodyHook1;
-let App__StatementBodyHook2;
-let App__StatementBodyHook3;
 let App__StatementBodyHook4;
+let App__StatementBodyHook3;
+let App__StatementBodyHook2;
 
 export function App({ kind }: { kind: 'a' | 'b' | 'c' }) {
 	let x: number | undefined;
@@ -360,28 +370,34 @@ export function App({ kind }: { kind: 'a' | 'b' | 'c' }) {
 		return null;
 	});
 
+	const _tsrx_StatementBodyHook2_x = x;
+
+	const StatementBodyHook2 = App__StatementBodyHook2 ?? (App__StatementBodyHook2 = function StatementBodyHook2({ x }: { x: typeof _tsrx_StatementBodyHook2_x }) {
+		[x] = useState(100);
+
+		return <><div>{x}</div><StatementBodyHook1 x={x} /></>;
+	});
+
+	const _tsrx_StatementBodyHook3_x = x;
+
+	const StatementBodyHook3 = App__StatementBodyHook3 ?? (App__StatementBodyHook3 = function StatementBodyHook3({ x }: { x: typeof _tsrx_StatementBodyHook3_x }) {
+		return <>{App__static2}<StatementBodyHook1 x={x} /></>;
+	});
+
+	const _tsrx_StatementBodyHook4_x = x;
+
+	const StatementBodyHook4 = App__StatementBodyHook4 ?? (App__StatementBodyHook4 = function StatementBodyHook4({ x }: { x: typeof _tsrx_StatementBodyHook4_x }) {
+		return <>{App__static1}<StatementBodyHook1 x={x} /></>;
+	});
+
 	switch (kind) {
 		case 'a':
-			const _tsrx_StatementBodyHook2_x = x;
-			const StatementBodyHook2 = App__StatementBodyHook2 ?? (App__StatementBodyHook2 = function StatementBodyHook2({ x }: { x: typeof _tsrx_StatementBodyHook2_x }) {
-				[x] = useState(100);
-
-				return <><div>{x}</div><StatementBodyHook1 x={x} /></>;
-			});
 			return <StatementBodyHook2 x={x} />;
 
 		case 'b':
-			const _tsrx_StatementBodyHook3_x = x;
-			const StatementBodyHook3 = App__StatementBodyHook3 ?? (App__StatementBodyHook3 = function StatementBodyHook3({ x }: { x: typeof _tsrx_StatementBodyHook3_x }) {
-				return <>{App__static1}<StatementBodyHook1 x={x} /></>;
-			});
 			return <StatementBodyHook3 x={x} />;
 
 		default:
-			const _tsrx_StatementBodyHook4_x = x;
-			const StatementBodyHook4 = App__StatementBodyHook4 ?? (App__StatementBodyHook4 = function StatementBodyHook4({ x }: { x: typeof _tsrx_StatementBodyHook4_x }) {
-				return <>{App__static2}<StatementBodyHook1 x={x} /></>;
-			});
 			return <StatementBodyHook4 x={x} />;
 	}
 
@@ -421,8 +437,8 @@ export function App({ kind }: { kind: 'a' | 'b' }) {
 
 exports[`[preact] continuation lift for switch-with-hook > non-empty fall-through merges the trailing case body into the falling case 1`] = `
 "let App__StatementBodyHook1;
-let App__StatementBodyHook2;
 let App__StatementBodyHook3;
+let App__StatementBodyHook2;
 
 export function App({ kind }: { kind: 'a' | 'b' }) {
 	let x: number | undefined;
@@ -434,24 +450,27 @@ export function App({ kind }: { kind: 'a' | 'b' }) {
 		return null;
 	});
 
+	const _tsrx_StatementBodyHook2_x = x;
+
+	const StatementBodyHook2 = App__StatementBodyHook2 ?? (App__StatementBodyHook2 = function StatementBodyHook2({ x }: { x: typeof _tsrx_StatementBodyHook2_x }) {
+		x = 1;
+
+		return <StatementBodyHook3 x={x} />;
+	});
+
+	const _tsrx_StatementBodyHook3_x = x;
+
+	const StatementBodyHook3 = App__StatementBodyHook3 ?? (App__StatementBodyHook3 = function StatementBodyHook3({ x }: { x: typeof _tsrx_StatementBodyHook3_x }) {
+		[x] = useState(100);
+
+		return <><div>{x}</div><StatementBodyHook1 x={x} /></>;
+	});
+
 	switch (kind) {
 		case 'a':
-			const _tsrx_StatementBodyHook2_x = x;
-			const StatementBodyHook2 = App__StatementBodyHook2 ?? (App__StatementBodyHook2 = function StatementBodyHook2({ x }: { x: typeof _tsrx_StatementBodyHook2_x }) {
-				x = 1;
-				[x] = useState(100);
-
-				return <><div>{x}</div><StatementBodyHook1 x={x} /></>;
-			});
 			return <StatementBodyHook2 x={x} />;
 
 		case 'b':
-			const _tsrx_StatementBodyHook3_x = x;
-			const StatementBodyHook3 = App__StatementBodyHook3 ?? (App__StatementBodyHook3 = function StatementBodyHook3({ x }: { x: typeof _tsrx_StatementBodyHook3_x }) {
-				[x] = useState(100);
-
-				return <><div>{x}</div><StatementBodyHook1 x={x} /></>;
-			});
 			return <StatementBodyHook3 x={x} />;
 	}
 
@@ -462,8 +481,8 @@ export function App({ kind }: { kind: 'a' | 'b' }) {
 exports[`[preact] continuation lift for switch-with-hook > preserves empty fall-through cases that share a body with the next case 1`] = `
 "const App__static1 = <span>{'other'}</span>;
 let App__StatementBodyHook1;
-let App__StatementBodyHook2;
 let App__StatementBodyHook3;
+let App__StatementBodyHook2;
 
 export function App({ kind }: { kind: 'a' | 'b' | 'c' }) {
 	let x: number | undefined;
@@ -475,23 +494,27 @@ export function App({ kind }: { kind: 'a' | 'b' | 'c' }) {
 		return null;
 	});
 
+	const _tsrx_StatementBodyHook2_x = x;
+
+	const StatementBodyHook2 = App__StatementBodyHook2 ?? (App__StatementBodyHook2 = function StatementBodyHook2({ x }: { x: typeof _tsrx_StatementBodyHook2_x }) {
+		[x] = useState(100);
+
+		return <><div>{x}</div><StatementBodyHook1 x={x} /></>;
+	});
+
+	const _tsrx_StatementBodyHook3_x = x;
+
+	const StatementBodyHook3 = App__StatementBodyHook3 ?? (App__StatementBodyHook3 = function StatementBodyHook3({ x }: { x: typeof _tsrx_StatementBodyHook3_x }) {
+		return <>{App__static1}<StatementBodyHook1 x={x} /></>;
+	});
+
 	switch (kind) {
 		case 'a':
 
 		case 'b':
-			const _tsrx_StatementBodyHook2_x = x;
-			const StatementBodyHook2 = App__StatementBodyHook2 ?? (App__StatementBodyHook2 = function StatementBodyHook2({ x }: { x: typeof _tsrx_StatementBodyHook2_x }) {
-				[x] = useState(100);
-
-				return <><div>{x}</div><StatementBodyHook1 x={x} /></>;
-			});
 			return <StatementBodyHook2 x={x} />;
 
 		default:
-			const _tsrx_StatementBodyHook3_x = x;
-			const StatementBodyHook3 = App__StatementBodyHook3 ?? (App__StatementBodyHook3 = function StatementBodyHook3({ x }: { x: typeof _tsrx_StatementBodyHook3_x }) {
-				return <>{App__static1}<StatementBodyHook1 x={x} /></>;
-			});
 			return <StatementBodyHook3 x={x} />;
 	}
 

--- a/packages/tsrx-preact/tests/__snapshots__/basic.test.js.snap
+++ b/packages/tsrx-preact/tests/__snapshots__/basic.test.js.snap
@@ -1,0 +1,805 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`[preact] continuation lift for if-with-hook > chains tail helpers across sibling ifs that each contain hooks 1`] = `
+"let App__StatementBodyHook2;
+let App__StatementBodyHook3;
+let App__StatementBodyHook1;
+let App__StatementBodyHook4;
+
+export function App({ a, b }: { a: boolean; b: boolean }) {
+	let x: number | undefined;
+	let y: number | undefined;
+	const _tsrx_StatementBodyHook1_b = b;
+	const _tsrx_StatementBodyHook1_x = x;
+	const _tsrx_StatementBodyHook1_y = y;
+
+	const StatementBodyHook1 = App__StatementBodyHook1 ?? (App__StatementBodyHook1 = function StatementBodyHook1(
+		{ b, x, y }: { 
+			b: typeof _tsrx_StatementBodyHook1_b;
+			x: typeof _tsrx_StatementBodyHook1_x;
+			y: typeof _tsrx_StatementBodyHook1_y
+		 }
+	) {
+		const _tsrx_StatementBodyHook2_x = x;
+		const _tsrx_StatementBodyHook2_y = y;
+
+		const StatementBodyHook2 = App__StatementBodyHook2 ?? (App__StatementBodyHook2 = function StatementBodyHook2(
+			{ x, y }: { 
+				x: typeof _tsrx_StatementBodyHook2_x;
+				y: typeof _tsrx_StatementBodyHook2_y
+			 }
+		) {
+			console.log(x, y);
+
+			return null;
+		});
+
+		if (b) {
+			const _tsrx_StatementBodyHook3_x = x;
+			const _tsrx_StatementBodyHook3_y = y;
+
+			const StatementBodyHook3 = App__StatementBodyHook3 ?? (App__StatementBodyHook3 = function StatementBodyHook3(
+				{ x, y }: { 
+					x: typeof _tsrx_StatementBodyHook3_x;
+					y: typeof _tsrx_StatementBodyHook3_y
+				 }
+			) {
+				[y] = useState(200);
+
+				return <><span>{y}</span><StatementBodyHook2 x={x} y={y} /></>;
+			});
+
+			return <StatementBodyHook3 x={x} y={y} />;
+		}
+
+		return <StatementBodyHook2 x={x} y={y} />;
+	});
+
+	if (a) {
+		const _tsrx_StatementBodyHook4_b = b;
+		const _tsrx_StatementBodyHook4_x = x;
+		const _tsrx_StatementBodyHook4_y = y;
+
+		const StatementBodyHook4 = App__StatementBodyHook4 ?? (App__StatementBodyHook4 = function StatementBodyHook4(
+			{ b, x, y }: { 
+				b: typeof _tsrx_StatementBodyHook4_b;
+				x: typeof _tsrx_StatementBodyHook4_x;
+				y: typeof _tsrx_StatementBodyHook4_y
+			 }
+		) {
+			[x] = useState(100);
+
+			return <><div>{x}</div><StatementBodyHook1 b={b} x={x} y={y} /></>;
+		});
+
+		return <StatementBodyHook4 b={b} x={x} y={y} />;
+	}
+
+	return <StatementBodyHook1 b={b} x={x} y={y} />;
+}"
+`;
+
+exports[`[preact] continuation lift for if-with-hook > does not lift when the if has an else branch 1`] = `
+"const App__static1 = <div>{'no'}</div>;
+let App__StatementBodyHook1;
+
+export function App({ show }: { show: boolean }) {
+	let x: number | undefined;
+
+	const _tsrx_child_0 = show
+		? (() => {
+			const _tsrx_StatementBodyHook1_x = x;
+
+			const StatementBodyHook1 = App__StatementBodyHook1 ?? (App__StatementBodyHook1 = function StatementBodyHook1({ x }: { x: typeof _tsrx_StatementBodyHook1_x }) {
+				[x] = useState(100);
+
+				return <div>{x}</div>;
+			});
+
+			return <StatementBodyHook1 x={x} />;
+		})()
+		: App__static1;
+
+	console.log(x);
+
+	return _tsrx_child_0;
+}"
+`;
+
+exports[`[preact] continuation lift for if-with-hook > does not lift when the if has no statements after it 1`] = `
+"let App__StatementBodyHook1;
+
+export function App({ show }: { show: boolean }) {
+	return show
+		? (() => {
+			const StatementBodyHook1 = App__StatementBodyHook1 ?? (App__StatementBodyHook1 = function StatementBodyHook1() {
+				const [x] = useState(100);
+
+				return <div>{x}</div>;
+			});
+
+			return <StatementBodyHook1 />;
+		})()
+		: null;
+}"
+`;
+
+exports[`[preact] continuation lift for if-with-hook > handles nested if-with-hook so the mid-tail observes the inner hook 1`] = `
+"let App__StatementBodyHook1;
+let App__StatementBodyHook3;
+let App__StatementBodyHook4;
+let App__StatementBodyHook2;
+
+export function App({ a, b }: { a: boolean; b: boolean }) {
+	let x: number | undefined;
+	const _tsrx_StatementBodyHook1_x = x;
+
+	const StatementBodyHook1 = App__StatementBodyHook1 ?? (App__StatementBodyHook1 = function StatementBodyHook1({ x }: { x: typeof _tsrx_StatementBodyHook1_x }) {
+		console.log('end', x);
+
+		return null;
+	});
+
+	if (a) {
+		const _tsrx_StatementBodyHook2_b = b;
+		const _tsrx_StatementBodyHook2_x = x;
+
+		const StatementBodyHook2 = App__StatementBodyHook2 ?? (App__StatementBodyHook2 = function StatementBodyHook2(
+			{ b, x }: { 
+				b: typeof _tsrx_StatementBodyHook2_b;
+				x: typeof _tsrx_StatementBodyHook2_x
+			 }
+		) {
+			const _tsrx_StatementBodyHook3_x = x;
+
+			const StatementBodyHook3 = App__StatementBodyHook3 ?? (App__StatementBodyHook3 = function StatementBodyHook3({ x }: { x: typeof _tsrx_StatementBodyHook3_x }) {
+				console.log('mid', x);
+
+				return <StatementBodyHook1 x={x} />;
+			});
+
+			if (b) {
+				const _tsrx_StatementBodyHook4_x = x;
+
+				const StatementBodyHook4 = App__StatementBodyHook4 ?? (App__StatementBodyHook4 = function StatementBodyHook4({ x }: { x: typeof _tsrx_StatementBodyHook4_x }) {
+					[x] = useState(100);
+
+					return <><div>{x}</div><StatementBodyHook3 x={x} /></>;
+				});
+
+				return <StatementBodyHook4 x={x} />;
+			}
+
+			return <StatementBodyHook3 x={x} />;
+		});
+
+		return <StatementBodyHook2 b={b} x={x} />;
+	}
+
+	return <StatementBodyHook1 x={x} />;
+}"
+`;
+
+exports[`[preact] continuation lift for if-with-hook > lifts the tail of a single non-returning if-with-hook into a helper 1`] = `
+"let App__StatementBodyHook1;
+let App__StatementBodyHook2;
+
+export function App({ show }: { show: boolean }) {
+	let x: number | undefined;
+	const _tsrx_StatementBodyHook1_x = x;
+
+	const StatementBodyHook1 = App__StatementBodyHook1 ?? (App__StatementBodyHook1 = function StatementBodyHook1({ x }: { x: typeof _tsrx_StatementBodyHook1_x }) {
+		console.log(x);
+
+		return null;
+	});
+
+	if (show) {
+		const _tsrx_StatementBodyHook2_x = x;
+
+		const StatementBodyHook2 = App__StatementBodyHook2 ?? (App__StatementBodyHook2 = function StatementBodyHook2({ x }: { x: typeof _tsrx_StatementBodyHook2_x }) {
+			[x] = useState(100);
+
+			return <><div>{x}</div><StatementBodyHook1 x={x} /></>;
+		});
+
+		return <StatementBodyHook2 x={x} />;
+	}
+
+	return <StatementBodyHook1 x={x} />;
+}"
+`;
+
+exports[`[preact] continuation lift for switch-with-hook > does not lift when the switch has no statements after it 1`] = `
+"let App__StatementBodyHook1;
+
+export function App({ kind }: { kind: 'a' | 'b' }) {
+	return (() => {
+		switch (kind) {
+			case 'a':
+				const StatementBodyHook1 = App__StatementBodyHook1 ?? (App__StatementBodyHook1 = function StatementBodyHook1() {
+					const [x] = useState(100);
+
+					return <div>{x}</div>;
+				});
+				return <StatementBodyHook1 />;
+
+			case 'b':
+				return <span>{'b'}</span>;
+		}
+
+		return null;
+	})();
+}"
+`;
+
+exports[`[preact] continuation lift for switch-with-hook > lifts the tail of a switch whose cases contain hooks 1`] = `
+"let App__StatementBodyHook1;
+let App__StatementBodyHook2;
+let App__StatementBodyHook3;
+
+export function App({ kind }: { kind: 'a' | 'b' }) {
+	let x: number | undefined;
+	const _tsrx_StatementBodyHook1_x = x;
+
+	const StatementBodyHook1 = App__StatementBodyHook1 ?? (App__StatementBodyHook1 = function StatementBodyHook1({ x }: { x: typeof _tsrx_StatementBodyHook1_x }) {
+		console.log(x);
+
+		return null;
+	});
+
+	switch (kind) {
+		case 'a':
+			const _tsrx_StatementBodyHook2_x = x;
+			const StatementBodyHook2 = App__StatementBodyHook2 ?? (App__StatementBodyHook2 = function StatementBodyHook2({ x }: { x: typeof _tsrx_StatementBodyHook2_x }) {
+				[x] = useState(100);
+
+				return <><div>{x}</div><StatementBodyHook1 x={x} /></>;
+			});
+			return <StatementBodyHook2 x={x} />;
+
+		case 'b':
+			const _tsrx_StatementBodyHook3_x = x;
+			const StatementBodyHook3 = App__StatementBodyHook3 ?? (App__StatementBodyHook3 = function StatementBodyHook3({ x }: { x: typeof _tsrx_StatementBodyHook3_x }) {
+				[x] = useState(200);
+
+				return <><span>{x}</span><StatementBodyHook1 x={x} /></>;
+			});
+			return <StatementBodyHook3 x={x} />;
+	}
+
+	return <StatementBodyHook1 x={x} />;
+}"
+`;
+
+exports[`[preact] continuation lift for switch-with-hook > lifts the tail when a switch has a default case with a hook 1`] = `
+"const App__static1 = <div>{'a'}</div>;
+let App__StatementBodyHook1;
+let App__StatementBodyHook2;
+let App__StatementBodyHook3;
+
+export function App({ kind }: { kind: string }) {
+	let x: number | undefined;
+	const _tsrx_StatementBodyHook1_x = x;
+
+	const StatementBodyHook1 = App__StatementBodyHook1 ?? (App__StatementBodyHook1 = function StatementBodyHook1({ x }: { x: typeof _tsrx_StatementBodyHook1_x }) {
+		console.log(x);
+
+		return null;
+	});
+
+	switch (kind) {
+		case 'a':
+			const _tsrx_StatementBodyHook2_x = x;
+			const StatementBodyHook2 = App__StatementBodyHook2 ?? (App__StatementBodyHook2 = function StatementBodyHook2({ x }: { x: typeof _tsrx_StatementBodyHook2_x }) {
+				return <>{App__static1}<StatementBodyHook1 x={x} /></>;
+			});
+			return <StatementBodyHook2 x={x} />;
+
+		default:
+			const _tsrx_StatementBodyHook3_x = x;
+			const StatementBodyHook3 = App__StatementBodyHook3 ?? (App__StatementBodyHook3 = function StatementBodyHook3({ x }: { x: typeof _tsrx_StatementBodyHook3_x }) {
+				[x] = useState(100);
+
+				return <><div>{x}</div><StatementBodyHook1 x={x} /></>;
+			});
+			return <StatementBodyHook3 x={x} />;
+	}
+
+	return <StatementBodyHook1 x={x} />;
+}"
+`;
+
+exports[`[preact] continuation lift for switch-with-hook > lifts the tail when only some switch cases contain hooks 1`] = `
+"const App__static1 = <span>{'static'}</span>;
+const App__static2 = <p>{'fallback'}</p>;
+let App__StatementBodyHook1;
+let App__StatementBodyHook2;
+let App__StatementBodyHook3;
+let App__StatementBodyHook4;
+
+export function App({ kind }: { kind: 'a' | 'b' | 'c' }) {
+	let x: number | undefined;
+	const _tsrx_StatementBodyHook1_x = x;
+
+	const StatementBodyHook1 = App__StatementBodyHook1 ?? (App__StatementBodyHook1 = function StatementBodyHook1({ x }: { x: typeof _tsrx_StatementBodyHook1_x }) {
+		console.log(x);
+
+		return null;
+	});
+
+	switch (kind) {
+		case 'a':
+			const _tsrx_StatementBodyHook2_x = x;
+			const StatementBodyHook2 = App__StatementBodyHook2 ?? (App__StatementBodyHook2 = function StatementBodyHook2({ x }: { x: typeof _tsrx_StatementBodyHook2_x }) {
+				[x] = useState(100);
+
+				return <><div>{x}</div><StatementBodyHook1 x={x} /></>;
+			});
+			return <StatementBodyHook2 x={x} />;
+
+		case 'b':
+			const _tsrx_StatementBodyHook3_x = x;
+			const StatementBodyHook3 = App__StatementBodyHook3 ?? (App__StatementBodyHook3 = function StatementBodyHook3({ x }: { x: typeof _tsrx_StatementBodyHook3_x }) {
+				return <>{App__static1}<StatementBodyHook1 x={x} /></>;
+			});
+			return <StatementBodyHook3 x={x} />;
+
+		default:
+			const _tsrx_StatementBodyHook4_x = x;
+			const StatementBodyHook4 = App__StatementBodyHook4 ?? (App__StatementBodyHook4 = function StatementBodyHook4({ x }: { x: typeof _tsrx_StatementBodyHook4_x }) {
+				return <>{App__static2}<StatementBodyHook1 x={x} /></>;
+			});
+			return <StatementBodyHook4 x={x} />;
+	}
+
+	return <StatementBodyHook1 x={x} />;
+}"
+`;
+
+exports[`[preact] continuation lift for try-with-hook > try with a hook but no statements after it (no tail to lift) 1`] = `
+"import { TsrxErrorBoundary } from '@tsrx/preact/error-boundary';
+
+const App__static1 = <div>{'error'}</div>;
+let App__StatementBodyHook1;
+
+export function App({ load }: { load: () => number }) {
+	return <TsrxErrorBoundary fallback={(err, _reset) => {
+		return App__static1;
+	}}>{(() => {
+			const _tsrx_StatementBodyHook1_load = load;
+
+			const StatementBodyHook1 = App__StatementBodyHook1 ?? (App__StatementBodyHook1 = function StatementBodyHook1({ load }: { load: typeof _tsrx_StatementBodyHook1_load }) {
+				const [data] = useState(load());
+
+				return <div>{data}</div>;
+			});
+
+			return <StatementBodyHook1 load={load} />;
+		})()}</TsrxErrorBoundary>;
+}"
+`;
+
+exports[`[preact] continuation lift for try-with-hook > try without hooks falls back to the existing transform 1`] = `
+"import { TsrxErrorBoundary } from '@tsrx/preact/error-boundary';
+
+const App__static1 = <div>{'error'}</div>;
+
+export function App({ load }: { load: () => number }) {
+	return <TsrxErrorBoundary fallback={(err, _reset) => {
+		return App__static1;
+	}}>{(() => {
+			return <div>{load()}</div>;
+		})()}</TsrxErrorBoundary>;
+}"
+`;
+
+exports[`[preact] continuation lift for try-with-hook > try/catch with a hook in the catch body and a tail that reads the mutated outer 1`] = `
+"import { TsrxErrorBoundary } from '@tsrx/preact/error-boundary';
+
+let App__StatementBodyHook1;
+
+export function App({ load }: { load: () => number }) {
+	let attempt: number | undefined;
+	const _tsrx_StatementBodyHook1_attempt = attempt;
+
+	const StatementBodyHook1 = App__StatementBodyHook1 ?? (App__StatementBodyHook1 = function StatementBodyHook1(
+		{ attempt }: { attempt: typeof _tsrx_StatementBodyHook1_attempt }
+	) {
+		console.log(attempt);
+
+		return null;
+	});
+
+	return <TsrxErrorBoundary fallback={(err, _reset) => {
+		[attempt] = useState(0);
+
+		return <><div>{attempt}</div><StatementBodyHook1 attempt={attempt} /></>;
+	}}>{(() => {
+			return <><div>{load()}</div><StatementBodyHook1 attempt={attempt} /></>;
+		})()}</TsrxErrorBoundary>;
+}"
+`;
+
+exports[`[preact] continuation lift for try-with-hook > try/catch with a hook in the try body and a tail that reads the mutated outer 1`] = `
+"import { TsrxErrorBoundary } from '@tsrx/preact/error-boundary';
+
+const App__static1 = <div>{'error'}</div>;
+let App__StatementBodyHook1;
+let App__StatementBodyHook2;
+
+export function App({ load }: { load: () => number }) {
+	let data: number | undefined;
+	const _tsrx_StatementBodyHook1_data = data;
+
+	const StatementBodyHook1 = App__StatementBodyHook1 ?? (App__StatementBodyHook1 = function StatementBodyHook1({ data }: { data: typeof _tsrx_StatementBodyHook1_data }) {
+		console.log(data);
+
+		return null;
+	});
+
+	return <TsrxErrorBoundary fallback={(err, _reset) => {
+		return <>{App__static1}<StatementBodyHook1 data={data} /></>;
+	}}>{(() => {
+			const _tsrx_StatementBodyHook2_load = load;
+			const _tsrx_StatementBodyHook2_data = data;
+
+			const StatementBodyHook2 = App__StatementBodyHook2 ?? (App__StatementBodyHook2 = function StatementBodyHook2(
+				{ load, data }: { 
+					load: typeof _tsrx_StatementBodyHook2_load;
+					data: typeof _tsrx_StatementBodyHook2_data
+				 }
+			) {
+				[data] = useState(load());
+
+				return <><div>{data}</div><StatementBodyHook1 data={data} /></>;
+			});
+
+			return <StatementBodyHook2 load={load} data={data} />;
+		})()}</TsrxErrorBoundary>;
+}"
+`;
+
+exports[`[preact] continuation lift for try-with-hook > try/pending/catch with a hook in the try body and a tail that reads the mutated outer 1`] = `
+"import { Suspense } from 'preact/compat';
+import { TsrxErrorBoundary } from '@tsrx/preact/error-boundary';
+
+const App__static1 = <p>{'loading'}</p>;
+const App__static2 = <div>{'error'}</div>;
+let App__StatementBodyHook1;
+let App__StatementBodyHook2;
+
+export function App({ load }: { load: () => number }) {
+	let data: number | undefined;
+	const _tsrx_StatementBodyHook1_data = data;
+
+	const StatementBodyHook1 = App__StatementBodyHook1 ?? (App__StatementBodyHook1 = function StatementBodyHook1({ data }: { data: typeof _tsrx_StatementBodyHook1_data }) {
+		console.log(data);
+
+		return null;
+	});
+
+	return <TsrxErrorBoundary fallback={(err, _reset) => {
+		return <>{App__static2}<StatementBodyHook1 data={data} /></>;
+	}}><Suspense fallback={(() => {
+			return App__static1;
+		})()}>{(() => {
+				const _tsrx_StatementBodyHook2_load = load;
+				const _tsrx_StatementBodyHook2_data = data;
+
+				const StatementBodyHook2 = App__StatementBodyHook2 ?? (App__StatementBodyHook2 = function StatementBodyHook2(
+					{ load, data }: { 
+						load: typeof _tsrx_StatementBodyHook2_load;
+						data: typeof _tsrx_StatementBodyHook2_data
+					 }
+				) {
+					[data] = useState(load());
+
+					return <><div>{data}</div><StatementBodyHook1 data={data} /></>;
+				});
+
+				return <StatementBodyHook2 load={load} data={data} />;
+			})()}</Suspense></TsrxErrorBoundary>;
+}"
+`;
+
+exports[`[preact] hoisted helper and tail lift for for-of-with-hook > falls back to the existing transform for non-hook for-of loops 1`] = `
+"export function App({ items }: { items: number[] }) {
+	return items.map((item, i) => {
+		return <div key={i}>{item}</div>;
+	});
+}"
+`;
+
+exports[`[preact] hoisted helper and tail lift for for-of-with-hook > hoists the helper without a tail lift when nothing follows the loop 1`] = `
+"let App__StatementBodyHook1;
+
+export function App({ items }: { items: string[] }) {
+	let _tsrx_iteration_items_1 = items;
+
+	_tsrx_iteration_items_1 = Array.isArray(_tsrx_iteration_items_1)
+		? _tsrx_iteration_items_1
+		: Array.from(_tsrx_iteration_items_1);
+
+	type _tsrx_StatementBodyHook1_name = typeof _tsrx_iteration_items_1[number];
+
+	const StatementBodyHook1 = App__StatementBodyHook1 ?? (App__StatementBodyHook1 = function StatementBodyHook1({ name }: { name: _tsrx_StatementBodyHook1_name }) {
+		const [val] = useState(name);
+
+		return <div key={name}>{val}</div>;
+	});
+
+	return _tsrx_iteration_items_1.map((name) => <StatementBodyHook1 name={name} key={name} />);
+}"
+`;
+
+exports[`[preact] hoisted helper and tail lift for for-of-with-hook > lifts the tail across nested for-of-with-hooks 1`] = `
+"let App__StatementBodyHook1;
+let App__StatementBodyHook3;
+let App__StatementBodyHook4;
+let App__StatementBodyHook2;
+
+export function App({ groups }: { groups: number[][] }) {
+	let last: number | undefined;
+	let _tsrx_iteration_items_2 = groups;
+
+	_tsrx_iteration_items_2 = Array.isArray(_tsrx_iteration_items_2)
+		? _tsrx_iteration_items_2
+		: Array.from(_tsrx_iteration_items_2);
+
+	const _tsrx_StatementBodyHook1_last = last;
+
+	const StatementBodyHook1 = App__StatementBodyHook1 ?? (App__StatementBodyHook1 = function StatementBodyHook1({ last }: { last: typeof _tsrx_StatementBodyHook1_last }) {
+		console.log('end', last);
+
+		return null;
+	});
+
+	const _tsrx_StatementBodyHook2_last = last;
+
+	type _tsrx_StatementBodyHook2_group = typeof _tsrx_iteration_items_2[number];
+	type _tsrx_StatementBodyHook2_isLast = boolean;
+
+	const StatementBodyHook2 = App__StatementBodyHook2 ?? (App__StatementBodyHook2 = function StatementBodyHook2(
+		{ last, group, _tsrx_isLast_2 }: { 
+			last: typeof _tsrx_StatementBodyHook2_last;
+			group: _tsrx_StatementBodyHook2_group;
+			_tsrx_isLast_2: _tsrx_StatementBodyHook2_isLast
+		 }
+	) {
+		let _tsrx_iteration_items_4 = group;
+
+		_tsrx_iteration_items_4 = Array.isArray(_tsrx_iteration_items_4)
+			? _tsrx_iteration_items_4
+			: Array.from(_tsrx_iteration_items_4);
+
+		const _tsrx_StatementBodyHook3_last = last;
+		const _tsrx_StatementBodyHook3__tsrx_isLast_2 = _tsrx_isLast_2;
+
+		const StatementBodyHook3 = App__StatementBodyHook3 ?? (App__StatementBodyHook3 = function StatementBodyHook3(
+			{ last, _tsrx_isLast_2 }: { 
+				last: typeof _tsrx_StatementBodyHook3_last;
+				_tsrx_isLast_2: typeof _tsrx_StatementBodyHook3__tsrx_isLast_2
+			 }
+		) {
+			console.log('mid', last);
+
+			return _tsrx_isLast_2 && <StatementBodyHook1 last={last} />;
+		});
+
+		const _tsrx_StatementBodyHook4_last = last;
+		const _tsrx_StatementBodyHook4__tsrx_isLast_2 = _tsrx_isLast_2;
+
+		type _tsrx_StatementBodyHook4_item = typeof _tsrx_iteration_items_4[number];
+		type _tsrx_StatementBodyHook4_isLast = boolean;
+
+		const StatementBodyHook4 = App__StatementBodyHook4 ?? (App__StatementBodyHook4 = function StatementBodyHook4(
+			{ last, _tsrx_isLast_2, item, _tsrx_isLast_4 }: { 
+				last: typeof _tsrx_StatementBodyHook4_last;
+				_tsrx_isLast_2: typeof _tsrx_StatementBodyHook4__tsrx_isLast_2;
+				item: _tsrx_StatementBodyHook4_item;
+				_tsrx_isLast_4: _tsrx_StatementBodyHook4_isLast
+			 }
+		) {
+			[last] = useState(item);
+
+			return <><div key={item}>{last}</div>{_tsrx_isLast_4 && <StatementBodyHook3 last={last} _tsrx_isLast_2={_tsrx_isLast_2} />}</>;
+		});
+
+		return _tsrx_iteration_items_4.length === 0
+			? <StatementBodyHook3 last={last} _tsrx_isLast_2={_tsrx_isLast_2} />
+			: _tsrx_iteration_items_4.map((item, i) => <StatementBodyHook4 last={last} _tsrx_isLast_2={_tsrx_isLast_2} item={item} key={item} _tsrx_isLast_4={i === _tsrx_iteration_items_4.length - 1} />);
+	});
+
+	return _tsrx_iteration_items_2.length === 0
+		? <StatementBodyHook1 last={last} />
+		: _tsrx_iteration_items_2.map((group, i) => <StatementBodyHook2 last={last} group={group} _tsrx_isLast_2={i === _tsrx_iteration_items_2.length - 1} />);
+}"
+`;
+
+exports[`[preact] hoisted helper and tail lift for for-of-with-hook > lifts the tail across sibling for-of-with-hooks at the same level 1`] = `
+"let App__StatementBodyHook2;
+let App__StatementBodyHook3;
+let App__StatementBodyHook1;
+let App__StatementBodyHook4;
+
+export function App({ as, bs }: { as: number[]; bs: number[] }) {
+	let lastA: number | undefined;
+	let lastB: number | undefined;
+	let _tsrx_iteration_items_4 = as;
+
+	_tsrx_iteration_items_4 = Array.isArray(_tsrx_iteration_items_4)
+		? _tsrx_iteration_items_4
+		: Array.from(_tsrx_iteration_items_4);
+
+	const _tsrx_StatementBodyHook1_bs = bs;
+	const _tsrx_StatementBodyHook1_lastA = lastA;
+	const _tsrx_StatementBodyHook1_lastB = lastB;
+
+	const StatementBodyHook1 = App__StatementBodyHook1 ?? (App__StatementBodyHook1 = function StatementBodyHook1(
+		{ bs, lastA, lastB }: { 
+			bs: typeof _tsrx_StatementBodyHook1_bs;
+			lastA: typeof _tsrx_StatementBodyHook1_lastA;
+			lastB: typeof _tsrx_StatementBodyHook1_lastB
+		 }
+	) {
+		let _tsrx_iteration_items_3 = bs;
+
+		_tsrx_iteration_items_3 = Array.isArray(_tsrx_iteration_items_3)
+			? _tsrx_iteration_items_3
+			: Array.from(_tsrx_iteration_items_3);
+
+		const _tsrx_StatementBodyHook2_lastA = lastA;
+		const _tsrx_StatementBodyHook2_lastB = lastB;
+
+		const StatementBodyHook2 = App__StatementBodyHook2 ?? (App__StatementBodyHook2 = function StatementBodyHook2(
+			{ lastA, lastB }: { 
+				lastA: typeof _tsrx_StatementBodyHook2_lastA;
+				lastB: typeof _tsrx_StatementBodyHook2_lastB
+			 }
+		) {
+			console.log(lastA, lastB);
+
+			return null;
+		});
+
+		const _tsrx_StatementBodyHook3_lastA = lastA;
+		const _tsrx_StatementBodyHook3_lastB = lastB;
+
+		type _tsrx_StatementBodyHook3_b = typeof _tsrx_iteration_items_3[number];
+		type _tsrx_StatementBodyHook3_isLast = boolean;
+
+		const StatementBodyHook3 = App__StatementBodyHook3 ?? (App__StatementBodyHook3 = function StatementBodyHook3(
+			{ lastA, lastB, b, _tsrx_isLast_3 }: { 
+				lastA: typeof _tsrx_StatementBodyHook3_lastA;
+				lastB: typeof _tsrx_StatementBodyHook3_lastB;
+				b: _tsrx_StatementBodyHook3_b;
+				_tsrx_isLast_3: _tsrx_StatementBodyHook3_isLast
+			 }
+		) {
+			[lastB] = useState(b);
+
+			return <><span key={b}>{lastB}</span>{_tsrx_isLast_3 && <StatementBodyHook2 lastA={lastA} lastB={lastB} />}</>;
+		});
+
+		return _tsrx_iteration_items_3.length === 0
+			? <StatementBodyHook2 lastA={lastA} lastB={lastB} />
+			: _tsrx_iteration_items_3.map((b, i) => <StatementBodyHook3 lastA={lastA} lastB={lastB} b={b} key={b} _tsrx_isLast_3={i === _tsrx_iteration_items_3.length - 1} />);
+	});
+
+	const _tsrx_StatementBodyHook4_bs = bs;
+	const _tsrx_StatementBodyHook4_lastA = lastA;
+	const _tsrx_StatementBodyHook4_lastB = lastB;
+
+	type _tsrx_StatementBodyHook4_a = typeof _tsrx_iteration_items_4[number];
+	type _tsrx_StatementBodyHook4_isLast = boolean;
+
+	const StatementBodyHook4 = App__StatementBodyHook4 ?? (App__StatementBodyHook4 = function StatementBodyHook4(
+		{ bs, lastA, lastB, a, _tsrx_isLast_4 }: { 
+			bs: typeof _tsrx_StatementBodyHook4_bs;
+			lastA: typeof _tsrx_StatementBodyHook4_lastA;
+			lastB: typeof _tsrx_StatementBodyHook4_lastB;
+			a: _tsrx_StatementBodyHook4_a;
+			_tsrx_isLast_4: _tsrx_StatementBodyHook4_isLast
+		 }
+	) {
+		[lastA] = useState(a);
+
+		return <><div key={a}>{lastA}</div>{_tsrx_isLast_4 && <StatementBodyHook1 bs={bs} lastA={lastA} lastB={lastB} />}</>;
+	});
+
+	return _tsrx_iteration_items_4.length === 0
+		? <StatementBodyHook1 bs={bs} lastA={lastA} lastB={lastB} />
+		: _tsrx_iteration_items_4.map((a, i) => <StatementBodyHook4 bs={bs} lastA={lastA} lastB={lastB} a={a} key={a} _tsrx_isLast_4={i === _tsrx_iteration_items_4.length - 1} />);
+}"
+`;
+
+exports[`[preact] hoisted helper and tail lift for for-of-with-hook > lifts the tail of a for-of with hooks (inline-literal iteration source) 1`] = `
+"let App__StatementBodyHook1;
+let App__StatementBodyHook2;
+
+export function App() {
+	let last: number | undefined;
+	let _tsrx_iteration_items_2 = [1, 2, 3];
+
+	_tsrx_iteration_items_2 = Array.isArray(_tsrx_iteration_items_2)
+		? _tsrx_iteration_items_2
+		: Array.from(_tsrx_iteration_items_2);
+
+	const _tsrx_StatementBodyHook1_last = last;
+
+	const StatementBodyHook1 = App__StatementBodyHook1 ?? (App__StatementBodyHook1 = function StatementBodyHook1({ last }: { last: typeof _tsrx_StatementBodyHook1_last }) {
+		console.log(last);
+
+		return null;
+	});
+
+	const _tsrx_StatementBodyHook2_last = last;
+
+	type _tsrx_StatementBodyHook2_item = typeof _tsrx_iteration_items_2[number];
+	type _tsrx_StatementBodyHook2_i = number;
+	type _tsrx_StatementBodyHook2_isLast = boolean;
+
+	const StatementBodyHook2 = App__StatementBodyHook2 ?? (App__StatementBodyHook2 = function StatementBodyHook2(
+		{ last, item, i, _tsrx_isLast_2 }: { 
+			last: typeof _tsrx_StatementBodyHook2_last;
+			item: _tsrx_StatementBodyHook2_item;
+			i: _tsrx_StatementBodyHook2_i;
+			_tsrx_isLast_2: _tsrx_StatementBodyHook2_isLast
+		 }
+	) {
+		[last] = useState(item);
+
+		return <><div key={i}>{last}</div>{_tsrx_isLast_2 && <StatementBodyHook1 last={last} />}</>;
+	});
+
+	return _tsrx_iteration_items_2.length === 0
+		? <StatementBodyHook1 last={last} />
+		: _tsrx_iteration_items_2.map((item, i) => <StatementBodyHook2 last={last} item={item} i={i} key={i} _tsrx_isLast_2={i === _tsrx_iteration_items_2.length - 1} />);
+}"
+`;
+
+exports[`[preact] hoisted helper and tail lift for for-of-with-hook > lifts the tail of a for-of with hooks (prop iteration source) 1`] = `
+"let App__StatementBodyHook1;
+let App__StatementBodyHook2;
+
+export function App({ items }: { items: number[] }) {
+	let last: number | undefined;
+	let _tsrx_iteration_items_2 = items;
+
+	_tsrx_iteration_items_2 = Array.isArray(_tsrx_iteration_items_2)
+		? _tsrx_iteration_items_2
+		: Array.from(_tsrx_iteration_items_2);
+
+	const _tsrx_StatementBodyHook1_last = last;
+
+	const StatementBodyHook1 = App__StatementBodyHook1 ?? (App__StatementBodyHook1 = function StatementBodyHook1({ last }: { last: typeof _tsrx_StatementBodyHook1_last }) {
+		console.log(last);
+
+		return null;
+	});
+
+	const _tsrx_StatementBodyHook2_last = last;
+
+	type _tsrx_StatementBodyHook2_item = typeof _tsrx_iteration_items_2[number];
+	type _tsrx_StatementBodyHook2_i = number;
+	type _tsrx_StatementBodyHook2_isLast = boolean;
+
+	const StatementBodyHook2 = App__StatementBodyHook2 ?? (App__StatementBodyHook2 = function StatementBodyHook2(
+		{ last, item, i, _tsrx_isLast_2 }: { 
+			last: typeof _tsrx_StatementBodyHook2_last;
+			item: _tsrx_StatementBodyHook2_item;
+			i: _tsrx_StatementBodyHook2_i;
+			_tsrx_isLast_2: _tsrx_StatementBodyHook2_isLast
+		 }
+	) {
+		[last] = useState(item);
+
+		return <><div key={i}>{last}</div>{_tsrx_isLast_2 && <StatementBodyHook1 last={last} />}</>;
+	});
+
+	return _tsrx_iteration_items_2.length === 0
+		? <StatementBodyHook1 last={last} />
+		: _tsrx_iteration_items_2.map((item, i) => <StatementBodyHook2 last={last} item={item} i={i} key={i} _tsrx_isLast_2={i === _tsrx_iteration_items_2.length - 1} />);
+}"
+`;

--- a/packages/tsrx-preact/tests/__snapshots__/basic.test.js.snap
+++ b/packages/tsrx-preact/tests/__snapshots__/basic.test.js.snap
@@ -210,6 +210,38 @@ export function App({ show }: { show: boolean }) {
 }"
 `;
 
+exports[`[preact] continuation lift for switch-with-hook > break-only case does not silently fall through into another case 1`] = `
+"let App__StatementBodyHook1;
+let App__StatementBodyHook2;
+
+export function App({ kind }: { kind: 'a' | 'b' }) {
+	let x: number | undefined;
+	const _tsrx_StatementBodyHook1_x = x;
+
+	const StatementBodyHook1 = App__StatementBodyHook1 ?? (App__StatementBodyHook1 = function StatementBodyHook1({ x }: { x: typeof _tsrx_StatementBodyHook1_x }) {
+		console.log(x);
+
+		return null;
+	});
+
+	switch (kind) {
+		case 'a':
+			return <StatementBodyHook1 x={x} />;
+
+		case 'b':
+			const _tsrx_StatementBodyHook2_x = x;
+			const StatementBodyHook2 = App__StatementBodyHook2 ?? (App__StatementBodyHook2 = function StatementBodyHook2({ x }: { x: typeof _tsrx_StatementBodyHook2_x }) {
+				[x] = useState(100);
+
+				return <><div>{x}</div><StatementBodyHook1 x={x} /></>;
+			});
+			return <StatementBodyHook2 x={x} />;
+	}
+
+	return <StatementBodyHook1 x={x} />;
+}"
+`;
+
 exports[`[preact] continuation lift for switch-with-hook > does not lift when the switch has no statements after it 1`] = `
 "let App__StatementBodyHook1;
 
@@ -351,6 +383,116 @@ export function App({ kind }: { kind: 'a' | 'b' | 'c' }) {
 				return <>{App__static2}<StatementBodyHook1 x={x} /></>;
 			});
 			return <StatementBodyHook4 x={x} />;
+	}
+
+	return <StatementBodyHook1 x={x} />;
+}"
+`;
+
+exports[`[preact] continuation lift for switch-with-hook > non-empty fall-through (case with body but no terminator) bails out of the lift 1`] = `
+"let App__StatementBodyHook1;
+
+export function App({ kind }: { kind: 'a' | 'b' }) {
+	let x: number | undefined;
+
+	const _tsrx_child_0 = (() => {
+		switch (kind) {
+			case 'a':
+				x = 1;
+
+			case 'b':
+				const _tsrx_StatementBodyHook1_x = x;
+				const StatementBodyHook1 = App__StatementBodyHook1 ?? (App__StatementBodyHook1 = function StatementBodyHook1({ x }: { x: typeof _tsrx_StatementBodyHook1_x }) {
+					[x] = useState(100);
+
+					return <div>{x}</div>;
+				});
+				return <StatementBodyHook1 x={x} />;
+		}
+
+		return null;
+	})();
+
+	console.log(x);
+
+	return _tsrx_child_0;
+}"
+`;
+
+exports[`[preact] continuation lift for switch-with-hook > non-empty fall-through merges the trailing case body into the falling case 1`] = `
+"let App__StatementBodyHook1;
+let App__StatementBodyHook2;
+let App__StatementBodyHook3;
+
+export function App({ kind }: { kind: 'a' | 'b' }) {
+	let x: number | undefined;
+	const _tsrx_StatementBodyHook1_x = x;
+
+	const StatementBodyHook1 = App__StatementBodyHook1 ?? (App__StatementBodyHook1 = function StatementBodyHook1({ x }: { x: typeof _tsrx_StatementBodyHook1_x }) {
+		console.log(x);
+
+		return null;
+	});
+
+	switch (kind) {
+		case 'a':
+			const _tsrx_StatementBodyHook2_x = x;
+			const StatementBodyHook2 = App__StatementBodyHook2 ?? (App__StatementBodyHook2 = function StatementBodyHook2({ x }: { x: typeof _tsrx_StatementBodyHook2_x }) {
+				x = 1;
+				[x] = useState(100);
+
+				return <><div>{x}</div><StatementBodyHook1 x={x} /></>;
+			});
+			return <StatementBodyHook2 x={x} />;
+
+		case 'b':
+			const _tsrx_StatementBodyHook3_x = x;
+			const StatementBodyHook3 = App__StatementBodyHook3 ?? (App__StatementBodyHook3 = function StatementBodyHook3({ x }: { x: typeof _tsrx_StatementBodyHook3_x }) {
+				[x] = useState(100);
+
+				return <><div>{x}</div><StatementBodyHook1 x={x} /></>;
+			});
+			return <StatementBodyHook3 x={x} />;
+	}
+
+	return <StatementBodyHook1 x={x} />;
+}"
+`;
+
+exports[`[preact] continuation lift for switch-with-hook > preserves empty fall-through cases that share a body with the next case 1`] = `
+"const App__static1 = <span>{'other'}</span>;
+let App__StatementBodyHook1;
+let App__StatementBodyHook2;
+let App__StatementBodyHook3;
+
+export function App({ kind }: { kind: 'a' | 'b' | 'c' }) {
+	let x: number | undefined;
+	const _tsrx_StatementBodyHook1_x = x;
+
+	const StatementBodyHook1 = App__StatementBodyHook1 ?? (App__StatementBodyHook1 = function StatementBodyHook1({ x }: { x: typeof _tsrx_StatementBodyHook1_x }) {
+		console.log(x);
+
+		return null;
+	});
+
+	switch (kind) {
+		case 'a':
+
+		case 'b':
+			const _tsrx_StatementBodyHook2_x = x;
+			const StatementBodyHook2 = App__StatementBodyHook2 ?? (App__StatementBodyHook2 = function StatementBodyHook2({ x }: { x: typeof _tsrx_StatementBodyHook2_x }) {
+				[x] = useState(100);
+
+				return <><div>{x}</div><StatementBodyHook1 x={x} /></>;
+			});
+			return <StatementBodyHook2 x={x} />;
+
+		default:
+			const _tsrx_StatementBodyHook3_x = x;
+			const StatementBodyHook3 = App__StatementBodyHook3 ?? (App__StatementBodyHook3 = function StatementBodyHook3({ x }: { x: typeof _tsrx_StatementBodyHook3_x }) {
+				return <>{App__static1}<StatementBodyHook1 x={x} /></>;
+			});
+			return <StatementBodyHook3 x={x} />;
 	}
 
 	return <StatementBodyHook1 x={x} />;

--- a/packages/tsrx-preact/tests/__snapshots__/basic.test.js.snap
+++ b/packages/tsrx-preact/tests/__snapshots__/basic.test.js.snap
@@ -405,36 +405,6 @@ export function App({ kind }: { kind: 'a' | 'b' | 'c' }) {
 }"
 `;
 
-exports[`[preact] continuation lift for switch-with-hook > non-empty fall-through (case with body but no terminator) bails out of the lift 1`] = `
-"let App__StatementBodyHook1;
-
-export function App({ kind }: { kind: 'a' | 'b' }) {
-	let x: number | undefined;
-
-	const _tsrx_child_0 = (() => {
-		switch (kind) {
-			case 'a':
-				x = 1;
-
-			case 'b':
-				const _tsrx_StatementBodyHook1_x = x;
-				const StatementBodyHook1 = App__StatementBodyHook1 ?? (App__StatementBodyHook1 = function StatementBodyHook1({ x }: { x: typeof _tsrx_StatementBodyHook1_x }) {
-					[x] = useState(100);
-
-					return <div>{x}</div>;
-				});
-				return <StatementBodyHook1 x={x} />;
-		}
-
-		return null;
-	})();
-
-	console.log(x);
-
-	return _tsrx_child_0;
-}"
-`;
-
 exports[`[preact] continuation lift for switch-with-hook > non-empty fall-through merges the trailing case body into the falling case 1`] = `
 "let App__StatementBodyHook1;
 let App__StatementBodyHook3;

--- a/packages/tsrx-react/tests/__snapshots__/basic.test.js.snap
+++ b/packages/tsrx-react/tests/__snapshots__/basic.test.js.snap
@@ -210,6 +210,38 @@ export function App({ show }: { show: boolean }) {
 }"
 `;
 
+exports[`[react] continuation lift for switch-with-hook > break-only case does not silently fall through into another case 1`] = `
+"let App__StatementBodyHook1;
+let App__StatementBodyHook2;
+
+export function App({ kind }: { kind: 'a' | 'b' }) {
+	let x: number | undefined;
+	const _tsrx_StatementBodyHook1_x = x;
+
+	const StatementBodyHook1 = App__StatementBodyHook1 ?? (App__StatementBodyHook1 = function StatementBodyHook1({ x }: { x: typeof _tsrx_StatementBodyHook1_x }) {
+		console.log(x);
+
+		return null;
+	});
+
+	switch (kind) {
+		case 'a':
+			return <StatementBodyHook1 x={x} />;
+
+		case 'b':
+			const _tsrx_StatementBodyHook2_x = x;
+			const StatementBodyHook2 = App__StatementBodyHook2 ?? (App__StatementBodyHook2 = function StatementBodyHook2({ x }: { x: typeof _tsrx_StatementBodyHook2_x }) {
+				[x] = useState(100);
+
+				return <><div>{x}</div><StatementBodyHook1 x={x} /></>;
+			});
+			return <StatementBodyHook2 x={x} />;
+	}
+
+	return <StatementBodyHook1 x={x} />;
+}"
+`;
+
 exports[`[react] continuation lift for switch-with-hook > does not lift when the switch has no statements after it 1`] = `
 "let App__StatementBodyHook1;
 
@@ -351,6 +383,116 @@ export function App({ kind }: { kind: 'a' | 'b' | 'c' }) {
 				return <>{App__static2}<StatementBodyHook1 x={x} /></>;
 			});
 			return <StatementBodyHook4 x={x} />;
+	}
+
+	return <StatementBodyHook1 x={x} />;
+}"
+`;
+
+exports[`[react] continuation lift for switch-with-hook > non-empty fall-through (case with body but no terminator) bails out of the lift 1`] = `
+"let App__StatementBodyHook1;
+
+export function App({ kind }: { kind: 'a' | 'b' }) {
+	let x: number | undefined;
+
+	const _tsrx_child_0 = (() => {
+		switch (kind) {
+			case 'a':
+				x = 1;
+
+			case 'b':
+				const _tsrx_StatementBodyHook1_x = x;
+				const StatementBodyHook1 = App__StatementBodyHook1 ?? (App__StatementBodyHook1 = function StatementBodyHook1({ x }: { x: typeof _tsrx_StatementBodyHook1_x }) {
+					[x] = useState(100);
+
+					return <div>{x}</div>;
+				});
+				return <StatementBodyHook1 x={x} />;
+		}
+
+		return null;
+	})();
+
+	console.log(x);
+
+	return _tsrx_child_0;
+}"
+`;
+
+exports[`[react] continuation lift for switch-with-hook > non-empty fall-through merges the trailing case body into the falling case 1`] = `
+"let App__StatementBodyHook1;
+let App__StatementBodyHook2;
+let App__StatementBodyHook3;
+
+export function App({ kind }: { kind: 'a' | 'b' }) {
+	let x: number | undefined;
+	const _tsrx_StatementBodyHook1_x = x;
+
+	const StatementBodyHook1 = App__StatementBodyHook1 ?? (App__StatementBodyHook1 = function StatementBodyHook1({ x }: { x: typeof _tsrx_StatementBodyHook1_x }) {
+		console.log(x);
+
+		return null;
+	});
+
+	switch (kind) {
+		case 'a':
+			const _tsrx_StatementBodyHook2_x = x;
+			const StatementBodyHook2 = App__StatementBodyHook2 ?? (App__StatementBodyHook2 = function StatementBodyHook2({ x }: { x: typeof _tsrx_StatementBodyHook2_x }) {
+				x = 1;
+				[x] = useState(100);
+
+				return <><div>{x}</div><StatementBodyHook1 x={x} /></>;
+			});
+			return <StatementBodyHook2 x={x} />;
+
+		case 'b':
+			const _tsrx_StatementBodyHook3_x = x;
+			const StatementBodyHook3 = App__StatementBodyHook3 ?? (App__StatementBodyHook3 = function StatementBodyHook3({ x }: { x: typeof _tsrx_StatementBodyHook3_x }) {
+				[x] = useState(100);
+
+				return <><div>{x}</div><StatementBodyHook1 x={x} /></>;
+			});
+			return <StatementBodyHook3 x={x} />;
+	}
+
+	return <StatementBodyHook1 x={x} />;
+}"
+`;
+
+exports[`[react] continuation lift for switch-with-hook > preserves empty fall-through cases that share a body with the next case 1`] = `
+"const App__static1 = <span>{'other'}</span>;
+let App__StatementBodyHook1;
+let App__StatementBodyHook2;
+let App__StatementBodyHook3;
+
+export function App({ kind }: { kind: 'a' | 'b' | 'c' }) {
+	let x: number | undefined;
+	const _tsrx_StatementBodyHook1_x = x;
+
+	const StatementBodyHook1 = App__StatementBodyHook1 ?? (App__StatementBodyHook1 = function StatementBodyHook1({ x }: { x: typeof _tsrx_StatementBodyHook1_x }) {
+		console.log(x);
+
+		return null;
+	});
+
+	switch (kind) {
+		case 'a':
+
+		case 'b':
+			const _tsrx_StatementBodyHook2_x = x;
+			const StatementBodyHook2 = App__StatementBodyHook2 ?? (App__StatementBodyHook2 = function StatementBodyHook2({ x }: { x: typeof _tsrx_StatementBodyHook2_x }) {
+				[x] = useState(100);
+
+				return <><div>{x}</div><StatementBodyHook1 x={x} /></>;
+			});
+			return <StatementBodyHook2 x={x} />;
+
+		default:
+			const _tsrx_StatementBodyHook3_x = x;
+			const StatementBodyHook3 = App__StatementBodyHook3 ?? (App__StatementBodyHook3 = function StatementBodyHook3({ x }: { x: typeof _tsrx_StatementBodyHook3_x }) {
+				return <>{App__static1}<StatementBodyHook1 x={x} /></>;
+			});
+			return <StatementBodyHook3 x={x} />;
 	}
 
 	return <StatementBodyHook1 x={x} />;

--- a/packages/tsrx-react/tests/__snapshots__/basic.test.js.snap
+++ b/packages/tsrx-react/tests/__snapshots__/basic.test.js.snap
@@ -224,17 +224,19 @@ export function App({ kind }: { kind: 'a' | 'b' }) {
 		return null;
 	});
 
+	const _tsrx_StatementBodyHook2_x = x;
+
+	const StatementBodyHook2 = App__StatementBodyHook2 ?? (App__StatementBodyHook2 = function StatementBodyHook2({ x }: { x: typeof _tsrx_StatementBodyHook2_x }) {
+		[x] = useState(100);
+
+		return <><div>{x}</div><StatementBodyHook1 x={x} /></>;
+	});
+
 	switch (kind) {
 		case 'a':
 			return <StatementBodyHook1 x={x} />;
 
 		case 'b':
-			const _tsrx_StatementBodyHook2_x = x;
-			const StatementBodyHook2 = App__StatementBodyHook2 ?? (App__StatementBodyHook2 = function StatementBodyHook2({ x }: { x: typeof _tsrx_StatementBodyHook2_x }) {
-				[x] = useState(100);
-
-				return <><div>{x}</div><StatementBodyHook1 x={x} /></>;
-			});
 			return <StatementBodyHook2 x={x} />;
 	}
 
@@ -267,8 +269,8 @@ export function App({ kind }: { kind: 'a' | 'b' }) {
 
 exports[`[react] continuation lift for switch-with-hook > lifts the tail of a switch whose cases contain hooks 1`] = `
 "let App__StatementBodyHook1;
-let App__StatementBodyHook2;
 let App__StatementBodyHook3;
+let App__StatementBodyHook2;
 
 export function App({ kind }: { kind: 'a' | 'b' }) {
 	let x: number | undefined;
@@ -280,23 +282,27 @@ export function App({ kind }: { kind: 'a' | 'b' }) {
 		return null;
 	});
 
+	const _tsrx_StatementBodyHook2_x = x;
+
+	const StatementBodyHook2 = App__StatementBodyHook2 ?? (App__StatementBodyHook2 = function StatementBodyHook2({ x }: { x: typeof _tsrx_StatementBodyHook2_x }) {
+		[x] = useState(100);
+
+		return <><div>{x}</div><StatementBodyHook1 x={x} /></>;
+	});
+
+	const _tsrx_StatementBodyHook3_x = x;
+
+	const StatementBodyHook3 = App__StatementBodyHook3 ?? (App__StatementBodyHook3 = function StatementBodyHook3({ x }: { x: typeof _tsrx_StatementBodyHook3_x }) {
+		[x] = useState(200);
+
+		return <><span>{x}</span><StatementBodyHook1 x={x} /></>;
+	});
+
 	switch (kind) {
 		case 'a':
-			const _tsrx_StatementBodyHook2_x = x;
-			const StatementBodyHook2 = App__StatementBodyHook2 ?? (App__StatementBodyHook2 = function StatementBodyHook2({ x }: { x: typeof _tsrx_StatementBodyHook2_x }) {
-				[x] = useState(100);
-
-				return <><div>{x}</div><StatementBodyHook1 x={x} /></>;
-			});
 			return <StatementBodyHook2 x={x} />;
 
 		case 'b':
-			const _tsrx_StatementBodyHook3_x = x;
-			const StatementBodyHook3 = App__StatementBodyHook3 ?? (App__StatementBodyHook3 = function StatementBodyHook3({ x }: { x: typeof _tsrx_StatementBodyHook3_x }) {
-				[x] = useState(200);
-
-				return <><span>{x}</span><StatementBodyHook1 x={x} /></>;
-			});
 			return <StatementBodyHook3 x={x} />;
 	}
 
@@ -307,8 +313,8 @@ export function App({ kind }: { kind: 'a' | 'b' }) {
 exports[`[react] continuation lift for switch-with-hook > lifts the tail when a switch has a default case with a hook 1`] = `
 "const App__static1 = <div>{'a'}</div>;
 let App__StatementBodyHook1;
-let App__StatementBodyHook2;
 let App__StatementBodyHook3;
+let App__StatementBodyHook2;
 
 export function App({ kind }: { kind: string }) {
 	let x: number | undefined;
@@ -320,21 +326,25 @@ export function App({ kind }: { kind: string }) {
 		return null;
 	});
 
+	const _tsrx_StatementBodyHook2_x = x;
+
+	const StatementBodyHook2 = App__StatementBodyHook2 ?? (App__StatementBodyHook2 = function StatementBodyHook2({ x }: { x: typeof _tsrx_StatementBodyHook2_x }) {
+		return <>{App__static1}<StatementBodyHook1 x={x} /></>;
+	});
+
+	const _tsrx_StatementBodyHook3_x = x;
+
+	const StatementBodyHook3 = App__StatementBodyHook3 ?? (App__StatementBodyHook3 = function StatementBodyHook3({ x }: { x: typeof _tsrx_StatementBodyHook3_x }) {
+		[x] = useState(100);
+
+		return <><div>{x}</div><StatementBodyHook1 x={x} /></>;
+	});
+
 	switch (kind) {
 		case 'a':
-			const _tsrx_StatementBodyHook2_x = x;
-			const StatementBodyHook2 = App__StatementBodyHook2 ?? (App__StatementBodyHook2 = function StatementBodyHook2({ x }: { x: typeof _tsrx_StatementBodyHook2_x }) {
-				return <>{App__static1}<StatementBodyHook1 x={x} /></>;
-			});
 			return <StatementBodyHook2 x={x} />;
 
 		default:
-			const _tsrx_StatementBodyHook3_x = x;
-			const StatementBodyHook3 = App__StatementBodyHook3 ?? (App__StatementBodyHook3 = function StatementBodyHook3({ x }: { x: typeof _tsrx_StatementBodyHook3_x }) {
-				[x] = useState(100);
-
-				return <><div>{x}</div><StatementBodyHook1 x={x} /></>;
-			});
 			return <StatementBodyHook3 x={x} />;
 	}
 
@@ -343,12 +353,12 @@ export function App({ kind }: { kind: string }) {
 `;
 
 exports[`[react] continuation lift for switch-with-hook > lifts the tail when only some switch cases contain hooks 1`] = `
-"const App__static1 = <span>{'static'}</span>;
-const App__static2 = <p>{'fallback'}</p>;
+"const App__static1 = <p>{'fallback'}</p>;
+const App__static2 = <span>{'static'}</span>;
 let App__StatementBodyHook1;
-let App__StatementBodyHook2;
-let App__StatementBodyHook3;
 let App__StatementBodyHook4;
+let App__StatementBodyHook3;
+let App__StatementBodyHook2;
 
 export function App({ kind }: { kind: 'a' | 'b' | 'c' }) {
 	let x: number | undefined;
@@ -360,28 +370,34 @@ export function App({ kind }: { kind: 'a' | 'b' | 'c' }) {
 		return null;
 	});
 
+	const _tsrx_StatementBodyHook2_x = x;
+
+	const StatementBodyHook2 = App__StatementBodyHook2 ?? (App__StatementBodyHook2 = function StatementBodyHook2({ x }: { x: typeof _tsrx_StatementBodyHook2_x }) {
+		[x] = useState(100);
+
+		return <><div>{x}</div><StatementBodyHook1 x={x} /></>;
+	});
+
+	const _tsrx_StatementBodyHook3_x = x;
+
+	const StatementBodyHook3 = App__StatementBodyHook3 ?? (App__StatementBodyHook3 = function StatementBodyHook3({ x }: { x: typeof _tsrx_StatementBodyHook3_x }) {
+		return <>{App__static2}<StatementBodyHook1 x={x} /></>;
+	});
+
+	const _tsrx_StatementBodyHook4_x = x;
+
+	const StatementBodyHook4 = App__StatementBodyHook4 ?? (App__StatementBodyHook4 = function StatementBodyHook4({ x }: { x: typeof _tsrx_StatementBodyHook4_x }) {
+		return <>{App__static1}<StatementBodyHook1 x={x} /></>;
+	});
+
 	switch (kind) {
 		case 'a':
-			const _tsrx_StatementBodyHook2_x = x;
-			const StatementBodyHook2 = App__StatementBodyHook2 ?? (App__StatementBodyHook2 = function StatementBodyHook2({ x }: { x: typeof _tsrx_StatementBodyHook2_x }) {
-				[x] = useState(100);
-
-				return <><div>{x}</div><StatementBodyHook1 x={x} /></>;
-			});
 			return <StatementBodyHook2 x={x} />;
 
 		case 'b':
-			const _tsrx_StatementBodyHook3_x = x;
-			const StatementBodyHook3 = App__StatementBodyHook3 ?? (App__StatementBodyHook3 = function StatementBodyHook3({ x }: { x: typeof _tsrx_StatementBodyHook3_x }) {
-				return <>{App__static1}<StatementBodyHook1 x={x} /></>;
-			});
 			return <StatementBodyHook3 x={x} />;
 
 		default:
-			const _tsrx_StatementBodyHook4_x = x;
-			const StatementBodyHook4 = App__StatementBodyHook4 ?? (App__StatementBodyHook4 = function StatementBodyHook4({ x }: { x: typeof _tsrx_StatementBodyHook4_x }) {
-				return <>{App__static2}<StatementBodyHook1 x={x} /></>;
-			});
 			return <StatementBodyHook4 x={x} />;
 	}
 
@@ -421,8 +437,8 @@ export function App({ kind }: { kind: 'a' | 'b' }) {
 
 exports[`[react] continuation lift for switch-with-hook > non-empty fall-through merges the trailing case body into the falling case 1`] = `
 "let App__StatementBodyHook1;
-let App__StatementBodyHook2;
 let App__StatementBodyHook3;
+let App__StatementBodyHook2;
 
 export function App({ kind }: { kind: 'a' | 'b' }) {
 	let x: number | undefined;
@@ -434,24 +450,27 @@ export function App({ kind }: { kind: 'a' | 'b' }) {
 		return null;
 	});
 
+	const _tsrx_StatementBodyHook2_x = x;
+
+	const StatementBodyHook2 = App__StatementBodyHook2 ?? (App__StatementBodyHook2 = function StatementBodyHook2({ x }: { x: typeof _tsrx_StatementBodyHook2_x }) {
+		x = 1;
+
+		return <StatementBodyHook3 x={x} />;
+	});
+
+	const _tsrx_StatementBodyHook3_x = x;
+
+	const StatementBodyHook3 = App__StatementBodyHook3 ?? (App__StatementBodyHook3 = function StatementBodyHook3({ x }: { x: typeof _tsrx_StatementBodyHook3_x }) {
+		[x] = useState(100);
+
+		return <><div>{x}</div><StatementBodyHook1 x={x} /></>;
+	});
+
 	switch (kind) {
 		case 'a':
-			const _tsrx_StatementBodyHook2_x = x;
-			const StatementBodyHook2 = App__StatementBodyHook2 ?? (App__StatementBodyHook2 = function StatementBodyHook2({ x }: { x: typeof _tsrx_StatementBodyHook2_x }) {
-				x = 1;
-				[x] = useState(100);
-
-				return <><div>{x}</div><StatementBodyHook1 x={x} /></>;
-			});
 			return <StatementBodyHook2 x={x} />;
 
 		case 'b':
-			const _tsrx_StatementBodyHook3_x = x;
-			const StatementBodyHook3 = App__StatementBodyHook3 ?? (App__StatementBodyHook3 = function StatementBodyHook3({ x }: { x: typeof _tsrx_StatementBodyHook3_x }) {
-				[x] = useState(100);
-
-				return <><div>{x}</div><StatementBodyHook1 x={x} /></>;
-			});
 			return <StatementBodyHook3 x={x} />;
 	}
 
@@ -462,8 +481,8 @@ export function App({ kind }: { kind: 'a' | 'b' }) {
 exports[`[react] continuation lift for switch-with-hook > preserves empty fall-through cases that share a body with the next case 1`] = `
 "const App__static1 = <span>{'other'}</span>;
 let App__StatementBodyHook1;
-let App__StatementBodyHook2;
 let App__StatementBodyHook3;
+let App__StatementBodyHook2;
 
 export function App({ kind }: { kind: 'a' | 'b' | 'c' }) {
 	let x: number | undefined;
@@ -475,23 +494,27 @@ export function App({ kind }: { kind: 'a' | 'b' | 'c' }) {
 		return null;
 	});
 
+	const _tsrx_StatementBodyHook2_x = x;
+
+	const StatementBodyHook2 = App__StatementBodyHook2 ?? (App__StatementBodyHook2 = function StatementBodyHook2({ x }: { x: typeof _tsrx_StatementBodyHook2_x }) {
+		[x] = useState(100);
+
+		return <><div>{x}</div><StatementBodyHook1 x={x} /></>;
+	});
+
+	const _tsrx_StatementBodyHook3_x = x;
+
+	const StatementBodyHook3 = App__StatementBodyHook3 ?? (App__StatementBodyHook3 = function StatementBodyHook3({ x }: { x: typeof _tsrx_StatementBodyHook3_x }) {
+		return <>{App__static1}<StatementBodyHook1 x={x} /></>;
+	});
+
 	switch (kind) {
 		case 'a':
 
 		case 'b':
-			const _tsrx_StatementBodyHook2_x = x;
-			const StatementBodyHook2 = App__StatementBodyHook2 ?? (App__StatementBodyHook2 = function StatementBodyHook2({ x }: { x: typeof _tsrx_StatementBodyHook2_x }) {
-				[x] = useState(100);
-
-				return <><div>{x}</div><StatementBodyHook1 x={x} /></>;
-			});
 			return <StatementBodyHook2 x={x} />;
 
 		default:
-			const _tsrx_StatementBodyHook3_x = x;
-			const StatementBodyHook3 = App__StatementBodyHook3 ?? (App__StatementBodyHook3 = function StatementBodyHook3({ x }: { x: typeof _tsrx_StatementBodyHook3_x }) {
-				return <>{App__static1}<StatementBodyHook1 x={x} /></>;
-			});
 			return <StatementBodyHook3 x={x} />;
 	}
 

--- a/packages/tsrx-react/tests/__snapshots__/basic.test.js.snap
+++ b/packages/tsrx-react/tests/__snapshots__/basic.test.js.snap
@@ -405,36 +405,6 @@ export function App({ kind }: { kind: 'a' | 'b' | 'c' }) {
 }"
 `;
 
-exports[`[react] continuation lift for switch-with-hook > non-empty fall-through (case with body but no terminator) bails out of the lift 1`] = `
-"let App__StatementBodyHook1;
-
-export function App({ kind }: { kind: 'a' | 'b' }) {
-	let x: number | undefined;
-
-	const _tsrx_child_0 = (() => {
-		switch (kind) {
-			case 'a':
-				x = 1;
-
-			case 'b':
-				const _tsrx_StatementBodyHook1_x = x;
-				const StatementBodyHook1 = App__StatementBodyHook1 ?? (App__StatementBodyHook1 = function StatementBodyHook1({ x }: { x: typeof _tsrx_StatementBodyHook1_x }) {
-					[x] = useState(100);
-
-					return <div>{x}</div>;
-				});
-				return <StatementBodyHook1 x={x} />;
-		}
-
-		return null;
-	})();
-
-	console.log(x);
-
-	return _tsrx_child_0;
-}"
-`;
-
 exports[`[react] continuation lift for switch-with-hook > non-empty fall-through merges the trailing case body into the falling case 1`] = `
 "let App__StatementBodyHook1;
 let App__StatementBodyHook3;

--- a/packages/tsrx-react/tests/__snapshots__/basic.test.js.snap
+++ b/packages/tsrx-react/tests/__snapshots__/basic.test.js.snap
@@ -1,0 +1,805 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`[react] continuation lift for if-with-hook > chains tail helpers across sibling ifs that each contain hooks 1`] = `
+"let App__StatementBodyHook2;
+let App__StatementBodyHook3;
+let App__StatementBodyHook1;
+let App__StatementBodyHook4;
+
+export function App({ a, b }: { a: boolean; b: boolean }) {
+	let x: number | undefined;
+	let y: number | undefined;
+	const _tsrx_StatementBodyHook1_b = b;
+	const _tsrx_StatementBodyHook1_x = x;
+	const _tsrx_StatementBodyHook1_y = y;
+
+	const StatementBodyHook1 = App__StatementBodyHook1 ?? (App__StatementBodyHook1 = function StatementBodyHook1(
+		{ b, x, y }: { 
+			b: typeof _tsrx_StatementBodyHook1_b;
+			x: typeof _tsrx_StatementBodyHook1_x;
+			y: typeof _tsrx_StatementBodyHook1_y
+		 }
+	) {
+		const _tsrx_StatementBodyHook2_x = x;
+		const _tsrx_StatementBodyHook2_y = y;
+
+		const StatementBodyHook2 = App__StatementBodyHook2 ?? (App__StatementBodyHook2 = function StatementBodyHook2(
+			{ x, y }: { 
+				x: typeof _tsrx_StatementBodyHook2_x;
+				y: typeof _tsrx_StatementBodyHook2_y
+			 }
+		) {
+			console.log(x, y);
+
+			return null;
+		});
+
+		if (b) {
+			const _tsrx_StatementBodyHook3_x = x;
+			const _tsrx_StatementBodyHook3_y = y;
+
+			const StatementBodyHook3 = App__StatementBodyHook3 ?? (App__StatementBodyHook3 = function StatementBodyHook3(
+				{ x, y }: { 
+					x: typeof _tsrx_StatementBodyHook3_x;
+					y: typeof _tsrx_StatementBodyHook3_y
+				 }
+			) {
+				[y] = useState(200);
+
+				return <><span>{y}</span><StatementBodyHook2 x={x} y={y} /></>;
+			});
+
+			return <StatementBodyHook3 x={x} y={y} />;
+		}
+
+		return <StatementBodyHook2 x={x} y={y} />;
+	});
+
+	if (a) {
+		const _tsrx_StatementBodyHook4_b = b;
+		const _tsrx_StatementBodyHook4_x = x;
+		const _tsrx_StatementBodyHook4_y = y;
+
+		const StatementBodyHook4 = App__StatementBodyHook4 ?? (App__StatementBodyHook4 = function StatementBodyHook4(
+			{ b, x, y }: { 
+				b: typeof _tsrx_StatementBodyHook4_b;
+				x: typeof _tsrx_StatementBodyHook4_x;
+				y: typeof _tsrx_StatementBodyHook4_y
+			 }
+		) {
+			[x] = useState(100);
+
+			return <><div>{x}</div><StatementBodyHook1 b={b} x={x} y={y} /></>;
+		});
+
+		return <StatementBodyHook4 b={b} x={x} y={y} />;
+	}
+
+	return <StatementBodyHook1 b={b} x={x} y={y} />;
+}"
+`;
+
+exports[`[react] continuation lift for if-with-hook > does not lift when the if has an else branch 1`] = `
+"const App__static1 = <div>{'no'}</div>;
+let App__StatementBodyHook1;
+
+export function App({ show }: { show: boolean }) {
+	let x: number | undefined;
+
+	const _tsrx_child_0 = show
+		? (() => {
+			const _tsrx_StatementBodyHook1_x = x;
+
+			const StatementBodyHook1 = App__StatementBodyHook1 ?? (App__StatementBodyHook1 = function StatementBodyHook1({ x }: { x: typeof _tsrx_StatementBodyHook1_x }) {
+				[x] = useState(100);
+
+				return <div>{x}</div>;
+			});
+
+			return <StatementBodyHook1 x={x} />;
+		})()
+		: App__static1;
+
+	console.log(x);
+
+	return _tsrx_child_0;
+}"
+`;
+
+exports[`[react] continuation lift for if-with-hook > does not lift when the if has no statements after it 1`] = `
+"let App__StatementBodyHook1;
+
+export function App({ show }: { show: boolean }) {
+	return show
+		? (() => {
+			const StatementBodyHook1 = App__StatementBodyHook1 ?? (App__StatementBodyHook1 = function StatementBodyHook1() {
+				const [x] = useState(100);
+
+				return <div>{x}</div>;
+			});
+
+			return <StatementBodyHook1 />;
+		})()
+		: null;
+}"
+`;
+
+exports[`[react] continuation lift for if-with-hook > handles nested if-with-hook so the mid-tail observes the inner hook 1`] = `
+"let App__StatementBodyHook1;
+let App__StatementBodyHook3;
+let App__StatementBodyHook4;
+let App__StatementBodyHook2;
+
+export function App({ a, b }: { a: boolean; b: boolean }) {
+	let x: number | undefined;
+	const _tsrx_StatementBodyHook1_x = x;
+
+	const StatementBodyHook1 = App__StatementBodyHook1 ?? (App__StatementBodyHook1 = function StatementBodyHook1({ x }: { x: typeof _tsrx_StatementBodyHook1_x }) {
+		console.log('end', x);
+
+		return null;
+	});
+
+	if (a) {
+		const _tsrx_StatementBodyHook2_b = b;
+		const _tsrx_StatementBodyHook2_x = x;
+
+		const StatementBodyHook2 = App__StatementBodyHook2 ?? (App__StatementBodyHook2 = function StatementBodyHook2(
+			{ b, x }: { 
+				b: typeof _tsrx_StatementBodyHook2_b;
+				x: typeof _tsrx_StatementBodyHook2_x
+			 }
+		) {
+			const _tsrx_StatementBodyHook3_x = x;
+
+			const StatementBodyHook3 = App__StatementBodyHook3 ?? (App__StatementBodyHook3 = function StatementBodyHook3({ x }: { x: typeof _tsrx_StatementBodyHook3_x }) {
+				console.log('mid', x);
+
+				return <StatementBodyHook1 x={x} />;
+			});
+
+			if (b) {
+				const _tsrx_StatementBodyHook4_x = x;
+
+				const StatementBodyHook4 = App__StatementBodyHook4 ?? (App__StatementBodyHook4 = function StatementBodyHook4({ x }: { x: typeof _tsrx_StatementBodyHook4_x }) {
+					[x] = useState(100);
+
+					return <><div>{x}</div><StatementBodyHook3 x={x} /></>;
+				});
+
+				return <StatementBodyHook4 x={x} />;
+			}
+
+			return <StatementBodyHook3 x={x} />;
+		});
+
+		return <StatementBodyHook2 b={b} x={x} />;
+	}
+
+	return <StatementBodyHook1 x={x} />;
+}"
+`;
+
+exports[`[react] continuation lift for if-with-hook > lifts the tail of a single non-returning if-with-hook into a helper 1`] = `
+"let App__StatementBodyHook1;
+let App__StatementBodyHook2;
+
+export function App({ show }: { show: boolean }) {
+	let x: number | undefined;
+	const _tsrx_StatementBodyHook1_x = x;
+
+	const StatementBodyHook1 = App__StatementBodyHook1 ?? (App__StatementBodyHook1 = function StatementBodyHook1({ x }: { x: typeof _tsrx_StatementBodyHook1_x }) {
+		console.log(x);
+
+		return null;
+	});
+
+	if (show) {
+		const _tsrx_StatementBodyHook2_x = x;
+
+		const StatementBodyHook2 = App__StatementBodyHook2 ?? (App__StatementBodyHook2 = function StatementBodyHook2({ x }: { x: typeof _tsrx_StatementBodyHook2_x }) {
+			[x] = useState(100);
+
+			return <><div>{x}</div><StatementBodyHook1 x={x} /></>;
+		});
+
+		return <StatementBodyHook2 x={x} />;
+	}
+
+	return <StatementBodyHook1 x={x} />;
+}"
+`;
+
+exports[`[react] continuation lift for switch-with-hook > does not lift when the switch has no statements after it 1`] = `
+"let App__StatementBodyHook1;
+
+export function App({ kind }: { kind: 'a' | 'b' }) {
+	return (() => {
+		switch (kind) {
+			case 'a':
+				const StatementBodyHook1 = App__StatementBodyHook1 ?? (App__StatementBodyHook1 = function StatementBodyHook1() {
+					const [x] = useState(100);
+
+					return <div>{x}</div>;
+				});
+				return <StatementBodyHook1 />;
+
+			case 'b':
+				return <span>{'b'}</span>;
+		}
+
+		return null;
+	})();
+}"
+`;
+
+exports[`[react] continuation lift for switch-with-hook > lifts the tail of a switch whose cases contain hooks 1`] = `
+"let App__StatementBodyHook1;
+let App__StatementBodyHook2;
+let App__StatementBodyHook3;
+
+export function App({ kind }: { kind: 'a' | 'b' }) {
+	let x: number | undefined;
+	const _tsrx_StatementBodyHook1_x = x;
+
+	const StatementBodyHook1 = App__StatementBodyHook1 ?? (App__StatementBodyHook1 = function StatementBodyHook1({ x }: { x: typeof _tsrx_StatementBodyHook1_x }) {
+		console.log(x);
+
+		return null;
+	});
+
+	switch (kind) {
+		case 'a':
+			const _tsrx_StatementBodyHook2_x = x;
+			const StatementBodyHook2 = App__StatementBodyHook2 ?? (App__StatementBodyHook2 = function StatementBodyHook2({ x }: { x: typeof _tsrx_StatementBodyHook2_x }) {
+				[x] = useState(100);
+
+				return <><div>{x}</div><StatementBodyHook1 x={x} /></>;
+			});
+			return <StatementBodyHook2 x={x} />;
+
+		case 'b':
+			const _tsrx_StatementBodyHook3_x = x;
+			const StatementBodyHook3 = App__StatementBodyHook3 ?? (App__StatementBodyHook3 = function StatementBodyHook3({ x }: { x: typeof _tsrx_StatementBodyHook3_x }) {
+				[x] = useState(200);
+
+				return <><span>{x}</span><StatementBodyHook1 x={x} /></>;
+			});
+			return <StatementBodyHook3 x={x} />;
+	}
+
+	return <StatementBodyHook1 x={x} />;
+}"
+`;
+
+exports[`[react] continuation lift for switch-with-hook > lifts the tail when a switch has a default case with a hook 1`] = `
+"const App__static1 = <div>{'a'}</div>;
+let App__StatementBodyHook1;
+let App__StatementBodyHook2;
+let App__StatementBodyHook3;
+
+export function App({ kind }: { kind: string }) {
+	let x: number | undefined;
+	const _tsrx_StatementBodyHook1_x = x;
+
+	const StatementBodyHook1 = App__StatementBodyHook1 ?? (App__StatementBodyHook1 = function StatementBodyHook1({ x }: { x: typeof _tsrx_StatementBodyHook1_x }) {
+		console.log(x);
+
+		return null;
+	});
+
+	switch (kind) {
+		case 'a':
+			const _tsrx_StatementBodyHook2_x = x;
+			const StatementBodyHook2 = App__StatementBodyHook2 ?? (App__StatementBodyHook2 = function StatementBodyHook2({ x }: { x: typeof _tsrx_StatementBodyHook2_x }) {
+				return <>{App__static1}<StatementBodyHook1 x={x} /></>;
+			});
+			return <StatementBodyHook2 x={x} />;
+
+		default:
+			const _tsrx_StatementBodyHook3_x = x;
+			const StatementBodyHook3 = App__StatementBodyHook3 ?? (App__StatementBodyHook3 = function StatementBodyHook3({ x }: { x: typeof _tsrx_StatementBodyHook3_x }) {
+				[x] = useState(100);
+
+				return <><div>{x}</div><StatementBodyHook1 x={x} /></>;
+			});
+			return <StatementBodyHook3 x={x} />;
+	}
+
+	return <StatementBodyHook1 x={x} />;
+}"
+`;
+
+exports[`[react] continuation lift for switch-with-hook > lifts the tail when only some switch cases contain hooks 1`] = `
+"const App__static1 = <span>{'static'}</span>;
+const App__static2 = <p>{'fallback'}</p>;
+let App__StatementBodyHook1;
+let App__StatementBodyHook2;
+let App__StatementBodyHook3;
+let App__StatementBodyHook4;
+
+export function App({ kind }: { kind: 'a' | 'b' | 'c' }) {
+	let x: number | undefined;
+	const _tsrx_StatementBodyHook1_x = x;
+
+	const StatementBodyHook1 = App__StatementBodyHook1 ?? (App__StatementBodyHook1 = function StatementBodyHook1({ x }: { x: typeof _tsrx_StatementBodyHook1_x }) {
+		console.log(x);
+
+		return null;
+	});
+
+	switch (kind) {
+		case 'a':
+			const _tsrx_StatementBodyHook2_x = x;
+			const StatementBodyHook2 = App__StatementBodyHook2 ?? (App__StatementBodyHook2 = function StatementBodyHook2({ x }: { x: typeof _tsrx_StatementBodyHook2_x }) {
+				[x] = useState(100);
+
+				return <><div>{x}</div><StatementBodyHook1 x={x} /></>;
+			});
+			return <StatementBodyHook2 x={x} />;
+
+		case 'b':
+			const _tsrx_StatementBodyHook3_x = x;
+			const StatementBodyHook3 = App__StatementBodyHook3 ?? (App__StatementBodyHook3 = function StatementBodyHook3({ x }: { x: typeof _tsrx_StatementBodyHook3_x }) {
+				return <>{App__static1}<StatementBodyHook1 x={x} /></>;
+			});
+			return <StatementBodyHook3 x={x} />;
+
+		default:
+			const _tsrx_StatementBodyHook4_x = x;
+			const StatementBodyHook4 = App__StatementBodyHook4 ?? (App__StatementBodyHook4 = function StatementBodyHook4({ x }: { x: typeof _tsrx_StatementBodyHook4_x }) {
+				return <>{App__static2}<StatementBodyHook1 x={x} /></>;
+			});
+			return <StatementBodyHook4 x={x} />;
+	}
+
+	return <StatementBodyHook1 x={x} />;
+}"
+`;
+
+exports[`[react] continuation lift for try-with-hook > try with a hook but no statements after it (no tail to lift) 1`] = `
+"import { TsrxErrorBoundary } from '@tsrx/react/error-boundary';
+
+const App__static1 = <div>{'error'}</div>;
+let App__StatementBodyHook1;
+
+export function App({ load }: { load: () => number }) {
+	return <TsrxErrorBoundary fallback={(err, _reset) => {
+		return App__static1;
+	}}>{(() => {
+			const _tsrx_StatementBodyHook1_load = load;
+
+			const StatementBodyHook1 = App__StatementBodyHook1 ?? (App__StatementBodyHook1 = function StatementBodyHook1({ load }: { load: typeof _tsrx_StatementBodyHook1_load }) {
+				const [data] = useState(load());
+
+				return <div>{data}</div>;
+			});
+
+			return <StatementBodyHook1 load={load} />;
+		})()}</TsrxErrorBoundary>;
+}"
+`;
+
+exports[`[react] continuation lift for try-with-hook > try without hooks falls back to the existing transform 1`] = `
+"import { TsrxErrorBoundary } from '@tsrx/react/error-boundary';
+
+const App__static1 = <div>{'error'}</div>;
+
+export function App({ load }: { load: () => number }) {
+	return <TsrxErrorBoundary fallback={(err, _reset) => {
+		return App__static1;
+	}}>{(() => {
+			return <div>{load()}</div>;
+		})()}</TsrxErrorBoundary>;
+}"
+`;
+
+exports[`[react] continuation lift for try-with-hook > try/catch with a hook in the catch body and a tail that reads the mutated outer 1`] = `
+"import { TsrxErrorBoundary } from '@tsrx/react/error-boundary';
+
+let App__StatementBodyHook1;
+
+export function App({ load }: { load: () => number }) {
+	let attempt: number | undefined;
+	const _tsrx_StatementBodyHook1_attempt = attempt;
+
+	const StatementBodyHook1 = App__StatementBodyHook1 ?? (App__StatementBodyHook1 = function StatementBodyHook1(
+		{ attempt }: { attempt: typeof _tsrx_StatementBodyHook1_attempt }
+	) {
+		console.log(attempt);
+
+		return null;
+	});
+
+	return <TsrxErrorBoundary fallback={(err, _reset) => {
+		[attempt] = useState(0);
+
+		return <><div>{attempt}</div><StatementBodyHook1 attempt={attempt} /></>;
+	}}>{(() => {
+			return <><div>{load()}</div><StatementBodyHook1 attempt={attempt} /></>;
+		})()}</TsrxErrorBoundary>;
+}"
+`;
+
+exports[`[react] continuation lift for try-with-hook > try/catch with a hook in the try body and a tail that reads the mutated outer 1`] = `
+"import { TsrxErrorBoundary } from '@tsrx/react/error-boundary';
+
+const App__static1 = <div>{'error'}</div>;
+let App__StatementBodyHook1;
+let App__StatementBodyHook2;
+
+export function App({ load }: { load: () => number }) {
+	let data: number | undefined;
+	const _tsrx_StatementBodyHook1_data = data;
+
+	const StatementBodyHook1 = App__StatementBodyHook1 ?? (App__StatementBodyHook1 = function StatementBodyHook1({ data }: { data: typeof _tsrx_StatementBodyHook1_data }) {
+		console.log(data);
+
+		return null;
+	});
+
+	return <TsrxErrorBoundary fallback={(err, _reset) => {
+		return <>{App__static1}<StatementBodyHook1 data={data} /></>;
+	}}>{(() => {
+			const _tsrx_StatementBodyHook2_load = load;
+			const _tsrx_StatementBodyHook2_data = data;
+
+			const StatementBodyHook2 = App__StatementBodyHook2 ?? (App__StatementBodyHook2 = function StatementBodyHook2(
+				{ load, data }: { 
+					load: typeof _tsrx_StatementBodyHook2_load;
+					data: typeof _tsrx_StatementBodyHook2_data
+				 }
+			) {
+				[data] = useState(load());
+
+				return <><div>{data}</div><StatementBodyHook1 data={data} /></>;
+			});
+
+			return <StatementBodyHook2 load={load} data={data} />;
+		})()}</TsrxErrorBoundary>;
+}"
+`;
+
+exports[`[react] continuation lift for try-with-hook > try/pending/catch with a hook in the try body and a tail that reads the mutated outer 1`] = `
+"import { Suspense } from 'react';
+import { TsrxErrorBoundary } from '@tsrx/react/error-boundary';
+
+const App__static1 = <p>{'loading'}</p>;
+const App__static2 = <div>{'error'}</div>;
+let App__StatementBodyHook1;
+let App__StatementBodyHook2;
+
+export function App({ load }: { load: () => number }) {
+	let data: number | undefined;
+	const _tsrx_StatementBodyHook1_data = data;
+
+	const StatementBodyHook1 = App__StatementBodyHook1 ?? (App__StatementBodyHook1 = function StatementBodyHook1({ data }: { data: typeof _tsrx_StatementBodyHook1_data }) {
+		console.log(data);
+
+		return null;
+	});
+
+	return <TsrxErrorBoundary fallback={(err, _reset) => {
+		return <>{App__static2}<StatementBodyHook1 data={data} /></>;
+	}}><Suspense fallback={(() => {
+			return App__static1;
+		})()}>{(() => {
+				const _tsrx_StatementBodyHook2_load = load;
+				const _tsrx_StatementBodyHook2_data = data;
+
+				const StatementBodyHook2 = App__StatementBodyHook2 ?? (App__StatementBodyHook2 = function StatementBodyHook2(
+					{ load, data }: { 
+						load: typeof _tsrx_StatementBodyHook2_load;
+						data: typeof _tsrx_StatementBodyHook2_data
+					 }
+				) {
+					[data] = useState(load());
+
+					return <><div>{data}</div><StatementBodyHook1 data={data} /></>;
+				});
+
+				return <StatementBodyHook2 load={load} data={data} />;
+			})()}</Suspense></TsrxErrorBoundary>;
+}"
+`;
+
+exports[`[react] hoisted helper and tail lift for for-of-with-hook > falls back to the existing transform for non-hook for-of loops 1`] = `
+"export function App({ items }: { items: number[] }) {
+	return items.map((item, i) => {
+		return <div key={i}>{item}</div>;
+	});
+}"
+`;
+
+exports[`[react] hoisted helper and tail lift for for-of-with-hook > hoists the helper without a tail lift when nothing follows the loop 1`] = `
+"let App__StatementBodyHook1;
+
+export function App({ items }: { items: string[] }) {
+	let _tsrx_iteration_items_1 = items;
+
+	_tsrx_iteration_items_1 = Array.isArray(_tsrx_iteration_items_1)
+		? _tsrx_iteration_items_1
+		: Array.from(_tsrx_iteration_items_1);
+
+	type _tsrx_StatementBodyHook1_name = typeof _tsrx_iteration_items_1[number];
+
+	const StatementBodyHook1 = App__StatementBodyHook1 ?? (App__StatementBodyHook1 = function StatementBodyHook1({ name }: { name: _tsrx_StatementBodyHook1_name }) {
+		const [val] = useState(name);
+
+		return <div key={name}>{val}</div>;
+	});
+
+	return _tsrx_iteration_items_1.map((name) => <StatementBodyHook1 name={name} key={name} />);
+}"
+`;
+
+exports[`[react] hoisted helper and tail lift for for-of-with-hook > lifts the tail across nested for-of-with-hooks 1`] = `
+"let App__StatementBodyHook1;
+let App__StatementBodyHook3;
+let App__StatementBodyHook4;
+let App__StatementBodyHook2;
+
+export function App({ groups }: { groups: number[][] }) {
+	let last: number | undefined;
+	let _tsrx_iteration_items_2 = groups;
+
+	_tsrx_iteration_items_2 = Array.isArray(_tsrx_iteration_items_2)
+		? _tsrx_iteration_items_2
+		: Array.from(_tsrx_iteration_items_2);
+
+	const _tsrx_StatementBodyHook1_last = last;
+
+	const StatementBodyHook1 = App__StatementBodyHook1 ?? (App__StatementBodyHook1 = function StatementBodyHook1({ last }: { last: typeof _tsrx_StatementBodyHook1_last }) {
+		console.log('end', last);
+
+		return null;
+	});
+
+	const _tsrx_StatementBodyHook2_last = last;
+
+	type _tsrx_StatementBodyHook2_group = typeof _tsrx_iteration_items_2[number];
+	type _tsrx_StatementBodyHook2_isLast = boolean;
+
+	const StatementBodyHook2 = App__StatementBodyHook2 ?? (App__StatementBodyHook2 = function StatementBodyHook2(
+		{ last, group, _tsrx_isLast_2 }: { 
+			last: typeof _tsrx_StatementBodyHook2_last;
+			group: _tsrx_StatementBodyHook2_group;
+			_tsrx_isLast_2: _tsrx_StatementBodyHook2_isLast
+		 }
+	) {
+		let _tsrx_iteration_items_4 = group;
+
+		_tsrx_iteration_items_4 = Array.isArray(_tsrx_iteration_items_4)
+			? _tsrx_iteration_items_4
+			: Array.from(_tsrx_iteration_items_4);
+
+		const _tsrx_StatementBodyHook3_last = last;
+		const _tsrx_StatementBodyHook3__tsrx_isLast_2 = _tsrx_isLast_2;
+
+		const StatementBodyHook3 = App__StatementBodyHook3 ?? (App__StatementBodyHook3 = function StatementBodyHook3(
+			{ last, _tsrx_isLast_2 }: { 
+				last: typeof _tsrx_StatementBodyHook3_last;
+				_tsrx_isLast_2: typeof _tsrx_StatementBodyHook3__tsrx_isLast_2
+			 }
+		) {
+			console.log('mid', last);
+
+			return _tsrx_isLast_2 && <StatementBodyHook1 last={last} />;
+		});
+
+		const _tsrx_StatementBodyHook4_last = last;
+		const _tsrx_StatementBodyHook4__tsrx_isLast_2 = _tsrx_isLast_2;
+
+		type _tsrx_StatementBodyHook4_item = typeof _tsrx_iteration_items_4[number];
+		type _tsrx_StatementBodyHook4_isLast = boolean;
+
+		const StatementBodyHook4 = App__StatementBodyHook4 ?? (App__StatementBodyHook4 = function StatementBodyHook4(
+			{ last, _tsrx_isLast_2, item, _tsrx_isLast_4 }: { 
+				last: typeof _tsrx_StatementBodyHook4_last;
+				_tsrx_isLast_2: typeof _tsrx_StatementBodyHook4__tsrx_isLast_2;
+				item: _tsrx_StatementBodyHook4_item;
+				_tsrx_isLast_4: _tsrx_StatementBodyHook4_isLast
+			 }
+		) {
+			[last] = useState(item);
+
+			return <><div key={item}>{last}</div>{_tsrx_isLast_4 && <StatementBodyHook3 last={last} _tsrx_isLast_2={_tsrx_isLast_2} />}</>;
+		});
+
+		return _tsrx_iteration_items_4.length === 0
+			? <StatementBodyHook3 last={last} _tsrx_isLast_2={_tsrx_isLast_2} />
+			: _tsrx_iteration_items_4.map((item, i) => <StatementBodyHook4 last={last} _tsrx_isLast_2={_tsrx_isLast_2} item={item} key={item} _tsrx_isLast_4={i === _tsrx_iteration_items_4.length - 1} />);
+	});
+
+	return _tsrx_iteration_items_2.length === 0
+		? <StatementBodyHook1 last={last} />
+		: _tsrx_iteration_items_2.map((group, i) => <StatementBodyHook2 last={last} group={group} _tsrx_isLast_2={i === _tsrx_iteration_items_2.length - 1} />);
+}"
+`;
+
+exports[`[react] hoisted helper and tail lift for for-of-with-hook > lifts the tail across sibling for-of-with-hooks at the same level 1`] = `
+"let App__StatementBodyHook2;
+let App__StatementBodyHook3;
+let App__StatementBodyHook1;
+let App__StatementBodyHook4;
+
+export function App({ as, bs }: { as: number[]; bs: number[] }) {
+	let lastA: number | undefined;
+	let lastB: number | undefined;
+	let _tsrx_iteration_items_4 = as;
+
+	_tsrx_iteration_items_4 = Array.isArray(_tsrx_iteration_items_4)
+		? _tsrx_iteration_items_4
+		: Array.from(_tsrx_iteration_items_4);
+
+	const _tsrx_StatementBodyHook1_bs = bs;
+	const _tsrx_StatementBodyHook1_lastA = lastA;
+	const _tsrx_StatementBodyHook1_lastB = lastB;
+
+	const StatementBodyHook1 = App__StatementBodyHook1 ?? (App__StatementBodyHook1 = function StatementBodyHook1(
+		{ bs, lastA, lastB }: { 
+			bs: typeof _tsrx_StatementBodyHook1_bs;
+			lastA: typeof _tsrx_StatementBodyHook1_lastA;
+			lastB: typeof _tsrx_StatementBodyHook1_lastB
+		 }
+	) {
+		let _tsrx_iteration_items_3 = bs;
+
+		_tsrx_iteration_items_3 = Array.isArray(_tsrx_iteration_items_3)
+			? _tsrx_iteration_items_3
+			: Array.from(_tsrx_iteration_items_3);
+
+		const _tsrx_StatementBodyHook2_lastA = lastA;
+		const _tsrx_StatementBodyHook2_lastB = lastB;
+
+		const StatementBodyHook2 = App__StatementBodyHook2 ?? (App__StatementBodyHook2 = function StatementBodyHook2(
+			{ lastA, lastB }: { 
+				lastA: typeof _tsrx_StatementBodyHook2_lastA;
+				lastB: typeof _tsrx_StatementBodyHook2_lastB
+			 }
+		) {
+			console.log(lastA, lastB);
+
+			return null;
+		});
+
+		const _tsrx_StatementBodyHook3_lastA = lastA;
+		const _tsrx_StatementBodyHook3_lastB = lastB;
+
+		type _tsrx_StatementBodyHook3_b = typeof _tsrx_iteration_items_3[number];
+		type _tsrx_StatementBodyHook3_isLast = boolean;
+
+		const StatementBodyHook3 = App__StatementBodyHook3 ?? (App__StatementBodyHook3 = function StatementBodyHook3(
+			{ lastA, lastB, b, _tsrx_isLast_3 }: { 
+				lastA: typeof _tsrx_StatementBodyHook3_lastA;
+				lastB: typeof _tsrx_StatementBodyHook3_lastB;
+				b: _tsrx_StatementBodyHook3_b;
+				_tsrx_isLast_3: _tsrx_StatementBodyHook3_isLast
+			 }
+		) {
+			[lastB] = useState(b);
+
+			return <><span key={b}>{lastB}</span>{_tsrx_isLast_3 && <StatementBodyHook2 lastA={lastA} lastB={lastB} />}</>;
+		});
+
+		return _tsrx_iteration_items_3.length === 0
+			? <StatementBodyHook2 lastA={lastA} lastB={lastB} />
+			: _tsrx_iteration_items_3.map((b, i) => <StatementBodyHook3 lastA={lastA} lastB={lastB} b={b} key={b} _tsrx_isLast_3={i === _tsrx_iteration_items_3.length - 1} />);
+	});
+
+	const _tsrx_StatementBodyHook4_bs = bs;
+	const _tsrx_StatementBodyHook4_lastA = lastA;
+	const _tsrx_StatementBodyHook4_lastB = lastB;
+
+	type _tsrx_StatementBodyHook4_a = typeof _tsrx_iteration_items_4[number];
+	type _tsrx_StatementBodyHook4_isLast = boolean;
+
+	const StatementBodyHook4 = App__StatementBodyHook4 ?? (App__StatementBodyHook4 = function StatementBodyHook4(
+		{ bs, lastA, lastB, a, _tsrx_isLast_4 }: { 
+			bs: typeof _tsrx_StatementBodyHook4_bs;
+			lastA: typeof _tsrx_StatementBodyHook4_lastA;
+			lastB: typeof _tsrx_StatementBodyHook4_lastB;
+			a: _tsrx_StatementBodyHook4_a;
+			_tsrx_isLast_4: _tsrx_StatementBodyHook4_isLast
+		 }
+	) {
+		[lastA] = useState(a);
+
+		return <><div key={a}>{lastA}</div>{_tsrx_isLast_4 && <StatementBodyHook1 bs={bs} lastA={lastA} lastB={lastB} />}</>;
+	});
+
+	return _tsrx_iteration_items_4.length === 0
+		? <StatementBodyHook1 bs={bs} lastA={lastA} lastB={lastB} />
+		: _tsrx_iteration_items_4.map((a, i) => <StatementBodyHook4 bs={bs} lastA={lastA} lastB={lastB} a={a} key={a} _tsrx_isLast_4={i === _tsrx_iteration_items_4.length - 1} />);
+}"
+`;
+
+exports[`[react] hoisted helper and tail lift for for-of-with-hook > lifts the tail of a for-of with hooks (inline-literal iteration source) 1`] = `
+"let App__StatementBodyHook1;
+let App__StatementBodyHook2;
+
+export function App() {
+	let last: number | undefined;
+	let _tsrx_iteration_items_2 = [1, 2, 3];
+
+	_tsrx_iteration_items_2 = Array.isArray(_tsrx_iteration_items_2)
+		? _tsrx_iteration_items_2
+		: Array.from(_tsrx_iteration_items_2);
+
+	const _tsrx_StatementBodyHook1_last = last;
+
+	const StatementBodyHook1 = App__StatementBodyHook1 ?? (App__StatementBodyHook1 = function StatementBodyHook1({ last }: { last: typeof _tsrx_StatementBodyHook1_last }) {
+		console.log(last);
+
+		return null;
+	});
+
+	const _tsrx_StatementBodyHook2_last = last;
+
+	type _tsrx_StatementBodyHook2_item = typeof _tsrx_iteration_items_2[number];
+	type _tsrx_StatementBodyHook2_i = number;
+	type _tsrx_StatementBodyHook2_isLast = boolean;
+
+	const StatementBodyHook2 = App__StatementBodyHook2 ?? (App__StatementBodyHook2 = function StatementBodyHook2(
+		{ last, item, i, _tsrx_isLast_2 }: { 
+			last: typeof _tsrx_StatementBodyHook2_last;
+			item: _tsrx_StatementBodyHook2_item;
+			i: _tsrx_StatementBodyHook2_i;
+			_tsrx_isLast_2: _tsrx_StatementBodyHook2_isLast
+		 }
+	) {
+		[last] = useState(item);
+
+		return <><div key={i}>{last}</div>{_tsrx_isLast_2 && <StatementBodyHook1 last={last} />}</>;
+	});
+
+	return _tsrx_iteration_items_2.length === 0
+		? <StatementBodyHook1 last={last} />
+		: _tsrx_iteration_items_2.map((item, i) => <StatementBodyHook2 last={last} item={item} i={i} key={i} _tsrx_isLast_2={i === _tsrx_iteration_items_2.length - 1} />);
+}"
+`;
+
+exports[`[react] hoisted helper and tail lift for for-of-with-hook > lifts the tail of a for-of with hooks (prop iteration source) 1`] = `
+"let App__StatementBodyHook1;
+let App__StatementBodyHook2;
+
+export function App({ items }: { items: number[] }) {
+	let last: number | undefined;
+	let _tsrx_iteration_items_2 = items;
+
+	_tsrx_iteration_items_2 = Array.isArray(_tsrx_iteration_items_2)
+		? _tsrx_iteration_items_2
+		: Array.from(_tsrx_iteration_items_2);
+
+	const _tsrx_StatementBodyHook1_last = last;
+
+	const StatementBodyHook1 = App__StatementBodyHook1 ?? (App__StatementBodyHook1 = function StatementBodyHook1({ last }: { last: typeof _tsrx_StatementBodyHook1_last }) {
+		console.log(last);
+
+		return null;
+	});
+
+	const _tsrx_StatementBodyHook2_last = last;
+
+	type _tsrx_StatementBodyHook2_item = typeof _tsrx_iteration_items_2[number];
+	type _tsrx_StatementBodyHook2_i = number;
+	type _tsrx_StatementBodyHook2_isLast = boolean;
+
+	const StatementBodyHook2 = App__StatementBodyHook2 ?? (App__StatementBodyHook2 = function StatementBodyHook2(
+		{ last, item, i, _tsrx_isLast_2 }: { 
+			last: typeof _tsrx_StatementBodyHook2_last;
+			item: _tsrx_StatementBodyHook2_item;
+			i: _tsrx_StatementBodyHook2_i;
+			_tsrx_isLast_2: _tsrx_StatementBodyHook2_isLast
+		 }
+	) {
+		[last] = useState(item);
+
+		return <><div key={i}>{last}</div>{_tsrx_isLast_2 && <StatementBodyHook1 last={last} />}</>;
+	});
+
+	return _tsrx_iteration_items_2.length === 0
+		? <StatementBodyHook1 last={last} />
+		: _tsrx_iteration_items_2.map((item, i) => <StatementBodyHook2 last={last} item={item} i={i} key={i} _tsrx_isLast_2={i === _tsrx_iteration_items_2.length - 1} />);
+}"
+`;

--- a/packages/tsrx-react/tests/basic.test.js
+++ b/packages/tsrx-react/tests/basic.test.js
@@ -1080,8 +1080,10 @@ describe('@tsrx/react basic', () => {
 		);
 
 		expect(code).toContain('function StatementBodyHook');
-		expect(code).toContain('.map(');
-		// Hook should be inside the helper, not the map callback directly
+		// Hook-bearing for-of bodies emit `Array.from(source, callback)` so
+		// any Iterable works, with the helper hoisted above the iteration.
+		expect(code).toContain('Array.from(');
+		// Hook should be inside the helper, not the iteration callback directly
 		const hook_pos = code.indexOf('useState(false)');
 		const helper_pos = code.indexOf('function StatementBodyHook');
 		expect(hook_pos).toBeGreaterThan(helper_pos);

--- a/packages/tsrx/src/transform/jsx/index.js
+++ b/packages/tsrx/src/transform/jsx/index.js
@@ -589,6 +589,106 @@ function build_render_statements(body_nodes, return_null_when_empty, transform_c
 			continue;
 		}
 
+		if (
+			child.type === 'IfStatement' &&
+			!child.alternate &&
+			!is_returning_if_statement(child) &&
+			!transform_context.platform.hooks?.isTopLevelSetupCall &&
+			body_contains_top_level_hook_call([child], transform_context, true) &&
+			i + 1 < body_nodes.length
+		) {
+			statements.push(
+				...create_continuation_lift_if_statement(
+					child,
+					body_nodes.slice(i + 1),
+					render_nodes,
+					transform_context,
+				),
+			);
+			transform_context.available_bindings = saved_bindings;
+			return statements;
+		}
+
+		if (
+			child.type === 'ForOfStatement' &&
+			!child.await &&
+			!transform_context.platform.hooks?.isTopLevelSetupCall &&
+			!transform_context.platform.hooks?.controlFlow?.forOf &&
+			body_contains_top_level_hook_call(
+				child.body.type === 'BlockStatement' ? child.body.body : [child.body],
+				transform_context,
+				true,
+			)
+		) {
+			const for_of_continuation = body_nodes.slice(i + 1);
+			const hoisted = build_hoisted_for_of_with_hooks(
+				child,
+				for_of_continuation,
+				transform_context,
+			);
+			if (hoisted) {
+				statements.push(...hoisted.hoist_statements);
+				if (for_of_continuation.length > 0) {
+					// Tail was lifted into the helper; everything after the for-of
+					// now lives there. Combine prior render_nodes with the iteration
+					// JSX and return.
+					statements.push({
+						type: 'ReturnStatement',
+						argument: combine_render_return_argument(render_nodes, hoisted.jsx_child),
+						metadata: { path: [] },
+					});
+					transform_context.available_bindings = saved_bindings;
+					return statements;
+				}
+				if (interleaved && is_capturable_jsx_child(hoisted.jsx_child)) {
+					const { declaration, reference } = captureJsxChild(hoisted.jsx_child, capture_index++);
+					statements.push(declaration);
+					render_nodes.push(reference);
+				} else {
+					render_nodes.push(hoisted.jsx_child);
+				}
+				continue;
+			}
+		}
+
+		if (
+			child.type === 'TryStatement' &&
+			!child.finalizer &&
+			!transform_context.platform.hooks?.isTopLevelSetupCall &&
+			try_statement_contains_hooks(child, transform_context) &&
+			i + 1 < body_nodes.length
+		) {
+			statements.push(
+				...create_continuation_lift_try_statement(
+					child,
+					body_nodes.slice(i + 1),
+					render_nodes,
+					transform_context,
+				),
+			);
+			transform_context.available_bindings = saved_bindings;
+			return statements;
+		}
+
+		if (
+			child.type === 'SwitchStatement' &&
+			!transform_context.platform.hooks?.isTopLevelSetupCall &&
+			body_contains_top_level_hook_call([child], transform_context, true) &&
+			i + 1 < body_nodes.length &&
+			switch_supports_continuation_lift(child)
+		) {
+			statements.push(
+				...create_continuation_lift_switch_statement(
+					child,
+					body_nodes.slice(i + 1),
+					render_nodes,
+					transform_context,
+				),
+			);
+			transform_context.available_bindings = saved_bindings;
+			return statements;
+		}
+
 		if (is_jsx_child(child)) {
 			const jsx = to_jsx_child(child, transform_context);
 			if (interleaved && is_capturable_jsx_child(jsx)) {
@@ -1318,6 +1418,786 @@ function create_component_helper_split_returning_if_statements(
 			metadata: { path: [] },
 		},
 	];
+}
+
+/**
+ * Lift a non-returning `if` whose consequent contains hook calls plus the
+ * statements that follow it into helper components.
+ *
+ * Without this, the consequent's hook would be wrapped into a child component
+ * (StatementBodyHook) but any code after the `if` that reads bindings the hook
+ * mutates would observe the pre-hook value, because React commits children
+ * after their parent has finished rendering. The fix mirrors the early-return
+ * splitter: emit a tail helper that owns the post-`if` statements, append a
+ * call to it inside the branch helper so the post-hook bindings flow forward,
+ * and render the tail helper directly when the `if` is false.
+ *
+ * @param {any} if_node
+ * @param {any[]} continuation_body
+ * @param {any[]} render_nodes
+ * @param {TransformContext} transform_context
+ * @returns {any[]}
+ */
+function create_continuation_lift_if_statement(
+	if_node,
+	continuation_body,
+	render_nodes,
+	transform_context,
+) {
+	const consequent_body = get_if_consequent_body(if_node);
+	const tail_helper = create_hook_safe_helper(
+		continuation_body,
+		undefined,
+		if_node,
+		transform_context,
+	);
+	const tail_invocation_in_branch = clone_expression_node_without_locations(
+		tail_helper.component_element,
+	);
+	const branch_helper = create_hook_safe_helper(
+		[...consequent_body, tail_invocation_in_branch],
+		undefined,
+		if_node.consequent,
+		transform_context,
+	);
+
+	return [
+		...tail_helper.setup_statements,
+		set_loc(
+			/** @type {any} */ ({
+				type: 'IfStatement',
+				test: if_node.test,
+				consequent: set_loc(
+					/** @type {any} */ ({
+						type: 'BlockStatement',
+						body: [
+							...branch_helper.setup_statements,
+							{
+								type: 'ReturnStatement',
+								argument: combine_render_return_argument(
+									render_nodes,
+									branch_helper.component_element,
+								),
+								metadata: { path: [] },
+							},
+						],
+						metadata: { path: [] },
+					}),
+					if_node.consequent,
+				),
+				alternate: null,
+				metadata: { path: [] },
+			}),
+			if_node,
+		),
+		{
+			type: 'ReturnStatement',
+			argument: combine_render_return_argument(render_nodes, tail_helper.component_element),
+			metadata: { path: [] },
+		},
+	];
+}
+
+/**
+ * Continuation lift for `try` / `try / pending / catch` statements. Same
+ * shape as if/switch: build a tail helper from the post-`try` statements, and
+ * append a clone of its invocation to the try body and the catch body so the
+ * post-hook locals inside each branch flow forward into the tail. The pending
+ * body is left untouched — when Suspense renders the pending fallback the
+ * parent's render is unwound, so the tail wouldn't run in source semantics
+ * either. Once augmented, the existing try transform builds the
+ * Suspense / TsrxErrorBoundary wrapper as usual.
+ *
+ * @param {any} node - TryStatement
+ * @param {any[]} continuation_body
+ * @param {any[]} render_nodes
+ * @param {TransformContext} transform_context
+ * @returns {any[]}
+ */
+function create_continuation_lift_try_statement(
+	node,
+	continuation_body,
+	render_nodes,
+	transform_context,
+) {
+	const tail_helper = create_hook_safe_helper(
+		continuation_body,
+		undefined,
+		node,
+		transform_context,
+	);
+
+	const augmented_block_body = [
+		...(node.block.body || []),
+		clone_expression_node_without_locations(tail_helper.component_element),
+	];
+	const augmented_block = { ...node.block, body: augmented_block_body };
+
+	let augmented_handler = node.handler;
+	if (node.handler) {
+		const augmented_catch_body = [
+			...(node.handler.body.body || []),
+			clone_expression_node_without_locations(tail_helper.component_element),
+		];
+		augmented_handler = {
+			...node.handler,
+			body: { ...node.handler.body, body: augmented_catch_body },
+		};
+	}
+
+	const augmented_try = {
+		...node,
+		block: augmented_block,
+		handler: augmented_handler,
+	};
+
+	const try_jsx_child = (
+		transform_context.platform.hooks?.controlFlow?.tryStatement ?? try_statement_to_jsx_child
+	)(augmented_try, transform_context);
+
+	return [
+		...tail_helper.setup_statements,
+		{
+			type: 'ReturnStatement',
+			argument: combine_render_return_argument(render_nodes, try_jsx_child),
+			metadata: { path: [] },
+		},
+	];
+}
+
+/**
+ * @param {any} node - TryStatement
+ * @param {TransformContext} transform_context
+ * @returns {boolean}
+ */
+function try_statement_contains_hooks(node, transform_context) {
+	if (body_contains_top_level_hook_call(node.block?.body || [], transform_context, true)) {
+		return true;
+	}
+	if (
+		node.handler &&
+		body_contains_top_level_hook_call(node.handler.body?.body || [], transform_context, true)
+	) {
+		return true;
+	}
+	if (
+		node.pending &&
+		body_contains_top_level_hook_call(node.pending.body || [], transform_context, true)
+	) {
+		return true;
+	}
+	return false;
+}
+
+/**
+ * Continuation lift for `switch` statements. Same shape as the if-version:
+ * each case body is wrapped in its own helper component that ends with a
+ * call to a shared tail helper, so post-hook bindings inside any case flow
+ * forward to the statements after the switch. The fall-through return at
+ * the end renders the tail helper directly, covering the case where no
+ * `case` (and no `default`) matched.
+ *
+ * Empty fall-through cases (`case 'a':` with no body, falling through to
+ * the next case) are preserved as-is — they must not get their own helper
+ * because that would convert fall-through into early-return.
+ *
+ * @param {any} switch_node
+ * @param {any[]} continuation_body
+ * @param {any[]} render_nodes
+ * @param {TransformContext} transform_context
+ * @returns {any[]}
+ */
+function create_continuation_lift_switch_statement(
+	switch_node,
+	continuation_body,
+	render_nodes,
+	transform_context,
+) {
+	const tail_helper = create_hook_safe_helper(
+		continuation_body,
+		undefined,
+		switch_node,
+		transform_context,
+	);
+
+	const new_cases = switch_node.cases.map((/** @type {any} */ switch_case) => {
+		const consequent = flatten_switch_consequent(switch_case.consequent || []);
+		const body_without_terminator = [];
+		for (const node of consequent) {
+			if (node.type === 'BreakStatement' || node.type === 'ReturnStatement') break;
+			body_without_terminator.push(node);
+		}
+
+		if (body_without_terminator.length === 0) {
+			return /** @type {any} */ ({
+				type: 'SwitchCase',
+				test: switch_case.test,
+				consequent: [],
+				metadata: { path: [] },
+			});
+		}
+
+		const tail_invocation_in_case = clone_expression_node_without_locations(
+			tail_helper.component_element,
+		);
+		const case_helper = create_hook_safe_helper(
+			[...body_without_terminator, tail_invocation_in_case],
+			undefined,
+			switch_case,
+			transform_context,
+		);
+
+		return /** @type {any} */ ({
+			type: 'SwitchCase',
+			test: switch_case.test,
+			consequent: [
+				...case_helper.setup_statements,
+				{
+					type: 'ReturnStatement',
+					argument: combine_render_return_argument(render_nodes, case_helper.component_element),
+					metadata: { path: [] },
+				},
+			],
+			metadata: { path: [] },
+		});
+	});
+
+	return [
+		...tail_helper.setup_statements,
+		set_loc(
+			/** @type {any} */ ({
+				type: 'SwitchStatement',
+				discriminant: switch_node.discriminant,
+				cases: new_cases,
+				metadata: { path: [] },
+			}),
+			switch_node,
+		),
+		{
+			type: 'ReturnStatement',
+			argument: combine_render_return_argument(render_nodes, tail_helper.component_element),
+			metadata: { path: [] },
+		},
+	];
+}
+
+/**
+ * Hoist the helper for a hook-bearing for-of body out of the iteration
+ * callback so the helper is declared once per render rather than re-bound on
+ * every iteration. Loop-scoped param types are derived from the iteration
+ * source via a TS `type` alias (rather than the const+typeof pattern used
+ * for outer bindings, which would require the loop var to be in scope).
+ *
+ * The iteration source is hoisted into a generated `let` and normalized via
+ * `Array.isArray(src) ? src : Array.from(src)` so any Iterable / ArrayLike
+ * works while skipping the copy when the source is already an array. The
+ * iteration itself is emitted as `source.map((item, i) => ...)`.
+ *
+ * If `continuation_body` is non-empty (the for-of has a tail) we also lift
+ * the tail into a TailHelper and call it conditionally on the last iteration
+ * via an `isLast={i === source.length - 1}` prop on the loop helper. The
+ * loop helper's mutated locals (post-`useState`) flow into the TailHelper as
+ * its props. When the source is empty, `.map` returns `[]` and the TailHelper
+ * never renders — we add a sibling fallback so the source's tail still runs
+ * with the original outer values in that case.
+ *
+ * Bails out (returns null) when the loop pattern is destructured — deriving
+ * element types from a tuple/object pattern is more involved and deferred.
+ *
+ * @param {any} node - ForOfStatement
+ * @param {any[]} continuation_body
+ * @param {TransformContext} transform_context
+ * @returns {{ hoist_statements: any[], jsx_child: any } | null}
+ */
+function build_hoisted_for_of_with_hooks(node, continuation_body, transform_context) {
+	const loop_params = get_for_of_iteration_params(node.left, node.index);
+	for (const param of loop_params) {
+		if (param.type !== 'Identifier') return null;
+	}
+
+	const has_tail = continuation_body.length > 0;
+	const original_loop_body = node.body.type === 'BlockStatement' ? node.body.body : [node.body];
+
+	// When there's a tail, build TailHelper first so its component_element can
+	// be embedded inside the loop helper's body (gated on isLast). The
+	// synthetic isLast prop uses the loop helper's index (which will be the
+	// next one assigned, since `create_hook_safe_helper` for the tail just
+	// consumed one) so it lines up with `StatementBodyHook<N>` in the output.
+	let tail_helper = null;
+	/** @type {AST.Identifier} */ let tail_synthetic_id;
+	if (has_tail) {
+		tail_helper = create_hook_safe_helper(continuation_body, undefined, node, transform_context);
+		tail_synthetic_id = create_generated_identifier(
+			`_tsrx_isLast_${transform_context.local_statement_component_index + 1}`,
+		);
+	} else {
+		tail_synthetic_id = /** @type {any} */ (null);
+	}
+	const loop_body = has_tail
+		? [
+				...original_loop_body,
+				/** @type {any} */ ({
+					type: 'JSXExpressionContainer',
+					expression: {
+						type: 'LogicalExpression',
+						operator: '&&',
+						left: clone_identifier(tail_synthetic_id),
+						right: clone_expression_node_without_locations(
+							/** @type {any} */ (tail_helper).component_element,
+						),
+						metadata: { path: [] },
+					},
+					metadata: { path: [] },
+				}),
+			]
+		: original_loop_body;
+
+	// Always hoist the iteration source into a generated `let` so that
+	// (a) the type aliases below have a stable name to reference and
+	// (b) we can normalize it at runtime via
+	// `Array.isArray(src) ? src : Array.from(src)`, avoiding a copy when
+	// the source is already an array but still working for any iterable.
+	const source_id = create_generated_identifier(
+		`_tsrx_iteration_items_${transform_context.local_statement_component_index + 1}`,
+	);
+	const source_decl = /** @type {any} */ ({
+		type: 'VariableDeclaration',
+		kind: 'let',
+		declarations: [
+			{
+				type: 'VariableDeclarator',
+				id: clone_identifier(source_id),
+				init: clone_expression_node(node.right),
+				metadata: { path: [] },
+			},
+		],
+		metadata: { path: [] },
+	});
+	const source_normalize_decl = /** @type {any} */ ({
+		type: 'ExpressionStatement',
+		expression: {
+			type: 'AssignmentExpression',
+			operator: '=',
+			left: clone_identifier(source_id),
+			right: {
+				type: 'ConditionalExpression',
+				test: {
+					type: 'CallExpression',
+					callee: {
+						type: 'MemberExpression',
+						object: { type: 'Identifier', name: 'Array', metadata: { path: [] } },
+						property: { type: 'Identifier', name: 'isArray', metadata: { path: [] } },
+						computed: false,
+						optional: false,
+						metadata: { path: [] },
+					},
+					arguments: [clone_identifier(source_id)],
+					optional: false,
+					metadata: { path: [] },
+				},
+				consequent: clone_identifier(source_id),
+				alternate: {
+					type: 'CallExpression',
+					callee: {
+						type: 'MemberExpression',
+						object: { type: 'Identifier', name: 'Array', metadata: { path: [] } },
+						property: { type: 'Identifier', name: 'from', metadata: { path: [] } },
+						computed: false,
+						optional: false,
+						metadata: { path: [] },
+					},
+					arguments: [clone_identifier(source_id)],
+					optional: false,
+					metadata: { path: [] },
+				},
+				metadata: { path: [] },
+			},
+			metadata: { path: [] },
+		},
+		metadata: { path: [] },
+	});
+
+	const saved_bindings = transform_context.available_bindings;
+	transform_context.available_bindings = new Map(saved_bindings);
+	for (const param of loop_params) {
+		collect_pattern_bindings(param, transform_context.available_bindings);
+	}
+
+	const all_helper_bindings = get_referenced_helper_bindings(
+		loop_body,
+		transform_context.available_bindings,
+	);
+	const loop_scoped_names = new Set(loop_params.map((/** @type {any} */ p) => p.name));
+	const outer_bindings = all_helper_bindings.filter(
+		(b) => !loop_scoped_names.has(b.name) && b.name !== '_tsrx_isLast',
+	);
+	const loop_bindings = all_helper_bindings.filter((b) => loop_scoped_names.has(b.name));
+
+	const helper_id = create_generated_identifier(
+		create_local_statement_component_name(transform_context),
+	);
+
+	const outer_aliases = outer_bindings.map((binding) =>
+		create_helper_type_alias_declaration(helper_id, binding),
+	);
+	const loop_aliases = loop_bindings.map((binding) =>
+		create_loop_scoped_type_alias_declaration(helper_id, binding, source_id, loop_params),
+	);
+
+	// Synthetic `isLast` prop on the loop helper when there's a tail. It's
+	// passed from the .map callback as `i === source.length - 1` so the loop
+	// helper renders the tail helper only on the last iteration. We do not
+	// gate on this prop's value here — the JSXLogicalExpression appended to
+	// `loop_body` does the gating at render time.
+	const tail_isLast_alias = has_tail
+		? {
+				id: create_generated_identifier(`_tsrx_${helper_id.name}_isLast`),
+				declaration: /** @type {any} */ ({
+					type: 'TSTypeAliasDeclaration',
+					id: create_generated_identifier(`_tsrx_${helper_id.name}_isLast`),
+					typeAnnotation: { type: 'TSBooleanKeyword', metadata: { path: [] } },
+					typeParameters: null,
+					metadata: { path: [] },
+				}),
+			}
+		: null;
+
+	const ordered_bindings = [...outer_bindings, ...loop_bindings];
+	const ordered_aliases = [...outer_aliases, ...loop_aliases];
+	const ordered_use_typeof = [...outer_bindings.map(() => true), ...loop_bindings.map(() => false)];
+
+	const signature_bindings = has_tail ? [...ordered_bindings, tail_synthetic_id] : ordered_bindings;
+	const signature_aliases = has_tail
+		? [...ordered_aliases, /** @type {any} */ (tail_isLast_alias)]
+		: ordered_aliases;
+	const signature_use_typeof = has_tail ? [...ordered_use_typeof, false] : ordered_use_typeof;
+
+	const props_type =
+		signature_bindings.length > 0
+			? create_helper_props_type_literal_with_typeof_flags(
+					signature_bindings,
+					signature_aliases,
+					signature_use_typeof,
+				)
+			: null;
+	const params =
+		props_type !== null ? [create_typed_helper_props_pattern(signature_bindings, props_type)] : [];
+
+	const fn_saved_bindings = transform_context.available_bindings;
+	transform_context.available_bindings = new Map(fn_saved_bindings);
+	if (has_tail) {
+		transform_context.available_bindings.set(tail_synthetic_id.name, tail_synthetic_id);
+	}
+	const fn_body_statements = build_render_statements(loop_body, true, transform_context);
+	transform_context.available_bindings = fn_saved_bindings;
+
+	const helper_fn = /** @type {any} */ ({
+		type: 'FunctionExpression',
+		id: clone_identifier(helper_id),
+		params,
+		body: {
+			type: 'BlockStatement',
+			body: fn_body_statements,
+			metadata: { path: [] },
+		},
+		async: false,
+		generator: false,
+		metadata: { path: [], is_component: true, is_method: false },
+	});
+
+	let helper_decl;
+	if (transform_context.helper_state) {
+		const cache_id = create_generated_identifier(
+			`${transform_context.helper_state.base_name}__${helper_id.name}`,
+		);
+		transform_context.helper_state.helpers.push(create_helper_cache_declaration(cache_id));
+		helper_decl = create_cached_helper_declaration(
+			helper_id,
+			cache_id,
+			create_helper_init_expression(helper_id, helper_fn, node, transform_context),
+		);
+	} else {
+		helper_decl = create_helper_declaration(helper_id, helper_fn, node, transform_context);
+	}
+
+	transform_context.available_bindings = saved_bindings;
+
+	const callback_invocation_element = create_helper_component_element(
+		helper_id,
+		ordered_bindings,
+		node,
+		{ mapWrapper: false, mapBindingNames: false, mapBindingValues: false },
+	);
+
+	// When there's a tail, the .map callback always needs an index to compute
+	// `isLast`. If the user didn't write `index i`, synthesize one. The same
+	// identifier is also used as the implicit key fallback below.
+	let index_identifier;
+	if (loop_params.length >= 2) {
+		index_identifier = clone_identifier(loop_params[1]);
+	} else if (has_tail) {
+		index_identifier = create_generated_identifier('i');
+	} else {
+		index_identifier = null;
+	}
+
+	const body_key_expression = find_key_expression_in_body(loop_body);
+	const explicit_key_expression =
+		body_key_expression ?? (node.key ? clone_expression_node(node.key) : undefined);
+	const key_expression =
+		explicit_key_expression ??
+		(loop_params.length >= 2 ? clone_identifier(loop_params[1]) : undefined);
+	if (key_expression) {
+		callback_invocation_element.openingElement.attributes.push(
+			/** @type {any} */ ({
+				type: 'JSXAttribute',
+				name: { type: 'JSXIdentifier', name: 'key', metadata: { path: [] } },
+				value: to_jsx_expression_container(key_expression, key_expression),
+				metadata: { path: [] },
+			}),
+		);
+	}
+
+	if (has_tail && index_identifier) {
+		callback_invocation_element.openingElement.attributes.push(
+			/** @type {any} */ ({
+				type: 'JSXAttribute',
+				name: {
+					type: 'JSXIdentifier',
+					name: tail_synthetic_id.name,
+					metadata: { path: [] },
+				},
+				value: to_jsx_expression_container(
+					/** @type {any} */ ({
+						type: 'BinaryExpression',
+						operator: '===',
+						left: clone_identifier(index_identifier),
+						right: {
+							type: 'BinaryExpression',
+							operator: '-',
+							left: {
+								type: 'MemberExpression',
+								object: clone_identifier(source_id),
+								property: {
+									type: 'Identifier',
+									name: 'length',
+									metadata: { path: [] },
+								},
+								computed: false,
+								optional: false,
+								metadata: { path: [] },
+							},
+							right: { type: 'Literal', value: 1, raw: '1' },
+							metadata: { path: [] },
+						},
+						metadata: { path: [] },
+					}),
+				),
+				metadata: { path: [] },
+			}),
+		);
+	}
+
+	const callback_params =
+		has_tail && loop_params.length < 2 && index_identifier
+			? [
+					...loop_params.map((/** @type {any} */ p) => clone_identifier(p)),
+					clone_identifier(index_identifier),
+				]
+			: loop_params.map((/** @type {any} */ p) => clone_identifier(p));
+
+	const iter_callback = /** @type {any} */ ({
+		type: 'ArrowFunctionExpression',
+		params: callback_params,
+		body: callback_invocation_element,
+		async: false,
+		generator: false,
+		expression: true,
+		metadata: { path: [] },
+	});
+
+	const map_call = /** @type {any} */ ({
+		type: 'CallExpression',
+		callee: {
+			type: 'MemberExpression',
+			object: clone_identifier(source_id),
+			property: /** @type {any} */ ({
+				type: 'Identifier',
+				name: 'map',
+				metadata: { path: [] },
+			}),
+			computed: false,
+			optional: false,
+			metadata: { path: [] },
+		},
+		arguments: [iter_callback],
+		optional: false,
+		metadata: { path: [] },
+	});
+
+	// jsx_child for the iteration. When there's a tail, also render the tail
+	// helper directly when the source is empty (no iterations means the loop
+	// helper never fires, so the tail wouldn't run otherwise).
+	let jsx_child;
+	if (has_tail) {
+		jsx_child = to_jsx_expression_container(
+			/** @type {any} */ ({
+				type: 'ConditionalExpression',
+				test: {
+					type: 'BinaryExpression',
+					operator: '===',
+					left: {
+						type: 'MemberExpression',
+						object: clone_identifier(source_id),
+						property: { type: 'Identifier', name: 'length', metadata: { path: [] } },
+						computed: false,
+						optional: false,
+						metadata: { path: [] },
+					},
+					right: { type: 'Literal', value: 0, raw: '0' },
+					metadata: { path: [] },
+				},
+				consequent: clone_expression_node_without_locations(
+					/** @type {any} */ (tail_helper).component_element,
+				),
+				alternate: map_call,
+				metadata: { path: [] },
+			}),
+			node,
+		);
+	} else {
+		jsx_child = to_jsx_expression_container(map_call, node);
+	}
+
+	const hoist_statements = [source_decl, source_normalize_decl];
+	if (has_tail) {
+		// TailHelper's setup statements (its alias consts and cache decl).
+		hoist_statements.push(.../** @type {any} */ (tail_helper).setup_statements);
+	}
+	for (const alias of ordered_aliases) hoist_statements.push(alias.declaration);
+	if (has_tail && tail_isLast_alias) {
+		hoist_statements.push(tail_isLast_alias.declaration);
+	}
+	hoist_statements.push(helper_decl);
+
+	return {
+		hoist_statements,
+		jsx_child,
+	};
+}
+
+/**
+ * Build a TS `type` alias for a loop-scoped binding, deriving the type
+ * from the iteration source. For the value param we use
+ * `(typeof source)[number]`, which gives the right element type for arrays
+ * and tuples (the common case in JSX templates). For the index param,
+ * the type is always `number`.
+ *
+ * @param {AST.Identifier} helper_id
+ * @param {AST.Identifier} binding
+ * @param {AST.Identifier} source_id
+ * @param {any[]} loop_params
+ * @returns {{ id: AST.Identifier, declaration: any }}
+ */
+function create_loop_scoped_type_alias_declaration(helper_id, binding, source_id, loop_params) {
+	const alias_id = create_generated_identifier(`_tsrx_${helper_id.name}_${binding.name}`);
+	const is_index = loop_params.length > 1 && binding.name === loop_params[1].name;
+	const type_annotation = is_index
+		? /** @type {any} */ ({ type: 'TSNumberKeyword', metadata: { path: [] } })
+		: /** @type {any} */ ({
+				type: 'TSIndexedAccessType',
+				objectType: {
+					type: 'TSTypeQuery',
+					exprName: clone_identifier(source_id),
+					typeArguments: null,
+					metadata: { path: [] },
+				},
+				indexType: { type: 'TSNumberKeyword', metadata: { path: [] } },
+				metadata: { path: [] },
+			});
+
+	return {
+		id: alias_id,
+		declaration: /** @type {any} */ ({
+			type: 'TSTypeAliasDeclaration',
+			id: clone_identifier(alias_id),
+			typeAnnotation: type_annotation,
+			typeParameters: null,
+			metadata: { path: [] },
+		}),
+	};
+}
+
+/**
+ * Variant of {@link create_helper_props_type_literal} that lets each
+ * binding's type reference the alias either via `typeof <alias>` (for
+ * outer-scope const aliases) or directly as `<alias>` (for TS `type`
+ * aliases derived from a loop source).
+ *
+ * @param {AST.Identifier[]} bindings
+ * @param {{ id: AST.Identifier }[]} aliases
+ * @param {boolean[]} use_typeof
+ * @returns {any}
+ */
+function create_helper_props_type_literal_with_typeof_flags(bindings, aliases, use_typeof) {
+	return /** @type {any} */ ({
+		type: 'TSTypeLiteral',
+		members: bindings.map((binding, i) => ({
+			type: 'TSPropertySignature',
+			key: create_generated_identifier(binding.name),
+			computed: false,
+			optional: false,
+			readonly: false,
+			static: false,
+			kind: 'init',
+			typeAnnotation: {
+				type: 'TSTypeAnnotation',
+				typeAnnotation: use_typeof[i]
+					? {
+							type: 'TSTypeQuery',
+							exprName: clone_identifier(aliases[i].id),
+							typeArguments: null,
+							metadata: { path: [] },
+						}
+					: {
+							type: 'TSTypeReference',
+							typeName: clone_identifier(aliases[i].id),
+							typeArguments: null,
+							metadata: { path: [] },
+						},
+				metadata: { path: [] },
+			},
+			metadata: { path: [] },
+		})),
+		metadata: { path: [] },
+	});
+}
+
+/**
+ * The lift converts each non-empty case into `... return <CaseHelper/>`.
+ * That changes a case that runs statements but lacks a terminator (and so
+ * falls through to the next case under JS semantics) into one that returns
+ * early. Bail out of the lift in that scenario and let the existing
+ * transform run, preserving the source's fall-through behavior.
+ *
+ * @param {any} switch_node
+ * @returns {boolean}
+ */
+function switch_supports_continuation_lift(switch_node) {
+	for (const switch_case of switch_node.cases) {
+		const consequent = flatten_switch_consequent(switch_case.consequent || []);
+		let has_body = false;
+		let has_terminator = false;
+		for (const node of consequent) {
+			if (node.type === 'BreakStatement' || node.type === 'ReturnStatement') {
+				has_terminator = true;
+				break;
+			}
+			has_body = true;
+		}
+		if (has_body && !has_terminator) return false;
+	}
+	return true;
 }
 
 /**

--- a/packages/tsrx/src/transform/jsx/index.js
+++ b/packages/tsrx/src/transform/jsx/index.js
@@ -675,8 +675,7 @@ function build_render_statements(body_nodes, return_null_when_empty, transform_c
 			child.type === 'SwitchStatement' &&
 			!transform_context.platform.hooks?.isTopLevelSetupCall &&
 			body_contains_top_level_hook_call([child], transform_context, true) &&
-			i + 1 < body_nodes.length &&
-			switch_supports_continuation_lift(child)
+			i + 1 < body_nodes.length
 		) {
 			statements.push(
 				...create_continuation_lift_switch_statement(
@@ -1571,30 +1570,72 @@ function create_continuation_lift_switch_statement(
 ) {
 	const tail_helper = build_tail_helper(continuation_body, switch_node, transform_context);
 
-	const new_cases = switch_node.cases.map((/** @type {any} */ original_case) => {
-		const consequent = flatten_switch_consequent(original_case.consequent || []);
-		const body_without_terminator = [];
-		for (const node of consequent) {
-			if (node.type === 'BreakStatement' || node.type === 'ReturnStatement') break;
-			body_without_terminator.push(node);
-		}
+	const new_cases = switch_node.cases.map(
+		(/** @type {any} */ original_case, /** @type {number} */ case_index) => {
+			const own_consequent = flatten_switch_consequent(original_case.consequent || []);
+			const own_body = [];
+			let own_has_terminator = false;
+			for (const node of own_consequent) {
+				if (node.type === 'BreakStatement' || node.type === 'ReturnStatement') {
+					own_has_terminator = true;
+					break;
+				}
+				own_body.push(node);
+			}
 
-		if (body_without_terminator.length === 0) {
-			return b.switch_case(original_case.test, []);
-		}
+			if (own_body.length === 0) {
+				// `case 'a': break;` (break-only / return-only) originally exited
+				// the switch and ran the tail. Emitting an empty case here would
+				// silently fall through to the next case's body — running its
+				// hook and rendering its content for the wrong input. Render the
+				// tail directly so we preserve the source's semantics.
+				if (own_has_terminator) {
+					return b.switch_case(original_case.test, [
+						combined_return_statement(render_nodes, tail_helper.component_element),
+					]);
+				}
+				// `case 'a': case 'b': ...` — genuine empty fall-through. The
+				// original source has no body for 'a' and means 'a' to share 'b's
+				// body. Preserve as an empty case so JS fall-through drops into
+				// the next case's helper (and the helper component identity is
+				// shared, preserving useState slots across kind toggles).
+				return b.switch_case(original_case.test, []);
+			}
 
-		const case_helper = create_hook_safe_helper(
-			append_tail_invocation(body_without_terminator, tail_helper),
-			undefined,
-			original_case,
-			transform_context,
-		);
+			// Non-empty case: compute the *effective* body by following
+			// fall-through into subsequent cases until we hit a terminator.
+			// `case 'a': x = 1; case 'b': useState(100); break;` — case 'a's
+			// effective body is `[x = 1, useState(100)]` so CaseHelperA runs the
+			// merged body and the post-hook value flows into the tail.
+			const effective_body = [...own_body];
+			if (!own_has_terminator) {
+				for (let j = case_index + 1; j < switch_node.cases.length; j++) {
+					const next_consequent = flatten_switch_consequent(switch_node.cases[j].consequent || []);
+					let next_has_terminator = false;
+					for (const node of next_consequent) {
+						if (node.type === 'BreakStatement' || node.type === 'ReturnStatement') {
+							next_has_terminator = true;
+							break;
+						}
+						effective_body.push(node);
+					}
+					if (next_has_terminator) break;
+				}
+			}
 
-		return b.switch_case(original_case.test, [
-			...case_helper.setup_statements,
-			combined_return_statement(render_nodes, case_helper.component_element),
-		]);
-	});
+			const case_helper = create_hook_safe_helper(
+				append_tail_invocation(effective_body, tail_helper),
+				undefined,
+				original_case,
+				transform_context,
+			);
+
+			return b.switch_case(original_case.test, [
+				...case_helper.setup_statements,
+				combined_return_statement(render_nodes, case_helper.component_element),
+			]);
+		},
+	);
 
 	return [
 		...tail_helper.setup_statements,
@@ -1913,33 +1954,6 @@ function create_helper_props_type_literal_with_typeof_flags(bindings, aliases, u
 			);
 		}),
 	);
-}
-
-/**
- * The lift converts each non-empty case into `... return <CaseHelper/>`.
- * That changes a case that runs statements but lacks a terminator (and so
- * falls through to the next case under JS semantics) into one that returns
- * early. Bail out of the lift in that scenario and let the existing
- * transform run, preserving the source's fall-through behavior.
- *
- * @param {any} switch_node
- * @returns {boolean}
- */
-function switch_supports_continuation_lift(switch_node) {
-	for (const switch_case of switch_node.cases) {
-		const consequent = flatten_switch_consequent(switch_case.consequent || []);
-		let has_body = false;
-		let has_terminator = false;
-		for (const node of consequent) {
-			if (node.type === 'BreakStatement' || node.type === 'ReturnStatement') {
-				has_terminator = true;
-				break;
-			}
-			has_body = true;
-		}
-		if (has_body && !has_terminator) return false;
-	}
-	return true;
 }
 
 /**

--- a/packages/tsrx/src/transform/jsx/index.js
+++ b/packages/tsrx/src/transform/jsx/index.js
@@ -1531,28 +1531,17 @@ function create_continuation_lift_if_statement(
 		transform_context,
 	);
 
+	const branch_block = set_loc(
+		b.block([
+			...branch_helper.setup_statements,
+			combined_return_statement(render_nodes, branch_helper.component_element),
+		]),
+		if_node.consequent,
+	);
+
 	return [
 		...tail_helper.setup_statements,
-		set_loc(
-			/** @type {any} */ ({
-				type: 'IfStatement',
-				test: if_node.test,
-				consequent: set_loc(
-					/** @type {any} */ ({
-						type: 'BlockStatement',
-						body: [
-							...branch_helper.setup_statements,
-							combined_return_statement(render_nodes, branch_helper.component_element),
-						],
-						metadata: { path: [] },
-					}),
-					if_node.consequent,
-				),
-				alternate: null,
-				metadata: { path: [] },
-			}),
-			if_node,
-		),
+		set_loc(b.if(if_node.test, branch_block, null), if_node),
 		combined_return_statement(render_nodes, tail_helper.component_element),
 	];
 }
@@ -1660,8 +1649,8 @@ function create_continuation_lift_switch_statement(
 ) {
 	const tail_helper = build_tail_helper(continuation_body, switch_node, transform_context);
 
-	const new_cases = switch_node.cases.map((/** @type {any} */ switch_case) => {
-		const consequent = flatten_switch_consequent(switch_case.consequent || []);
+	const new_cases = switch_node.cases.map((/** @type {any} */ original_case) => {
+		const consequent = flatten_switch_consequent(original_case.consequent || []);
 		const body_without_terminator = [];
 		for (const node of consequent) {
 			if (node.type === 'BreakStatement' || node.type === 'ReturnStatement') break;
@@ -1669,43 +1658,25 @@ function create_continuation_lift_switch_statement(
 		}
 
 		if (body_without_terminator.length === 0) {
-			return /** @type {any} */ ({
-				type: 'SwitchCase',
-				test: switch_case.test,
-				consequent: [],
-				metadata: { path: [] },
-			});
+			return b.switch_case(original_case.test, []);
 		}
 
 		const case_helper = create_hook_safe_helper(
 			append_tail_invocation(body_without_terminator, tail_helper),
 			undefined,
-			switch_case,
+			original_case,
 			transform_context,
 		);
 
-		return /** @type {any} */ ({
-			type: 'SwitchCase',
-			test: switch_case.test,
-			consequent: [
-				...case_helper.setup_statements,
-				combined_return_statement(render_nodes, case_helper.component_element),
-			],
-			metadata: { path: [] },
-		});
+		return b.switch_case(original_case.test, [
+			...case_helper.setup_statements,
+			combined_return_statement(render_nodes, case_helper.component_element),
+		]);
 	});
 
 	return [
 		...tail_helper.setup_statements,
-		set_loc(
-			/** @type {any} */ ({
-				type: 'SwitchStatement',
-				discriminant: switch_node.discriminant,
-				cases: new_cases,
-				metadata: { path: [] },
-			}),
-			switch_node,
-		),
+		set_loc(b.switch(switch_node.discriminant, new_cases), switch_node),
 		combined_return_statement(render_nodes, tail_helper.component_element),
 	];
 }
@@ -1765,17 +1736,13 @@ function build_hoisted_for_of_with_hooks(node, continuation_body, transform_cont
 	const loop_body = has_tail
 		? [
 				...original_loop_body,
-				/** @type {any} */ ({
-					type: 'JSXExpressionContainer',
-					expression: {
-						type: 'LogicalExpression',
-						operator: '&&',
-						left: clone_identifier(tail_synthetic_id),
-						right: clone_tail_invocation(/** @type {any} */ (tail_helper)),
-						metadata: { path: [] },
-					},
-					metadata: { path: [] },
-				}),
+				b.jsx_expression_container(
+					b.logical(
+						'&&',
+						clone_identifier(tail_synthetic_id),
+						clone_tail_invocation(/** @type {any} */ (tail_helper)),
+					),
+				),
 			]
 		: original_loop_body;
 
@@ -1822,13 +1789,10 @@ function build_hoisted_for_of_with_hooks(node, continuation_body, transform_cont
 	const tail_isLast_alias = has_tail
 		? {
 				id: create_generated_identifier(`_tsrx_${helper_id.name}_isLast`),
-				declaration: /** @type {any} */ ({
-					type: 'TSTypeAliasDeclaration',
-					id: create_generated_identifier(`_tsrx_${helper_id.name}_isLast`),
-					typeAnnotation: { type: 'TSBooleanKeyword', metadata: { path: [] } },
-					typeParameters: null,
-					metadata: { path: [] },
-				}),
+				declaration: b.ts_type_alias(
+					create_generated_identifier(`_tsrx_${helper_id.name}_isLast`),
+					b.ts_keyword_type('boolean'),
+				),
 			}
 		: null;
 
@@ -1861,19 +1825,10 @@ function build_hoisted_for_of_with_hooks(node, continuation_body, transform_cont
 	const fn_body_statements = build_render_statements(loop_body, true, transform_context);
 	transform_context.available_bindings = fn_saved_bindings;
 
-	const helper_fn = /** @type {any} */ ({
-		type: 'FunctionExpression',
-		id: clone_identifier(helper_id),
-		params,
-		body: {
-			type: 'BlockStatement',
-			body: fn_body_statements,
-			metadata: { path: [] },
-		},
-		async: false,
-		generator: false,
-		metadata: { path: [], is_component: true, is_method: false },
-	});
+	const helper_fn = /** @type {any} */ (
+		b.function(clone_identifier(helper_id), params, b.block(fn_body_statements))
+	);
+	helper_fn.metadata = { path: [], is_component: true, is_method: false };
 
 	let helper_decl;
 	if (transform_context.helper_state) {
@@ -1919,52 +1874,23 @@ function build_hoisted_for_of_with_hooks(node, continuation_body, transform_cont
 		(loop_params.length >= 2 ? clone_identifier(loop_params[1]) : undefined);
 	if (key_expression) {
 		callback_invocation_element.openingElement.attributes.push(
-			/** @type {any} */ ({
-				type: 'JSXAttribute',
-				name: { type: 'JSXIdentifier', name: 'key', metadata: { path: [] } },
-				value: to_jsx_expression_container(key_expression, key_expression),
-				metadata: { path: [] },
-			}),
+			b.jsx_attribute(b.jsx_id('key'), to_jsx_expression_container(key_expression, key_expression)),
 		);
 	}
 
 	if (has_tail && index_identifier) {
+		const length_minus_one = b.binary(
+			'-',
+			b.member(clone_identifier(source_id), 'length'),
+			b.literal(1),
+		);
 		callback_invocation_element.openingElement.attributes.push(
-			/** @type {any} */ ({
-				type: 'JSXAttribute',
-				name: {
-					type: 'JSXIdentifier',
-					name: tail_synthetic_id.name,
-					metadata: { path: [] },
-				},
-				value: to_jsx_expression_container(
-					/** @type {any} */ ({
-						type: 'BinaryExpression',
-						operator: '===',
-						left: clone_identifier(index_identifier),
-						right: {
-							type: 'BinaryExpression',
-							operator: '-',
-							left: {
-								type: 'MemberExpression',
-								object: clone_identifier(source_id),
-								property: {
-									type: 'Identifier',
-									name: 'length',
-									metadata: { path: [] },
-								},
-								computed: false,
-								optional: false,
-								metadata: { path: [] },
-							},
-							right: { type: 'Literal', value: 1, raw: '1' },
-							metadata: { path: [] },
-						},
-						metadata: { path: [] },
-					}),
+			b.jsx_attribute(
+				b.jsx_id(tail_synthetic_id.name),
+				to_jsx_expression_container(
+					b.binary('===', clone_identifier(index_identifier), length_minus_one),
 				),
-				metadata: { path: [] },
-			}),
+			),
 		);
 	}
 
@@ -1976,66 +1902,23 @@ function build_hoisted_for_of_with_hooks(node, continuation_body, transform_cont
 				]
 			: loop_params.map((/** @type {any} */ p) => clone_identifier(p));
 
-	const iter_callback = /** @type {any} */ ({
-		type: 'ArrowFunctionExpression',
-		params: callback_params,
-		body: callback_invocation_element,
-		async: false,
-		generator: false,
-		expression: true,
-		metadata: { path: [] },
-	});
+	const iter_callback = b.arrow(callback_params, callback_invocation_element);
 
-	const map_call = /** @type {any} */ ({
-		type: 'CallExpression',
-		callee: {
-			type: 'MemberExpression',
-			object: clone_identifier(source_id),
-			property: /** @type {any} */ ({
-				type: 'Identifier',
-				name: 'map',
-				metadata: { path: [] },
-			}),
-			computed: false,
-			optional: false,
-			metadata: { path: [] },
-		},
-		arguments: [iter_callback],
-		optional: false,
-		metadata: { path: [] },
-	});
+	const map_call = b.call(b.member(clone_identifier(source_id), 'map'), iter_callback);
 
 	// jsx_child for the iteration. When there's a tail, also render the tail
 	// helper directly when the source is empty (no iterations means the loop
 	// helper never fires, so the tail wouldn't run otherwise).
-	let jsx_child;
-	if (has_tail) {
-		jsx_child = to_jsx_expression_container(
-			/** @type {any} */ ({
-				type: 'ConditionalExpression',
-				test: {
-					type: 'BinaryExpression',
-					operator: '===',
-					left: {
-						type: 'MemberExpression',
-						object: clone_identifier(source_id),
-						property: { type: 'Identifier', name: 'length', metadata: { path: [] } },
-						computed: false,
-						optional: false,
-						metadata: { path: [] },
-					},
-					right: { type: 'Literal', value: 0, raw: '0' },
-					metadata: { path: [] },
-				},
-				consequent: clone_tail_invocation(/** @type {any} */ (tail_helper)),
-				alternate: map_call,
-				metadata: { path: [] },
-			}),
-			node,
-		);
-	} else {
-		jsx_child = to_jsx_expression_container(map_call, node);
-	}
+	const jsx_child = has_tail
+		? to_jsx_expression_container(
+				b.conditional(
+					b.binary('===', b.member(clone_identifier(source_id), 'length'), b.literal(0)),
+					clone_tail_invocation(/** @type {any} */ (tail_helper)),
+					map_call,
+				),
+				node,
+			)
+		: to_jsx_expression_container(map_call, node);
 
 	const hoist_statements = [source_decl, source_normalize_decl];
 	if (has_tail) {
@@ -2071,28 +1954,17 @@ function create_loop_scoped_type_alias_declaration(helper_id, binding, source_id
 	const alias_id = create_generated_identifier(`_tsrx_${helper_id.name}_${binding.name}`);
 	const is_index = loop_params.length > 1 && binding.name === loop_params[1].name;
 	const type_annotation = is_index
-		? /** @type {any} */ ({ type: 'TSNumberKeyword', metadata: { path: [] } })
+		? b.ts_keyword_type('number')
 		: /** @type {any} */ ({
 				type: 'TSIndexedAccessType',
-				objectType: {
-					type: 'TSTypeQuery',
-					exprName: clone_identifier(source_id),
-					typeArguments: null,
-					metadata: { path: [] },
-				},
-				indexType: { type: 'TSNumberKeyword', metadata: { path: [] } },
+				objectType: b.ts_type_query(clone_identifier(source_id)),
+				indexType: b.ts_keyword_type('number'),
 				metadata: { path: [] },
 			});
 
 	return {
 		id: alias_id,
-		declaration: /** @type {any} */ ({
-			type: 'TSTypeAliasDeclaration',
-			id: clone_identifier(alias_id),
-			typeAnnotation: type_annotation,
-			typeParameters: null,
-			metadata: { path: [] },
-		}),
+		declaration: b.ts_type_alias(clone_identifier(alias_id), type_annotation),
 	};
 }
 
@@ -2108,37 +1980,17 @@ function create_loop_scoped_type_alias_declaration(helper_id, binding, source_id
  * @returns {any}
  */
 function create_helper_props_type_literal_with_typeof_flags(bindings, aliases, use_typeof) {
-	return /** @type {any} */ ({
-		type: 'TSTypeLiteral',
-		members: bindings.map((binding, i) => ({
-			type: 'TSPropertySignature',
-			key: create_generated_identifier(binding.name),
-			computed: false,
-			optional: false,
-			readonly: false,
-			static: false,
-			kind: 'init',
-			typeAnnotation: {
-				type: 'TSTypeAnnotation',
-				typeAnnotation: use_typeof[i]
-					? {
-							type: 'TSTypeQuery',
-							exprName: clone_identifier(aliases[i].id),
-							typeArguments: null,
-							metadata: { path: [] },
-						}
-					: {
-							type: 'TSTypeReference',
-							typeName: clone_identifier(aliases[i].id),
-							typeArguments: null,
-							metadata: { path: [] },
-						},
-				metadata: { path: [] },
-			},
-			metadata: { path: [] },
-		})),
-		metadata: { path: [] },
-	});
+	return b.ts_type_literal(
+		bindings.map((binding, i) => {
+			const alias_ref = use_typeof[i]
+				? b.ts_type_query(clone_identifier(aliases[i].id))
+				: b.ts_type_reference(clone_identifier(aliases[i].id));
+			return b.ts_property_signature(
+				create_generated_identifier(binding.name),
+				b.ts_type_annotation(alias_ref),
+			);
+		}),
+	);
 }
 
 /**

--- a/packages/tsrx/src/transform/jsx/index.js
+++ b/packages/tsrx/src/transform/jsx/index.js
@@ -1570,75 +1570,100 @@ function create_continuation_lift_switch_statement(
 ) {
 	const tail_helper = build_tail_helper(continuation_body, switch_node, transform_context);
 
-	const new_cases = switch_node.cases.map(
-		(/** @type {any} */ original_case, /** @type {number} */ case_index) => {
-			const own_consequent = flatten_switch_consequent(original_case.consequent || []);
-			const own_body = [];
-			let own_has_terminator = false;
-			for (const node of own_consequent) {
-				if (node.type === 'BreakStatement' || node.type === 'ReturnStatement') {
-					own_has_terminator = true;
+	// Per-case info computed once: own body (statements before any
+	// terminator) and whether the case has a `break` / `return`.
+	const case_info = switch_node.cases.map((/** @type {any} */ c) => {
+		const consequent = flatten_switch_consequent(c.consequent || []);
+		const own_body = [];
+		let own_has_terminator = false;
+		for (const node of consequent) {
+			if (node.type === 'BreakStatement' || node.type === 'ReturnStatement') {
+				own_has_terminator = true;
+				break;
+			}
+			own_body.push(node);
+		}
+		return { own_body, own_has_terminator };
+	});
+
+	// Allocate helper ids in source order (forward pass) so the snapshot's
+	// `StatementBodyHook<N>` numbering reads top-to-bottom by case position.
+	/** @type {Array<AST.Identifier | null>} */
+	const helper_ids = case_info.map(
+		(/** @type {{ own_body: any[], own_has_terminator: boolean }} */ info) =>
+			info.own_body.length === 0
+				? null
+				: create_generated_identifier(create_local_statement_component_name(transform_context)),
+	);
+
+	// Build helpers in reverse order: each fall-through case's helper body
+	// invokes the *next* case's helper, so the chain forwards post-mutation
+	// locals through the switch. Reverse iteration ensures the next helper's
+	// component_element is already constructed when we need to embed it.
+	/** @type {Array<{ setup_statements: any[], component_element: any } | null>} */
+	const case_helper_by_index = new Array(switch_node.cases.length).fill(null);
+	for (let i = switch_node.cases.length - 1; i >= 0; i--) {
+		const { own_body, own_has_terminator } = case_info[i];
+		if (own_body.length === 0) continue;
+
+		// Determine the downstream helper this case invokes after its own body.
+		// - With a terminator: invoke the tail helper directly (case exits switch).
+		// - Otherwise (fall-through): invoke the next non-empty case's helper,
+		//   or the tail if nothing else follows.
+		let downstream;
+		if (own_has_terminator) {
+			downstream = tail_helper;
+		} else {
+			let next_helper = null;
+			for (let j = i + 1; j < switch_node.cases.length; j++) {
+				if (case_helper_by_index[j]) {
+					next_helper = case_helper_by_index[j];
 					break;
 				}
-				own_body.push(node);
+			}
+			downstream = next_helper ?? tail_helper;
+		}
+
+		case_helper_by_index[i] = create_hook_safe_helper(
+			append_tail_invocation(own_body, downstream),
+			undefined,
+			switch_node.cases[i],
+			transform_context,
+			/** @type {any} */ (helper_ids[i]),
+		);
+	}
+
+	const new_cases = switch_node.cases.map(
+		(/** @type {any} */ original_case, /** @type {number} */ i) => {
+			const helper = case_helper_by_index[i];
+			if (helper) {
+				return b.switch_case(original_case.test, [
+					combined_return_statement(render_nodes, helper.component_element),
+				]);
 			}
 
-			if (own_body.length === 0) {
-				// `case 'a': break;` (break-only / return-only) originally exited
-				// the switch and ran the tail. Emitting an empty case here would
-				// silently fall through to the next case's body — running its
-				// hook and rendering its content for the wrong input. Render the
-				// tail directly so we preserve the source's semantics.
-				if (own_has_terminator) {
-					return b.switch_case(original_case.test, [
-						combined_return_statement(render_nodes, tail_helper.component_element),
-					]);
-				}
-				// `case 'a': case 'b': ...` — genuine empty fall-through. The
-				// original source has no body for 'a' and means 'a' to share 'b's
-				// body. Preserve as an empty case so JS fall-through drops into
-				// the next case's helper (and the helper component identity is
-				// shared, preserving useState slots across kind toggles).
-				return b.switch_case(original_case.test, []);
+			const { own_body, own_has_terminator } = case_info[i];
+			if (own_body.length === 0 && own_has_terminator) {
+				// `case 'a': break;` — exits the switch, then runs the tail.
+				return b.switch_case(original_case.test, [
+					combined_return_statement(render_nodes, tail_helper.component_element),
+				]);
 			}
-
-			// Non-empty case: compute the *effective* body by following
-			// fall-through into subsequent cases until we hit a terminator.
-			// `case 'a': x = 1; case 'b': useState(100); break;` — case 'a's
-			// effective body is `[x = 1, useState(100)]` so CaseHelperA runs the
-			// merged body and the post-hook value flows into the tail.
-			const effective_body = [...own_body];
-			if (!own_has_terminator) {
-				for (let j = case_index + 1; j < switch_node.cases.length; j++) {
-					const next_consequent = flatten_switch_consequent(switch_node.cases[j].consequent || []);
-					let next_has_terminator = false;
-					for (const node of next_consequent) {
-						if (node.type === 'BreakStatement' || node.type === 'ReturnStatement') {
-							next_has_terminator = true;
-							break;
-						}
-						effective_body.push(node);
-					}
-					if (next_has_terminator) break;
-				}
-			}
-
-			const case_helper = create_hook_safe_helper(
-				append_tail_invocation(effective_body, tail_helper),
-				undefined,
-				original_case,
-				transform_context,
-			);
-
-			return b.switch_case(original_case.test, [
-				...case_helper.setup_statements,
-				combined_return_statement(render_nodes, case_helper.component_element),
-			]);
+			// Genuine empty fall-through (`case 'a': case 'b': ...`).
+			return b.switch_case(original_case.test, []);
 		},
 	);
 
+	// Hoist all case helpers' setup statements above the switch in source
+	// order so the switch body is purely a dispatcher.
+	const case_helper_setup_statements = [];
+	for (const helper of case_helper_by_index) {
+		if (helper) case_helper_setup_statements.push(...helper.setup_statements);
+	}
+
 	return [
 		...tail_helper.setup_statements,
+		...case_helper_setup_statements,
 		set_loc(b.switch(switch_node.discriminant, new_cases), switch_node),
 		combined_return_statement(render_nodes, tail_helper.component_element),
 	];
@@ -2405,12 +2430,22 @@ function get_referenced_helper_bindings(body_nodes, available_bindings) {
  * @param {any} key_expression
  * @param {any} source_node
  * @param {TransformContext} transform_context
+ * @param {AST.Identifier} [preallocated_helper_id] - Optional pre-allocated id.
+ *   Used by the switch lift's chained-call build, which allocates ids in
+ *   source order in a forward pass and then constructs helpers in reverse so
+ *   each fall-through case can reference the next case's component element.
  * @returns {{ setup_statements: any[], component_element: ESTreeJSX.JSXElement }}
  */
-function create_hook_safe_helper(body_nodes, key_expression, source_node, transform_context) {
-	const helper_id = create_generated_identifier(
-		create_local_statement_component_name(transform_context),
-	);
+function create_hook_safe_helper(
+	body_nodes,
+	key_expression,
+	source_node,
+	transform_context,
+	preallocated_helper_id,
+) {
+	const helper_id =
+		preallocated_helper_id ??
+		create_generated_identifier(create_local_statement_component_name(transform_context));
 	const helper_bindings = get_referenced_helper_bindings(
 		body_nodes,
 		transform_context.available_bindings,

--- a/packages/tsrx/src/transform/jsx/index.js
+++ b/packages/tsrx/src/transform/jsx/index.js
@@ -939,35 +939,26 @@ function create_helper_props_property(binding) {
  */
 function create_helper_component_element(helper_id, bindings, source_node, mapping = {}) {
 	const { mapWrapper = true, mapBindingNames = true, mapBindingValues = true } = mapping;
-	const attributes = bindings.map(
-		(binding) =>
-			/** @type {any} */ ({
-				type: 'JSXAttribute',
-				name: identifier_to_jsx_name(
-					mapBindingNames ? clone_identifier(binding) : create_generated_identifier(binding.name),
-				),
-				value: to_jsx_expression_container(
-					mapBindingValues ? clone_identifier(binding) : create_generated_identifier(binding.name),
-					binding,
-				),
-				metadata: { path: [] },
-			}),
+	const attributes = bindings.map((binding) =>
+		b.jsx_attribute(
+			identifier_to_jsx_name(
+				mapBindingNames ? clone_identifier(binding) : create_generated_identifier(binding.name),
+			),
+			to_jsx_expression_container(
+				mapBindingValues ? clone_identifier(binding) : create_generated_identifier(binding.name),
+				binding,
+			),
+		),
 	);
 
-	const openingElement = {
-		type: 'JSXOpeningElement',
-		name: identifier_to_jsx_name(clone_identifier(helper_id)),
+	const opening_element = b.jsx_opening_element(
+		identifier_to_jsx_name(clone_identifier(helper_id)),
 		attributes,
-		selfClosing: true,
-		metadata: { path: [] },
-	};
-	const element = /** @type {any} */ ({
-		type: 'JSXElement',
-		openingElement: mapWrapper ? set_loc(openingElement, source_node) : openingElement,
-		closingElement: null,
-		children: [],
-		metadata: { path: [] },
-	});
+		true,
+	);
+	const element = b.jsx_element_fresh(
+		mapWrapper ? set_loc(opening_element, source_node) : opening_element,
+	);
 
 	return mapWrapper ? set_loc(element, source_node) : element;
 }
@@ -1157,21 +1148,7 @@ function hoist_static_render_nodes(render_nodes, transform_context) {
 		const name = create_helper_name(transform_context.helper_state, 'static');
 		const id = create_generated_identifier(name);
 
-		transform_context.helper_state.statics.push(
-			/** @type {any} */ ({
-				type: 'VariableDeclaration',
-				kind: 'const',
-				declarations: [
-					{
-						type: 'VariableDeclarator',
-						id,
-						init: node,
-						metadata: { path: [] },
-					},
-				],
-				metadata: { path: [] },
-			}),
-		);
+		transform_context.helper_state.statics.push(b.const(id, node));
 
 		render_nodes[i] = to_jsx_expression_container(clone_identifier(id), node);
 	}
@@ -1277,25 +1254,13 @@ function create_component_return_statement(
 	source_node,
 	map_render_node_locations = true,
 ) {
-	return set_loc(
-		/** @type {any} */ ({
-			type: 'ReturnStatement',
-			argument: build_return_expression(
-				render_nodes.map((node) =>
-					map_render_node_locations
-						? clone_expression_node(node)
-						: clone_expression_node_without_locations(node),
-				),
-			) || {
-				type: 'Literal',
-				value: null,
-				raw: 'null',
-				metadata: { path: [] },
-			},
-			metadata: { path: [] },
-		}),
-		source_node,
+	const cloned = render_nodes.map((node) =>
+		map_render_node_locations
+			? clone_expression_node(node)
+			: clone_expression_node_without_locations(node),
 	);
+
+	return set_loc(b.return(build_return_expression(cloned) || create_null_literal()), source_node);
 }
 
 /**
@@ -1307,20 +1272,14 @@ function create_component_lone_return_if_statement(node, render_nodes) {
 	const consequent_body = get_if_consequent_body(node);
 
 	return set_loc(
-		/** @type {any} */ ({
-			type: 'IfStatement',
-			test: node.test,
-			consequent: set_loc(
-				/** @type {any} */ ({
-					type: 'BlockStatement',
-					body: [create_component_return_statement(render_nodes, consequent_body[0], false)],
-					metadata: { path: [] },
-				}),
+		b.if(
+			node.test,
+			set_loc(
+				b.block([create_component_return_statement(render_nodes, consequent_body[0], false)]),
 				node.consequent,
 			),
-			alternate: null,
-			metadata: { path: [] },
-		}),
+			null,
+		),
 		node,
 	);
 }
@@ -1336,23 +1295,7 @@ function create_component_returning_if_statement(node, render_nodes, transform_c
 	const branch_statements = build_render_statements(consequent_body, true, transform_context);
 	prepend_render_nodes_to_return_statements(branch_statements, render_nodes);
 
-	return set_loc(
-		/** @type {any} */ ({
-			type: 'IfStatement',
-			test: node.test,
-			consequent: set_loc(
-				/** @type {any} */ ({
-					type: 'BlockStatement',
-					body: branch_statements,
-					metadata: { path: [] },
-				}),
-				node.consequent,
-			),
-			alternate: null,
-			metadata: { path: [] },
-		}),
-		node,
-	);
+	return set_loc(b.if(node.test, set_loc(b.block(branch_statements), node.consequent), null), node);
 }
 
 /* ---------------------------------------------------------------------- *
@@ -1461,40 +1404,19 @@ function create_component_helper_split_returning_if_statements(
 		node,
 		transform_context,
 	);
+
+	const branch_block = set_loc(
+		b.block([
+			...branch_helper.setup_statements,
+			combined_return_statement(render_nodes, branch_helper.component_element),
+		]),
+		node.consequent,
+	);
+
 	return [
-		set_loc(
-			/** @type {any} */ ({
-				type: 'IfStatement',
-				test: node.test,
-				consequent: set_loc(
-					/** @type {any} */ ({
-						type: 'BlockStatement',
-						body: [
-							...branch_helper.setup_statements,
-							{
-								type: 'ReturnStatement',
-								argument: combine_render_return_argument(
-									render_nodes,
-									branch_helper.component_element,
-								),
-								metadata: { path: [] },
-							},
-						],
-						metadata: { path: [] },
-					}),
-					node.consequent,
-				),
-				alternate: null,
-				metadata: { path: [] },
-			}),
-			node,
-		),
+		set_loc(b.if(node.test, branch_block, null), node),
 		...continuation_helper.setup_statements,
-		{
-			type: 'ReturnStatement',
-			argument: combine_render_return_argument(render_nodes, continuation_helper.component_element),
-			metadata: { path: [] },
-		},
+		combined_return_statement(render_nodes, continuation_helper.component_element),
 	];
 }
 
@@ -2250,47 +2172,21 @@ function to_jsx_element(node, transform_context, raw_children = node.children ||
 		(/** @type {any} */ attribute) => attribute?.metadata?.has_unmappable_value,
 	);
 
-	/** @type {ESTreeJSX.JSXOpeningElement} */
-	const openingElement = /** @type {ESTreeJSX.JSXOpeningElement} */ (
-		has_unmappable_attribute
-			? {
-					type: 'JSXOpeningElement',
-					name,
-					attributes,
-					selfClosing,
-					metadata: { path: [] },
-				}
-			: set_loc(
-					/** @type {any} */ ({
-						type: 'JSXOpeningElement',
-						name,
-						attributes,
-						selfClosing,
-					}),
-					node.openingElement || node,
-				)
-	);
+	const opening_element_node = b.jsx_opening_element(name, attributes, selfClosing);
+	const openingElement = has_unmappable_attribute
+		? opening_element_node
+		: set_loc(opening_element_node, node.openingElement || node);
 
-	/** @type {ESTreeJSX.JSXClosingElement | null} */
 	const closingElement = selfClosing
 		? null
 		: set_loc(
-				/** @type {any} */ ({
-					type: 'JSXClosingElement',
-					name: clone_jsx_name(name, node.closingElement?.name || node.closingElement || node),
-				}),
+				b.jsx_closing_element(
+					clone_jsx_name(name, node.closingElement?.name || node.closingElement || node),
+				),
 				node.closingElement || node,
 			);
 
-	return set_loc(
-		/** @type {any} */ ({
-			type: 'JSXElement',
-			openingElement,
-			closingElement,
-			children,
-		}),
-		node,
-	);
+	return set_loc(b.jsx_element_fresh(openingElement, closingElement, children), node);
 }
 
 /**
@@ -3401,27 +3297,10 @@ function try_statement_to_jsx_child(node, transform_context) {
  * @returns {any}
  */
 function create_jsx_element(tag_name, attributes, children) {
-	const name = { type: 'JSXIdentifier', name: tag_name, metadata: { path: [] } };
-	return {
-		type: 'JSXElement',
-		openingElement: {
-			type: 'JSXOpeningElement',
-			name,
-			attributes,
-			selfClosing: children.length === 0,
-			metadata: { path: [] },
-		},
-		closingElement:
-			children.length > 0
-				? {
-						type: 'JSXClosingElement',
-						name: { type: 'JSXIdentifier', name: tag_name, metadata: { path: [] } },
-						metadata: { path: [] },
-					}
-				: null,
-		children,
-		metadata: { path: [] },
-	};
+	const self_closing = children.length === 0;
+	const opening_element = b.jsx_opening_element(b.jsx_id(tag_name), attributes, self_closing);
+	const closing_element = self_closing ? null : b.jsx_closing_element(b.jsx_id(tag_name));
+	return b.jsx_element_fresh(opening_element, closing_element, children);
 }
 
 /**
@@ -4065,25 +3944,11 @@ function create_dynamic_jsx_element(dynamic_id, node, transform_context) {
 	const children = create_element_children(node.children || [], transform_context);
 	const name = identifier_to_jsx_name(clone_identifier(dynamic_id));
 
-	return /** @type {any} */ ({
-		type: 'JSXElement',
-		openingElement: {
-			type: 'JSXOpeningElement',
-			name,
-			attributes,
-			selfClosing,
-			metadata: { path: [] },
-		},
-		closingElement: selfClosing
-			? null
-			: {
-					type: 'JSXClosingElement',
-					name: clone_jsx_name(name),
-					metadata: { path: [] },
-				},
+	return b.jsx_element_fresh(
+		b.jsx_opening_element(name, attributes, selfClosing),
+		selfClosing ? null : b.jsx_closing_element(clone_jsx_name(name)),
 		children,
-		metadata: { path: [] },
-	});
+	);
 }
 
 /**

--- a/packages/tsrx/src/transform/jsx/index.js
+++ b/packages/tsrx/src/transform/jsx/index.js
@@ -31,6 +31,7 @@ import {
 	jsx_attribute as build_jsx_attribute,
 	jsx_id as build_jsx_id,
 } from '../../utils/builders.js';
+import * as b from '../../utils/builders.js';
 import {
 	apply_lazy_transforms,
 	collect_lazy_bindings_from_component,
@@ -1407,11 +1408,7 @@ function append_tail_invocation(body, tail_helper) {
  * @returns {any}
  */
 function combined_return_statement(render_nodes, jsx_child) {
-	return /** @type {any} */ ({
-		type: 'ReturnStatement',
-		argument: combine_render_return_argument(render_nodes, jsx_child),
-		metadata: { path: [] },
-	});
+	return b.return(combine_render_return_argument(render_nodes, jsx_child));
 }
 
 /**
@@ -1426,62 +1423,11 @@ function combined_return_statement(render_nodes, jsx_child) {
  * @returns {{ source_decl: any, source_normalize_decl: any }}
  */
 function build_array_normalization_decls(source_id, source_expr) {
-	const source_decl = /** @type {any} */ ({
-		type: 'VariableDeclaration',
-		kind: 'let',
-		declarations: [
-			{
-				type: 'VariableDeclarator',
-				id: clone_identifier(source_id),
-				init: clone_expression_node(source_expr),
-				metadata: { path: [] },
-			},
-		],
-		metadata: { path: [] },
-	});
-	const source_normalize_decl = /** @type {any} */ ({
-		type: 'ExpressionStatement',
-		expression: {
-			type: 'AssignmentExpression',
-			operator: '=',
-			left: clone_identifier(source_id),
-			right: {
-				type: 'ConditionalExpression',
-				test: {
-					type: 'CallExpression',
-					callee: {
-						type: 'MemberExpression',
-						object: { type: 'Identifier', name: 'Array', metadata: { path: [] } },
-						property: { type: 'Identifier', name: 'isArray', metadata: { path: [] } },
-						computed: false,
-						optional: false,
-						metadata: { path: [] },
-					},
-					arguments: [clone_identifier(source_id)],
-					optional: false,
-					metadata: { path: [] },
-				},
-				consequent: clone_identifier(source_id),
-				alternate: {
-					type: 'CallExpression',
-					callee: {
-						type: 'MemberExpression',
-						object: { type: 'Identifier', name: 'Array', metadata: { path: [] } },
-						property: { type: 'Identifier', name: 'from', metadata: { path: [] } },
-						computed: false,
-						optional: false,
-						metadata: { path: [] },
-					},
-					arguments: [clone_identifier(source_id)],
-					optional: false,
-					metadata: { path: [] },
-				},
-				metadata: { path: [] },
-			},
-			metadata: { path: [] },
-		},
-		metadata: { path: [] },
-	});
+	const source_decl = b.let(clone_identifier(source_id), clone_expression_node(source_expr));
+	const is_array_call = b.call(b.member(b.id('Array'), 'isArray'), clone_identifier(source_id));
+	const from_call = b.call(b.member(b.id('Array'), 'from'), clone_identifier(source_id));
+	const normalized = b.conditional(is_array_call, clone_identifier(source_id), from_call);
+	const source_normalize_decl = b.stmt(b.assignment('=', clone_identifier(source_id), normalized));
 
 	return { source_decl, source_normalize_decl };
 }

--- a/packages/tsrx/src/transform/jsx/index.js
+++ b/packages/tsrx/src/transform/jsx/index.js
@@ -1354,6 +1354,138 @@ function create_component_returning_if_statement(node, render_nodes, transform_c
 	);
 }
 
+/* ---------------------------------------------------------------------- *
+ * Continuation-lift primitives shared across if / switch / try / for-of  *
+ * ---------------------------------------------------------------------- */
+
+/**
+ * Build the helper component that owns the post-control-flow continuation.
+ * Same shape as `create_hook_safe_helper`; named for intent at lift call sites.
+ *
+ * @param {any[]} continuation_body
+ * @param {any} source_node
+ * @param {TransformContext} transform_context
+ * @returns {{ setup_statements: any[], component_element: ESTreeJSX.JSXElement }}
+ */
+function build_tail_helper(continuation_body, source_node, transform_context) {
+	return create_hook_safe_helper(continuation_body, undefined, source_node, transform_context);
+}
+
+/**
+ * Clone the tail helper's component element for embedding inside another
+ * branch's body. Loses location info because the same element appears in
+ * multiple positions and downstream tooling treats AST nodes as identity-keyed.
+ *
+ * @param {{ component_element: ESTreeJSX.JSXElement }} tail_helper
+ * @returns {any}
+ */
+function clone_tail_invocation(tail_helper) {
+	return clone_expression_node_without_locations(tail_helper.component_element);
+}
+
+/**
+ * Return `[...body, <TailHelper x={x} />]` so the branch's render output
+ * includes the tail invocation and the post-hook locals flow forward.
+ * Used by if / switch / try (unconditional append). For-of uses a different
+ * shape — gating on `_tsrx_isLast_<n>` — so it constructs its own.
+ *
+ * @param {any[]} body
+ * @param {{ component_element: ESTreeJSX.JSXElement }} tail_helper
+ * @returns {any[]}
+ */
+function append_tail_invocation(body, tail_helper) {
+	return [...body, clone_tail_invocation(tail_helper)];
+}
+
+/**
+ * Build a `return <combined-render-fragment>;` statement, prepending any
+ * `render_nodes` collected before the control-flow construct so they don't
+ * get dropped on the lift path.
+ *
+ * @param {any[]} render_nodes
+ * @param {any} jsx_child
+ * @returns {any}
+ */
+function combined_return_statement(render_nodes, jsx_child) {
+	return /** @type {any} */ ({
+		type: 'ReturnStatement',
+		argument: combine_render_return_argument(render_nodes, jsx_child),
+		metadata: { path: [] },
+	});
+}
+
+/**
+ * Hoist a for-of iteration source into a generated `let` and add a
+ * normalization assignment via `Array.isArray(src) ? src : Array.from(src)`.
+ * Always emits both — even when the source is already a simple identifier —
+ * so the loop-scoped TS type aliases have a stable name to reference and the
+ * runtime check skips the copy when the value is already an array.
+ *
+ * @param {AST.Identifier} source_id
+ * @param {any} source_expr
+ * @returns {{ source_decl: any, source_normalize_decl: any }}
+ */
+function build_array_normalization_decls(source_id, source_expr) {
+	const source_decl = /** @type {any} */ ({
+		type: 'VariableDeclaration',
+		kind: 'let',
+		declarations: [
+			{
+				type: 'VariableDeclarator',
+				id: clone_identifier(source_id),
+				init: clone_expression_node(source_expr),
+				metadata: { path: [] },
+			},
+		],
+		metadata: { path: [] },
+	});
+	const source_normalize_decl = /** @type {any} */ ({
+		type: 'ExpressionStatement',
+		expression: {
+			type: 'AssignmentExpression',
+			operator: '=',
+			left: clone_identifier(source_id),
+			right: {
+				type: 'ConditionalExpression',
+				test: {
+					type: 'CallExpression',
+					callee: {
+						type: 'MemberExpression',
+						object: { type: 'Identifier', name: 'Array', metadata: { path: [] } },
+						property: { type: 'Identifier', name: 'isArray', metadata: { path: [] } },
+						computed: false,
+						optional: false,
+						metadata: { path: [] },
+					},
+					arguments: [clone_identifier(source_id)],
+					optional: false,
+					metadata: { path: [] },
+				},
+				consequent: clone_identifier(source_id),
+				alternate: {
+					type: 'CallExpression',
+					callee: {
+						type: 'MemberExpression',
+						object: { type: 'Identifier', name: 'Array', metadata: { path: [] } },
+						property: { type: 'Identifier', name: 'from', metadata: { path: [] } },
+						computed: false,
+						optional: false,
+						metadata: { path: [] },
+					},
+					arguments: [clone_identifier(source_id)],
+					optional: false,
+					metadata: { path: [] },
+				},
+				metadata: { path: [] },
+			},
+			metadata: { path: [] },
+		},
+		metadata: { path: [] },
+	});
+
+	return { source_decl, source_normalize_decl };
+}
+
 /**
  * @param {any} node
  * @param {any[]} continuation_body
@@ -1445,17 +1577,9 @@ function create_continuation_lift_if_statement(
 	transform_context,
 ) {
 	const consequent_body = get_if_consequent_body(if_node);
-	const tail_helper = create_hook_safe_helper(
-		continuation_body,
-		undefined,
-		if_node,
-		transform_context,
-	);
-	const tail_invocation_in_branch = clone_expression_node_without_locations(
-		tail_helper.component_element,
-	);
+	const tail_helper = build_tail_helper(continuation_body, if_node, transform_context);
 	const branch_helper = create_hook_safe_helper(
-		[...consequent_body, tail_invocation_in_branch],
+		append_tail_invocation(consequent_body, tail_helper),
 		undefined,
 		if_node.consequent,
 		transform_context,
@@ -1472,14 +1596,7 @@ function create_continuation_lift_if_statement(
 						type: 'BlockStatement',
 						body: [
 							...branch_helper.setup_statements,
-							{
-								type: 'ReturnStatement',
-								argument: combine_render_return_argument(
-									render_nodes,
-									branch_helper.component_element,
-								),
-								metadata: { path: [] },
-							},
+							combined_return_statement(render_nodes, branch_helper.component_element),
 						],
 						metadata: { path: [] },
 					}),
@@ -1490,11 +1607,7 @@ function create_continuation_lift_if_statement(
 			}),
 			if_node,
 		),
-		{
-			type: 'ReturnStatement',
-			argument: combine_render_return_argument(render_nodes, tail_helper.component_element),
-			metadata: { path: [] },
-		},
+		combined_return_statement(render_nodes, tail_helper.component_element),
 	];
 }
 
@@ -1520,28 +1633,21 @@ function create_continuation_lift_try_statement(
 	render_nodes,
 	transform_context,
 ) {
-	const tail_helper = create_hook_safe_helper(
-		continuation_body,
-		undefined,
-		node,
-		transform_context,
-	);
+	const tail_helper = build_tail_helper(continuation_body, node, transform_context);
 
-	const augmented_block_body = [
-		...(node.block.body || []),
-		clone_expression_node_without_locations(tail_helper.component_element),
-	];
-	const augmented_block = { ...node.block, body: augmented_block_body };
+	const augmented_block = {
+		...node.block,
+		body: append_tail_invocation(node.block.body || [], tail_helper),
+	};
 
 	let augmented_handler = node.handler;
 	if (node.handler) {
-		const augmented_catch_body = [
-			...(node.handler.body.body || []),
-			clone_expression_node_without_locations(tail_helper.component_element),
-		];
 		augmented_handler = {
 			...node.handler,
-			body: { ...node.handler.body, body: augmented_catch_body },
+			body: {
+				...node.handler.body,
+				body: append_tail_invocation(node.handler.body.body || [], tail_helper),
+			},
 		};
 	}
 
@@ -1555,14 +1661,7 @@ function create_continuation_lift_try_statement(
 		transform_context.platform.hooks?.controlFlow?.tryStatement ?? try_statement_to_jsx_child
 	)(augmented_try, transform_context);
 
-	return [
-		...tail_helper.setup_statements,
-		{
-			type: 'ReturnStatement',
-			argument: combine_render_return_argument(render_nodes, try_jsx_child),
-			metadata: { path: [] },
-		},
-	];
+	return [...tail_helper.setup_statements, combined_return_statement(render_nodes, try_jsx_child)];
 }
 
 /**
@@ -1613,12 +1712,7 @@ function create_continuation_lift_switch_statement(
 	render_nodes,
 	transform_context,
 ) {
-	const tail_helper = create_hook_safe_helper(
-		continuation_body,
-		undefined,
-		switch_node,
-		transform_context,
-	);
+	const tail_helper = build_tail_helper(continuation_body, switch_node, transform_context);
 
 	const new_cases = switch_node.cases.map((/** @type {any} */ switch_case) => {
 		const consequent = flatten_switch_consequent(switch_case.consequent || []);
@@ -1637,11 +1731,8 @@ function create_continuation_lift_switch_statement(
 			});
 		}
 
-		const tail_invocation_in_case = clone_expression_node_without_locations(
-			tail_helper.component_element,
-		);
 		const case_helper = create_hook_safe_helper(
-			[...body_without_terminator, tail_invocation_in_case],
+			append_tail_invocation(body_without_terminator, tail_helper),
 			undefined,
 			switch_case,
 			transform_context,
@@ -1652,11 +1743,7 @@ function create_continuation_lift_switch_statement(
 			test: switch_case.test,
 			consequent: [
 				...case_helper.setup_statements,
-				{
-					type: 'ReturnStatement',
-					argument: combine_render_return_argument(render_nodes, case_helper.component_element),
-					metadata: { path: [] },
-				},
+				combined_return_statement(render_nodes, case_helper.component_element),
 			],
 			metadata: { path: [] },
 		});
@@ -1673,11 +1760,7 @@ function create_continuation_lift_switch_statement(
 			}),
 			switch_node,
 		),
-		{
-			type: 'ReturnStatement',
-			argument: combine_render_return_argument(render_nodes, tail_helper.component_element),
-			metadata: { path: [] },
-		},
+		combined_return_statement(render_nodes, tail_helper.component_element),
 	];
 }
 
@@ -1726,7 +1809,7 @@ function build_hoisted_for_of_with_hooks(node, continuation_body, transform_cont
 	let tail_helper = null;
 	/** @type {AST.Identifier} */ let tail_synthetic_id;
 	if (has_tail) {
-		tail_helper = create_hook_safe_helper(continuation_body, undefined, node, transform_context);
+		tail_helper = build_tail_helper(continuation_body, node, transform_context);
 		tail_synthetic_id = create_generated_identifier(
 			`_tsrx_isLast_${transform_context.local_statement_component_index + 1}`,
 		);
@@ -1742,9 +1825,7 @@ function build_hoisted_for_of_with_hooks(node, continuation_body, transform_cont
 						type: 'LogicalExpression',
 						operator: '&&',
 						left: clone_identifier(tail_synthetic_id),
-						right: clone_expression_node_without_locations(
-							/** @type {any} */ (tail_helper).component_element,
-						),
+						right: clone_tail_invocation(/** @type {any} */ (tail_helper)),
 						metadata: { path: [] },
 					},
 					metadata: { path: [] },
@@ -1752,70 +1833,13 @@ function build_hoisted_for_of_with_hooks(node, continuation_body, transform_cont
 			]
 		: original_loop_body;
 
-	// Always hoist the iteration source into a generated `let` so that
-	// (a) the type aliases below have a stable name to reference and
-	// (b) we can normalize it at runtime via
-	// `Array.isArray(src) ? src : Array.from(src)`, avoiding a copy when
-	// the source is already an array but still working for any iterable.
 	const source_id = create_generated_identifier(
 		`_tsrx_iteration_items_${transform_context.local_statement_component_index + 1}`,
 	);
-	const source_decl = /** @type {any} */ ({
-		type: 'VariableDeclaration',
-		kind: 'let',
-		declarations: [
-			{
-				type: 'VariableDeclarator',
-				id: clone_identifier(source_id),
-				init: clone_expression_node(node.right),
-				metadata: { path: [] },
-			},
-		],
-		metadata: { path: [] },
-	});
-	const source_normalize_decl = /** @type {any} */ ({
-		type: 'ExpressionStatement',
-		expression: {
-			type: 'AssignmentExpression',
-			operator: '=',
-			left: clone_identifier(source_id),
-			right: {
-				type: 'ConditionalExpression',
-				test: {
-					type: 'CallExpression',
-					callee: {
-						type: 'MemberExpression',
-						object: { type: 'Identifier', name: 'Array', metadata: { path: [] } },
-						property: { type: 'Identifier', name: 'isArray', metadata: { path: [] } },
-						computed: false,
-						optional: false,
-						metadata: { path: [] },
-					},
-					arguments: [clone_identifier(source_id)],
-					optional: false,
-					metadata: { path: [] },
-				},
-				consequent: clone_identifier(source_id),
-				alternate: {
-					type: 'CallExpression',
-					callee: {
-						type: 'MemberExpression',
-						object: { type: 'Identifier', name: 'Array', metadata: { path: [] } },
-						property: { type: 'Identifier', name: 'from', metadata: { path: [] } },
-						computed: false,
-						optional: false,
-						metadata: { path: [] },
-					},
-					arguments: [clone_identifier(source_id)],
-					optional: false,
-					metadata: { path: [] },
-				},
-				metadata: { path: [] },
-			},
-			metadata: { path: [] },
-		},
-		metadata: { path: [] },
-	});
+	const { source_decl, source_normalize_decl } = build_array_normalization_decls(
+		source_id,
+		node.right,
+	);
 
 	const saved_bindings = transform_context.available_bindings;
 	transform_context.available_bindings = new Map(saved_bindings);
@@ -2057,9 +2081,7 @@ function build_hoisted_for_of_with_hooks(node, continuation_body, transform_cont
 					right: { type: 'Literal', value: 0, raw: '0' },
 					metadata: { path: [] },
 				},
-				consequent: clone_expression_node_without_locations(
-					/** @type {any} */ (tail_helper).component_element,
-				),
+				consequent: clone_tail_invocation(/** @type {any} */ (tail_helper)),
 				alternate: map_call,
 				metadata: { path: [] },
 			}),

--- a/packages/tsrx/src/transform/jsx/index.js
+++ b/packages/tsrx/src/transform/jsx/index.js
@@ -1753,9 +1753,7 @@ function build_hoisted_for_of_with_hooks(node, continuation_body, transform_cont
 		transform_context.available_bindings,
 	);
 	const loop_scoped_names = new Set(loop_params.map((/** @type {any} */ p) => p.name));
-	const outer_bindings = all_helper_bindings.filter(
-		(b) => !loop_scoped_names.has(b.name) && b.name !== '_tsrx_isLast',
-	);
+	const outer_bindings = all_helper_bindings.filter((b) => !loop_scoped_names.has(b.name));
 	const loop_bindings = all_helper_bindings.filter((b) => loop_scoped_names.has(b.name));
 
 	const helper_id = create_generated_identifier(

--- a/packages/tsrx/src/utils/builders.js
+++ b/packages/tsrx/src/utils/builders.js
@@ -1101,6 +1101,74 @@ export function jsx_attribute(name, value = null, shorthand = false, loc_info) {
 }
 
 /**
+ * Build a fresh `JSXOpeningElement`. For elements derived from an existing
+ * Element node, prefer `jsx_element` which spreads from the source.
+ *
+ * @param {ESTreeJSX.JSXOpeningElement['name']} name
+ * @param {ESTreeJSX.JSXOpeningElement['attributes']} [attributes]
+ * @param {boolean} [self_closing]
+ * @param {AST.NodeWithLocation} [loc_info]
+ * @returns {ESTreeJSX.JSXOpeningElement}
+ */
+export function jsx_opening_element(name, attributes = [], self_closing = false, loc_info) {
+	const node = /** @type {ESTreeJSX.JSXOpeningElement} */ ({
+		type: 'JSXOpeningElement',
+		name,
+		attributes,
+		selfClosing: self_closing,
+		metadata: { path: [] },
+	});
+
+	return set_location(node, loc_info);
+}
+
+/**
+ * Build a fresh `JSXClosingElement`.
+ *
+ * @param {ESTreeJSX.JSXClosingElement['name']} name
+ * @param {AST.NodeWithLocation} [loc_info]
+ * @returns {ESTreeJSX.JSXClosingElement}
+ */
+export function jsx_closing_element(name, loc_info) {
+	const node = /** @type {ESTreeJSX.JSXClosingElement} */ ({
+		type: 'JSXClosingElement',
+		name,
+		metadata: { path: [] },
+	});
+
+	return set_location(node, loc_info);
+}
+
+/**
+ * Build a fresh `JSXElement` from explicit opening / closing / children.
+ * Companion to `jsx_opening_element` / `jsx_closing_element`. For elements
+ * derived from an existing source node, use `jsx_element` (which spreads
+ * the source's name and metadata).
+ *
+ * @param {ESTreeJSX.JSXOpeningElement} opening_element
+ * @param {ESTreeJSX.JSXClosingElement | null} [closing_element]
+ * @param {ESTreeJSX.JSXElement['children']} [children]
+ * @param {AST.NodeWithLocation} [loc_info]
+ * @returns {ESTreeJSX.JSXElement}
+ */
+export function jsx_element_fresh(
+	opening_element,
+	closing_element = null,
+	children = [],
+	loc_info,
+) {
+	const node = /** @type {ESTreeJSX.JSXElement} */ ({
+		type: 'JSXElement',
+		openingElement: opening_element,
+		closingElement: closing_element,
+		children,
+		metadata: { path: [] },
+	});
+
+	return set_location(node, loc_info);
+}
+
+/**
  * @param {AST.Element} node
  * @param {ESTreeJSX.JSXOpeningElement['attributes']} attributes
  * @param {ESTreeJSX.JSXElement['children']} children

--- a/packages/tsrx/tests/shared/compile.js
+++ b/packages/tsrx/tests/shared/compile.js
@@ -1176,4 +1176,432 @@ export function optionalFn(bar: string, baz?: string) {
 			expect(code).toContain('accent"');
 		});
 	});
+
+	// When a non-returning `if` whose branch contains a hook is followed by
+	// statements that read bindings the hook mutates, those reads happen in
+	// the parent's render frame, before the child component containing the
+	// hook has run. React/Preact apply a continuation lift to fix this; Solid
+	// uses a `<Show>` wrapper, and Vue's setup-once platform skips the lift.
+	// Snapshots are per-target to make the divergence explicit.
+	describe.runIf(['react', 'preact'].includes(name))(
+		`[${name}] continuation lift for if-with-hook`,
+		() => {
+			it('lifts the tail of a single non-returning if-with-hook into a helper', () => {
+				const { code } = compile(
+					`export component App({ show }: { show: boolean }) {
+					let x: number | undefined;
+					if (show) {
+						[x] = useState(100);
+						<div>{x}</div>
+					}
+					console.log(x);
+				}`,
+					'App.tsrx',
+				);
+
+				expect(code).toMatchSnapshot();
+			});
+
+			it('chains tail helpers across sibling ifs that each contain hooks', () => {
+				const { code } = compile(
+					`export component App({ a, b }: { a: boolean, b: boolean }) {
+					let x: number | undefined;
+					let y: number | undefined;
+					if (a) {
+						[x] = useState(100);
+						<div>{x}</div>
+					}
+					if (b) {
+						[y] = useState(200);
+						<span>{y}</span>
+					}
+					console.log(x, y);
+				}`,
+					'App.tsrx',
+				);
+
+				expect(code).toMatchSnapshot();
+			});
+
+			it('handles nested if-with-hook so the mid-tail observes the inner hook', () => {
+				const { code } = compile(
+					`export component App({ a, b }: { a: boolean, b: boolean }) {
+					let x: number | undefined;
+					if (a) {
+						if (b) {
+							[x] = useState(100);
+							<div>{x}</div>
+						}
+						console.log('mid', x);
+					}
+					console.log('end', x);
+				}`,
+					'App.tsrx',
+				);
+
+				expect(code).toMatchSnapshot();
+			});
+
+			it('does not lift when the if has no statements after it', () => {
+				const { code } = compile(
+					`export component App({ show }: { show: boolean }) {
+					if (show) {
+						const [x] = useState(100);
+						<div>{x}</div>
+					}
+				}`,
+					'App.tsrx',
+				);
+
+				expect(code).toMatchSnapshot();
+			});
+
+			it('does not lift when the if has an else branch', () => {
+				const { code } = compile(
+					`export component App({ show }: { show: boolean }) {
+					let x: number | undefined;
+					if (show) {
+						[x] = useState(100);
+						<div>{x}</div>
+					} else {
+						<div>{'no'}</div>
+					}
+					console.log(x);
+				}`,
+					'App.tsrx',
+				);
+
+				expect(code).toMatchSnapshot();
+			});
+		},
+	);
+
+	// `switch` cases with hooks are wrapped in their own helper components for
+	// the same reason `if` branches are, and the same parent-reads-stale
+	// problem applies when statements after the switch read bindings the case
+	// bodies mutate. The lift extends to switches: each case body becomes its
+	// own helper that ends with a call to a shared tail helper, and the
+	// fall-through return renders the tail helper directly. Cases that fall
+	// through (have a non-empty body without a terminator) bail out of the
+	// lift to preserve their original semantics.
+	describe.runIf(['react', 'preact'].includes(name))(
+		`[${name}] continuation lift for switch-with-hook`,
+		() => {
+			it('lifts the tail of a switch whose cases contain hooks', () => {
+				const { code } = compile(
+					`export component App({ kind }: { kind: 'a' | 'b' }) {
+						let x: number | undefined;
+						switch (kind) {
+							case 'a':
+								[x] = useState(100);
+								<div>{x}</div>
+								break;
+							case 'b':
+								[x] = useState(200);
+								<span>{x}</span>
+								break;
+						}
+						console.log(x);
+					}`,
+					'App.tsrx',
+				);
+
+				expect(code).toMatchSnapshot();
+			});
+
+			it('lifts the tail when only some switch cases contain hooks', () => {
+				const { code } = compile(
+					`export component App({ kind }: { kind: 'a' | 'b' | 'c' }) {
+						let x: number | undefined;
+						switch (kind) {
+							case 'a':
+								[x] = useState(100);
+								<div>{x}</div>
+								break;
+							case 'b':
+								<span>{'static'}</span>
+								break;
+							default:
+								<p>{'fallback'}</p>
+								break;
+						}
+						console.log(x);
+					}`,
+					'App.tsrx',
+				);
+
+				expect(code).toMatchSnapshot();
+			});
+
+			it('lifts the tail when a switch has a default case with a hook', () => {
+				const { code } = compile(
+					`export component App({ kind }: { kind: string }) {
+						let x: number | undefined;
+						switch (kind) {
+							case 'a':
+								<div>{'a'}</div>
+								break;
+							default:
+								[x] = useState(100);
+								<div>{x}</div>
+								break;
+						}
+						console.log(x);
+					}`,
+					'App.tsrx',
+				);
+
+				expect(code).toMatchSnapshot();
+			});
+
+			it('does not lift when the switch has no statements after it', () => {
+				const { code } = compile(
+					`export component App({ kind }: { kind: 'a' | 'b' }) {
+						switch (kind) {
+							case 'a':
+								const [x] = useState(100);
+								<div>{x}</div>
+								break;
+							case 'b':
+								<span>{'b'}</span>
+								break;
+						}
+					}`,
+					'App.tsrx',
+				);
+
+				expect(code).toMatchSnapshot();
+			});
+		},
+	);
+
+	// `for-of` loops with hooks have a multi-iteration bug shape: each
+	// iteration becomes a sibling component, so post-loop reads of bindings
+	// the iteration body mutated would observe the parent's stale value.
+	// The lift wraps each iteration in a loop helper, threads an `isLast`
+	// prop computed from the index, and renders the tail helper inside the
+	// last iteration so it sees that iteration's post-`useState` locals.
+	// When the iteration source is empty, the tail helper is rendered
+	// directly so the source's tail still runs once.
+	//
+	// We also hoist the helper declaration above the loop (so it isn't
+	// re-bound on every iteration) and normalize the source via
+	// `Array.isArray(src) ? src : Array.from(src)` so any Iterable / ArrayLike
+	// works. Loop-scoped param types are derived from the iteration source
+	// via TS `type` aliases.
+	describe.runIf(['react', 'preact'].includes(name))(
+		`[${name}] hoisted helper and tail lift for for-of-with-hook`,
+		() => {
+			it('lifts the tail of a for-of with hooks (prop iteration source)', () => {
+				const { code } = compile(
+					`export component App({ items }: { items: number[] }) {
+						let last: number | undefined;
+						for (const item of items; index i) {
+							[last] = useState(item);
+							<div key={i}>{last}</div>
+						}
+						console.log(last);
+					}`,
+					'App.tsrx',
+				);
+
+				expect(code).toMatchSnapshot();
+			});
+
+			it('lifts the tail of a for-of with hooks (inline-literal iteration source)', () => {
+				const { code } = compile(
+					`export component App() {
+						let last: number | undefined;
+						for (const item of [1, 2, 3]; index i) {
+							[last] = useState(item);
+							<div key={i}>{last}</div>
+						}
+						console.log(last);
+					}`,
+					'App.tsrx',
+				);
+
+				expect(code).toMatchSnapshot();
+			});
+
+			it('lifts the tail across nested for-of-with-hooks', () => {
+				// Inner for-of's tail is `console.log('mid', last)` (lifted into
+				// its own helper called on the inner-last iteration). Outer
+				// for-of's tail is `console.log('end', last)` (lifted into a
+				// helper called on the outer-last iteration). The mid-tail flows
+				// the inner helper's local `last` forward; the end-tail flows
+				// the outer helper's local `last` forward.
+				const { code } = compile(
+					`export component App({ groups }: { groups: number[][] }) {
+						let last: number | undefined;
+						for (const group of groups) {
+							for (const item of group) {
+								[last] = useState(item);
+								<div key={item}>{last}</div>
+							}
+							console.log('mid', last);
+						}
+						console.log('end', last);
+					}`,
+					'App.tsrx',
+				);
+
+				expect(code).toMatchSnapshot();
+			});
+
+			it('lifts the tail across sibling for-of-with-hooks at the same level', () => {
+				// Both for-ofs have hooks, so each gets its own loop helper. The
+				// trigger fires on the first for-of, lifting `[second-for-of,
+				// console.log]` into a tail helper. That tail helper itself
+				// recursively triggers on the inner for-of, lifting
+				// `[console.log]` into a deeper tail helper.
+				const { code } = compile(
+					`export component App({ as, bs }: { as: number[], bs: number[] }) {
+						let lastA: number | undefined;
+						let lastB: number | undefined;
+						for (const a of as) {
+							[lastA] = useState(a);
+							<div key={a}>{lastA}</div>
+						}
+						for (const b of bs) {
+							[lastB] = useState(b);
+							<span key={b}>{lastB}</span>
+						}
+						console.log(lastA, lastB);
+					}`,
+					'App.tsrx',
+				);
+
+				expect(code).toMatchSnapshot();
+			});
+
+			it('hoists the helper without a tail lift when nothing follows the loop', () => {
+				// No tail means no synthesizing of `isLast` or empty fallback —
+				// just the hoist + Array.isArray-check + .map.
+				const { code } = compile(
+					`export component App({ items }: { items: string[] }) {
+						for (const name of items) {
+							const [val] = useState(name);
+							<div key={name}>{val}</div>
+						}
+					}`,
+					'App.tsrx',
+				);
+
+				expect(code).toMatchSnapshot();
+			});
+
+			it('falls back to the existing transform for non-hook for-of loops', () => {
+				// Without hooks in the body, the lift trigger doesn't fire and
+				// the existing `items.map(...)` shape is preserved.
+				const { code } = compile(
+					`export component App({ items }: { items: number[] }) {
+						for (const item of items; index i) {
+							<div key={i}>{item}</div>
+						}
+					}`,
+					'App.tsrx',
+				);
+
+				expect(code).toMatchSnapshot();
+			});
+		},
+	);
+
+	// Try statements with hooks in the try (or catch) body have the same
+	// parent-reads-stale problem as if/switch: the body is wrapped into a
+	// helper component, so post-try statements that read bindings the body
+	// mutated observe the parent's frozen value. These snapshots capture the
+	// current shape (potentially buggy) so we can see what needs fixing.
+	describe.runIf(['react', 'preact'].includes(name))(
+		`[${name}] continuation lift for try-with-hook`,
+		() => {
+			it('try/catch with a hook in the try body and a tail that reads the mutated outer', () => {
+				const { code } = compile(
+					`export component App({ load }: { load: () => number }) {
+						let data: number | undefined;
+						try {
+							[data] = useState(load());
+							<div>{data}</div>
+						} catch (err) {
+							<div>{'error'}</div>
+						}
+						console.log(data);
+					}`,
+					'App.tsrx',
+				);
+
+				expect(code).toMatchSnapshot();
+			});
+
+			it('try/pending/catch with a hook in the try body and a tail that reads the mutated outer', () => {
+				const { code } = compile(
+					`export component App({ load }: { load: () => number }) {
+						let data: number | undefined;
+						try {
+							[data] = useState(load());
+							<div>{data}</div>
+						} pending {
+							<p>{'loading'}</p>
+						} catch (err) {
+							<div>{'error'}</div>
+						}
+						console.log(data);
+					}`,
+					'App.tsrx',
+				);
+
+				expect(code).toMatchSnapshot();
+			});
+
+			it('try/catch with a hook in the catch body and a tail that reads the mutated outer', () => {
+				const { code } = compile(
+					`export component App({ load }: { load: () => number }) {
+						let attempt: number | undefined;
+						try {
+							<div>{load()}</div>
+						} catch (err) {
+							[attempt] = useState(0);
+							<div>{attempt}</div>
+						}
+						console.log(attempt);
+					}`,
+					'App.tsrx',
+				);
+
+				expect(code).toMatchSnapshot();
+			});
+
+			it('try with a hook but no statements after it (no tail to lift)', () => {
+				const { code } = compile(
+					`export component App({ load }: { load: () => number }) {
+						try {
+							const [data] = useState(load());
+							<div>{data}</div>
+						} catch (err) {
+							<div>{'error'}</div>
+						}
+					}`,
+					'App.tsrx',
+				);
+
+				expect(code).toMatchSnapshot();
+			});
+
+			it('try without hooks falls back to the existing transform', () => {
+				const { code } = compile(
+					`export component App({ load }: { load: () => number }) {
+						try {
+							<div>{load()}</div>
+						} catch (err) {
+							<div>{'error'}</div>
+						}
+					}`,
+					'App.tsrx',
+				);
+
+				expect(code).toMatchSnapshot();
+			});
+		},
+	);
 }

--- a/packages/tsrx/tests/shared/compile.js
+++ b/packages/tsrx/tests/shared/compile.js
@@ -1372,6 +1372,92 @@ export function optionalFn(bar: string, baz?: string) {
 
 				expect(code).toMatchSnapshot();
 			});
+
+			it('break-only case does not silently fall through into another case', () => {
+				// A `case 'a': break;` with no other body originally exits the
+				// switch and runs the tail. Naively producing an empty case in
+				// the lift would make 'a' fall through into the next case's
+				// helper (which here calls a hook), executing the wrong branch
+				// for the wrong input. The fixed shape returns the tail helper
+				// directly for break-only cases.
+				const { code } = compile(
+					`export component App({ kind }: { kind: 'a' | 'b' }) {
+						let x: number | undefined;
+						switch (kind) {
+							case 'a':
+								break;
+							case 'b':
+								[x] = useState(100);
+								<div>{x}</div>
+								break;
+						}
+						console.log(x);
+					}`,
+					'App.tsrx',
+				);
+
+				// Bug: break-only 'a' must NOT collapse to an empty case that
+				// then falls into 'b' and runs `useState(100)`.
+				expect(code).not.toMatch(/case 'a':\s*\n\s*case 'b':/);
+				expect(code).toMatchSnapshot();
+			});
+
+			it('preserves empty fall-through cases that share a body with the next case', () => {
+				// `case 'a': case 'b': hook + JSX; break;` is genuine
+				// empty-fall-through — 'a' has no body of its own and is meant
+				// to share 'b's body. The lift must keep 'a' as an empty case
+				// so the switch falls into 'b's body.
+				const { code } = compile(
+					`export component App({ kind }: { kind: 'a' | 'b' | 'c' }) {
+						let x: number | undefined;
+						switch (kind) {
+							case 'a':
+							case 'b':
+								[x] = useState(100);
+								<div>{x}</div>
+								break;
+							default:
+								<span>{'other'}</span>
+								break;
+						}
+						console.log(x);
+					}`,
+					'App.tsrx',
+				);
+
+				expect(code).toMatchSnapshot();
+			});
+
+			it('non-empty fall-through merges the trailing case body into the falling case', () => {
+				// `case 'a': x = 1; case 'b': [x] = useState(100); break;` —
+				// when 'a' matches it should run `x = 1` then fall through
+				// into 'b's hook + JSX. Naive lifting would either bail out
+				// (preserving the existing transform's bug) or convert 'a'
+				// into an early-return that skips 'b's body entirely.
+				// Instead we merge fall-through cases: 'a' gets its own helper
+				// whose body is `[x = 1, [x] = useState(100), <div>{x}</div>]`
+				// so the post-hook `x` correctly flows into the tail. Both
+				// 'a' and 'b' end up printing 100.
+				const { code } = compile(
+					`export component App({ kind }: { kind: 'a' | 'b' }) {
+						let x: number | undefined;
+						switch (kind) {
+							case 'a':
+								x = 1;
+							case 'b':
+								[x] = useState(100);
+								<div>{x}</div>
+								break;
+						}
+						console.log(x);
+					}`,
+					'App.tsrx',
+				);
+
+				// Lift applies: each case returns its own helper (no bail-out).
+				expect(code).not.toContain('(() =>');
+				expect(code).toMatchSnapshot();
+			});
 		},
 	);
 

--- a/playground/react/vite.config.js
+++ b/playground/react/vite.config.js
@@ -3,4 +3,7 @@ import tsrxReact from '@tsrx/vite-plugin-react';
 
 export default defineConfig({
 	plugins: [tsrxReact()],
+	build: {
+		minify: false,
+	},
 });

--- a/playground/solid/package.json
+++ b/playground/solid/package.json
@@ -12,6 +12,7 @@
     "debug-tsx": "node ../../scripts/debug-mode.js tsx @tsrx/solid"
   },
   "dependencies": {
+    "@solidjs/web": "2.0.0-beta.7",
     "solid-js": "2.0.0-beta.7"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1290,6 +1290,9 @@ importers:
 
   playground/solid:
     dependencies:
+      '@solidjs/web':
+        specifier: 2.0.0-beta.7
+        version: 2.0.0-beta.7(@solidjs/signals@2.0.0-beta.7)(solid-js@2.0.0-beta.7)
       solid-js:
         specifier: 2.0.0-beta.7
         version: 2.0.0-beta.7


### PR DESCRIPTION
The code after control flows should have the values of the shared top variables set inside the flows.  This only focused on fixing React and Preact.  Solid and Vue, I think should not have these issues but I only checked if statements for Solid.  Ripple definitely cannot have these issues.

I haven't checked the volar editor support to make sure things are mapped to the correct generated items.  I'll do that in my morning.

```tsx
export component App({ show }: { show: boolean }) {
	let x: number | undefined;
	if (!show) {
		[x] = useState(100);

		<div>{x}</div>
	}
	console.log(x); // should print 100 and not undefined
}
```

```tsx
export component App({ kind }: { kind: 'a' | 'b' }) {
	let x: number | undefined;
	kind = 'b';
	switch (kind) {
		case 'a':
			[x] = useState(100);
			<div>{x}</div>
			break;
		case 'b':
			[x] = useState(200);
			<span>{x}</span>
			break;
	}
	console.log(x); // should print 200 and not undefined
```

```tsx
// obviously not something one should do lol
export component App({ items }: { items: string[] }) {
	let last: number | undefined;

	for (const item of [1, 2, 3]; index index; key item) {
		[last] = useState(item);

		<div>{last}</div>
	}
	console.log(last); / should print 3 and not undefined
}
```

```tsx
let cache: number | undefined;
const dataPromise = new Promise<number>((resolve) => setTimeout(() => resolve(42), 2000)).then(
	(v) => {
		cache = v;
	},
);

const loadData = () => {
	if (cache !== undefined) return cache;
	throw dataPromise;
};

export component Test({ load }: { load: () => number }) {
	let data: number | undefined;
	try {
		[data] = useState(load());
		<div>{data}</div>
	} pending {
		<p>{'loading'}</p> // should show 'loading' first for a couple of seconds
	} catch (err) {
		<div>{'error'}</div>
	}
	console.log(data); // should show 42 vs undefined
}

export component App() {
	<Test load={loadData} />
}
```



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core JSX transform control-flow rewriting for React/Preact (if/switch/try/for-of) and alters generated output shapes; mistakes could break render semantics (fall-through, error boundaries, iteration) or source mapping.
> 
> **Overview**
> Fixes a React/Preact-only bug where hooks inside control-flow blocks (`if`, `switch`, `try`/`pending`/`catch`, `for-of`) could mutate outer bindings but code *after* the block would still see stale values.
> 
> This introduces a **continuation-lift** transform in `packages/tsrx/src/transform/jsx/index.js`: it generates a “tail helper” component for the statements following a hook-bearing control-flow block and ensures each branch/case/iteration invokes that tail so post-hook values flow into subsequent code (with special handling for `switch` fall-through/break-only cases and empty-iteration `for-of`).
> 
> `for-of` hook bodies are additionally hoisted: the loop helper and TS type aliases move outside the loop, the iteration source is normalized via `Array.isArray(...) ? ... : Array.from(...)`, and tail execution is gated on the last iteration.
> 
> Adds extensive new snapshot coverage for these scenarios (React/Preact), updates a React test assertion, and refactors various manually-built JSX AST nodes to use new builder helpers (`jsx_opening_element`, `jsx_closing_element`, `jsx_element_fresh`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d00699bea60ce815152cd1f75ff506475b0fc7e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->