### PR TITLE
chore: update @marko/tsrx

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1430,8 +1430,8 @@ importers:
         specifier: ^6.38.6
         version: 6.41.1
       '@marko/tsrx':
-        specifier: ^0.0.2
-        version: 0.0.2
+        specifier: ^0.0.3
+        version: 0.0.3
       '@ripple-ts/adapter-node':
         specifier: workspace:*
         version: link:../packages/adapter-node
@@ -2304,8 +2304,8 @@ packages:
   '@marijn/find-cluster-break@1.0.2':
     resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
 
-  '@marko/tsrx@0.0.2':
-    resolution: {integrity: sha512-AicFpdN8G9OByQp3+hc9Lq9U6bYGvS3Ly6gk59nXCOzEsWftpsA8+cpFAepeIrzOkr+PwGNuc6hcBze5ZHM22Q==}
+  '@marko/tsrx@0.0.3':
+    resolution: {integrity: sha512-LqQaNcwuVSTrp3pKxSBHOJV5DN/QymgzTZ+R81tbEHF8ckueiRinyYdF+L22boRGHr6VbE1Nv2CIUyALWhs/9Q==}
     engines: {node: '>=18.0.0'}
 
   '@modelcontextprotocol/sdk@1.27.1':
@@ -8213,7 +8213,7 @@ snapshots:
 
   '@marijn/find-cluster-break@1.0.2': {}
 
-  '@marko/tsrx@0.0.2':
+  '@marko/tsrx@0.0.3':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
       '@tsrx/core': 0.0.14

--- a/website-tsrx/package.json
+++ b/website-tsrx/package.json
@@ -26,7 +26,7 @@
     "@tsrx/react": "workspace:*",
     "@tsrx/ripple": "workspace:*",
     "@tsrx/solid": "workspace:*",
-    "@marko/tsrx": "^0.0.2",
+    "@marko/tsrx": "^0.0.3",
     "prettier-plugin-marko": "^4.0.9",
     "@tsrx/vue": "workspace:*",
     "prettier": "catalog:",


### PR DESCRIPTION
We fixed a few bugs yesterday with `@marko/tsrx`, and added some polish. Would be great to see the new version in the playground!


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency bump limited to `@marko/tsrx`; main risk is minor build/runtime behavior changes in the updated package affecting the website/playground.
> 
> **Overview**
> Updates the website/playground to use `@marko/tsrx` `^0.0.3` (from `^0.0.2`) and refreshes `pnpm-lock.yaml` to lock the new version/integrity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 576bbdcc1d53d531b44a8a07c7312f52a4d43924. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->