### PR TITLE
more fixes

### DIFF
--- a/.changeset/kind-text-branches.md
+++ b/.changeset/kind-text-branches.md
@@ -1,0 +1,10 @@
+---
+'@tsrx/core': patch
+'@tsrx/ripple': patch
+'@tsrx/react': patch
+'@tsrx/preact': patch
+'@tsrx/solid': patch
+'@tsrx/vue': patch
+---
+
+Parse direct double-quoted text in bare if/else branches and backtick-delimited fragment text as renderable template text.

--- a/packages/ripple/tests/client/basic/basic.rendering.test.tsrx
+++ b/packages/ripple/tests/client/basic/basic.rendering.test.tsrx
@@ -55,6 +55,20 @@ second"</pre>
 		expect(container.querySelector('.multiline').textContent).toBe('first\nsecond');
 	});
 
+	it('renders bare double-quoted text in if-else branches', () => {
+		component App() {
+			let condition = false;
+
+			if (condition) {
+				"Hello Ripple"
+			} else "Hello React"
+		}
+
+		render(App);
+
+		expect(container.textContent).toBe('Hello React');
+	});
+
 	it('renders dynamic text', () => {
 		component Basic() {
 			let &[message] = track('Hello World');

--- a/packages/ripple/tests/client/compiler/compiler.basic.test.tsrx
+++ b/packages/ripple/tests/client/compiler/compiler.basic.test.tsrx
@@ -79,6 +79,48 @@ describe('compiler > basics', () => {
 		);
 	});
 
+	it('parses backtick text inside fragments as JSX text', () => {
+		const source = `let a = component () {
+			<>
+				\`333\`
+			</>
+		}`;
+
+		const ast = parse(source);
+		const declaration = (ast.body[0] as AST.VariableDeclaration).declarations[0];
+		const component_node = declaration.init as unknown as AST.Component;
+		const fragment = component_node.body[0] as any;
+
+		expect(fragment.type).toBe('Tsx');
+		expect(fragment.children[0].type).toBe('JSXText');
+		expect(fragment.children[0].value).toContain('`333`');
+	});
+
+	it('parses backtick text around JSX elements inside fragments', () => {
+		const source = `let a = component () {
+			<>
+				\`
+				<b></b>
+				\`
+			</>
+		}`;
+
+		const ast = parse(source);
+		const declaration = (ast.body[0] as AST.VariableDeclaration).declarations[0];
+		const component_node = declaration.init as unknown as AST.Component;
+		const fragment = component_node.body[0] as any;
+
+		expect(fragment.type).toBe('Tsx');
+		expect(fragment.children.map((child: any) => child.type)).toEqual([
+			'JSXText',
+			'JSXElement',
+			'JSXText',
+		]);
+		expect(fragment.children[0].value).toContain('`');
+		expect(fragment.children[1].openingElement.name.name).toBe('b');
+		expect(fragment.children[2].value).toContain('`');
+	});
+
 	it('renders without crashing', () => {
 		component App() {
 			let foo: Record<string, number>;

--- a/packages/ripple/tests/server/if.test.tsrx
+++ b/packages/ripple/tests/server/if.test.tsrx
@@ -27,6 +27,19 @@ describe('if statements in SSR', () => {
 		expect(body).toBeHtml('<div>Else block</div>');
 	});
 
+	it('renders bare double-quoted text in if-else branches', async () => {
+		component App() {
+			let condition = false;
+
+			if (condition) {
+				"Hello Ripple"
+			} else "Hello React"
+		}
+
+		const { body } = await render(App);
+		expect(body).toBeHtml('Hello React');
+	});
+
 	it('renders else if block when condition is true', async () => {
 		component App() {
 			let value = 'b';

--- a/packages/tsrx-ripple/src/transform/server/index.js
+++ b/packages/tsrx-ripple/src/transform/server/index.js
@@ -1453,7 +1453,9 @@ const visitors = {
 			const alternate_body_nodes =
 				node.alternate.type === 'IfStatement'
 					? [node.alternate]
-					: /** @type {AST.BlockStatement} */ (node.alternate).body;
+					: node.alternate.type === 'BlockStatement'
+						? node.alternate.body
+						: [node.alternate];
 
 			alternate = b.block(
 				transform_body(alternate_body_nodes, {

--- a/packages/tsrx-solid/tests/basic.test.js
+++ b/packages/tsrx-solid/tests/basic.test.js
@@ -451,6 +451,29 @@ describe('@tsrx/solid basic', () => {
 			expect(show_idx).toBeGreaterThan(-1);
 			expect(signal_idx).toBeLessThan(show_idx);
 		});
+
+		it('early-return keeps preceding JSX outside the guarded continuation', () => {
+			const { code } = compile(
+				`export default component A() {
+					let early = true;
+					<>"Hello"</>
+					if (early) {
+						return
+					}
+					<>"World"</>
+				}`,
+				'A.tsrx',
+			);
+
+			const hello_idx = code.indexOf('<>"Hello"</>');
+			const show_idx = code.indexOf('<Show when={!early}');
+			const world_idx = code.indexOf('<>"World"</>');
+			expect(hello_idx).toBeGreaterThan(-1);
+			expect(show_idx).toBeGreaterThan(-1);
+			expect(world_idx).toBeGreaterThan(show_idx);
+			expect(hello_idx).toBeLessThan(show_idx);
+			expect(code).not.toContain('return <Show when={!early}');
+		});
 	});
 
 	describe('<tsx> fragments', () => {

--- a/packages/tsrx/src/plugin.js
+++ b/packages/tsrx/src/plugin.js
@@ -313,6 +313,12 @@ export function TSRXPlugin(config) {
 				}
 			}
 
+			#popTemplateLiteralTokenContext() {
+				while (this.curContext()?.token === '`') {
+					this.context.pop();
+				}
+			}
+
 			#isDoubleQuotedTextChildStart() {
 				if (this.#path.findLast((n) => n.type === 'TsxCompat' || n.type === 'Tsx')) {
 					return false;
@@ -2383,7 +2389,7 @@ export function TSRXPlugin(config) {
 							body.push(node);
 						} else if (this.type === tstt.jsxTagStart) {
 							// Parse JSX element
-							const node = super.parseExpression();
+							const node = super.jsx_parseElement();
 							body.push(node);
 						} else {
 							const start = this.start;
@@ -2414,6 +2420,7 @@ export function TSRXPlugin(config) {
 								body.push(node);
 							}
 
+							this.#popTemplateLiteralTokenContext();
 							// Always call next() to ensure parser makes progress
 							this.next();
 						}
@@ -2446,7 +2453,7 @@ export function TSRXPlugin(config) {
 							body.push(node);
 						} else if (this.type === tstt.jsxTagStart) {
 							// Parse JSX element
-							const node = super.parseExpression();
+							const node = super.jsx_parseElement();
 							body.push(node);
 						} else {
 							const start = this.start;
@@ -2477,6 +2484,7 @@ export function TSRXPlugin(config) {
 								body.push(node);
 							}
 
+							this.#popTemplateLiteralTokenContext();
 							this.next();
 						}
 					}
@@ -2758,6 +2766,17 @@ export function TSRXPlugin(config) {
 					if (!node) {
 						this.unexpected();
 					}
+					return node;
+				}
+
+				if (
+					this.#functionBodyDepth === 0 &&
+					this.type === tt.string &&
+					this.input.charCodeAt(this.start) === 34 &&
+					(this.#path.at(-1)?.type === 'Component' || this.#path.at(-1)?.type === 'Element')
+				) {
+					const node = this.parseDoubleQuotedTextChild();
+					this.semicolon();
 					return node;
 				}
 

--- a/packages/tsrx/src/plugin.js
+++ b/packages/tsrx/src/plugin.js
@@ -2775,6 +2775,8 @@ export function TSRXPlugin(config) {
 					this.input.charCodeAt(this.start) === 34 &&
 					(this.#path.at(-1)?.type === 'Component' || this.#path.at(-1)?.type === 'Element')
 				) {
+					this.pos = this.start;
+					this.#readDoubleQuotedTextChildToken();
 					const node = this.parseDoubleQuotedTextChild();
 					this.semicolon();
 					return node;

--- a/packages/tsrx/tests/shared/compile.js
+++ b/packages/tsrx/tests/shared/compile.js
@@ -461,6 +461,21 @@ export function runSharedCompileTests({ compile, name, classAttrName }) {
 			expect(code).toContain('"hello"');
 		});
 
+		it('accepts direct double-quoted text in if-else branches', () => {
+			const { code } = compile(
+				`export component App() {
+					if (false) {
+						"Hello Ripple"
+					} else "Hello React";
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('"Hello Ripple"');
+			expect(code).toContain('"Hello React"');
+			expect(code).not.toContain('return null;');
+		});
+
 		it('decodes entities in direct double-quoted text children like JSX attributes', () => {
 			const { code } = compile(
 				`export component App() {
@@ -883,6 +898,35 @@ export function optionalFn(bar: string, baz?: string) {
 
 			expect(code).toContain('const x = <>Hello world</>;');
 			expect(code).toContain('return x;');
+		});
+
+		it('parses backtick text inside fragments as JSX text', () => {
+			const { code } = compile(
+				`let a = component () {
+					<>
+						\`333\`
+					</>
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('`333`');
+		});
+
+		it('parses backtick text around JSX elements inside fragments', () => {
+			const { code } = compile(
+				`let a = component () {
+					<>
+						\`
+						<b></b>
+						\`
+					</>
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('`');
+			expect(code).toContain('<b></b>');
 		});
 
 		it('wraps multiple tsx children in a fragment', () => {

--- a/packages/vite-plugin-react/tests/runtime.test.tsrx
+++ b/packages/vite-plugin-react/tests/runtime.test.tsrx
@@ -48,6 +48,27 @@ component DirectQuotedTextApp() {
 second"</pre>
 }
 
+component DirectQuotedTextIfElseTrueApp() {
+	if (true) {
+		"Hello Ripple"
+	} else "Hello React"
+}
+
+component DirectQuotedTextIfElseFalseApp() {
+	if (false) {
+		"Hello Ripple"
+	} else "Hello React"
+}
+
+component DirectQuotedTextIfElseApp() {
+	<div class="direct-quoted-if-then">
+		<DirectQuotedTextIfElseTrueApp />
+	</div>
+	<div class="direct-quoted-if-else">
+		<DirectQuotedTextIfElseFalseApp />
+	</div>
+}
+
 component Child(props: { text: string }) {
 	<span class="child">{props.text}</span>
 }
@@ -838,6 +859,12 @@ describe('tsrx-react runtime', () => {
 		expect(text('.direct-quoted-entities')).toBe('Rock & "Roll"');
 		expect(text('.direct-quoted-backslash')).toBe('line\\nbreak');
 		expect(text('.direct-quoted-multiline')).toBe('first\nsecond');
+	});
+
+	it('renders bare direct double-quoted text in if-else branches', async () => {
+		await render(DirectQuotedTextIfElseApp);
+		expect(text('.direct-quoted-if-then')).toBe('Hello Ripple');
+		expect(text('.direct-quoted-if-else')).toBe('Hello React');
 	});
 
 	it('renders nested components', async () => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core TSRX parsing and SSR `IfStatement` transformation logic, which can affect compilation/rendering across targets; risk is mitigated by added client/SSR/compiler/runtime tests covering the new syntaxes.
> 
> **Overview**
> Extends the TSRX parser to treat **standalone double-quoted string statements** (e.g. `else "Hello"`) as renderable template text, including when used as bare `if/else` branch bodies.
> 
> Improves fragment (`<>...</>`) parsing so **backtick-delimited text inside fragments** is preserved as `JSXText` (and cleans up template-literal token context), and adjusts SSR `IfStatement` transform to accept non-block `alternate` bodies.
> 
> Adds coverage across Ripple client/SSR/compiler tests, Vite React runtime tests, and Solid compilation tests (including an early-return ordering regression).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b90dc5b1aa945fc12cd3a9bb6deec9be5f151f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->