### PR TITLE
fix: generic type on opening element

### DIFF
--- a/.changeset/jsx-generic-type-args.md
+++ b/.changeset/jsx-generic-type-args.md
@@ -1,0 +1,11 @@
+---
+'@tsrx/prettier-plugin': patch
+'@tsrx/core': patch
+'@tsrx/ripple': patch
+'@tsrx/react': patch
+'@tsrx/preact': patch
+'@tsrx/solid': patch
+'@tsrx/vue': patch
+---
+
+Preserve generic type arguments on JSX component tags (e.g. `<RenderProp<User>>`). They were being silently dropped during prettier formatting, during the tsrx → JSX compile output for React/Preact/Solid/Vue, and in Ripple's `to_ts` virtual-code output used by the language server for typechecking.

--- a/packages/prettier-plugin/src/index.js
+++ b/packages/prettier-plugin/src/index.js
@@ -5748,6 +5748,12 @@ function printJSXElement(node, path, options, print) {
 	const hasAttributes = openingElement.attributes && openingElement.attributes.length > 0;
 	const hasChildren = node.children && node.children.length > 0;
 
+	/** @type {Doc} */
+	let typeArgsDoc = '';
+	if (openingElement.typeArguments) {
+		typeArgsDoc = path.call(print, 'openingElement', 'typeArguments');
+	}
+
 	// Format attributes
 	/** @type {Doc} */
 	let attributesDoc = '';
@@ -5778,11 +5784,11 @@ function printJSXElement(node, path, options, print) {
 	}
 
 	if (isSelfClosing) {
-		return ['<', tagName, attributesDoc, ' />'];
+		return ['<', tagName, typeArgsDoc, attributesDoc, ' />'];
 	}
 
 	if (!hasChildren) {
-		return ['<', tagName, attributesDoc, '></', tagName, '>'];
+		return ['<', tagName, typeArgsDoc, attributesDoc, '></', tagName, '>'];
 	}
 
 	// Format children - filter out empty text nodes and merge adjacent text nodes
@@ -5826,7 +5832,7 @@ function printJSXElement(node, path, options, print) {
 
 	// Check if content can be inlined (single text node or single expression)
 	if (childrenDocs.length === 1 && typeof childrenDocs[0] === 'string') {
-		return ['<', tagName, attributesDoc, '>', childrenDocs[0], '</', tagName, '>'];
+		return ['<', tagName, typeArgsDoc, attributesDoc, '>', childrenDocs[0], '</', tagName, '>'];
 	}
 
 	// Multiple children or complex children - format with line breaks
@@ -5842,6 +5848,7 @@ function printJSXElement(node, path, options, print) {
 	return group([
 		'<',
 		tagName,
+		typeArgsDoc,
 		attributesDoc,
 		'>',
 		indent([hardline, ...formattedChildren]),
@@ -6019,6 +6026,12 @@ function is_attribute_value_breakable(value, is_nested_in_object = false) {
 function printElement(element, path, options, print) {
 	const node = /** @type {AST.Element & AST.NodeWithLocation} */ (element);
 	const tagName = printMemberExpressionSimple(node.id, options);
+	const openingElement = /** @type {any} */ (node.openingElement);
+	/** @type {Doc} */
+	let typeArgsDoc = '';
+	if (openingElement?.typeArguments) {
+		typeArgsDoc = path.call(print, 'openingElement', 'typeArguments');
+	}
 	const elementLeadingComments = getElementLeadingComments(node);
 
 	// `metadata.elementLeadingComments` may include comments that actually appear *inside* the element
@@ -6095,7 +6108,7 @@ function printElement(element, path, options, print) {
 	}
 
 	if (isSelfClosing && !hasInnerComments && !hasAttributes) {
-		const elementDoc = group(['<', tagName, ' />']);
+		const elementDoc = group(['<', tagName, typeArgsDoc, ' />']);
 		return metadataCommentParts.length > 0 ? [...metadataCommentParts, elementDoc] : elementDoc;
 	}
 
@@ -6146,6 +6159,7 @@ function printElement(element, path, options, print) {
 	const openingTag = group([
 		'<',
 		tagName,
+		typeArgsDoc,
 		hasAttributes
 			? indent([
 					...attrDocs,

--- a/packages/prettier-plugin/src/index.test.js
+++ b/packages/prettier-plugin/src/index.test.js
@@ -3477,6 +3477,46 @@ declare function processData<T>(data: T): Promise<T>;`;
 			expect(result).toBeWithNewline(expected);
 		});
 
+		it('should preserve generic type arguments on JSX component tags', async () => {
+			const input = `type User = { name: string };
+component RenderProp<Item>(props: { children: (item: Item) => any }) {}
+export component App() {
+	<RenderProp<User>>
+		{(item) => item.name}
+	</RenderProp>
+}`;
+
+			const expected = `type User = { name: string };
+component RenderProp<Item>(props: { children: (item: Item) => any }) {}
+export component App() {
+  <RenderProp<User>>
+    {(item) => item.name}
+  </RenderProp>
+}`;
+
+			const result = await format(input);
+			expect(result).toBeWithNewline(expected);
+		});
+
+		it('should preserve generic type arguments on self-closing JSX component tags', async () => {
+			const input = `component Box<T>({ value }: { value: T }) {
+	<div>{String(value)}</div>
+}
+export component App() {
+	<Box<string> value="hi" />
+}`;
+
+			const expected = `component Box<T>({ value }: { value: T }) {
+  <div>{String(value)}</div>
+}
+export component App() {
+  <Box<string> value="hi" />
+}`;
+
+			const result = await format(input);
+			expect(result).toBeWithNewline(expected);
+		});
+
 		it('should preserve multiple generics on method shorthand', async () => {
 			const input = `const obj = {
   method<V, T, U>(): { build: () => V; data: T; key: U } {

--- a/packages/ripple/tests/client/compiler/compiler.basic.test.tsrx
+++ b/packages/ripple/tests/client/compiler/compiler.basic.test.tsrx
@@ -426,6 +426,38 @@ export component MyComponent<Item>(props: Props<Item>) {
 		expect(result).toContain('export function MyComponent<Item>(props: Props<Item>)');
 	});
 
+	it('preserves generic type arguments on JSX component tags in to_ts output', () => {
+		const source = `
+type User = { name: string };
+
+component RenderProp<Item>(props: { children: (item: Item) => any }) {}
+
+export component App() {
+	<RenderProp<User>>
+		{(item) => item.name}
+	</RenderProp>
+}
+`;
+		const result = compile_to_volar_mappings(source, 'test.tsrx').code;
+
+		expect(result).toContain('<RenderProp<User>');
+	});
+
+	it('preserves generic type arguments on self-closing JSX component tags in to_ts output', () => {
+		const source = `
+component Box<T>({ value }: { value: T }) {
+	<div>{String(value)}</div>
+}
+
+export component App() {
+	<Box<string> value="hi" />
+}
+`;
+		const result = compile_to_volar_mappings(source, 'test.tsrx').code;
+
+		expect(result).toContain('<Box<string>');
+	});
+
 	it('preserves regular function type parameters in to_ts output', () => {
 		const source = `
 type Props<Item> = {

--- a/packages/tsrx-ripple/src/transform/client/index.js
+++ b/packages/tsrx-ripple/src/transform/client/index.js
@@ -4499,6 +4499,10 @@ function create_tsx_with_typescript_support(comments) {
 
 			context.visit(node.name);
 
+			if (node.typeArguments) {
+				context.visit(node.typeArguments);
+			}
+
 			for (const attr of node.attributes || []) {
 				context.write(' ');
 				context.visit(attr);

--- a/packages/tsrx-solid/src/transform.js
+++ b/packages/tsrx-solid/src/transform.js
@@ -31,6 +31,8 @@ import {
 	to_text_expression,
 } from '@tsrx/core';
 
+import { builders as b } from '@tsrx/core';
+
 /**
  * Solid extends the shared `JsxTransformContext` with `needs_*` flags that
  * track which Solid runtime primitives (`Show`, `For`, `Switch`, `Match`,
@@ -1159,12 +1161,7 @@ function to_jsx_element(node, transform_context, pre_walk_children) {
 	}
 
 	const openingElement = set_loc(
-		/** @type {any} */ ({
-			type: 'JSXOpeningElement',
-			name,
-			attributes,
-			selfClosing,
-		}),
+		b.jsx_opening_element(name, attributes, selfClosing, node.openingElement?.typeArguments),
 		node.openingElement || node,
 	);
 

--- a/packages/tsrx/src/transform/jsx/helpers.js
+++ b/packages/tsrx/src/transform/jsx/helpers.js
@@ -217,5 +217,25 @@ export function tsx_with_ts_locations() {
 		wrappers[type] = (node, context) => wrap_with_locations(node, context, base[type]);
 	}
 
+	// esrap's JSXOpeningElement printer doesn't emit `typeArguments`, so generic
+	// component tags like `<RenderProp<User>>` lose the `<User>` in the output.
+	const print_jsx_opening_element = (/** @type {any} */ node, /** @type {any} */ context) => {
+		context.write('<');
+		context.visit(node.name);
+		if (node.typeArguments) {
+			context.visit(node.typeArguments);
+		}
+		for (const attribute of node.attributes) {
+			context.write(' ');
+			context.visit(attribute);
+		}
+		if (node.selfClosing) {
+			context.write(' /');
+		}
+		context.write('>');
+	};
+	wrappers.JSXOpeningElement = (node, context) =>
+		wrap_with_locations(node, context, print_jsx_opening_element);
+
 	return { ...base, ...wrappers };
 }

--- a/packages/tsrx/src/transform/jsx/helpers.js
+++ b/packages/tsrx/src/transform/jsx/helpers.js
@@ -186,7 +186,31 @@ export function tsx_with_ts_locations() {
 				context.visit(body);
 			}
 		},
+
+		// esrap's JSXOpeningElement printer doesn't emit `typeArguments`, so generic
+		// component tags like `<RenderProp<User>>` lose the `<User>` in the output.
+		JSXOpeningElement: (node, context) => {
+			context.write('<');
+			context.visit(node.name);
+			if (node.typeArguments) {
+				context.visit(node.typeArguments);
+			}
+			for (const attribute of node.attributes) {
+				context.write(' ');
+				context.visit(attribute);
+			}
+			if (node.selfClosing) {
+				context.write(' /');
+			}
+			context.write('>');
+		},
 	};
+
+	// Be careful when duplicating visitors that are already defined
+	// above in the `wrappers`
+	// if there is already a visitor but you still need a mapping
+	// on the whole node, only then duplicate it here
+	// e.g. JSXOpeningElement is such a case
 	for (const type of [
 		// JS nodes whose esrap printer emits no location marker, causing
 		// segments.js get_mapping_from_node() to throw when it asks for the
@@ -214,28 +238,10 @@ export function tsx_with_ts_locations() {
 		'TSTypeParameterDeclaration',
 		'TSTypeParameter',
 	]) {
-		wrappers[type] = (node, context) => wrap_with_locations(node, context, base[type]);
-	}
+		const visitor = wrappers[type];
 
-	// esrap's JSXOpeningElement printer doesn't emit `typeArguments`, so generic
-	// component tags like `<RenderProp<User>>` lose the `<User>` in the output.
-	const print_jsx_opening_element = (/** @type {any} */ node, /** @type {any} */ context) => {
-		context.write('<');
-		context.visit(node.name);
-		if (node.typeArguments) {
-			context.visit(node.typeArguments);
-		}
-		for (const attribute of node.attributes) {
-			context.write(' ');
-			context.visit(attribute);
-		}
-		if (node.selfClosing) {
-			context.write(' /');
-		}
-		context.write('>');
-	};
-	wrappers.JSXOpeningElement = (node, context) =>
-		wrap_with_locations(node, context, print_jsx_opening_element);
+		wrappers[type] = (node, context) => wrap_with_locations(node, context, visitor ?? base[type]);
+	}
 
 	return { ...base, ...wrappers };
 }

--- a/packages/tsrx/src/transform/jsx/index.js
+++ b/packages/tsrx/src/transform/jsx/index.js
@@ -2209,10 +2209,12 @@ function to_jsx_element(node, transform_context, raw_children = node.children ||
 		(/** @type {any} */ attribute) => attribute?.metadata?.has_unmappable_value,
 	);
 
-	const opening_element_node = b.jsx_opening_element(name, attributes, selfClosing);
-	if (node.openingElement?.typeArguments) {
-		/** @type {any} */ (opening_element_node).typeArguments = node.openingElement.typeArguments;
-	}
+	const opening_element_node = b.jsx_opening_element(
+		name,
+		attributes,
+		selfClosing,
+		node.openingElement?.typeArguments,
+	);
 	const openingElement = has_unmappable_attribute
 		? opening_element_node
 		: set_loc(opening_element_node, node.openingElement || node);

--- a/packages/tsrx/src/transform/jsx/index.js
+++ b/packages/tsrx/src/transform/jsx/index.js
@@ -2210,6 +2210,9 @@ function to_jsx_element(node, transform_context, raw_children = node.children ||
 	);
 
 	const opening_element_node = b.jsx_opening_element(name, attributes, selfClosing);
+	if (node.openingElement?.typeArguments) {
+		/** @type {any} */ (opening_element_node).typeArguments = node.openingElement.typeArguments;
+	}
 	const openingElement = has_unmappable_attribute
 		? opening_element_node
 		: set_loc(opening_element_node, node.openingElement || node);

--- a/packages/tsrx/src/transform/segments.js
+++ b/packages/tsrx/src/transform/segments.js
@@ -653,8 +653,11 @@ export function convert_source_map_to_mappings(
 				// Nothing to visit (just source string)
 				return;
 			} else if (node.type === 'JSXOpeningElement') {
-				// Visit name and attributes in source order
+				// Visit name, type arguments, and attributes in source order
 				visit(node.name);
+				if (node.typeArguments) {
+					visit(node.typeArguments);
+				}
 				for (const attr of node.attributes) {
 					visit(attr);
 				}

--- a/packages/tsrx/src/utils/builders.js
+++ b/packages/tsrx/src/utils/builders.js
@@ -1107,15 +1107,23 @@ export function jsx_attribute(name, value = null, shorthand = false, loc_info) {
  * @param {ESTreeJSX.JSXOpeningElement['name']} name
  * @param {ESTreeJSX.JSXOpeningElement['attributes']} [attributes]
  * @param {boolean} [self_closing]
+ * @param {ESTreeJSX.JSXOpeningElement['typeArguments']} [type_arguments]
  * @param {AST.NodeWithLocation} [loc_info]
  * @returns {ESTreeJSX.JSXOpeningElement}
  */
-export function jsx_opening_element(name, attributes = [], self_closing = false, loc_info) {
+export function jsx_opening_element(
+	name,
+	attributes = [],
+	self_closing = false,
+	type_arguments = undefined,
+	loc_info,
+) {
 	const node = /** @type {ESTreeJSX.JSXOpeningElement} */ ({
 		type: 'JSXOpeningElement',
 		name,
 		attributes,
 		selfClosing: self_closing,
+		typeArguments: type_arguments,
 		metadata: { path: [] },
 	});
 

--- a/packages/tsrx/tests/shared/compile.js
+++ b/packages/tsrx/tests/shared/compile.js
@@ -127,6 +127,38 @@ export function runSharedCompileTests({ compile, name, classAttrName }) {
 
 			expect(code).toContain('export function MyComponent<Item>(props: Props<Item>)');
 		});
+
+		it('preserves generic type arguments on JSX component tags', () => {
+			const { code } = compile(
+				`type User = { name: string };
+
+				component RenderProp<Item>(props: { children: (item: Item) => any }) {}
+
+				export component App() {
+					<RenderProp<User>>
+						{(item) => item.name}
+					</RenderProp>
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('<RenderProp<User>>');
+		});
+
+		it('preserves generic type arguments on self-closing JSX component tags', () => {
+			const { code } = compile(
+				`component Box<T>({ value }: { value: T }) {
+					<div>{String(value)}</div>
+				}
+
+				export component App() {
+					<Box<string> value="hi" />
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('<Box<string>');
+		});
 	});
 
 	describe(`[${name}] TypeScript output`, () => {

--- a/packages/tsrx/tests/shared/source-mappings.js
+++ b/packages/tsrx/tests/shared/source-mappings.js
@@ -777,6 +777,36 @@ export function optionalFn(declRequired: string, declMaybe?: string) {
 		});
 	});
 
+	describe(`[${name}] generic type arguments on JSX component tags`, () => {
+		it('maps the type argument identifier back to source', () => {
+			const source = `type User = { name: string };
+
+component RenderProp<Item>(props: { children: (item: Item) => any }) {}
+
+export component App() {
+	<RenderProp<User>>
+		{(item) => item.name}
+	</RenderProp>
+}`;
+			const result = compile_to_volar_mappings(source, 'App.tsrx');
+
+			// The generated TSX must contain `<RenderProp<User>` (no leading
+			// space) so the type argument round-trips through the printer.
+			expect(result.code).toContain('<RenderProp<User>');
+
+			const source_user_offset = source.indexOf('<User>') + 1;
+			const generated_user_offset =
+				result.code.indexOf('RenderProp<User>') + 'RenderProp<'.length;
+
+			const user_mapping = result.mappings.find(
+				(/** @type {{ sourceOffsets: number[], lengths: number[] }} */ m) =>
+					m.sourceOffsets[0] === source_user_offset && m.lengths[0] === 'User'.length,
+			);
+			expect(user_mapping).toBeDefined();
+			expect(user_mapping.generatedOffsets[0]).toBe(generated_user_offset);
+		});
+	});
+
 	describe(`[${name}] shared tests conditionally run for specific frameworks`, () => {
 		it.runIf(['react', 'preact'].includes(name))(
 			`[${name}] maps source declarations to their own generated declarations when hook helpers are extracted`,

--- a/packages/tsrx/tests/shared/source-mappings.js
+++ b/packages/tsrx/tests/shared/source-mappings.js
@@ -795,8 +795,7 @@ export component App() {
 			expect(result.code).toContain('<RenderProp<User>');
 
 			const source_user_offset = source.indexOf('<User>') + 1;
-			const generated_user_offset =
-				result.code.indexOf('RenderProp<User>') + 'RenderProp<'.length;
+			const generated_user_offset = result.code.indexOf('RenderProp<User>') + 'RenderProp<'.length;
 
 			const user_mapping = result.mappings.find(
 				(/** @type {{ sourceOffsets: number[], lengths: number[] }} */ m) =>


### PR DESCRIPTION
closes #1015 

Fixes an issue where the generics on opening tag were removed by prettier and not printed by transformers and not mapped for volar.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches JSX printing and codegen across Prettier plugin, multiple framework transforms, and source-mapping logic; regressions could affect emitted TSX syntax or Volar typechecking/mappings.
> 
> **Overview**
> Preserves generic type arguments on JSX component opening tags (e.g. `<RenderProp<User>>`) end-to-end instead of silently dropping them during formatting, compilation, and Ripple language-server virtual TS output.
> 
> Updates the Prettier printer and TSRX/TSRX-Ripple/Solid JSX transforms to carry `openingElement.typeArguments` through `jsx_opening_element` creation and JSX printing, and adjusts segment-walking/source-mapping to visit `typeArguments` in source order. Adds regression tests covering normal/self-closing tags and verifies Volar mappings include and correctly map the type-argument identifier.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f29649290b2203c2e0819ca2862cf044cf6bb9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->