### PR TITLE
fix more issues

### DIFF
--- a/.changeset/solid-early-return-guards.md
+++ b/.changeset/solid-early-return-guards.md
@@ -1,0 +1,5 @@
+---
+'@tsrx/solid': patch
+---
+
+Fix sequential early-return guards so later JSX is nested under each remaining Solid continuation.

--- a/.changeset/static-react-return-captures.md
+++ b/.changeset/static-react-return-captures.md
@@ -1,0 +1,5 @@
+---
+'@tsrx/core': patch
+---
+
+Capture repeated static JSX before multiple React and Preact early-return guards to avoid duplicated output.

--- a/packages/tsrx-react/tests/basic.test.js
+++ b/packages/tsrx-react/tests/basic.test.js
@@ -292,6 +292,68 @@ describe('@tsrx/react basic', () => {
 		);
 	});
 
+	it('captures static JSX reused by multiple early returns', () => {
+		const { code } = compile(
+			`export default component A() {
+				let early = true
+				<>"Hello"</>
+				if (early) {
+					return
+				}
+
+				<>"World"</>
+				if (!early) {
+					return
+				}
+
+				<>"done"</>
+				if (3) {
+					return
+				}
+
+				<>"bye"</>
+			}`,
+			'A.tsrx',
+		);
+
+		expect(code).toContain('const _tsrx_child_0 = <>"Hello"</>;');
+		expect(code).toContain('const _tsrx_child_1 = <>"World"</>;');
+		expect(code).toContain('const _tsrx_child_2 = <>"done"</>;');
+		expect(code).toContain('return _tsrx_child_0;');
+		expect(code).toContain('return <>{_tsrx_child_0}{_tsrx_child_1}</>;');
+		expect(code).toContain('return <>{_tsrx_child_0}{_tsrx_child_1}{_tsrx_child_2}</>;');
+		expect(code.match(/<>"Hello"<\/>/g)).toHaveLength(1);
+		expect(code.match(/<>"World"<\/>/g)).toHaveLength(1);
+		expect(code.match(/<>"done"<\/>/g)).toHaveLength(1);
+	});
+
+	it('captures static JSX before mixed early-return branch shapes', () => {
+		const { code } = compile(
+			`export component App() {
+				let first = false;
+				let second = true;
+				<div>{"start"}</div>
+				if (first) {
+					<strong>{"branch"}</strong>
+					return
+				}
+				<span>{"after"}</span>
+				if (second) {
+					return
+				}
+				<p>{"done"}</p>
+			}`,
+			'App.tsrx',
+		);
+
+		expect(code).toContain('const _tsrx_child_0 = <div>{"start"}</div>;');
+		expect(code).toContain('return <>{_tsrx_child_0}<strong>{"branch"}</strong></>;');
+		expect(code).toContain('const _tsrx_child_1 = <span>{"after"}</span>;');
+		expect(code).toContain('return <>{_tsrx_child_0}{_tsrx_child_1}</>;');
+		expect(code.match(/<div>\{"start"\}<\/div>/g)).toHaveLength(1);
+		expect(code.match(/<span>\{"after"\}<\/span>/g)).toHaveLength(1);
+	});
+
 	it('keeps transforming unreachable component body statements after bare returns', () => {
 		const { code } = compile(
 			`export component App() {
@@ -664,6 +726,91 @@ describe('@tsrx/react basic', () => {
 		expect(code).toContain('if (count > 1) {');
 		expect(code).toContain("return 'Hello World';");
 		expect(code).toContain("<span>{'After'}</span>");
+	});
+
+	it('captures static JSX reused by early returns inside element children', () => {
+		const { code } = compile(
+			`component App() {
+				let first = false;
+				let second = true;
+				<section>
+					<div>{"first"}</div>
+					if (first) {
+						return
+					}
+					<span>{"second"}</span>
+					if (second) {
+						return
+					}
+					<p>{"third"}</p>
+				</section>
+			}`,
+			'App.tsrx',
+		);
+
+		expect(code).toContain('<section>{(() => {');
+		expect(code).toContain('const _tsrx_child_0 = <div>{"first"}</div>;');
+		expect(code).toContain('const _tsrx_child_1 = <span>{"second"}</span>;');
+		expect(code).toContain('return _tsrx_child_0;');
+		expect(code).toContain('return <>{_tsrx_child_0}{_tsrx_child_1}</>;');
+		expect(code.match(/<div>\{"first"\}<\/div>/g)).toHaveLength(1);
+		expect(code.match(/<span>\{"second"\}<\/span>/g)).toHaveLength(1);
+	});
+
+	it('captures static JSX reused by deeply nested element early returns', () => {
+		const { code } = compile(
+			`component App() {
+				let first = false;
+				let second = true;
+				<main>
+					<section>
+						<article>
+							<div>{"first"}</div>
+							if (first) {
+								return
+							}
+							<span>{"second"}</span>
+							if (second) {
+								return
+							}
+							<p>{"third"}</p>
+						</article>
+					</section>
+				</main>
+			}`,
+			'App.tsrx',
+		);
+
+		expect(code).toContain('<main><section><article>{(() => {');
+		expect(code).toContain('const _tsrx_child_0 = <div>{"first"}</div>;');
+		expect(code).toContain('const _tsrx_child_1 = <span>{"second"}</span>;');
+		expect(code).toContain('return <>{_tsrx_child_0}{_tsrx_child_1}</>;');
+		expect(code.match(/<div>\{"first"\}<\/div>/g)).toHaveLength(1);
+		expect(code.match(/<span>\{"second"\}<\/span>/g)).toHaveLength(1);
+	});
+
+	it('does not capture nested dynamic render expressions across early returns', () => {
+		const { code } = compile(
+			`component App() {
+				let first = false;
+				let second = true;
+				<section>
+					<div>{Date.now()}</div>
+					if (first) {
+						return
+					}
+					<span>{Date.now()}</span>
+					if (second) {
+						return
+					}
+					<p>{Date.now()}</p>
+				</section>
+			}`,
+			'App.tsrx',
+		);
+
+		expect(code).not.toContain('_tsrx_child_');
+		expect(code.match(/Date\.now\(\)/g)).toHaveLength(6);
 	});
 
 	it('extracts hook-bearing element child statement bodies into local components', () => {
@@ -1403,6 +1550,28 @@ describe('lazy destructuring', () => {
 		expect(code).toContain('if (Math.random() > 0.5) {');
 		expect(code.match(/return <div>\{Date\.now\(\)\}<\/div>;/g)).toHaveLength(2);
 		expect(code).not.toContain('return null;');
+	});
+
+	it('does not capture dynamic render expressions across multiple early returns', () => {
+		const { code } = compile(
+			`export component Test() {
+				let first = false;
+				let second = true;
+				<div>{Date.now()}</div>
+				if (first) {
+					return
+				}
+				<span>{Date.now()}</span>
+				if (second) {
+					return
+				}
+				<p>{Date.now()}</p>
+			}`,
+			'Test.tsrx',
+		);
+
+		expect(code).not.toContain('_tsrx_child_');
+		expect(code.match(/Date\.now\(\)/g)).toHaveLength(6);
 	});
 
 	it('combines lazy params and regular destructuring', () => {

--- a/packages/tsrx-solid/src/transform.js
+++ b/packages/tsrx-solid/src/transform.js
@@ -233,6 +233,10 @@ function component_to_function_declaration(component, transform_context) {
 		const collect = (nodes, outer, jsx_bucket) => {
 			for (const child of nodes) {
 				if (is_jsx_child(child)) {
+					if (get_returning_if_info(child) !== null) {
+						jsx_bucket.push(child);
+						continue;
+					}
 					if (early_interleaved) {
 						const jsx = to_jsx_child(child, transform_context);
 						if (is_capturable_jsx_child(jsx)) {
@@ -260,11 +264,11 @@ function component_to_function_declaration(component, transform_context) {
 			transform_context.needs_show = true;
 			const branch_body = body_to_jsx_child(early_info.consequent_body, transform_context);
 			const fallback_body =
-				after_jsx.length > 0 ? body_to_jsx_child(after_jsx, transform_context) : null;
+				after_jsx.length > 0 ? body_to_early_return_jsx_child(after_jsx, transform_context) : null;
 			next_body.push(build_show_element(early_if.test, branch_body, fallback_body));
 		} else if (after_jsx.length > 0) {
 			transform_context.needs_show = true;
-			const show_body = body_to_jsx_child(after_jsx, transform_context);
+			const show_body = body_to_early_return_jsx_child(after_jsx, transform_context);
 			next_body.push(build_show_element(negate_expression(early_if.test), show_body, null));
 		}
 
@@ -520,6 +524,45 @@ function body_to_jsx_child(body_nodes, transform_context) {
 		expression: false,
 		metadata: { path: [], is_branch_arrow: true },
 	});
+}
+
+/**
+ * Lower render-continuation bodies that may contain additional early-return
+ * guards. Sequential guards need to nest the remaining continuation instead
+ * of rendering later children beside a `<Show>` for the guard itself.
+ *
+ * @param {any[]} body_nodes
+ * @param {TransformContext} transform_context
+ * @returns {any}
+ */
+function body_to_early_return_jsx_child(body_nodes, transform_context) {
+	const early_idx = body_nodes.findIndex((node) => get_returning_if_info(node) !== null);
+	if (early_idx === -1) {
+		return body_to_jsx_child(body_nodes, transform_context);
+	}
+
+	const early_if = /** @type {any} */ (body_nodes[early_idx]);
+	const early_info = /** @type {{ consequent_body: any[], return_index: number }} */ (
+		get_returning_if_info(early_if)
+	);
+	const before = body_nodes.slice(0, early_idx);
+	const after = body_nodes.slice(early_idx + 1);
+	const branch_has_content_before_return = early_info.return_index > 0;
+	const children = [...before];
+
+	if (branch_has_content_before_return) {
+		transform_context.needs_show = true;
+		const branch_body = body_to_jsx_child(early_info.consequent_body, transform_context);
+		const fallback_body =
+			after.length > 0 ? body_to_early_return_jsx_child(after, transform_context) : null;
+		children.push(build_show_element(early_if.test, branch_body, fallback_body));
+	} else if (after.length > 0) {
+		transform_context.needs_show = true;
+		const show_body = body_to_early_return_jsx_child(after, transform_context);
+		children.push(build_show_element(negate_expression(early_if.test), show_body, null));
+	}
+
+	return body_to_jsx_child(children, transform_context);
 }
 
 /**
@@ -825,11 +868,15 @@ function get_returning_if_info(node) {
  * @returns {any}
  */
 function negate_expression(expr) {
+	if (expr?.type === 'UnaryExpression' && expr.operator === '!') {
+		return clone_expression_node(expr.argument);
+	}
+
 	return {
 		type: 'UnaryExpression',
 		operator: '!',
 		prefix: true,
-		argument: expr,
+		argument: clone_expression_node(expr),
 		metadata: { path: [] },
 	};
 }

--- a/packages/tsrx-solid/tests/basic.test.js
+++ b/packages/tsrx-solid/tests/basic.test.js
@@ -474,6 +474,36 @@ describe('@tsrx/solid basic', () => {
 			expect(hello_idx).toBeLessThan(show_idx);
 			expect(code).not.toContain('return <Show when={!early}');
 		});
+
+		it('nests sequential early-return continuations', () => {
+			const { code } = compile(
+				`export default component A() {
+					let early = true
+					<>"Hello"</>
+					if (early) {
+						return
+					}
+					<>"World"</>
+					if (!early) {
+						return
+					}
+					<>"done"</>
+				}`,
+				'A.tsrx',
+			);
+
+			const hello_idx = code.indexOf('<>"Hello"</>');
+			const outer_show_idx = code.indexOf('<Show when={!early}');
+			const world_idx = code.indexOf('<>"World"</>');
+			const inner_show_idx = code.indexOf('<Show when={early}');
+			const done_idx = code.indexOf('<>"done"</>');
+			expect(hello_idx).toBeGreaterThan(-1);
+			expect(outer_show_idx).toBeGreaterThan(hello_idx);
+			expect(world_idx).toBeGreaterThan(outer_show_idx);
+			expect(inner_show_idx).toBeGreaterThan(world_idx);
+			expect(done_idx).toBeGreaterThan(inner_show_idx);
+			expect(code).not.toContain('<Show when={!early}>{(_) =>');
+		});
 	});
 
 	describe('<tsx> fragments', () => {

--- a/packages/tsrx/src/transform/jsx/index.js
+++ b/packages/tsrx/src/transform/jsx/index.js
@@ -624,6 +624,10 @@ function build_render_statements(body_nodes, return_null_when_empty, transform_c
 	// any JSX is constructed, and every JSX child would observe the final
 	// state of mutable variables.
 	const interleaved = is_interleaved_body(body_nodes);
+	const capture_static_early_return_nodes =
+		!interleaved &&
+		!transform_context.platform.hooks?.isTopLevelSetupCall &&
+		body_nodes.filter(is_returning_if_statement).length > 1;
 	let capture_index = 0;
 
 	for (let i = 0; i < body_nodes.length; i += 1) {
@@ -647,6 +651,15 @@ function build_render_statements(body_nodes, return_null_when_empty, transform_c
 				transform_context,
 				true,
 			);
+
+			if (capture_static_early_return_nodes) {
+				capture_index = capture_static_early_return_render_nodes(
+					render_nodes,
+					statements,
+					capture_index,
+					transform_context,
+				);
+			}
 
 			if (branch_has_hooks || continuation_has_hooks) {
 				if (transform_context.platform.hooks?.isTopLevelSetupCall) {
@@ -1323,6 +1336,59 @@ function hoist_static_render_nodes(render_nodes, transform_context) {
 
 		render_nodes[i] = to_jsx_expression_container(clone_identifier(id), node);
 	}
+}
+
+/**
+ * Static JSX that appears before multiple early-return guards is otherwise
+ * cloned into every generated return. Capture it once at its source position
+ * and reuse the reference, matching the interleaved-statement capture path
+ * without moving dynamic render-time expressions across guards.
+ *
+ * @param {any[]} render_nodes
+ * @param {any[]} statements
+ * @param {number} capture_index
+ * @param {TransformContext} transform_context
+ * @returns {number}
+ */
+function capture_static_early_return_render_nodes(
+	render_nodes,
+	statements,
+	capture_index,
+	transform_context,
+) {
+	for (let i = 0; i < render_nodes.length; i += 1) {
+		const node = render_nodes[i];
+		if (!is_static_early_return_capture_node(node, transform_context)) {
+			continue;
+		}
+
+		const { declaration, reference } = captureJsxChild(node, capture_index++);
+		statements.push(declaration);
+		render_nodes[i] = reference;
+	}
+
+	return capture_index;
+}
+
+/**
+ * @param {any} node
+ * @param {TransformContext} transform_context
+ * @returns {boolean}
+ */
+function is_static_early_return_capture_node(node, transform_context) {
+	if (node?.type !== 'JSXElement' && node?.type !== 'JSXFragment') {
+		return false;
+	}
+	if (!is_hoist_safe_jsx_node(node)) {
+		return false;
+	}
+	if (
+		transform_context.platform.hooks?.canHoistStaticNode &&
+		!transform_context.platform.hooks.canHoistStaticNode(node, transform_context)
+	) {
+		return false;
+	}
+	return !references_scope_bindings(node, transform_context.available_bindings);
 }
 
 /**


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core JSX/early-return lowering logic for multiple guards, which can subtly alter generated output ordering and hoisting behavior across React/Preact/Solid. Risk is mitigated by added regression tests covering nested guards, static capture, and dynamic-expression non-hoisting.
> 
> **Overview**
> Fixes early-return guard lowering in **Solid** so *sequential* `if (...) return` guards correctly **nest** the remaining continuation JSX under each generated `<Show>` rather than rendering later JSX alongside the wrong guard.
> 
> Improves **React/Preact** early-return codegen by capturing reusable *static* JSX that appears before multiple early-return guards into `_tsrx_child_*` temporaries, avoiding duplicated JSX output while still **not hoisting dynamic render-time expressions** across guards. Adds targeted regression tests for top-level and element-children early returns, including mixed branch shapes and dynamic-expression cases.
> 
> Also tweaks Solid’s `negate_expression` to avoid producing `!!expr` by unwrapping existing unary negations when building the negated condition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b325b7ab348a7ca4e8ada5b5b801aefc67d8ed78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->