### PR TITLE
update static text to use direct double quoted string in website folder

### DIFF
--- a/website/docs/examples.ts
+++ b/website/docs/examples.ts
@@ -278,7 +278,7 @@ export default component App() {
 component ListWithIndex({ items }) {
   <ul>
     for (const item of items; index i) {
-      <li>{\`\${i}: \${item}\`}</li>
+      <li>{i}": "{item}</li>
     }
   </ul>
 }

--- a/website/docs/examples.ts
+++ b/website/docs/examples.ts
@@ -230,9 +230,9 @@ export default component App() {
 		code: `component Truthy({ x }) {
   <div>
     if (x) {
-      <span>{'x is truthy'}</span>
+      <span>"x is truthy"</span>
     } else {
-      <span>{'x is falsy'}</span>
+      <span>"x is falsy"</span>
     }
   </div>
 }
@@ -307,7 +307,7 @@ export default component ErrorBoundary() {
     } catch (e) {
       reportError(e);
 
-      <div>{'An error occurred! ' + e.message}</div>
+      <div>"An error occurred! "{e.message}</div>
     }
   </div>
 }`,
@@ -412,9 +412,9 @@ export default component App() {
 	});
 
 	<div>
-		<button onClick={() => first++}>{'First: '}{first}</button>
-		<button onClick={() => second++}>{'Second: '}{second}</button>
-		<p>{'Total: '}{total}</p>
+		<button onClick={() => first++}>"First: "{first}</button>
+		<button onClick={() => second++}>"Second: "{second}</button>
+		<p>"Total: "{total}</p>
 	</div>
 }
 `,
@@ -596,10 +596,10 @@ export default component App() {
   let &[count] = track(0);
 
   const &[ double ] = createDouble([ count ]); // array
-  <p>{'Double: ' + double}</p>
+  <p>"Double: "{double}</p>
 
   const &{ quad } = createQuad({ count }); // object
-  <p>{'Quadruple: ' + quad}</p>
+  <p>"Quadruple: "{quad}</p>
 
 	<button onClick={() => { count++; }}>"Increment"</button>
 }
@@ -615,7 +615,7 @@ export default component App() {
   <Child swapMe={swapMeTracked} />
 
   <button onClick={() => swapMe = swapMe === Child1 ? Child2 : Child1}>
-		{'Swap Component'}
+		"Swap Component"
 	</button>
 }
 
@@ -624,11 +624,11 @@ component Child({ swapMe }: {swapMe: Tracked<Component>}) {
 }
 
 component Child1(props) {
-  <pre>{'I am child 1'}</pre>
+  <pre>"I am child 1"</pre>
 }
 
 component Child2(props) {
-  <pre>{'I am child 2'}</pre>
+  <pre>"I am child 2"</pre>
 }
 `,
 	},
@@ -646,8 +646,8 @@ export default component App() {
   const &[AnotherButton] = track(() => SomeButton);
 
   <@ripple_object.tracked_basic />
-  <Child {Button}>{'Child Button'}</Child>
-  <AnotherChild Button={AnotherButton}>{'Another Child Button'}</AnotherChild>
+  <Child {Button}>"Child Button"</Child>
+  <AnotherChild Button={AnotherButton}>"Another Child Button"</AnotherChild>
 }
 
 component Child({ Button, children }) {
@@ -665,7 +665,7 @@ component SomeButton({ children }) {
 }
 
 component basic() {
-  <div>{'Basic Component'}</div>
+  <div>"Basic Component"</div>
 }
 `,
 	},
@@ -693,8 +693,8 @@ export default component App() {
   let &[message] = track('');
 
   <div>
-		<p>{'Try resizing the window!'}</p>
-    <button onClick={() => message = 'Clicked!'}>{'Click me'}</button>
+		<p>"Try resizing the window!"</p>
+    <button onClick={() => message = 'Clicked!'}>"Click me"</button>
     <input onInput={(e) => message = e.target.value} />
     <p>{message}</p>
   </div>

--- a/website/docs/guide/bindings.md
+++ b/website/docs/guide/bindings.md
@@ -36,11 +36,11 @@ export component App() {
       placeholder="Enter your name"
     />
     <p>
-      {'Hello, '}
+      "Hello, "
       {name || 'stranger'}
-      {'!'}
+      "!"
     </p>
-    <button onClick={() => (name = '')}>{'Clear'}</button>
+    <button onClick={() => (name = '')}>"Clear"</button>
   </div>
 }
 ```
@@ -60,9 +60,9 @@ export component App() {
   <div>
     <input type="number" {ref bindValue(ageTracked)} min="0" max="120" />
     <p>
-      {'Age: '}
+      "Age: "
       {age}
-      {' years old'}
+      " years old"
     </p>
     <button onClick={() => (age = age + 1)}>"Increment"</button>
   </div>
@@ -83,13 +83,13 @@ export component App() {
 
   <div>
     <select {ref bindValue(selectedFruitTracked)}>
-      <option value="apple">{'Apple'}</option>
-      <option value="banana">{'Banana'}</option>
-      <option value="cherry">{'Cherry'}</option>
-      <option value="durian">{'Durian'}</option>
+      <option value="apple">"Apple"</option>
+      <option value="banana">"Banana"</option>
+      <option value="cherry">"Cherry"</option>
+      <option value="durian">"Durian"</option>
     </select>
     <p>
-      {'You selected: '}
+      "You selected: "
       {selectedFruit}
     </p>
   </div>
@@ -110,13 +110,13 @@ export component App() {
 
   <div>
     <select multiple {ref bindValue(selectedColorsTracked)} style="height: 100px">
-      <option value="red">{'Red'}</option>
-      <option value="green">{'Green'}</option>
-      <option value="blue">{'Blue'}</option>
-      <option value="yellow">{'Yellow'}</option>
+      <option value="red">"Red"</option>
+      <option value="green">"Green"</option>
+      <option value="blue">"Blue"</option>
+      <option value="yellow">"Yellow"</option>
     </select>
     <p>
-      {'Selected colors: '}
+      "Selected colors: "
       {selectedColors.join(', ')}
     </p>
   </div>
@@ -141,13 +141,13 @@ export component App() {
   <div>
     <label>
       <input type="checkbox" {ref bindChecked(agreedTracked)} />
-      {' I agree to the terms and conditions'}
+      " I agree to the terms and conditions"
     </label>
     <p>
-      {'Status: '}
+      "Status: "
       {agreed ? 'Agreed' : 'Not agreed'}
     </p>
-    <button disabled={!agreed}>{'Submit'}</button>
+    <button disabled={!agreed}>"Submit"</button>
   </div>
 }
 ```
@@ -185,14 +185,14 @@ export component App() {
         {ref bindChecked(checkedTracked)}
         {ref bindIndeterminate(indeterminateTracked)}
       />
-      {' Select All'}
+      " Select All"
     </label>
     <p>
-      {'Checked: '}
+      "Checked: "
       {checked ? 'Yes' : 'No'}
     </p>
     <p>
-      {'Indeterminate: '}
+      "Indeterminate: "
       {indeterminate ? 'Yes' : 'No'}
     </p>
     <button
@@ -203,7 +203,7 @@ export component App() {
         }
       }}
     >
-      {'Toggle Indeterminate'}
+      "Toggle Indeterminate"
     </button>
   </div>
 }
@@ -240,22 +240,22 @@ export component App() {
   <div>
     <label>
       <input type="checkbox" value="reading" {ref bindGroup(hobbiesTracked)} />
-      {' Reading'}
+      " Reading"
     </label>
     <label>
       <input type="checkbox" value="gaming" {ref bindGroup(hobbiesTracked)} />
-      {' Gaming'}
+      " Gaming"
     </label>
     <label>
       <input type="checkbox" value="sports" {ref bindGroup(hobbiesTracked)} />
-      {' Sports'}
+      " Sports"
     </label>
     <label>
       <input type="checkbox" value="cooking" {ref bindGroup(hobbiesTracked)} />
-      {' Cooking'}
+      " Cooking"
     </label>
     <p>
-      {'Selected: '}
+      "Selected: "
       {hobbies.join(', ') || 'none'}
     </p>
   </div>
@@ -279,20 +279,20 @@ export component App() {
   <div>
     <label>
       <input type="radio" name="size" value="small" {ref bindGroup(sizeTracked)} />
-      {' Small'}
+      " Small"
     </label>
     <label>
       <input type="radio" name="size" value="medium" {ref bindGroup(sizeTracked)} />
-      {' Medium'}
+      " Medium"
     </label>
     <label>
       <input type="radio" name="size" value="large" {ref bindGroup(sizeTracked)} />
-      {' Large'}
+      " Large"
     </label>
-    <p>{'Selected size: '}{size}</p>
+    <p>"Selected size: "{size}</p>
   </div>
 
-  <button onClick={() => size = 'medium'>{'Reset to "medium"'}</button>
+  <button onClick={() => size = 'medium'}>"Reset to \"medium\""</button>
 }
 ```
 
@@ -359,24 +359,24 @@ export component App() {
 
     <div>
       if (files && files.length > 0) {
-        <p>{'Selected files:'}</p>
+        <p>"Selected files:"</p>
         <ul>
           for (const file of Array.from(files)) {
             <li>
               {file.name}
-              {' ('}
+              " ("
               {file.size}
-              {' bytes)'}
+              " bytes)"
             </li>
           }
         </ul>
       } else {
-        <p>{'No files selected'}</p>
+        <p>"No files selected"</p>
       }
     </div>
 
-    <button onClick={clearFiles}>{'Clear files'}</button>
-    <button onClick={createSampleFile}>{'Add sample file'}</button>
+    <button onClick={clearFiles}>"Clear files"</button>
+    <button onClick={createSampleFile}>"Add sample file"</button>
   </div>
 }
 ```
@@ -429,16 +429,16 @@ export component App() {
         minHeight: '100px',
       }}
     >
-      {'Resize me! (drag bottom-right corner)'}
+      "Resize me! (drag bottom-right corner)"
       <p>
-        {'Client Width: '}
+        "Client Width: "
         {width}
-        {'px'}
+        "px"
       </p>
       <p>
-        {'Client Height: '}
+        "Client Height: "
         {height}
-        {'px'}
+        "px"
       </p>
     </div>
   </div>
@@ -471,17 +471,17 @@ export component App() {
         height: '150px',
       }}
     >
-      {'Box with borders'}
+      "Box with borders"
     </div>
     <p>
-      {'Offset Width: '}
+      "Offset Width: "
       {width}
-      {'px (includes borders)'}
+      "px (includes borders)"
     </p>
     <p>
-      {'Offset Height: '}
+      "Offset Height: "
       {height}
-      {'px (includes borders)'}
+      "px (includes borders)"
     </p>
   </div>
 }
@@ -515,7 +515,7 @@ export component App() {
         minHeight: '100px',
       }}
     >
-      {'Resize me!'}
+      "Resize me!"
     </div>
     <pre>{JSON.stringify(rect, null, 2)}</pre>
   </div>
@@ -546,15 +546,15 @@ export component App() {
         height: '100px',
       }}
     >
-      {'Content box size'}
+      "Content box size"
     </div>
     <pre>
-      {'Block size: '}
+      "Block size: "
       {size[0]?.blockSize || 0}
-      {'px\n'}
-      {'Inline size: '}
+      "px\n"
+      "Inline size: "
       {size[0]?.inlineSize || 0}
-      {'px'}
+      "px"
     </pre>
   </div>
 }
@@ -584,15 +584,15 @@ export component App() {
         height: '100px',
       }}
     >
-      {'Border box size'}
+      "Border box size"
     </div>
     <pre>
-      {'Block size: '}
+      "Block size: "
       {size[0]?.blockSize || 0}
-      {'px\n'}
-      {'Inline size: '}
+      "px\n"
+      "Inline size: "
       {size[0]?.inlineSize || 0}
-      {'px'}
+      "px"
     </pre>
   </div>
 }
@@ -622,15 +622,15 @@ export component App() {
         height: '80px',
       }}
     >
-      {'Device pixel content box'}
+      "Device pixel content box"
     </div>
     <pre>
-      {'Block size: '}
+      "Block size: "
       {size[0]?.blockSize || 0}
-      {'px\n'}
-      {'Inline size: '}
+      "px\n"
+      "Inline size: "
       {size[0]?.inlineSize || 0}
-      {'px'}
+      "px"
     </pre>
   </div>
 }
@@ -662,7 +662,7 @@ export component App() {
         minHeight: '50px',
       }}
     />
-    <p>{'Raw HTML:'}</p>
+    <p>"Raw HTML:"</p>
     <pre>{content}</pre>
   </div>
 }
@@ -692,7 +692,7 @@ export component App() {
         minHeight: '50px'
       }}
     />
-    <p>{'Text content: '}{text}</p>
+    <p>"Text content: "{text}</p>
   </div>
 }
 ```
@@ -722,7 +722,7 @@ export component App() {
         whiteSpace: 'pre-wrap'
       }}
     />
-    <p>{'Text content: '}{text}</p>
+    <p>"Text content: "{text}</p>
   </div>
 }
 ```
@@ -760,9 +760,9 @@ export component App() {
         outline: 'none',
       }}
     >
-      {'Click the button to focus this div'}
+      "Click the button to focus this div"
     </div>
-    <button onClick={handleFocus}>{'Focus Div'}</button>
+    <button onClick={handleFocus}>"Focus Div"</button>
   </div>
 }
 ```
@@ -799,9 +799,9 @@ export component App() {
       placeholder="Type something..."
       style="width: 300px"
     />
-    <p>{'Text: '}{text}</p>
-    <p>{'Width: '}{width}{'px'}</p></p>
-    <button onClick={logInfo}>{'Log Info'}</button>
+    <p>"Text: "{text}</p>
+    <p>"Width: "{width}"px"</p>
+    <button onClick={logInfo}>"Log Info"</button>
   </div>
 }
 ```

--- a/website/docs/guide/bindings.md
+++ b/website/docs/guide/bindings.md
@@ -292,7 +292,7 @@ export component App() {
     <p>"Selected size: "{size}</p>
   </div>
 
-  <button onClick={() => size = 'medium'}>"Reset to \"medium\""</button>
+  <button onClick={() => size = 'medium'}>"Reset to &quot;medium&quot;"</button>
 }
 ```
 
@@ -551,8 +551,9 @@ export component App() {
     <pre>
       "Block size: "
       {size[0]?.blockSize || 0}
-      "px
-      Inline size: "
+      "px"
+      <br />
+      "Inline size: "
       {size[0]?.inlineSize || 0}
       "px"
     </pre>
@@ -627,7 +628,8 @@ export component App() {
     <pre>
       "Block size: "
       {size[0]?.blockSize || 0}
-      "px\n"
+      "px"
+      <br />
       "Inline size: "
       {size[0]?.inlineSize || 0}
       "px"

--- a/website/docs/guide/bindings.md
+++ b/website/docs/guide/bindings.md
@@ -551,8 +551,8 @@ export component App() {
     <pre>
       "Block size: "
       {size[0]?.blockSize || 0}
-      "px\n"
-      "Inline size: "
+      "px
+      Inline size: "
       {size[0]?.inlineSize || 0}
       "px"
     </pre>
@@ -589,8 +589,8 @@ export component App() {
     <pre>
       "Block size: "
       {size[0]?.blockSize || 0}
-      "px\n"
-      "Inline size: "
+      "px
+      Inline size: "
       {size[0]?.inlineSize || 0}
       "px"
     </pre>

--- a/website/docs/guide/components.md
+++ b/website/docs/guide/components.md
@@ -77,7 +77,7 @@ component Composite({ PropComp }: { PropComp: Component }) {
 }
 
 component Separate() {
-  <p>{`I'm a separate component.`}</p>
+  <p>"I'm a separate component."</p>
 }
 
 export component App() {
@@ -168,7 +168,7 @@ component Outer({ children }: { children: Children }) {
 export component App() {
   <Outer>
     component HelloGreeting() {
-      <p>{'Hello from inside!'}</p>
+      <p>"Hello from inside!"</p>
     }
 
     // It can be passed as a prop to <Inner>, which is also in this scope
@@ -200,12 +200,12 @@ export component App() {
   // <Outer> component call.
   <Outer {Footer}>
     component Footer() {
-      <button>{'OK'}</button>
+      <button>"OK"</button>
     }
   </Outer>
 
   component Footer() {
-    <button>{'OK'}</button>
+    <button>"OK"</button>
   }
 
   <Outer {Footer} />

--- a/website/docs/guide/control-flow.md
+++ b/website/docs/guide/control-flow.md
@@ -232,7 +232,7 @@ export component ErrorBoundary() {
     } catch (e) {
       reportError(e);
 
-      <div>"An error occurred! " + e.message</div>
+      <div>"An error occurred! "{e.message}</div>
     }
   </div>
 }

--- a/website/docs/guide/control-flow.md
+++ b/website/docs/guide/control-flow.md
@@ -16,9 +16,9 @@ with.
 export component Truthy({ x }) {
   <div>
     if (x) {
-      <span>{'x is truthy'}</span>
+      <span>"x is truthy"</span>
     } else {
-      <span>{'x is falsy'}</span>
+      <span>"x is falsy"</span>
     }
   </div>
 }
@@ -40,12 +40,12 @@ export component AuthGate() {
   let &[is_logged_in] = track(false);
 
   if (!is_logged_in) {
-    <p>{'Please sign in.'}</p>
+    <p>"Please sign in."</p>
     return;
   }
 
-  <h1>{'Dashboard'}</h1>
-  <p>{'Private content'}</p>
+  <h1>"Dashboard"</h1>
+  <p>"Private content"</p>
 }
 ```
 
@@ -113,7 +113,7 @@ export component InteractiveStatus() {
         <p>"Error!"</p>
         break;
       default:
-        <p>{'Unknown status'}</p>
+        <p>"Unknown status"</p>
     }
   </div>
 }
@@ -160,7 +160,7 @@ index.
 for (const item of items; index i) {
   <div>
     {item.label}
-    {' at index '}
+    " at index "
     {i}
   </div>
 }
@@ -172,7 +172,7 @@ You can also provide a `key` for efficient list updates and reconciliation:
 for (const item of items; index i; key item.id) {
   <div>
     {item.label}
-    {' at index '}
+    " at index "
     {i}
   </div>
 }
@@ -199,12 +199,12 @@ export component Numbers() {
   for (const item of array; index i) {
     <div>
       {item}
-      {' at index '}
+      " at index "
       {i}
     </div>
   }
 
-  <button onClick={() => array.push(array.length + 1)}>{'Add Item'}</button>
+  <button onClick={() => array.push(array.length + 1)}>"Add Item"</button>
 }
 ```
 
@@ -232,7 +232,7 @@ export component ErrorBoundary() {
     } catch (e) {
       reportError(e);
 
-      <div>{'An error occurred! ' + e.message}</div>
+      <div>"An error occurred! " + e.message</div>
     }
   </div>
 }
@@ -265,7 +265,7 @@ until the promise resolves.
 ```ripple
 component UserProfile({ id }: { id: number }) {
   // Renders immediately
-  <h1>{'Loading profile...'}</h1>
+  <h1>"Loading profile..."</h1>
 
   // Suspends here until resolved
   const user = await fetchUser(id);
@@ -286,7 +286,7 @@ export component App() {
     <p>"Loading..."</p>
   } catch (e) {
     <p>
-      {'Error: '}
+      "Error: "
       {e.message}
     </p>
   }
@@ -318,7 +318,7 @@ export component CitySearch() {
 
   // Only renders once city has resolved for the current query
   <p>
-    {'Showing: '}
+    "Showing: "
     {query}
   </p>
   <CityCard {city} />

--- a/website/docs/guide/events.md
+++ b/website/docs/guide/events.md
@@ -34,7 +34,7 @@ export component EventExample() {
   let &[message] = track('');
 
   <div>
-    <button onClick={() => (message = 'Clicked!')}>{'Click me'}</button>
+    <button onClick={() => (message = 'Clicked!')}>"Click me"</button>
     <input onInput={(e) => (message = e.target.value)} />
     <p>{message}</p>
   </div>
@@ -65,7 +65,7 @@ property when using an object as an event handler.
     handleEvent: (e) => console.log('clicked!'),
   }}
 >
-  {'Click me'}
+  "Click me"
 </button>
 ```
 
@@ -89,7 +89,7 @@ export component EventExample() {
       capture: true,
     }}
   >
-    <button onClick={() => order.push('inner-bubble')}>{'Click'}</button>
+    <button onClick={() => order.push('inner-bubble')}>"Click"</button>
     <p>{order.join(' → ')}</p>
   </div>
 }
@@ -116,9 +116,9 @@ export component EventExample() {
       once: true,
     }}
   >
-    {'Click me (only works once)'}
+    "Click me (only works once)"
   </button>
-  <p>{`Clicks: ${count}`}</p>
+  <p>"Clicks: "{count}</p>
 }
 // Button only responds to the first click
 ```
@@ -144,7 +144,7 @@ default.
     passive: true,
   }}
 >
-  {'Scroll over me'}
+  "Scroll over me"
 </div>
 ```
 
@@ -183,7 +183,7 @@ export component EventExample() {
       delegated: false, // Attach listener directly to this button
     }}
   >
-    {'Click me'}
+    "Click me"
   </button>
 }
 ```
@@ -208,9 +208,9 @@ export component EventExample() {
       customName: 'MyCustomEvent',
     }}
   >
-    {'Custom event target'}
+    "Custom event target"
   </div>
-  <p>{`Event count: ${count}`}</p>
+  <p>"Event count: "{count}</p>
 }
 // The element listens for 'MyCustomEvent' instead of 'mycustomevent'
 ```

--- a/website/docs/guide/head-management.md
+++ b/website/docs/guide/head-management.md
@@ -14,7 +14,7 @@ export component App() {
   let &[curr_step] = track(0);
 
   <head>
-    <title>{`Step ${curr_step}`}</title>
+    <title>"Step "{curr_step}</title>
   </head>
 
   <button
@@ -22,7 +22,7 @@ export component App() {
       curr_step++;
     }}
   >
-    {'Next Step'}
+    "Next Step"
   </button>
 }
 ```

--- a/website/docs/guide/reactivity.md
+++ b/website/docs/guide/reactivity.md
@@ -194,7 +194,7 @@ reactivity:
 component Child(&{ count, className, children }: Props) {
   // count, className, children are lazily read from the props object
   <button class={className}>{children}</button>
-  <pre>{`Count is: ${count}`}</pre>
+  <pre>"Count is: "{count}"</pre>
 }
 ```
 
@@ -244,7 +244,7 @@ export component App() {
 
   const &[double] = createDouble(countTracked);
 
-  <div>{'Double: ' + double}</div>
+  <div>"Double: "{double}</div>
   <button
     onClick={() => {
       count++;
@@ -282,7 +282,7 @@ export component App() {
   <Child swapMe={swapMeTracked} />
 
   <button onClick={() => (swapMe = swapMe === Child1 ? Child2 : Child1)}>
-    {'Swap Component'}
+    "Swap Component"
   </button>
 }
 
@@ -291,11 +291,11 @@ component Child(&{ swapMe }: { swapMe: Tracked<Component> }) {
 }
 
 component Child1(props) {
-  <pre>{'I am child 1'}</pre>
+  <pre>"I am child 1"</pre>
 }
 
 component Child2(props) {
-  <pre>{'I am child 2'}</pre>
+  <pre>"I am child 2"</pre>
 }
 ```
 
@@ -448,13 +448,13 @@ export component App() {
 
   <div>
     <p>
-      {'Length: '}
+      "Length: "
       {items.length}
     </p> // Reactive length
     for (const item of items) {
       <div>{item}</div>
     }
-    <button onClick={() => items.push(items.length + 1)}>{'Add'}</button>
+    <button onClick={() => items.push(items.length + 1)}>"Add"</button>
   </div>
 }
 ```
@@ -486,11 +486,11 @@ export component App() {
   obj.a = 0;
 
   <pre>
-    {'obj.a is: '}
+    "obj.a is: "
     {obj.a}
   </pre>
   <pre>
-    {'obj.b is: '}
+    "obj.b is: "
     {obj.b}
   </pre>
   <button
@@ -531,19 +531,19 @@ export component App() {
 
   // direct usage
   <p>
-    {'Direct usage: set contains 2: '}
+    "Direct usage: set contains 2: "
     {set.has(2)}
   </p>
 
   // reactive assignment
   let &[has] = track(() => set.has(2));
   <p>
-    {'Assigned usage: set contains 2: '}
+    "Assigned usage: set contains 2: "
     {has}
   </p>
 
-  <button onClick={() => set.delete(2)}>{'Delete 2'}</button>
-  <button onClick={() => set.add(2)}>{'Add 2'}</button>
+  <button onClick={() => set.delete(2)}>"Delete 2"</button>
+  <button onClick={() => set.add(2)}>"Add 2"</button>
 }
 ```
 
@@ -573,19 +573,19 @@ export component App() {
 
   // direct usage
   <p>
-    {'Direct usage: map has an item with key 2: '}
+    "Direct usage: map has an item with key 2: "
     {map.has(2)}
   </p>
 
   // reactive assignment
   let &[has] = track(() => map.has(2));
   <p>
-    {'Assigned usage: map has an item with key 2: '}
+    "Assigned usage: map has an item with key 2: "
     {has}
   </p>
 
-  <button onClick={() => map.delete(2)}>{'Delete item with key 2'}</button>
-  <button onClick={() => map.set(2, 2)}>{'Add key 2 with value 2'}</button>
+  <button onClick={() => map.delete(2)}>"Delete item with key 2"</button>
+  <button onClick={() => map.set(2, 2)}>"Add key 2 with value 2"</button>
 }
 ```
 
@@ -617,11 +617,11 @@ export component App() {
 
   // direct usage
   <p>
-    {'Direct usage: Current year is '}
+    "Direct usage: Current year is "
     {date.getFullYear()}
   </p>
   <p>
-    {'ISO String: '}
+    "ISO String: "
     {date.toISOString()}
   </p>
 
@@ -629,14 +629,14 @@ export component App() {
   let &[year] = track(() => date.getFullYear());
   let &[month] = track(() => date.getMonth());
   <p>
-    {'Assigned usage: Year '}
+    "Assigned usage: Year "
     {year}
-    {', Month '}
+    ", Month "
     {month}
   </p>
 
-  <button onClick={() => date.setFullYear(2026)}>{'Change to 2026'}</button>
-  <button onClick={() => date.setMonth(11)}>{'Change to December'}</button>
+  <button onClick={() => date.setFullYear(2026)}>"Change to 2026"</button>
+  <button onClick={() => date.setMonth(11)}>"Change to December"</button>
 }
 ```
 

--- a/website/docs/guide/reactivity.md
+++ b/website/docs/guide/reactivity.md
@@ -194,7 +194,7 @@ reactivity:
 component Child(&{ count, className, children }: Props) {
   // count, className, children are lazily read from the props object
   <button class={className}>{children}</button>
-  <pre>"Count is: "{count}"</pre>
+  <pre>"Count is: "{count}</pre>
 }
 ```
 

--- a/website/docs/guide/state-management.md
+++ b/website/docs/guide/state-management.md
@@ -50,16 +50,16 @@ export component App() {
       count2++;
     }}
   >
-    {'Click Me'}
+    "Click Me"
   </button>
 
   // context's reactive property count gets updated
   <pre>
-    {'Context: '}
+    "Context: "
     {count}
   </pre>
   <pre>
-    {'Context2: '}
+    "Context2: "
     {count2}
   </pre>
 }

--- a/website/docs/guide/styling.md
+++ b/website/docs/guide/styling.md
@@ -128,9 +128,9 @@ export component App() {
 component Child() {
   // The div should have its font-size at 2rem from parent
   <div>
-    <h2 class="header">{'This is a header with font-size 3rem'}</h2>
-    <span class="highlight">{'This will be red and bold'}</span>
-    <p class="nested">{'This will have left margin'}</p>
+    <h2 class="header">"This is a header with font-size 3rem"</h2>
+    <span class="highlight">"This will be red and bold"</span>
+    <p class="nested">"This will have left margin"</p>
   </div>
 }
 ```
@@ -178,7 +178,7 @@ export component App() {
 }
 
 component Child() {
-  <div class="child">{'Child content'}</div>
+  <div class="child">"Child content"</div>
 
   <style>
     .child {
@@ -204,7 +204,7 @@ elements via the `class` attribute.
 
 ```ripple
 component Child({ className }: { className: string }) {
-  <div class={className}>{'styled child'}</div>
+  <div class={className}>"styled child"</div>
 }
 
 component Parent() {
@@ -222,8 +222,8 @@ You can pass multiple classes:
 
 ```ripple
 component Child({ primary, secondary }: { primary: string; secondary: string }) {
-  <div class={primary}>{'primary'}</div>
-  <span class={secondary}>{'secondary'}</span>
+  <div class={primary}>"primary"</div>
+  <span class={secondary}>"secondary"</span>
 }
 
 component Parent() {
@@ -248,7 +248,7 @@ component Parent() {
 import { track } from 'ripple';
 
 component Child({ cls }: { cls: string }) {
-  <span class={cls}>{'text'}</span>
+  <span class={cls}>"text"</span>
 }
 
 component Parent() {
@@ -270,7 +270,7 @@ scoped classes:
 
 ```ripple
 component Card({ className }: { className?: string }) {
-  <div class={['card-base', className ?? '']}>{'card content'}</div>
+  <div class={['card-base', className ?? '']}>"card content"</div>
 
   <style>
     .card-base {

--- a/website/docs/guide/syntax.md
+++ b/website/docs/guide/syntax.md
@@ -39,14 +39,14 @@ hatch when you need to store, return, or pass JSX as a value.
 
 ```ripple
 // ❌ Wrong - Plain templates outside the component
-const element = <div>{"Hello"}</div>;  // Compilation error
+const element = <div>"Hello"</div>;  // Compilation error
 
 function regularFunction() {
-	return <span>{"Not allowed"}</span>;  // Compilation error
+	return <span>"Not allowed"</span>;  // Compilation error
 }
 
 const myTemplate = (
-	<div>{"Cannot assign JSX"}</div>  // Compilation error
+	<div>"Cannot assign JSX"</div>  // Compilation error
 );
 
 // ✅ Correct - Templates only inside components
@@ -82,7 +82,7 @@ variable, return it from a helper, or pass it directly as a prop or child.
 component App() {
   const title = <tsx>
     <span class="title">
-      {'Settings'}
+      "Settings"
     </span>
   </tsx>;
 
@@ -114,12 +114,12 @@ component App() {
   <Card
     title={<tsx>
       <span>
-        {'Settings'}
+        "Settings"
       </span>
     </tsx>}
     children={<tsx>
       <p>
-        {'Card body'}
+        "Card body"
       </p>
     </tsx>}
   />
@@ -143,7 +143,7 @@ condition is met.
 ```ripple
 component Profile({ user }) {
   if (!user) {
-    <p>{'Please sign in to continue.'}</p>
+    <p>"Please sign in to continue."</p>
     return;
   }
 

--- a/website/docs/introduction.md
+++ b/website/docs/introduction.md
@@ -30,14 +30,14 @@ import { track } from 'ripple';
 
 export component App() {
   <div class="container">
-    <h1>{'Welcome to Ripple!'}</h1>
+   <h1>"Welcome to Ripple!"</h1>
 
     <div>
       let &[count] = track(0);
 
-      <button onClick={() => count--}>{'-'}</button>
+      <button onClick={() => count--}>"-"</button>
       <span class="count">{count}</span>
-      <button onClick={() => count++}>{'+'}</button>
+      <button onClick={() => count++}>"+"</button>
     </div>
   </div>
 

--- a/website/docs/introduction.md
+++ b/website/docs/introduction.md
@@ -30,7 +30,7 @@ import { track } from 'ripple';
 
 export component App() {
   <div class="container">
-   <h1>"Welcome to Ripple!"</h1>
+    <h1>"Welcome to Ripple!"</h1>
 
     <div>
       let &[count] = track(0);

--- a/website/public/index.html
+++ b/website/public/index.html
@@ -965,46 +965,45 @@
 			<script>
 				// Typewriter effect for the code editor
 				const codeContent = `<span class="line-number"> 1</span> <span class="export-keyword">import</span> <span class="brace">{</span> <span class="property">Button</span> <span class="brace">}</span> <span class="export-keyword">from</span> <span class="string">'./Button.tsrx'</span>;
-<span class="line-number"> 2</span>
-<span class="line-number"> 3</span> <span class="export-keyword">export</span> <span class="keyword">component</span> <span class="function">TodoList</span><span class="brace">(</span><span class="brace">{</span> <span class="property">todos</span>, <span class="property">addTodo</span> <span class="brace">}</span>: <span class="component">Props</span><span class="brace">)</span> <span class="brace">{</span>
-<span class="line-number"> 4</span>   <span class="bracket">&lt;</span><span class="tag">div</span> <span class="attribute">class</span>=<span class="string">"container"</span><span class="bracket">&gt;</span>
-<span class="line-number"> 5</span>     <span class="bracket">&lt;</span><span class="tag">h2</span><span class="bracket">&gt;</span><span class="template-brace">{</span><span class="string">"Todo List"</span><span class="template-brace">}</span><span class="bracket">&lt;/</span><span class="tag">h2</span><span class="bracket">&gt;</span>
-<span class="line-number"> 6</span>     <span class="bracket">&lt;</span><span class="tag">ul</span><span class="bracket">&gt;</span>
-<span class="line-number"> 7</span>       <span class="control-keyword">for</span> <span class="brace">(</span><span class="keyword">const</span> <span class="property">todo</span> <span class="keyword">of</span> <span class="ripple-syntax">todos</span><span class="brace">)</span> <span class="block-brace">{</span>
-<span class="line-number"> 8</span>         <span class="bracket">&lt;</span><span class="tag">li</span><span class="bracket">&gt;</span><span class="template-brace">{</span><span class="property">todo.text</span><span class="template-brace">}</span><span class="bracket">&lt;/</span><span class="tag">li</span><span class="bracket">&gt;</span>
-<span class="line-number"> 9</span>       <span class="block-brace">}</span>
-<span class="line-number">10</span>     <span class="bracket">&lt;/</span><span class="tag">ul</span><span class="bracket">&gt;</span>
-<span class="line-number">11</span>
-<span class="line-number">12</span>     <span class="control-keyword">if</span> <span class="brace">(</span><span class="ripple-syntax">todos</span>.<span class="property">length</span> <span class="keyword">&gt;</span> <span class="value">0</span><span class="brace">)</span> <span class="block-brace">{</span>
-<span class="line-number">13</span>       <span class="bracket">&lt;</span><span class="tag">p</span><span class="bracket">&gt;</span><span class="template-brace">{</span><span class="ripple-syntax">todos</span>.<span class="property">length</span><span class="template-brace">}</span><span class="template-brace">{</span><span class="string">" items"</span><span class="template-brace">}</span><span class="bracket">&lt;/</span><span class="tag">p</span><span class="bracket">&gt;</span>
-<span class="line-number">14</span>     <span class="block-brace">}</span>
-<span class="line-number">15</span>
-<span class="line-number">16</span>     <span class="bracket">&lt;</span><span class="component">Button</span> <span class="attribute">onClick</span>=<span class="template-brace">{</span><span class="property">addTodo</span><span class="template-brace">}</span> <span class="attribute">label</span>=<span class="template-brace">{</span><span class="string">"Add Todo"</span><span class="template-brace">}</span> <span class="bracket">/&gt;</span>
-<span class="line-number">17</span>   <span class="bracket">&lt;/</span><span class="tag">div</span><span class="bracket">&gt;</span>
-<span class="line-number">18</span>
-<span class="line-number">19</span>   <span class="bracket">&lt;</span><span class="tag">style</span><span class="bracket">&gt;</span>
-<span class="line-number">20</span>     <span class="css-selector">.container</span> <span class="css-brace">{</span>
-<span class="line-number">21</span>       <span class="attribute">text-align</span>: <span class="value">center</span>;
-<span class="line-number">22</span>       <span class="attribute">font-family</span>: <span class="string">"Arial"</span>, <span class="value">sans-serif</span>;
-<span class="line-number">23</span>     <span class="css-brace">}</span>
-<span class="line-number">24</span>   <span class="bracket">&lt;/</span><span class="tag">style</span><span class="bracket">&gt;</span>
-<span class="line-number">25</span> <span class="brace">}</span>
-<span class="line-number">26</span>
-<span class="line-number">27</span> <span class="export-keyword">import</span> <span class="brace">{</span> <span class="property">track</span> <span class="brace">}</span> <span class="export-keyword">from</span> <span class="string">'ripple'</span>;
-<span class="line-number">28</span>
-<span class="line-number">29</span> <span class="export-keyword">export</span> <span class="keyword">component</span> <span class="function">Counter</span><span class="brace">()</span> <span class="brace">{</span>
-<span class="line-number">30</span>   <span class="keyword">let</span> <span class="ripple-syntax">&amp;</span><span class="brace">[</span><span class="property">count</span><span class="brace">]</span> <span class="operator">=</span> <span class="function">track</span><span class="brace">(</span><span class="value">0</span><span class="brace">)</span>;
-<span class="line-number">31</span>   <span class="keyword">let</span> <span class="ripple-syntax">&amp;</span><span class="brace">[</span><span class="property">double</span><span class="brace">]</span> <span class="operator">=</span> <span class="function">track</span><span class="brace">(</span><span class="brace">()</span> <span class="operator">=&gt;</span> <span class="property">count</span> <span class="operator">*</span> <span class="value">2</span><span class="brace">)</span>;
-<span class="line-number">32</span>
-<span class="line-number">33</span>   <span class="bracket">&lt;</span><span class="tag">div</span> <span class="attribute">class</span>=<span class="string">"counter"</span><span class="bracket">&gt;</span>
-<span class="line-number">34</span>     <span class="bracket">&lt;</span><span class="tag">h2</span><span class="bracket">&gt;</span><span class="template-brace">{</span><span class="string">"Counter"</span><span class="template-brace">}</span><span class="bracket">&lt;/</span><span class="tag">h2</span><span class="bracket">&gt;</span>
-<span class="line-number">35</span>     <span class="bracket">&lt;</span><span class="tag">p</span><span class="bracket">&gt;</span><span class="template-brace">{</span><span class="string">"Count: "</span><span class="template-brace">}</span><span class="template-brace">{</span><span class="property">count</span><span class="template-brace">}</span><span class="bracket">&lt;/</span><span class="tag">p</span><span class="bracket">&gt;</span>
-<span class="line-number">36</span>     <span class="bracket">&lt;</span><span class="tag">p</span><span class="bracket">&gt;</span><span class="template-brace">{</span><span class="string">"Double: "</span><span class="template-brace">}</span><span class="template-brace">{</span><span class="property">double</span><span class="template-brace">}</span><span class="bracket">&lt;/</span><span class="tag">p</span><span class="bracket">&gt;</span>
-<span class="line-number">37</span>
-<span class="line-number">38</span>     <span class="bracket">&lt;</span><span class="component">Button</span> <span class="attribute">onClick</span>=<span class="template-brace">{</span><span class="brace">()</span> <span class="operator">=&gt;</span> <span class="property">count</span><span class="operator">++</span><span class="template-brace">}</span> <span class="attribute">label</span>=<span class="template-brace">{</span><span class="string">"Increment"</span><span class="template-brace">}</span> <span class="bracket">/&gt;</span>
-<span class="line-number">39</span>     <span class="bracket">&lt;</span><span class="component">Button</span> <span class="attribute">onClick</span>=<span class="template-brace">{</span><span class="brace">()</span> <span class="operator">=&gt;</span> <span class="property">count</span> <span class="operator">=</span> <span class="value">0</span><span class="template-brace">}</span> <span class="attribute">label</span>=<span class="template-brace">{</span><span class="string">"Reset"</span><span class="template-brace">}</span> <span class="bracket">/&gt;</span>
-<span class="line-number">40</span>   <span class="bracket">&lt;/</span><span class="tag">div</span><span class="bracket">&gt;</span>
-<span class="line-number">41</span> <span class="brace">}</span>`;
+<span class="line-number"> 2</span> <span class="export-keyword">import</span> <span class="brace">{</span> <span class="property">track</span> <span class="brace">}</span> <span class="export-keyword">from</span> <span class="string">'ripple'</span>;
+<span class="line-number"> 3</span>
+<span class="line-number"> 4</span> <span class="export-keyword">export</span> <span class="keyword">component</span> <span class="function">TodoList</span><span class="brace">(</span><span class="brace">{</span> <span class="property">todos</span>, <span class="property">addTodo</span> <span class="brace">}</span>: <span class="component">Props</span><span class="brace">)</span> <span class="brace">{</span>
+<span class="line-number"> 5</span>   <span class="bracket">&lt;</span><span class="tag">div</span> <span class="attribute">class</span>=<span class="string">"container"</span><span class="bracket">&gt;</span>
+<span class="line-number"> 6</span>     <span class="bracket">&lt;</span><span class="tag">h2</span><span class="bracket">&gt;</span><span class="string">"Todo List"</span><span class="bracket">&lt;/</span><span class="tag">h2</span><span class="bracket">&gt;</span>
+<span class="line-number"> 7</span>     <span class="bracket">&lt;</span><span class="tag">ul</span><span class="bracket">&gt;</span>
+<span class="line-number"> 8</span>       <span class="control-keyword">for</span> <span class="brace">(</span><span class="keyword">const</span> <span class="property">todo</span> <span class="keyword">of</span> <span class="ripple-syntax">todos</span><span class="brace">)</span> <span class="block-brace">{</span>
+<span class="line-number"> 9</span>         <span class="bracket">&lt;</span><span class="tag">li</span><span class="bracket">&gt;</span><span class="template-brace">{</span><span class="property">todo.text</span><span class="template-brace">}</span><span class="bracket">&lt;/</span><span class="tag">li</span><span class="bracket">&gt;</span>
+<span class="line-number">10</span>       <span class="block-brace">}</span>
+<span class="line-number">11</span>     <span class="bracket">&lt;/</span><span class="tag">ul</span><span class="bracket">&gt;</span>
+<span class="line-number">12</span>
+<span class="line-number">13</span>     <span class="control-keyword">if</span> <span class="brace">(</span><span class="ripple-syntax">todos</span>.<span class="property">length</span> <span class="keyword">&gt;</span> <span class="value">0</span><span class="brace">)</span> <span class="block-brace">{</span>
+<span class="line-number">14</span>       <span class="bracket">&lt;</span><span class="tag">p</span><span class="bracket">&gt;</span><span class="template-brace">{</span><span class="ripple-syntax">todos</span>.<span class="property">length</span><span class="template-brace">}</span><span class="string">" items"</span><span class="bracket">&lt;/</span><span class="tag">p</span><span class="bracket">&gt;</span>
+<span class="line-number">15</span>     <span class="block-brace">}</span>
+<span class="line-number">16</span>
+<span class="line-number">17</span>     <span class="bracket">&lt;</span><span class="component">Button</span> <span class="attribute">onClick</span>=<span class="template-brace">{</span><span class="property">addTodo</span><span class="template-brace">}</span> <span class="attribute">label</span>=<span class="string">"Add Todo"</span> <span class="bracket">/&gt;</span>
+<span class="line-number">18</span>   <span class="bracket">&lt;/</span><span class="tag">div</span><span class="bracket">&gt;</span>
+<span class="line-number">19</span>
+<span class="line-number">20</span>   <span class="bracket">&lt;</span><span class="tag">style</span><span class="bracket">&gt;</span>
+<span class="line-number">21</span>     <span class="css-selector">.container</span> <span class="css-brace">{</span>
+<span class="line-number">22</span>       <span class="attribute">text-align</span>: <span class="value">center</span>;
+<span class="line-number">23</span>       <span class="attribute">font-family</span>: <span class="string">"Arial"</span>, <span class="value">sans-serif</span>;
+<span class="line-number">24</span>     <span class="css-brace">}</span>
+<span class="line-number">25</span>   <span class="bracket">&lt;/</span><span class="tag">style</span><span class="bracket">&gt;</span>
+<span class="line-number">26</span> <span class="brace">}</span>
+<span class="line-number">27</span>
+<span class="line-number">28</span> <span class="export-keyword">export</span> <span class="keyword">component</span> <span class="function">Counter</span><span class="brace">()</span> <span class="brace">{</span>
+<span class="line-number">29</span>   <span class="keyword">let</span> <span class="ripple-syntax">&amp;</span><span class="brace">[</span><span class="property">count</span><span class="brace">]</span> <span class="operator">=</span> <span class="function">track</span><span class="brace">(</span><span class="value">0</span><span class="brace">)</span>;
+<span class="line-number">30</span>   <span class="keyword">let</span> <span class="ripple-syntax">&amp;</span><span class="brace">[</span><span class="property">double</span><span class="brace">]</span> <span class="operator">=</span> <span class="function">track</span><span class="brace">(</span><span class="brace">()</span> <span class="operator">=&gt;</span> <span class="property">count</span> <span class="operator">*</span> <span class="value">2</span><span class="brace">)</span>;
+<span class="line-number">31</span>
+<span class="line-number">32</span>   <span class="bracket">&lt;</span><span class="tag">div</span> <span class="attribute">class</span>=<span class="string">"counter"</span><span class="bracket">&gt;</span>
+<span class="line-number">33</span>     <span class="bracket">&lt;</span><span class="tag">h2</span><span class="bracket">&gt;</span><span class="string">"Counter"</span><span class="bracket">&lt;/</span><span class="tag">h2</span><span class="bracket">&gt;</span>
+<span class="line-number">34</span>     <span class="bracket">&lt;</span><span class="tag">p</span><span class="bracket">&gt;</span><span class="string">"Count: "</span><span class="template-brace">{</span><span class="property">count</span><span class="template-brace">}</span><span class="bracket">&lt;/</span><span class="tag">p</span><span class="bracket">&gt;</span>
+<span class="line-number">35</span>     <span class="bracket">&lt;</span><span class="tag">p</span><span class="bracket">&gt;</span><span class="string">"Double: "</span><span class="template-brace">{</span><span class="property">double</span><span class="template-brace">}</span><span class="bracket">&lt;/</span><span class="tag">p</span><span class="bracket">&gt;</span>
+<span class="line-number">36</span>
+<span class="line-number">37</span>     <span class="bracket">&lt;</span><span class="component">Button</span> <span class="attribute">onClick</span>=<span class="template-brace">{</span><span class="brace">()</span> <span class="operator">=&gt;</span> <span class="property">count</span><span class="operator">++</span><span class="template-brace">}</span> <span class="attribute">label</span>=<span class="string">"Increment"</span> <span class="bracket">/&gt;</span>
+<span class="line-number">38</span>     <span class="bracket">&lt;</span><span class="component">Button</span> <span class="attribute">onClick</span>=<span class="template-brace">{</span><span class="brace">()</span> <span class="operator">=&gt;</span> <span class="property">count</span> <span class="operator">=</span> <span class="value">0</span><span class="template-brace">}</span> <span class="attribute">label</span>=<span class="string">"Reset"</span> <span class="bracket">/&gt;</span>
+<span class="line-number">39</span>   <span class="bracket">&lt;/</span><span class="tag">div</span><span class="bracket">&gt;</span>
+<span class="line-number">40</span> <span class="brace">}</span>`;
 
 				function typeWriter() {
 					const element = document.getElementById('typewriter-code');

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -1537,9 +1537,9 @@ explicit:
 ```ripple
 export component Frame({ children }) {
 	<div class="frame">
-		{text 'before"
+		{text 'before'}
 		{children}
-		{text 'after"
+		{text 'after'}
 	</div>
 }
 ```

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -61,7 +61,7 @@ expressions must be wrapped in curly braces `{}`.
 <p>"Use &quot; for a quote and &amp; for an ampersand"</p>
 
 // ✅ CORRECT - JavaScript strings in expressions
-<div>{"Hello World"}</div>
+<div>{'Hello World'}</div>
 <p>{"This works correctly"}</p>
 
 // ✅ CORRECT - Variables and expressions
@@ -85,14 +85,14 @@ closing quote.
 
 ```ripple
 // ❌ WRONG - Templates outside component
-const element = <div>{"Hello"}</div>;  // Compilation error
+const element = <div>"Hello"</div>;  // Compilation error
 
 function regularFunction() {
-  return <span>{"Not allowed"}</span>;  // Compilation error
+  return <span>"Not allowed"</span>;  // Compilation error
 }
 
 const myTemplate = (
-  <div>{"Cannot assign JSX"}</div>  // Compilation error
+  <div>"Cannot assign JSX"</div>  // Compilation error
 );
 
 // ✅ CORRECT - Templates only inside components
@@ -188,17 +188,17 @@ component App() {
 // ✅ CORRECT - Guard clause with early return
 component AuthGate({ is_logged_in }) {
   if (!is_logged_in) {
-    <p>{'Please sign in.'}</p>
+    <p>"Please sign in."</p>
     return;
   }
 
-  <h1>{'Dashboard'}</h1>
+  <h1>"Dashboard"</h1>
 }
 
 // ❌ WRONG - Returning templates from components
 component App() {
   if (loading) {
-    return <p>{'Loading...'}</p>;  // Compilation error
+    return <p>"Loading..."</p>;  // Compilation error
   }
 }
 
@@ -240,10 +240,10 @@ component TemplateScope() {
     const isEven = count % 2 === 0;
 
     <h1>{message}</h1>
-    <p>{"Count is: "}{count}</p>
+    <p>"Count is: "{count}</p>
 
     if (isEven) {
-      <span>{"Count is even"}</span>
+      <span>"Count is even"</span>
     }
 
     // Nested scopes work too
@@ -432,7 +432,7 @@ const &{ a, ...rest } = props;
 component Child(&{ count, className, children }: Props) {
   // count, className, children are lazily read from __props
   <button class={className}>{children}</button>
-  <pre>{`Count is: ${count}`}</pre>
+  <pre>"Count is: "{count}</pre>
 }
 ```
 
@@ -493,7 +493,7 @@ export component App() {
 
   <Child swapMe={swapMeTracked} />
 
-  <button onClick={() => swapMe = swapMe === Child1 ? Child2 : Child1}>{'Swap Component'}</button>
+  <button onClick={() => swapMe = swapMe === Child1 ? Child2 : Child1}>"Swap Component"</button>
 }
 
 component Child(&{ swapMe }: {swapMe: Tracked<Component>}) {
@@ -501,11 +501,11 @@ component Child(&{ swapMe }: {swapMe: Tracked<Component>}) {
 }
 
 component Child1(props) {
-  <pre>{'I am child 1'}</pre>
+  <pre>"I am child 1"</pre>
 }
 
 component Child2(props) {
-  <pre>{'I am child 2'}</pre>
+  <pre>"I am child 2"</pre>
 }
 ```
 
@@ -523,9 +523,9 @@ component Child2(props) {
 component Conditional({ isVisible }) {
   <div>
     if (isVisible) {
-      <span>{"Visible content"}</span>
+      <span>"Visible content"</span>
     } else {
-      <span>{"Hidden state"}</span>
+      <span>"Hidden state"</span>
     }
   </div>
 }
@@ -555,10 +555,10 @@ component StatusIndicator({ status }) {
       <p>"Success!"</p>
       break;
     case 'error':
-      <p>{'Error!'}</p>
+      <p>"Error!"</p>
       break;
     default:
-      <p>{'Unknown status'}</p>
+      <p>"Unknown status"</p>
       // No break needed for default
   }
 }
@@ -572,25 +572,25 @@ import { track } from 'ripple';
 component InteractiveStatus() {
   let &[status] = track('loading'); // Reactive state
 
-  <button onClick={() => status = 'success'>{'Set to Success'}</button>
-  <button onClick={() => status = 'error'}>{'Set to Error'}</button>
+  <button onClick={() => status = 'success'}>"Set to Success"</button>
+  <button onClick={() => status = 'error'}>"Set to Error"</button>
 
   // This switch block will update automatically when 'status' changes
   switch (status) {
 		case 'init':
-			<p>{'Status: Init'}</p>
+			<p>"Status: Init"</p>
 			// fall-through to the next
     case 'loading':
-      <p>{'Status: Loading...'}</p>
+      <p>"Status: Loading..."</p>
       break;
     case 'success':
-      <p>{'Status: Success!'}</p>
+      <p>"Status: Success!"</p>
       break;
     case 'error':
-      <p>{'Status: Error!'}</p>
+      <p>"Status: Error!"</p>
       break;
     default:
-      <p>{'Status: Unknown'}</p>
+      <p>"Status: Unknown"</p>
   }
 }
 ```
@@ -612,7 +612,7 @@ component ListView({ title, items }) {
   <h2>{title}</h2>
   <ul>
     for (const item of items; index i) {
-      <li>{item.text}{' at index '}{i}</li>
+      <li>{item.text}" at index "{i}</li>
     }
   </ul>
 }
@@ -624,7 +624,7 @@ component ListView({ title, items }) {
   <h2>{title}</h2>
   <ul>
     for (const item of items; index i; key item.id) {
-      <li>{item.text}{' at index '}{i}</li>
+      <li>{item.text}" at index "{i}</li>
     }
   </ul>
 }
@@ -653,7 +653,7 @@ component ErrorBoundary() {
     try {
       <ComponentThatMightFail />
     } catch (e) {
-      <div>{"Error: "}{e.message}</div>
+      <div>"Error: "{e.message}</div>
     }
   </div>
 }
@@ -698,7 +698,7 @@ component EventExample() {
   let &[message] = track("");
 
   <div>
-    <button onClick={() => message = "Clicked!"}>{"Click me"}</button>
+    <button onClick={() => message = "Clicked!"}>"Click me"</button>
     <input onInput={(e) => message = e.target.value} />
     <p>{message}</p>
   </div>
@@ -737,7 +737,7 @@ Components support scoped CSS with `<style>` elements:
 ```ripple
 component StyledComponent() {
   <div class="container">
-    <h1>{"Styled Content"}</h1>
+    <h1>"Styled Content"</h1>
   </div>
 
   <style>
@@ -772,7 +772,7 @@ component Parent() {
 }
 
 component Child() {
-  <div class="child-class">{"I won't be red"}</div>
+  <div class="child-class">"I won't be red"</div>
 }
 ```
 
@@ -1014,12 +1014,12 @@ export component App() {
   context2.set(count2Tracked);
 
   <button onClick={() => { objCount++; count2++ }}>
-    {'Click Me'}
+    "Click Me"
   </button>
 
   // context's reactive property count gets updated
-  <pre>{'Context: '}{objCount}</pre>
-  <pre>{'Context2: '}{count2}</pre>
+  <pre>"Context: "{objCount}</pre>
+  <pre>"Context2: "{count2}</pre>
 }
 ```
 
@@ -1104,11 +1104,11 @@ export component App() {
   const items = new RippleArray(1, 2, 3);
 
   <div>
-    <p>{"Length: "}{items.length}</p>  // Reactive length
+    <p>"Length: "{items.length}</p>  // Reactive length
     for (const item of items) {
       <div>{item}</div>
     }
-    <button onClick={() => items.push(items.length + 1)}>{"Add"}</button>
+    <button onClick={() => items.push(items.length + 1)}>"Add"</button>
   </div>
 }
 ```
@@ -1149,9 +1149,9 @@ component SetExample() {
   const mySet = new RippleSet([1, 2, 3]);
 
   <div>
-    <p>{"Size: "}{mySet.size}</p>  // Reactive size
-    <p>{"Has 2: "}{mySet.has(2)}</p>
-    <button onClick={() => mySet.add(4)}>{"Add 4"}</button>
+    <p>"Size: "{mySet.size}</p>  // Reactive size
+    <p>"Has 2: "{mySet.has(2)}</p>
+    <button onClick={() => mySet.add(4)}>"Add 4"</button>
   </div>
 }
 ```
@@ -1175,14 +1175,14 @@ export component App() {
   const map = new RippleMap([[1,1], [2,2], [3,3], [4,4]]);
 
   // direct usage
-  <p>{"Direct usage: map has an item with key 2: "}{map.has(2)}</p>
+  <p>"Direct usage: map has an item with key 2: "{map.has(2)}</p>
 
   // reactive assignment
   let &[has] = track(() => map.has(2));
-  <p>{"Assigned usage: map has an item with key 2: "}{has}</p>
+  <p>"Assigned usage: map has an item with key 2: "{has}</p>
 
-  <button onClick={() => map.delete(2)}>{"Delete item with key 2"}</button>
-  <button onClick={() => map.set(2, 2)}>{"Add key 2 with value 2"}</button>
+  <button onClick={() => map.delete(2)}>"Delete item with key 2"</button>
+  <button onClick={() => map.set(2, 2)}>"Add key 2 with value 2"</button>
 }
 ```
 
@@ -1205,16 +1205,16 @@ export component App() {
   const date = new RippleDate(2025, 0, 1, 12, 0, 0);
 
   // direct usage
-  <p>{"Direct usage: Current year is "}{date.getFullYear()}</p>
-  <p>{"ISO String: "}{date.toISOString()}</p>
+  <p>"Direct usage: Current year is "{date.getFullYear()}</p>
+  <p>"ISO String: "{date.toISOString()}</p>
 
   // reactive assignment
   let &[year] = track(() => date.getFullYear());
   let &[month] = track(() => date.getMonth());
-  <p>{"Assigned usage: Year "}{year}{", Month "}{month}</p>
+  <p>"Assigned usage: Year "{year}", Month "{month}</p>
 
-  <button onClick={() => date.setFullYear(2027)}>{"Change to 2026"}</button>
-  <button onClick={() => date.setMonth(11)}>{"Change to December"}</button>
+  <button onClick={() => date.setFullYear(2027)}>"Change to 2026"</button>
+  <button onClick={() => date.setMonth(11)}>"Change to December"</button>
 }
 ```
 
@@ -1244,7 +1244,7 @@ import { Suspense } from 'react';
 
 component App() {
   <div class="ripple-container">
-    <h1>{"Ripple App"}</h1>
+    <h1>"Ripple App"</h1>
 
     {/* Embed React components using tsx:react */}
     <tsx:react>
@@ -1354,7 +1354,7 @@ component App() {
       <BuggyReactComponent />
     </tsx:react>
   } catch (error) {
-    <div class="error">{"An error occurred in the React component"}</div>
+    <div class="error">"An error occurred in the React component"</div>
   }
 }
 ```
@@ -1365,14 +1365,14 @@ component App() {
 ```ripple
 component App() {
   // Wrong: className is React syntax, use class in Ripple
-  <div className="container">{"Hello"}</div>
+  <div className="container">"Hello"</div>
 }
 ```
 
 **✅ CORRECT: Use Ripple syntax outside tsx:react, React syntax inside**
 ```ripple
 component App() {
-  <div class="container">{"Hello"}</div>
+  <div class="container">"Hello"</div>
   <tsx:react>
     <div className="react-div">React content</div>
   </tsx:react>
@@ -1537,9 +1537,9 @@ explicit:
 ```ripple
 export component Frame({ children }) {
 	<div class="frame">
-		{text 'before'}
+		{text 'before"
 		{children}
-		{text 'after'}
+		{text 'after"
 	</div>
 }
 ```


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Mostly mechanical documentation/example rewrites, but the breadth of snippet changes risks introducing invalid Ripple code or broken formatting in rendered docs.
> 
> **Overview**
> Standardizes Ripple website docs and example snippets to use **direct double-quoted text nodes** (e.g., `<p>"Hello"</p>`) instead of `{"..."}`/`{'...'}`/template-literal patterns, across guides and `docs/examples.ts`.
> 
> Updates the homepage `public/index.html` typewriter code sample to match the new quoting style, and adjusts `public/llms.txt` guidance/examples accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a370df34ac5d3759cdaeefff2e9c194b8ba36199. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->