### PR TITLE
more fixes

### DIFF
--- a/.changeset/lone-fragment-expression-render.md
+++ b/.changeset/lone-fragment-expression-render.md
@@ -1,0 +1,9 @@
+---
+'@tsrx/core': patch
+'@tsrx/react': patch
+'@tsrx/preact': patch
+'@tsrx/solid': patch
+'@tsrx/vue': patch
+---
+
+Fix lone expression children inside fragment shorthand so they render from component, branch, and loop bodies.

--- a/packages/tsrx-solid/src/transform.js
+++ b/packages/tsrx-solid/src/transform.js
@@ -290,6 +290,8 @@ function component_to_function_declaration(component, transform_context) {
 			} else {
 				render_nodes.push(jsx);
 			}
+		} else if (is_bare_render_expression(child)) {
+			render_nodes.push(to_jsx_expression_container(child, child));
 		} else {
 			statements.push(child);
 		}
@@ -482,6 +484,8 @@ function body_to_jsx_child(body_nodes, transform_context) {
 			} else {
 				children.push(jsx);
 			}
+		} else if (is_bare_render_expression(child)) {
+			children.push(to_jsx_expression_container(child, child));
 		} else {
 			statements.push(child);
 		}
@@ -661,6 +665,8 @@ function loop_body_to_callback_statements(body_nodes, transform_context) {
 
 		if (is_jsx_child(child)) {
 			children.push(to_jsx_child(child, transform_context));
+		} else if (is_bare_render_expression(child)) {
+			children.push(to_jsx_expression_container(child, child));
 		} else {
 			statements.push(child);
 		}
@@ -763,6 +769,53 @@ function return_argument_to_render_node(argument) {
  */
 function is_null_literal(node) {
 	return node?.type === 'Literal' && node.value == null;
+}
+
+/**
+ * See the shared JSX transform's helper of the same name.
+ *
+ * @param {any} node
+ * @returns {boolean}
+ */
+function is_bare_render_expression(node) {
+	if (!node || typeof node !== 'object') {
+		return false;
+	}
+
+	switch (node.type) {
+		case 'ArrayExpression':
+		case 'ArrowFunctionExpression':
+		case 'AssignmentExpression':
+		case 'AwaitExpression':
+		case 'BinaryExpression':
+		case 'CallExpression':
+		case 'ChainExpression':
+		case 'ClassExpression':
+		case 'ConditionalExpression':
+		case 'FunctionExpression':
+		case 'Identifier':
+		case 'ImportExpression':
+		case 'Literal':
+		case 'LogicalExpression':
+		case 'MemberExpression':
+		case 'MetaProperty':
+		case 'NewExpression':
+		case 'ObjectExpression':
+		case 'ParenthesizedExpression':
+		case 'SequenceExpression':
+		case 'TaggedTemplateExpression':
+		case 'TemplateLiteral':
+		case 'ThisExpression':
+		case 'TSAsExpression':
+		case 'TSSatisfiesExpression':
+		case 'TSNonNullExpression':
+		case 'UnaryExpression':
+		case 'UpdateExpression':
+		case 'YieldExpression':
+			return true;
+		default:
+			return false;
+	}
 }
 
 /**

--- a/packages/tsrx-solid/src/transform.js
+++ b/packages/tsrx-solid/src/transform.js
@@ -26,6 +26,7 @@ import {
 	flatten_switch_consequent,
 	get_for_of_iteration_params,
 	identifier_to_jsx_name,
+	is_bare_render_expression,
 	is_dynamic_element_id,
 	is_jsx_child,
 	set_loc,
@@ -769,53 +770,6 @@ function return_argument_to_render_node(argument) {
  */
 function is_null_literal(node) {
 	return node?.type === 'Literal' && node.value == null;
-}
-
-/**
- * See the shared JSX transform's helper of the same name.
- *
- * @param {any} node
- * @returns {boolean}
- */
-function is_bare_render_expression(node) {
-	if (!node || typeof node !== 'object') {
-		return false;
-	}
-
-	switch (node.type) {
-		case 'ArrayExpression':
-		case 'ArrowFunctionExpression':
-		case 'AssignmentExpression':
-		case 'AwaitExpression':
-		case 'BinaryExpression':
-		case 'CallExpression':
-		case 'ChainExpression':
-		case 'ClassExpression':
-		case 'ConditionalExpression':
-		case 'FunctionExpression':
-		case 'Identifier':
-		case 'ImportExpression':
-		case 'Literal':
-		case 'LogicalExpression':
-		case 'MemberExpression':
-		case 'MetaProperty':
-		case 'NewExpression':
-		case 'ObjectExpression':
-		case 'ParenthesizedExpression':
-		case 'SequenceExpression':
-		case 'TaggedTemplateExpression':
-		case 'TemplateLiteral':
-		case 'ThisExpression':
-		case 'TSAsExpression':
-		case 'TSSatisfiesExpression':
-		case 'TSNonNullExpression':
-		case 'UnaryExpression':
-		case 'UpdateExpression':
-		case 'YieldExpression':
-			return true;
-		default:
-			return false;
-	}
 }
 
 /**

--- a/packages/tsrx/src/index.js
+++ b/packages/tsrx/src/index.js
@@ -164,6 +164,7 @@ export {
 	flatten_switch_consequent,
 	get_for_of_iteration_params,
 	identifier_to_jsx_name,
+	is_bare_render_expression,
 	is_dynamic_element_id,
 	is_jsx_child,
 	set_loc,

--- a/packages/tsrx/src/transform/jsx/ast-builders.js
+++ b/packages/tsrx/src/transform/jsx/ast-builders.js
@@ -188,6 +188,57 @@ export function is_jsx_child(node) {
 }
 
 /**
+ * The parser represents `<>{expr}</>` / `<tsx>{expr}</tsx>` as a Tsx node,
+ * and expression-position lowering unwraps that to the inner expression.
+ * When such a node appears directly in a component or statement render body,
+ * the unwrapped expression is still render output rather than an executable
+ * statement.
+ *
+ * @param {any} node
+ * @returns {boolean}
+ */
+export function is_bare_render_expression(node) {
+	if (!node || typeof node !== 'object') {
+		return false;
+	}
+
+	switch (node.type) {
+		case 'ArrayExpression':
+		case 'ArrowFunctionExpression':
+		case 'AssignmentExpression':
+		case 'AwaitExpression':
+		case 'BinaryExpression':
+		case 'CallExpression':
+		case 'ChainExpression':
+		case 'ClassExpression':
+		case 'ConditionalExpression':
+		case 'FunctionExpression':
+		case 'Identifier':
+		case 'ImportExpression':
+		case 'Literal':
+		case 'LogicalExpression':
+		case 'MemberExpression':
+		case 'MetaProperty':
+		case 'NewExpression':
+		case 'ObjectExpression':
+		case 'ParenthesizedExpression':
+		case 'SequenceExpression':
+		case 'TaggedTemplateExpression':
+		case 'TemplateLiteral':
+		case 'ThisExpression':
+		case 'TSAsExpression':
+		case 'TSSatisfiesExpression':
+		case 'TSNonNullExpression':
+		case 'UnaryExpression':
+		case 'UpdateExpression':
+		case 'YieldExpression':
+			return true;
+		default:
+			return false;
+	}
+}
+
+/**
  * A dynamic element id is one whose identifier is `tracked` — i.e. it was
  * introduced by reactive destructuring so its value can change at runtime.
  *

--- a/packages/tsrx/src/transform/jsx/index.js
+++ b/packages/tsrx/src/transform/jsx/index.js
@@ -4276,6 +4276,8 @@ function create_render_switch_case(switch_case, transform_context) {
 
 		if (is_jsx_child(child)) {
 			render_nodes.push(to_jsx_child(child, transform_context));
+		} else if (is_bare_render_expression(child)) {
+			render_nodes.push(to_jsx_expression_container(child, child));
 		} else {
 			case_body.push(child);
 		}

--- a/packages/tsrx/src/transform/jsx/index.js
+++ b/packages/tsrx/src/transform/jsx/index.js
@@ -20,6 +20,7 @@ import {
 	flatten_switch_consequent,
 	get_for_of_iteration_params,
 	identifier_to_jsx_name,
+	is_bare_render_expression,
 	is_dynamic_element_id,
 	is_jsx_child,
 	set_loc,
@@ -1402,57 +1403,6 @@ function is_static_early_return_capture_node(node, transform_context) {
 		return false;
 	}
 	return !references_scope_bindings(node, transform_context.available_bindings);
-}
-
-/**
- * The parser represents `<>{expr}</>` / `<tsx>{expr}</tsx>` as a Tsx node,
- * and expression-position lowering unwraps that to the inner expression.
- * When such a node appears directly in a component or statement render body,
- * the unwrapped expression is still render output rather than an executable
- * statement.
- *
- * @param {any} node
- * @returns {boolean}
- */
-function is_bare_render_expression(node) {
-	if (!node || typeof node !== 'object') {
-		return false;
-	}
-
-	switch (node.type) {
-		case 'ArrayExpression':
-		case 'ArrowFunctionExpression':
-		case 'AssignmentExpression':
-		case 'AwaitExpression':
-		case 'BinaryExpression':
-		case 'CallExpression':
-		case 'ChainExpression':
-		case 'ClassExpression':
-		case 'ConditionalExpression':
-		case 'FunctionExpression':
-		case 'Identifier':
-		case 'ImportExpression':
-		case 'Literal':
-		case 'LogicalExpression':
-		case 'MemberExpression':
-		case 'MetaProperty':
-		case 'NewExpression':
-		case 'ObjectExpression':
-		case 'ParenthesizedExpression':
-		case 'SequenceExpression':
-		case 'TaggedTemplateExpression':
-		case 'TemplateLiteral':
-		case 'ThisExpression':
-		case 'TSAsExpression':
-		case 'TSSatisfiesExpression':
-		case 'TSNonNullExpression':
-		case 'UnaryExpression':
-		case 'UpdateExpression':
-		case 'YieldExpression':
-			return true;
-		default:
-			return false;
-	}
 }
 
 /**

--- a/packages/tsrx/src/transform/jsx/index.js
+++ b/packages/tsrx/src/transform/jsx/index.js
@@ -894,6 +894,8 @@ function build_render_statements(body_nodes, return_null_when_empty, transform_c
 			} else {
 				render_nodes.push(jsx);
 			}
+		} else if (is_bare_render_expression(child)) {
+			render_nodes.push(to_jsx_expression_container(child, child));
 		} else {
 			statements.push(child);
 			collect_statement_bindings(child, transform_context.available_bindings);
@@ -1400,6 +1402,57 @@ function is_static_early_return_capture_node(node, transform_context) {
 		return false;
 	}
 	return !references_scope_bindings(node, transform_context.available_bindings);
+}
+
+/**
+ * The parser represents `<>{expr}</>` / `<tsx>{expr}</tsx>` as a Tsx node,
+ * and expression-position lowering unwraps that to the inner expression.
+ * When such a node appears directly in a component or statement render body,
+ * the unwrapped expression is still render output rather than an executable
+ * statement.
+ *
+ * @param {any} node
+ * @returns {boolean}
+ */
+function is_bare_render_expression(node) {
+	if (!node || typeof node !== 'object') {
+		return false;
+	}
+
+	switch (node.type) {
+		case 'ArrayExpression':
+		case 'ArrowFunctionExpression':
+		case 'AssignmentExpression':
+		case 'AwaitExpression':
+		case 'BinaryExpression':
+		case 'CallExpression':
+		case 'ChainExpression':
+		case 'ClassExpression':
+		case 'ConditionalExpression':
+		case 'FunctionExpression':
+		case 'Identifier':
+		case 'ImportExpression':
+		case 'Literal':
+		case 'LogicalExpression':
+		case 'MemberExpression':
+		case 'MetaProperty':
+		case 'NewExpression':
+		case 'ObjectExpression':
+		case 'ParenthesizedExpression':
+		case 'SequenceExpression':
+		case 'TaggedTemplateExpression':
+		case 'TemplateLiteral':
+		case 'ThisExpression':
+		case 'TSAsExpression':
+		case 'TSSatisfiesExpression':
+		case 'TSNonNullExpression':
+		case 'UnaryExpression':
+		case 'UpdateExpression':
+		case 'YieldExpression':
+			return true;
+		default:
+			return false;
+	}
 }
 
 /**

--- a/packages/tsrx/tests/shared/compile.js
+++ b/packages/tsrx/tests/shared/compile.js
@@ -56,6 +56,52 @@ export function runSharedCompileDiagnosticsTests({ compile_to_volar_mappings, na
 }
 
 /**
+ * @param {Pick<CompileHarness, 'compile' | 'name'>} harness
+ */
+export function runSharedFragmentExpressionRenderTests({ compile, name }) {
+	describe(`[${name}] fragment expression render bodies`, () => {
+		it('renders a component-body fragment shorthand with a lone expression child', () => {
+			const { code } = compile(
+				`export default component A() {
+					<>{"Hello"}</>
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('return "Hello";');
+		});
+
+		it('renders lone expression fragment shorthand inside conditional render bodies', () => {
+			const { code } = compile(
+				`export component A() {
+					if (show) {
+						<>{"Hello"}</>
+					}
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('"Hello"');
+			expect(code).not.toMatch(/^[\t ]*"Hello";?\n\s*return null;/m);
+		});
+
+		it('renders lone expression fragment shorthand inside loop render bodies', () => {
+			const { code } = compile(
+				`export component A() {
+					for (const value of values) {
+						<>{value}</>
+					}
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('value');
+			expect(code).not.toMatch(/^[\t ]*value;?\n\s*return null;/m);
+		});
+	});
+}
+
+/**
  * Shared component-loop regressions. Vue does not share the full JSX output
  * suite because its component export shape differs, but it should still share
  * these component-body validation rules.
@@ -63,6 +109,8 @@ export function runSharedCompileDiagnosticsTests({ compile_to_volar_mappings, na
  * @param {Pick<CompileHarness, 'compile' | 'name'>} harness
  */
 export function runSharedComponentLoopControlFlowTests({ compile, name }) {
+	runSharedFragmentExpressionRenderTests({ compile, name });
+
 	describe(`[${name}] component loop control flow`, () => {
 		it('uses continue to skip a for...of iteration', () => {
 			const { code } = compile(

--- a/packages/tsrx/tests/shared/compile.js
+++ b/packages/tsrx/tests/shared/compile.js
@@ -98,6 +98,26 @@ export function runSharedFragmentExpressionRenderTests({ compile, name }) {
 			expect(code).toContain('value');
 			expect(code).not.toMatch(/^[\t ]*value;?\n\s*return null;/m);
 		});
+
+		it('renders lone expression fragment shorthand inside switch case bodies', () => {
+			const { code } = compile(
+				`export component A() {
+					switch (state) {
+						case "ready":
+							<>{"Ready"}</>
+							break
+						default:
+							<>{"Waiting"}</>
+					}
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('"Ready"');
+			expect(code).toContain('"Waiting"');
+			expect(code).not.toMatch(/^[\t ]*"Ready";?\n\s*break;/m);
+			expect(code).not.toMatch(/^[\t ]*"Waiting";?\n\s*return null;/m);
+		});
 	});
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core and Solid JSX lowering logic to treat certain standalone expressions as render output, which could subtly change codegen for non-JSX expression statements in templates across targets.
> 
> **Overview**
> Fixes a codegen bug where fragment shorthand with a single expression child (e.g. `<> {value} </>`) could be lowered as an executable statement instead of render output when it appears directly in component bodies or inside `if`/`for...of`/`switch` render bodies.
> 
> This adds a new shared predicate `is_bare_render_expression` and uses it in both the core JSX transform and the Solid transform to wrap these expressions in `JSXExpressionContainer` so they participate in the returned render fragment, plus adds shared regression tests and a changeset bumping all framework packages as patch releases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e1b37c5fea3ee3e91fe2c93ba39d905b629ccde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->