### PR TITLE
fix: language-server setup + zed plugin

### DIFF
--- a/.changeset/six-rats-joke.md
+++ b/.changeset/six-rats-joke.md
@@ -1,0 +1,12 @@
+---
+'@ripple-ts/language-server': patch
+'@tsrx/react-playground': patch
+'@tsrx/solid-playground': patch
+'@tsrx/vue-playground': patch
+---
+
+We will no bump up the language-server version in zed's package.json config field automatically to keep things in sync
+
+Fixed issue with Zed to look and find the project's language-server first - useful for dev
+
+language-server was pointing to dist but dist wasn't published, also issues with bin, etc.

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "changeset": "changeset",
-    "changeset:version": "changeset version",
+    "changeset:version": "changeset version && node scripts/sync-zed-plugin-version.js",
     "changeset:publish": "changeset publish",
     "regenerate-textmate": "node scripts/regenerate-textmate.js",
     "copy-tree-sitter-queries": "node ./scripts/copy-tree-sitter-queries.js",

--- a/packages/language-server/bin/language-server.js
+++ b/packages/language-server/bin/language-server.js
@@ -1,5 +1,0 @@
-#!/usr/bin/env node
-
-import { createRippleLanguageServer } from '../src/server.js';
-
-createRippleLanguageServer();

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -5,12 +5,16 @@
   "main": "dist/server.js",
   "type": "module",
   "bin": {
-    "ripple-language-server": "bin/language-server.js"
+    "ripple-language-server": "./dist/language-server.js"
   },
+  "files": [
+    "dist"
+  ],
   "author": "Dominic Gannaway",
   "license": "MIT",
   "scripts": {
-    "build": "tsdown"
+    "build": "tsdown",
+    "prepare": "tsdown"
   },
   "repository": {
     "type": "git",

--- a/packages/language-server/src/language-server.js
+++ b/packages/language-server/src/language-server.js
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+import { createRippleLanguageServer } from './server.js';
+
+createRippleLanguageServer();

--- a/packages/language-server/tsdown.config.js
+++ b/packages/language-server/tsdown.config.js
@@ -15,11 +15,14 @@ const ROOT_EXTERNAL_PACKAGES = [
 	'volar-service-typescript',
 	/* also definitely need it for monkey patching */
 	/^volar-service-typescript(?:\/.*)?$/,
+	/* dynamic require()s of internal files — can't be bundled */
+	'volar-service-css',
+	/^volar-service-css(?:\/.*)?$/,
 ];
 
 export default defineConfig({
 	inlineOnly: false,
-	entry: ['src/server.js', 'bin/language-server.js'],
+	entry: ['src/server.js', 'src/language-server.js'],
 	format: ['cjs'],
 	outExtensions: () => ({ js: '.js' }),
 	platform: 'node',

--- a/packages/zed-plugin/Cargo.lock
+++ b/packages/zed-plugin/Cargo.lock
@@ -552,7 +552,7 @@ checksum = "ea68304e134ecd095ac6c3574494fc62b909f416c4fca77e440530221e549d3d"
 
 [[package]]
 name = "tsrx"
-version = "0.0.84"
+version = "0.0.85"
 dependencies = [
  "zed_extension_api",
 ]

--- a/packages/zed-plugin/Cargo.toml
+++ b/packages/zed-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tsrx"
-version = "0.0.84"
+version = "0.0.85"
 edition = "2021"
 
 [lib]

--- a/packages/zed-plugin/README.md
+++ b/packages/zed-plugin/README.md
@@ -29,14 +29,26 @@ Once published to the Zed extensions registry:
 
 ## Language Server Setup
 
-The extension automatically downloads the Ripple Language Server the first time it
-runs. The version is pinned via the `config` entry for
-`@ripple-ts/language-server` in this package's `package.json`. If you'd prefer to
-manage the dependency yourself, install it via npm:
+The extension looks for the language server `@ripple-ts/language-server` in this
+order:
 
-```bash
-npm install -g @ripple-ts/language-server
-```
+1. The local project that you have opened in Zed via the `package.json` and looks
+   for `node_modules/.bin/ripple-language-server`. So make sure to install your
+   dependencies first via:
+
+   ```bash
+   npm install
+   ```
+
+2. Globally installed:
+
+   ```bash
+   npm install -g @ripple-ts/language-server
+   ```
+
+3. The extension automatically downloads the Ripple Language Server the first time
+   it runs. The version is pinned via the `config` entry for
+   `@ripple-ts/language-server` in this package's `package.json`.
 
 Project-local installations (`node_modules/.bin/ripple-language-server`) are also
 detected automatically.

--- a/packages/zed-plugin/extension.toml
+++ b/packages/zed-plugin/extension.toml
@@ -1,7 +1,7 @@
 id = "tsrx"
 name = "TSRX"
 description = "TSRX language support with LSP and Tree-sitter syntax highlighting. TSRX is a TypeScript superset that compiles to Ripple, React, Solid, and Preact."
-version = "0.0.84"
+version = "0.0.85"
 schema_version = 1
 authors = ["Dominic Gannaway <trueadm@users.noreply.github.com>"]
 repository = "https://github.com/Ripple-TS/ripple"

--- a/packages/zed-plugin/package.json
+++ b/packages/zed-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ripple-ts/zed-plugin",
-  "version": "0.0.84",
+  "version": "0.0.85",
   "description": "",
   "private": true,
   "main": "index.js",
@@ -9,7 +9,7 @@
   "author": "",
   "license": "ISC",
   "config": {
-    "@ripple-ts/language-server": "0.2.208"
+    "@ripple-ts/language-server": "0.3.41"
   },
   "packageManager": "pnpm@10.18.2"
 }

--- a/packages/zed-plugin/src/lib.rs
+++ b/packages/zed-plugin/src/lib.rs
@@ -273,7 +273,7 @@ impl zed::Extension for TsrxExtension {
                        \"%RIPPLE_LSP_BIN%\" --stdio \
                      ) else ( \
                        echo [ripple-language-server] not found at \"%RIPPLE_LSP_BIN%\". \
-Run `pnpm install` (or `npm install`) in your project, \
+Run `pnpm install` ^(or `npm install`^) in your project, \
 or remove \"%RIPPLE_LSP_PKG%\" from your dependencies to use the auto-installed version. 1>&2 \
                        & exit /b 127 \
                      )".into(),

--- a/packages/zed-plugin/src/lib.rs
+++ b/packages/zed-plugin/src/lib.rs
@@ -149,21 +149,40 @@ impl TsrxExtension {
             return Ok(bin_path);
         }
 
-        let fallback_path = extension_dir
-            .join("node_modules")
-            .join(PACKAGE_NAME)
-            .join("bin")
-            .join("language-server.js");
+        // Fallback: parse the installed package's package.json `bin` field
+        // and resolve from there. Auto-tracks whatever path the package
+        // declares (string form or { "<name>": "<path>" } object form), so
+        // this stays correct if the LSP restructures its layout.
+        let pkg_dir = extension_dir.join("node_modules").join(PACKAGE_NAME);
+        let pkg_json_path = pkg_dir.join("package.json");
+        let manifest_fallback = if let Ok(contents) = fs::read_to_string(&pkg_json_path) {
+            if let Ok(manifest) = serde_json::from_str::<Value>(&contents) {
+                let rel = match manifest.get("bin") {
+                    Some(Value::String(s)) => Some(s.as_str().to_owned()),
+                    Some(Value::Object(map)) => map
+                        .values()
+                        .find_map(|v| v.as_str().map(str::to_owned)),
+                    _ => None,
+                };
+                rel.map(|r| pkg_dir.join(r))
+            } else {
+                None
+            }
+        } else {
+            None
+        };
 
-        if fs::metadata(&fallback_path).map_or(false, |stat| stat.is_file()) {
-            return Ok(fallback_path);
+        if let Some(path) = manifest_fallback.as_ref() {
+            if fs::metadata(path).map_or(false, |stat| stat.is_file()) {
+                return Ok(path.clone());
+            }
         }
 
-        Err(format!(
-            "expected a binary at {} or {}",
-            bin_path.display(),
-            fallback_path.display()
-        ))
+        let mut tried = format!("{}", bin_path.display());
+        if let Some(p) = manifest_fallback {
+            tried.push_str(&format!(" or {}", p.display()));
+        }
+        Err(format!("expected a binary at {}", tried))
     }
 
     fn extension_dir() -> Result<PathBuf, String> {
@@ -233,11 +252,53 @@ impl zed::Extension for TsrxExtension {
     ) -> Result<zed::Command, String> {
         let binary_path = self.language_server_binary_path(language_server_id, worktree)?;
 
-        Ok(zed::Command {
-            command: binary_path,
-            args: vec!["--stdio".to_string()],
-            env: worktree.shell_env(),
-        })
+        // Wrap the spawn in a shell snippet that prints an actionable error if
+        // the bin disappears between detection and exec. Needed because we
+        // cannot probe paths under node_modules from inside the wasm sandbox,
+        // so the project-local path returned by system_binary_path is a guess
+        // (we trust package.json + that the user ran their package manager).
+        // If the guess is wrong, this gives the user a clear message and
+        // recovery steps instead of a bare OS-level "no such file" error.
+        let (os, _) = zed::current_platform();
+        let mut env = worktree.shell_env();
+        env.push(("RIPPLE_LSP_BIN".into(), binary_path.clone()));
+        env.push(("RIPPLE_LSP_PKG".into(), PACKAGE_NAME.into()));
+
+        let cmd = match os {
+            zed::Os::Windows => zed::Command {
+                command: "cmd".into(),
+                args: vec![
+                    "/c".into(),
+                    "if exist \"%RIPPLE_LSP_BIN%\" ( \
+                       \"%RIPPLE_LSP_BIN%\" --stdio \
+                     ) else ( \
+                       echo [ripple-language-server] not found at \"%RIPPLE_LSP_BIN%\". \
+Run `pnpm install` (or `npm install`) in your project, \
+or remove \"%RIPPLE_LSP_PKG%\" from your dependencies to use the auto-installed version. 1>&2 \
+                       ^& exit /b 127 \
+                     )".into(),
+                ],
+                env,
+            },
+            _ => zed::Command {
+                command: "/bin/sh".into(),
+                args: vec![
+                    "-c".into(),
+                    "if [ -x \"$RIPPLE_LSP_BIN\" ]; then \
+                       exec \"$RIPPLE_LSP_BIN\" --stdio; \
+                     else \
+                       printf '%s\\n' \
+                         \"[ripple-language-server] not found at $RIPPLE_LSP_BIN. \
+Run \\`pnpm install\\` (or \\`npm install\\`) in your project, \
+or remove \\\"$RIPPLE_LSP_PKG\\\" from your dependencies to use the auto-installed version.\" >&2; \
+                       exit 127; \
+                     fi".into(),
+                ],
+                env,
+            },
+        };
+
+        Ok(cmd)
     }
 }
 

--- a/packages/zed-plugin/src/lib.rs
+++ b/packages/zed-plugin/src/lib.rs
@@ -275,7 +275,7 @@ impl zed::Extension for TsrxExtension {
                        echo [ripple-language-server] not found at \"%RIPPLE_LSP_BIN%\". \
 Run `pnpm install` (or `npm install`) in your project, \
 or remove \"%RIPPLE_LSP_PKG%\" from your dependencies to use the auto-installed version. 1>&2 \
-                       ^& exit /b 127 \
+                       & exit /b 127 \
                      )".into(),
                 ],
                 env,

--- a/packages/zed-plugin/src/lib.rs
+++ b/packages/zed-plugin/src/lib.rs
@@ -34,29 +34,43 @@ impl TsrxExtension {
 
     fn system_binary_path(worktree: &zed::Worktree) -> Option<PathBuf> {
         let (os, _) = zed::current_platform();
-        let candidates: &[&str] = match os {
-            zed::Os::Windows => &[
-                "ripple-language-server.cmd",
-                "ripple-language-server",
-                "node_modules/.bin/ripple-language-server.cmd",
-                "node_modules/.bin/ripple-language-server",
-            ],
-            _ => &[
-                "ripple-language-server",
-                "node_modules/.bin/ripple-language-server",
-            ],
+        let bin_name = match os {
+            zed::Os::Windows => "ripple-language-server.cmd",
+            _ => "ripple-language-server",
         };
 
-        for candidate in candidates {
-            if let Some(path) = worktree.which(candidate) {
-                let path_buf = PathBuf::from(path);
-                if fs::metadata(&path_buf).map_or(false, |stat| stat.is_file()) {
-                    return Some(path_buf);
-                }
+        let root_str = worktree.root_path();
+        eprintln!("[ripple-ext] worktree root: {}", root_str);
+        let root = PathBuf::from(&root_str);
+
+        // 1. Project-local: if the project's package.json declares
+        //    PACKAGE_NAME as a dep, npm/pnpm will have placed a bin wrapper at
+        //    node_modules/.bin/<bin_name>. We can't probe inside node_modules
+        //    via worktree.read_text_file (Zed excludes it from the indexed
+        //    worktree), so we read package.json instead and infer.
+        let needle = format!("\"{}\"", PACKAGE_NAME);
+        if let Ok(pkg_json) = worktree.read_text_file("package.json") {
+            if pkg_json.contains(&needle) {
+                let abs = root.join("node_modules").join(".bin").join(bin_name);
+                eprintln!("[ripple-ext] using project-local bin: {}", abs.display());
+                return Some(abs);
             }
+            eprintln!("[ripple-ext] package.json does not declare {}", PACKAGE_NAME);
+        } else {
+            eprintln!("[ripple-ext] no package.json at worktree root");
         }
 
-        None
+        // 2. PATH lookup (for global installs).
+        match worktree.which(bin_name) {
+            Some(path) => {
+                eprintln!("[ripple-ext] which({}) -> {}", bin_name, path);
+                Some(PathBuf::from(path))
+            }
+            None => {
+                eprintln!("[ripple-ext] which({}) -> None; falling back to npm install", bin_name);
+                None
+            }
+        }
     }
 
     fn install_language_server(

--- a/playground/react/package.json
+++ b/playground/react/package.json
@@ -16,6 +16,7 @@
     "react-dom": "catalog:default"
   },
   "devDependencies": {
+    "@ripple-ts/language-server": "workspace:*",
     "@tsrx/react": "workspace:*",
     "@tsrx/vite-plugin-react": "workspace:*",
     "@tsrx/typescript-plugin": "workspace:*",

--- a/playground/ripple/package.json
+++ b/playground/ripple/package.json
@@ -20,6 +20,7 @@
   "devDependencies": {
     "@tsrx/eslint-plugin": "workspace:*",
     "@tsrx/typescript-plugin": "workspace:*",
+    "@ripple-ts/language-server": "workspace:*",
     "@ripple-ts/vite-plugin": "workspace:*",
     "@typescript-eslint/parser": "catalog:default",
     "@tailwindcss/vite": "catalog:default",

--- a/playground/solid/package.json
+++ b/playground/solid/package.json
@@ -16,6 +16,7 @@
     "solid-js": "2.0.0-beta.7"
   },
   "devDependencies": {
+    "@ripple-ts/language-server": "workspace:*",
     "@tsrx/typescript-plugin": "workspace:*",
     "@tsrx/solid": "workspace:*",
     "@tsrx/vite-plugin-solid": "workspace:*",

--- a/playground/vue/package.json
+++ b/playground/vue/package.json
@@ -14,6 +14,7 @@
     "vue": "3.6.0-beta.8"
   },
   "devDependencies": {
+    "@ripple-ts/language-server": "workspace:*",
     "@tsrx/typescript-plugin": "workspace:*",
     "@tsrx/vue": "workspace:*",
     "typescript": "catalog:default",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1223,6 +1223,9 @@ importers:
         specifier: catalog:default
         version: 19.2.4(react@19.2.4)
     devDependencies:
+      '@ripple-ts/language-server':
+        specifier: workspace:*
+        version: link:../../packages/language-server
       '@tsrx/react':
         specifier: workspace:*
         version: link:../../packages/tsrx-react
@@ -1254,6 +1257,9 @@ importers:
         specifier: catalog:peer
         version: 4.2.1
     devDependencies:
+      '@ripple-ts/language-server':
+        specifier: workspace:*
+        version: link:../../packages/language-server
       '@ripple-ts/vite-plugin':
         specifier: workspace:*
         version: link:../../packages/vite-plugin
@@ -1297,6 +1303,9 @@ importers:
         specifier: 2.0.0-beta.7
         version: 2.0.0-beta.7
     devDependencies:
+      '@ripple-ts/language-server':
+        specifier: workspace:*
+        version: link:../../packages/language-server
       '@tsrx/solid':
         specifier: workspace:*
         version: link:../../packages/tsrx-solid
@@ -1322,6 +1331,9 @@ importers:
         specifier: 3.6.0-beta.8
         version: 3.6.0-beta.8(typescript@5.9.3)
     devDependencies:
+      '@ripple-ts/language-server':
+        specifier: workspace:*
+        version: link:../../packages/language-server
       '@tsrx/typescript-plugin':
         specifier: workspace:*
         version: link:../../packages/typescript-plugin

--- a/scripts/sync-zed-plugin-version.js
+++ b/scripts/sync-zed-plugin-version.js
@@ -1,0 +1,33 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const zedPluginPath = join(root, 'packages/zed-plugin/package.json');
+const lsPath = join(root, 'packages/language-server/package.json');
+
+const zedPlugin = JSON.parse(readFileSync(zedPluginPath, 'utf8'));
+const ls = JSON.parse(readFileSync(lsPath, 'utf8'));
+
+const keys = Object.keys(zedPlugin.config ?? {});
+if (keys.length !== 1) {
+	throw new Error(
+		`Expected exactly one entry under "config" in ${zedPluginPath}, got ${keys.length}`,
+	);
+}
+const pkgName = keys[0];
+if (pkgName !== ls.name) {
+	throw new Error(
+		`zed-plugin pins "${pkgName}" but language-server's name is "${ls.name}" — out of sync`,
+	);
+}
+
+const current = zedPlugin.config[pkgName];
+if (current === ls.version) {
+	console.log(`zed-plugin config.${pkgName} already at ${ls.version}, skipping`);
+	process.exit(0);
+}
+
+zedPlugin.config[pkgName] = ls.version;
+writeFileSync(zedPluginPath, JSON.stringify(zedPlugin, null, 2) + '\n');
+console.log(`zed-plugin config.${pkgName}: ${current} → ${ls.version}`);

--- a/templates/basic/package.json
+++ b/templates/basic/package.json
@@ -27,6 +27,7 @@
 		"@typescript-eslint/parser": "^8.20.0",
 		"vite": "^8.0.0 ",
 		"@ripple-ts/vite-plugin": "latest",
+		"@ripple-ts/language-server": "latest",
 		"@tsrx/typescript-plugin": "latest"
 	},
 	"dependencies": {


### PR DESCRIPTION
closes #1024 

and fixes a bunch of other issues.

- we now will bump up the language-server version in zed's package.json config field automatically to keep things in sync
- fixed issue with Zed to look and find the project's language-server first - useful for dev
- language-server was pointing to dist but dist wasn't published, also issues with bin, etc.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the Zed extension’s language-server discovery/launch behavior and the language-server package’s published entrypoints, which could break editor integration if paths or packaging are wrong across platforms.
> 
> **Overview**
> Fixes language-server packaging so the published npm artifact actually contains and exposes the runnable `ripple-language-server` binary from `dist` (moves the CLI entry to `src/language-server.js`, updates `tsdown` entries/externals, publishes only `dist`, and runs `tsdown` on `prepare`).
> 
> Updates the Zed extension to prefer a project-local language server (inferred from the opened project’s `package.json`), fall back to global PATH, and improve robustness by resolving the installed binary via the package’s `bin` field and wrapping execution with clearer missing-binary error messages.
> 
> Adds a `sync-zed-plugin-version.js` script that runs during `changeset:version` to keep the Zed plugin’s pinned `@ripple-ts/language-server` version in sync, bumps Zed plugin version to `0.0.85`, and wires the language-server as a dev dependency in the playgrounds/template for easier local development.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9cbaac82680f0ec931cf320fe99319a74e3f3c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->