### PR TITLE
more vue vapor fixes

### DIFF
--- a/.changeset/vue-vapor-for-loops.md
+++ b/.changeset/vue-vapor-for-loops.md
@@ -1,0 +1,7 @@
+---
+'@tsrx/vue': patch
+'@tsrx/vite-plugin-vue': patch
+'@tsrx/rspack-plugin-vue': patch
+---
+
+Lower Vue `for...of` templates to `VaporFor` so loop item and key callbacks preserve types. Update the Vue plugin bridge and peer floor for the `vue-jsx-vapor` runtime that provides `VaporFor`.

--- a/packages/rspack-plugin-vue/package.json
+++ b/packages/rspack-plugin-vue/package.json
@@ -26,13 +26,13 @@
   "peerDependencies": {
     "@rspack/core": ">=1.0.0",
     "vue": ">=3.5",
-    "vue-jsx-vapor": ">=3.2.10"
+    "vue-jsx-vapor": ">=3.2.12"
   },
   "devDependencies": {
     "@rspack/core": "^1.6.0",
     "typescript": "catalog:default",
     "vue": "3.6.0-beta.10",
-    "vue-jsx-vapor": "^3.2.11"
+    "vue-jsx-vapor": "^3.2.12"
   },
   "files": [
     "src",

--- a/packages/tsrx-vue/package.json
+++ b/packages/tsrx-vue/package.json
@@ -30,11 +30,12 @@
   "dependencies": {
     "@tsrx/core": "workspace:*",
     "esrap": "catalog:default",
+    "is-reference": "catalog:default",
     "zimmerframe": "catalog:default"
   },
   "peerDependencies": {
     "vue": ">=3.5",
-    "vue-jsx-vapor": ">=3.2.10"
+    "vue-jsx-vapor": ">=3.2.12"
   },
   "devDependencies": {
     "@types/estree": "catalog:default",

--- a/packages/tsrx-vue/src/transform.js
+++ b/packages/tsrx-vue/src/transform.js
@@ -458,6 +458,7 @@ function rewrite_vapor_for_keyed_slot_refs(node, loop_params, replacements = new
 			FunctionDeclaration: rewrite_function_shadowed_refs,
 			FunctionExpression: rewrite_function_shadowed_refs,
 			ArrowFunctionExpression: rewrite_function_shadowed_refs,
+			BlockStatement: rewrite_block_shadowed_refs,
 		},
 	);
 }
@@ -550,7 +551,81 @@ function rewrite_function_shadowed_refs(node, { state, next }) {
 	for (const param of node.params || []) {
 		collect_pattern_names(param, shadowed_names);
 	}
+	collect_function_var_names(node.body, shadowed_names);
 	return next({ ...state, shadowed_names });
+}
+
+/**
+ * @param {any} node
+ * @param {{ state: { loop_param_names: Set<string>, shadowed_names: Set<string> }, next: (state?: any) => any }} context
+ * @returns {any}
+ */
+function rewrite_block_shadowed_refs(node, { state, next }) {
+	const shadowed_names = new Set(state.shadowed_names);
+	collect_block_lexical_names(node.body, shadowed_names);
+	return next({ ...state, shadowed_names });
+}
+
+/**
+ * @param {any[]} statements
+ * @param {Set<string>} names
+ * @returns {void}
+ */
+function collect_block_lexical_names(statements, names) {
+	for (const statement of statements || []) {
+		if (statement.type === 'VariableDeclaration' && statement.kind !== 'var') {
+			for (const declaration of statement.declarations || []) {
+				collect_pattern_names(declaration.id, names);
+			}
+			continue;
+		}
+
+		if (
+			(statement.type === 'FunctionDeclaration' || statement.type === 'ClassDeclaration') &&
+			statement.id
+		) {
+			collect_pattern_names(statement.id, names);
+		}
+	}
+}
+
+/**
+ * @param {any} node
+ * @param {Set<string>} names
+ * @returns {void}
+ */
+function collect_function_var_names(node, names) {
+	if (!node || typeof node !== 'object') return;
+
+	if (Array.isArray(node)) {
+		for (const child of node) {
+			collect_function_var_names(child, names);
+		}
+		return;
+	}
+
+	if (
+		node.type === 'FunctionDeclaration' ||
+		node.type === 'FunctionExpression' ||
+		node.type === 'ArrowFunctionExpression' ||
+		node.type === 'ClassDeclaration' ||
+		node.type === 'ClassExpression'
+	) {
+		return;
+	}
+
+	if (node.type === 'VariableDeclaration' && node.kind === 'var') {
+		for (const declaration of node.declarations || []) {
+			collect_pattern_names(declaration.id, names);
+		}
+	}
+
+	for (const key of Object.keys(node)) {
+		if (key === 'loc' || key === 'start' || key === 'end' || key === 'metadata') {
+			continue;
+		}
+		collect_function_var_names(node[key], names);
+	}
 }
 
 /**

--- a/packages/tsrx-vue/src/transform.js
+++ b/packages/tsrx-vue/src/transform.js
@@ -202,17 +202,19 @@ function render_for_of_as_vapor_for(node, loop_params, body_statements, transfor
 		: (find_jsx_key_expression(rendered) ??
 			(node.index ? clone_expression_node(node.index) : null));
 
-	transform_context.needs_vapor_for = true;
-
-	if (key_expression) {
-		strip_top_level_jsx_keys(rendered);
-	}
 	const slot = key_expression
 		? create_keyed_vapor_for_slot(loop_params, rendered)
 		: { params: loop_params, body: rendered, expression: true };
 	if (!slot) {
 		return null;
 	}
+
+	transform_context.needs_vapor_for = true;
+
+	if (key_expression) {
+		strip_top_level_jsx_keys(slot.body);
+	}
+
 	const attributes = [
 		builders.jsx_attribute(
 			builders.jsx_id('in'),

--- a/packages/tsrx-vue/src/transform.js
+++ b/packages/tsrx-vue/src/transform.js
@@ -1,9 +1,12 @@
 /** @import { JsxPlatform } from '@tsrx/core/types' */
 
+import { walk } from 'zimmerframe';
+import is_reference from 'is-reference';
 import {
 	builders,
 	clone_expression_node,
 	clone_identifier,
+	create_generated_identifier,
 	componentToFunctionDeclaration,
 	createJsxTransform,
 	error,
@@ -41,6 +44,7 @@ const vue_platform = {
 	hooks: {
 		initialState: () => ({
 			needs_define_vapor_component: false,
+			needs_vapor_for: false,
 		}),
 		isTopLevelSetupCall(call_expression) {
 			return is_vue_setup_call(call_expression);
@@ -55,8 +59,8 @@ const vue_platform = {
 		preprocessElementAttributes(attrs, ctx, element) {
 			return preprocess_ref_attributes(attrs, element, ctx);
 		},
-		renderForOf: (node, loop_params, body_statements) =>
-			render_for_of_as_vapor_template(node, loop_params, body_statements),
+		renderForOf: (node, loop_params, body_statements, ctx) =>
+			render_for_of_as_vapor_for(node, loop_params, body_statements, ctx),
 		createErrorBoundaryContent(try_content) {
 			return {
 				type: 'ArrowFunctionExpression',
@@ -217,9 +221,10 @@ function create_define_vapor_component_call(
  * @param {any} node
  * @param {any[]} loop_params
  * @param {any[]} body_statements
+ * @param {any} transform_context
  * @returns {any | null}
  */
-function render_for_of_as_vapor_template(node, loop_params, body_statements) {
+function render_for_of_as_vapor_for(node, loop_params, body_statements, transform_context) {
 	if (body_statements.length !== 1) {
 		return null;
 	}
@@ -238,19 +243,23 @@ function render_for_of_as_vapor_template(node, loop_params, body_statements) {
 		? clone_expression_node(node.key)
 		: (find_jsx_key_expression(rendered) ??
 			(node.index ? clone_expression_node(node.index) : null));
-	strip_top_level_jsx_keys(rendered);
-	const children = rendered.type === 'JSXFragment' ? rendered.children : [rendered];
+
+	transform_context.needs_vapor_for = true;
+
+	if (key_expression) {
+		strip_top_level_jsx_keys(rendered);
+	}
+	const slot = key_expression
+		? create_keyed_vapor_for_slot(loop_params, rendered)
+		: { params: loop_params, body: rendered, expression: true };
+	if (!slot) {
+		return null;
+	}
 	const attributes = [
 		{
 			type: 'JSXAttribute',
-			name: { type: 'JSXIdentifier', name: 'v-for', metadata: { path: [] } },
-			value: to_jsx_expression_container({
-				type: 'BinaryExpression',
-				operator: 'in',
-				left: create_v_for_left(loop_params),
-				right: clone_expression_node(node.right),
-				metadata: { path: [] },
-			}),
+			name: { type: 'JSXIdentifier', name: 'in', metadata: { path: [] } },
+			value: to_jsx_expression_container(clone_expression_node(node.right)),
 			metadata: { path: [] },
 		},
 	];
@@ -258,8 +267,10 @@ function render_for_of_as_vapor_template(node, loop_params, body_statements) {
 	if (key_expression) {
 		attributes.push({
 			type: 'JSXAttribute',
-			name: { type: 'JSXIdentifier', name: 'key', metadata: { path: [] } },
-			value: to_jsx_expression_container(key_expression),
+			name: { type: 'JSXIdentifier', name: 'getKey', metadata: { path: [] } },
+			value: to_jsx_expression_container(
+				create_loop_callback(loop_params, key_expression, true),
+			),
 			metadata: { path: [] },
 		});
 	}
@@ -268,17 +279,17 @@ function render_for_of_as_vapor_template(node, loop_params, body_statements) {
 		type: 'JSXElement',
 		openingElement: {
 			type: 'JSXOpeningElement',
-			name: { type: 'JSXIdentifier', name: 'template', metadata: { path: [] } },
+			name: { type: 'JSXIdentifier', name: 'VaporFor', metadata: { path: [] } },
 			attributes,
 			selfClosing: false,
 			metadata: { path: [] },
 		},
 		closingElement: {
 			type: 'JSXClosingElement',
-			name: { type: 'JSXIdentifier', name: 'template', metadata: { path: [] } },
+			name: { type: 'JSXIdentifier', name: 'VaporFor', metadata: { path: [] } },
 			metadata: { path: [] },
 		},
-		children,
+		children: [to_jsx_expression_container(create_loop_callback(slot.params, slot.body, slot.expression))],
 		metadata: { path: [] },
 	});
 }
@@ -328,9 +339,8 @@ function render_for_of_as_flat_map(node, loop_params, rendered) {
 }
 
 /**
- * `<template v-for>` preserves one rendered slot per source item in the current
- * Vue runtime path. Loop bodies that can return `null` need the shared callback
- * lowering so `continue` truly skips the iteration.
+ * Loop bodies that can return `null` need the shared callback lowering so
+ * `continue` truly skips the iteration.
  *
  * @param {any} node
  * @returns {boolean}
@@ -387,22 +397,6 @@ function to_array_render_expression(node) {
 }
 
 /**
- * @param {any[]} loop_params
- * @returns {any}
- */
-function create_v_for_left(loop_params) {
-	if (loop_params.length === 1) {
-		return clone_expression_node(loop_params[0]);
-	}
-
-	return {
-		type: 'SequenceExpression',
-		expressions: loop_params.map((param) => clone_expression_node(param)),
-		metadata: { path: [] },
-	};
-}
-
-/**
  * @param {any} node
  * @returns {any | null}
  */
@@ -448,6 +442,299 @@ function strip_top_level_jsx_keys(node) {
 			strip_top_level_jsx_keys(child);
 		}
 	}
+}
+
+/**
+ * @param {any[]} loop_params
+ * @param {any} body
+ * @param {boolean} expression
+ * @returns {any}
+ */
+function create_loop_callback(loop_params, body, expression) {
+	return {
+		type: 'ArrowFunctionExpression',
+		params: loop_params.map((param) => clone_expression_node(param)),
+		body,
+		async: false,
+		generator: false,
+		expression,
+		metadata: { path: [] },
+	};
+}
+
+/**
+ * @param {any[]} loop_params
+ * @param {any} rendered
+ * @returns {{ params: any[], body: any, expression: boolean } | null}
+ */
+function create_keyed_vapor_for_slot(loop_params, rendered) {
+	if (loop_params[0]?.type === 'Identifier') {
+		return {
+			params: loop_params,
+			body: rewrite_vapor_for_keyed_slot_refs(rendered, loop_params),
+			expression: true,
+		};
+	}
+
+	const item_ref = create_generated_identifier('__vapor_item');
+	const item_ref_value = create_value_member_expression(item_ref);
+	const replacements = create_pattern_replacements(loop_params[0], item_ref_value);
+	if (!replacements) {
+		return null;
+	}
+
+	const params = [item_ref, ...loop_params.slice(1)];
+	const rewritten_rendered = rewrite_vapor_for_keyed_slot_refs(
+		rendered,
+		loop_params.slice(1),
+		replacements,
+	);
+
+	return {
+		params,
+		body: rewritten_rendered,
+		expression: true,
+	};
+}
+
+/**
+ * Vue's `VaporFor` passes plain item values to unkeyed slots, but keyed slots
+ * receive shallow refs so row instances can update in place. Match that runtime
+ * shape by reading loop params through `.value` inside the slot body.
+ *
+ * @param {any} node
+ * @param {any[]} loop_params
+ * @param {Map<string, any>} [replacements]
+ * @returns {any}
+ */
+function rewrite_vapor_for_keyed_slot_refs(node, loop_params, replacements = new Map()) {
+	const loop_param_names = new Set();
+	for (const param of loop_params) {
+		collect_pattern_names(param, loop_param_names);
+	}
+
+	if (loop_param_names.size === 0 && replacements.size === 0) {
+		return node;
+	}
+
+	return walk(node, { loop_param_names, shadowed_names: new Set() }, {
+		Identifier(identifier, { path, state, next }) {
+			const parent = path.at(-1);
+			if (
+				(state.loop_param_names.has(identifier.name) || replacements.has(identifier.name)) &&
+				!state.shadowed_names.has(identifier.name) &&
+				parent &&
+				is_runtime_reference(identifier, parent)
+			) {
+				const replacement = replacements.get(identifier.name);
+				if (replacement) {
+					return clone_expression_node(replacement);
+				}
+				return create_value_member_expression(identifier);
+			}
+
+			return next();
+		},
+		FunctionDeclaration: rewrite_function_shadowed_refs,
+		FunctionExpression: rewrite_function_shadowed_refs,
+		ArrowFunctionExpression: rewrite_function_shadowed_refs,
+	});
+}
+
+/**
+ * @param {any} identifier
+ * @param {any} parent
+ * @returns {boolean}
+ */
+function is_runtime_reference(identifier, parent) {
+	if (parent.type === 'JSXExpressionContainer') {
+		return parent.expression === identifier;
+	}
+	if (parent.type === 'JSXAttribute') {
+		return parent.value === identifier || parent.value?.expression === identifier;
+	}
+	return is_reference(identifier, parent);
+}
+
+/**
+ * @param {any} pattern
+ * @param {any} source
+ * @returns {Map<string, any> | null}
+ */
+function create_pattern_replacements(pattern, source) {
+	const replacements = new Map();
+	return collect_pattern_replacements(pattern, source, replacements) ? replacements : null;
+}
+
+/**
+ * @param {any} pattern
+ * @param {any} source
+ * @param {Map<string, any>} replacements
+ * @returns {boolean}
+ */
+function collect_pattern_replacements(pattern, source, replacements) {
+	if (!pattern) return true;
+
+	switch (pattern.type) {
+		case 'Identifier':
+			replacements.set(pattern.name, source);
+			return true;
+		case 'ObjectPattern':
+			for (const property of pattern.properties || []) {
+				if (property.type === 'RestElement' || property.computed) {
+					return false;
+				}
+				if (
+					property.type !== 'Property' ||
+					!collect_pattern_replacements(
+						property.value,
+						create_property_member_expression(source, property.key),
+						replacements,
+					)
+				) {
+					return false;
+				}
+			}
+			return true;
+		case 'ArrayPattern':
+			for (let index = 0; index < (pattern.elements || []).length; index++) {
+				const element = pattern.elements[index];
+				if (
+					element &&
+					!collect_pattern_replacements(
+						element,
+						create_index_member_expression(source, index),
+						replacements,
+					)
+				) {
+					return false;
+				}
+			}
+			return true;
+		default:
+			return false;
+	}
+}
+
+/**
+ * @param {any} node
+ * @param {{ state: { loop_param_names: Set<string>, shadowed_names: Set<string> }, next: (state?: any) => any }} context
+ * @returns {any}
+ */
+function rewrite_function_shadowed_refs(node, { state, next }) {
+	const shadowed_names = new Set(state.shadowed_names);
+	if (node.id) {
+		collect_pattern_names(node.id, shadowed_names);
+	}
+	for (const param of node.params || []) {
+		collect_pattern_names(param, shadowed_names);
+	}
+	return next({ ...state, shadowed_names });
+}
+
+/**
+ * @param {any} node
+ * @param {Set<string>} names
+ * @returns {void}
+ */
+function collect_pattern_names(node, names) {
+	if (!node) return;
+
+	switch (node.type) {
+		case 'Identifier':
+			names.add(node.name);
+			break;
+		case 'RestElement':
+			collect_pattern_names(node.argument, names);
+			break;
+		case 'AssignmentPattern':
+			collect_pattern_names(node.left, names);
+			break;
+		case 'ArrayPattern':
+			for (const element of node.elements || []) {
+				collect_pattern_names(element, names);
+			}
+			break;
+		case 'ObjectPattern':
+			for (const property of node.properties || []) {
+				collect_pattern_names(property, names);
+			}
+			break;
+		case 'Property':
+			collect_pattern_names(node.value, names);
+			break;
+	}
+}
+
+/**
+ * @param {any} object
+ * @param {any} key
+ * @returns {any}
+ */
+function create_property_member_expression(object, key) {
+	if (key?.type === 'Identifier') {
+		return create_member_expression(
+			clone_expression_node(object),
+			clone_identifier(key),
+			false,
+			key,
+		);
+	}
+
+	return create_member_expression(
+		clone_expression_node(object),
+		clone_expression_node(key),
+		true,
+		key,
+	);
+}
+
+/**
+ * @param {any} object
+ * @param {number} index
+ * @returns {any}
+ */
+function create_index_member_expression(object, index) {
+	return create_member_expression(
+		clone_expression_node(object),
+		builders.literal(index),
+		true,
+		object,
+	);
+}
+
+/**
+ * @param {any} identifier
+ * @returns {any}
+ */
+function create_value_member_expression(identifier) {
+	return create_member_expression(
+		clone_identifier(identifier),
+		{ type: 'Identifier', name: 'value', metadata: { path: [] } },
+		false,
+		identifier,
+	);
+}
+
+/**
+ * @param {any} object
+ * @param {any} property
+ * @param {boolean} computed
+ * @param {any} source_node
+ * @returns {any}
+ */
+function create_member_expression(object, property, computed, source_node) {
+	return setLocation(
+		{
+			type: 'MemberExpression',
+			object,
+			property,
+			computed,
+			optional: false,
+			metadata: { path: [] },
+		},
+		source_node,
+	);
 }
 
 /**
@@ -739,6 +1026,10 @@ function is_component_jsx_name(name) {
 function inject_vue_imports(program, transform_context) {
 	if (transform_context.needs_define_vapor_component) {
 		ensure_named_import(program, 'vue-jsx-vapor', 'defineVaporComponent');
+	}
+
+	if (transform_context.needs_vapor_for) {
+		ensure_named_import(program, 'vue-jsx-vapor', 'VaporFor');
 	}
 
 	if (transform_context.needs_suspense) {

--- a/packages/tsrx-vue/src/transform.js
+++ b/packages/tsrx-vue/src/transform.js
@@ -10,7 +10,6 @@ import {
 	componentToFunctionDeclaration,
 	createJsxTransform,
 	error,
-	identifier_to_jsx_name,
 	setLocation,
 } from '@tsrx/core';
 
@@ -62,15 +61,7 @@ const vue_platform = {
 		renderForOf: (node, loop_params, body_statements, ctx) =>
 			render_for_of_as_vapor_for(node, loop_params, body_statements, ctx),
 		createErrorBoundaryContent(try_content) {
-			return {
-				type: 'ArrowFunctionExpression',
-				params: [],
-				body: try_content.expression,
-				async: false,
-				generator: false,
-				expression: true,
-				metadata: { path: [] },
-			};
+			return builders.arrow([], try_content.expression);
 		},
 		transformElementChildren(node, walked_children, raw_children, attributes, ctx) {
 			return rewrite_host_text_or_html_children(
@@ -132,26 +123,12 @@ function component_to_vapor_component_declaration(component, transform_context, 
 	};
 	/** @type {any} */ (component_id.metadata).hover = create_component_hover_replacement(fn.params);
 
-	return setLocation(
-		/** @type {any} */ ({
-			type: 'VariableDeclaration',
-			kind: 'const',
-			declarations: [
-				{
-					type: 'VariableDeclarator',
-					id: component_id,
-					init: call,
-					metadata: { path: [] },
-				},
-			],
-			metadata: {
-				path: [],
-				generated_helpers,
-				generated_statics,
-			},
-		}),
-		component,
-	);
+	const declaration = builders.declaration('const', [builders.declarator(component_id, call)]);
+	Object.assign(/** @type {any} */ (declaration.metadata), {
+		generated_helpers,
+		generated_statics,
+	});
+	return setLocation(/** @type {any} */ (declaration), component);
 }
 
 /**
@@ -162,24 +139,17 @@ function component_to_vapor_component_declaration(component, transform_context, 
  */
 function wrap_helper_component(helper_fn, helper_id, source_node) {
 	return setLocation(
-		/** @type {any} */ ({
-			type: 'VariableDeclaration',
-			kind: 'const',
-			declarations: [
-				{
-					type: 'VariableDeclarator',
-					id: clone_identifier(helper_id),
-					init: create_define_vapor_component_call(
-						function_declaration_to_expression(helper_fn),
-						[],
-						[],
-						source_node,
-					),
-					metadata: { path: [] },
-				},
-			],
-			metadata: { path: [] },
-		}),
+		builders.declaration('const', [
+			builders.declarator(
+				clone_identifier(helper_id),
+				create_define_vapor_component_call(
+					function_declaration_to_expression(helper_fn),
+					[],
+					[],
+					source_node,
+				),
+			),
+		]),
 		source_node,
 	);
 }
@@ -197,24 +167,12 @@ function create_define_vapor_component_call(
 	generated_statics,
 	source_node,
 ) {
-	return setLocation(
-		/** @type {any} */ ({
-			type: 'CallExpression',
-			callee: {
-				type: 'Identifier',
-				name: 'defineVaporComponent',
-				metadata: { path: [] },
-			},
-			arguments: [fn_expression],
-			optional: false,
-			metadata: {
-				path: [],
-				generated_helpers,
-				generated_statics,
-			},
-		}),
-		source_node,
-	);
+	const call = builders.call('defineVaporComponent', fn_expression);
+	Object.assign(/** @type {any} */ (call.metadata), {
+		generated_helpers,
+		generated_statics,
+	});
+	return setLocation(call, source_node);
 }
 
 /**
@@ -256,42 +214,28 @@ function render_for_of_as_vapor_for(node, loop_params, body_statements, transfor
 		return null;
 	}
 	const attributes = [
-		{
-			type: 'JSXAttribute',
-			name: { type: 'JSXIdentifier', name: 'in', metadata: { path: [] } },
-			value: to_jsx_expression_container(clone_expression_node(node.right)),
-			metadata: { path: [] },
-		},
+		builders.jsx_attribute(
+			builders.jsx_id('in'),
+			to_jsx_expression_container(clone_expression_node(node.right)),
+		),
 	];
 
 	if (key_expression) {
-		attributes.push({
-			type: 'JSXAttribute',
-			name: { type: 'JSXIdentifier', name: 'getKey', metadata: { path: [] } },
-			value: to_jsx_expression_container(
-				create_loop_callback(loop_params, key_expression, true),
+		attributes.push(
+			builders.jsx_attribute(
+				builders.jsx_id('getKey'),
+				to_jsx_expression_container(create_loop_callback(loop_params, key_expression, true)),
 			),
-			metadata: { path: [] },
-		});
+		);
 	}
 
-	return to_jsx_expression_container({
-		type: 'JSXElement',
-		openingElement: {
-			type: 'JSXOpeningElement',
-			name: { type: 'JSXIdentifier', name: 'VaporFor', metadata: { path: [] } },
-			attributes,
-			selfClosing: false,
-			metadata: { path: [] },
-		},
-		closingElement: {
-			type: 'JSXClosingElement',
-			name: { type: 'JSXIdentifier', name: 'VaporFor', metadata: { path: [] } },
-			metadata: { path: [] },
-		},
-		children: [to_jsx_expression_container(create_loop_callback(slot.params, slot.body, slot.expression))],
-		metadata: { path: [] },
-	});
+	return to_jsx_expression_container(
+		builders.jsx_element_fresh(
+			builders.jsx_opening_element(builders.jsx_id('VaporFor'), attributes),
+			builders.jsx_closing_element(builders.jsx_id('VaporFor')),
+			[to_jsx_expression_container(create_loop_callback(slot.params, slot.body, slot.expression))],
+		),
+	);
 }
 
 /**
@@ -301,41 +245,15 @@ function render_for_of_as_vapor_for(node, loop_params, body_statements, transfor
  * @returns {any}
  */
 function render_for_of_as_flat_map(node, loop_params, rendered) {
-	return to_jsx_expression_container({
-		type: 'CallExpression',
-		callee: {
-			type: 'MemberExpression',
-			object: clone_expression_node(node.right),
-			property: { type: 'Identifier', name: 'flatMap', metadata: { path: [] } },
-			computed: false,
-			optional: false,
-			metadata: { path: [] },
-		},
-		arguments: [
-			{
-				type: 'ArrowFunctionExpression',
-				params: loop_params,
-				body: {
-					type: 'BlockStatement',
-					body: [
-						{
-							type: 'ReturnStatement',
-							argument: to_array_render_expression(rendered),
-							metadata: { path: [] },
-						},
-					],
-					metadata: { path: [] },
-				},
-				async: false,
-				generator: false,
-				expression: false,
-				metadata: { path: [] },
-			},
-		],
-		async: false,
-		optional: false,
-		metadata: { path: [] },
-	});
+	return to_jsx_expression_container(
+		builders.call(
+			builders.member(clone_expression_node(node.right), 'flatMap'),
+			builders.arrow(
+				loop_params,
+				builders.block([builders.return(to_array_render_expression(rendered))]),
+			),
+		),
+	);
 }
 
 /**
@@ -451,15 +369,12 @@ function strip_top_level_jsx_keys(node) {
  * @returns {any}
  */
 function create_loop_callback(loop_params, body, expression) {
-	return {
-		type: 'ArrowFunctionExpression',
-		params: loop_params.map((param) => clone_expression_node(param)),
+	const callback = builders.arrow(
+		loop_params.map((param) => clone_expression_node(param)),
 		body,
-		async: false,
-		generator: false,
-		expression,
-		metadata: { path: [] },
-	};
+	);
+	callback.expression = expression;
+	return callback;
 }
 
 /**
@@ -517,28 +432,32 @@ function rewrite_vapor_for_keyed_slot_refs(node, loop_params, replacements = new
 		return node;
 	}
 
-	return walk(node, { loop_param_names, shadowed_names: new Set() }, {
-		Identifier(identifier, { path, state, next }) {
-			const parent = path.at(-1);
-			if (
-				(state.loop_param_names.has(identifier.name) || replacements.has(identifier.name)) &&
-				!state.shadowed_names.has(identifier.name) &&
-				parent &&
-				is_runtime_reference(identifier, parent)
-			) {
-				const replacement = replacements.get(identifier.name);
-				if (replacement) {
-					return clone_expression_node(replacement);
+	return walk(
+		node,
+		{ loop_param_names, shadowed_names: new Set() },
+		{
+			Identifier(identifier, { path, state, next }) {
+				const parent = path.at(-1);
+				if (
+					(state.loop_param_names.has(identifier.name) || replacements.has(identifier.name)) &&
+					!state.shadowed_names.has(identifier.name) &&
+					parent &&
+					is_runtime_reference(identifier, parent)
+				) {
+					const replacement = replacements.get(identifier.name);
+					if (replacement) {
+						return clone_expression_node(replacement);
+					}
+					return create_value_member_expression(identifier);
 				}
-				return create_value_member_expression(identifier);
-			}
 
-			return next();
+				return next();
+			},
+			FunctionDeclaration: rewrite_function_shadowed_refs,
+			FunctionExpression: rewrite_function_shadowed_refs,
+			ArrowFunctionExpression: rewrite_function_shadowed_refs,
 		},
-		FunctionDeclaration: rewrite_function_shadowed_refs,
-		FunctionExpression: rewrite_function_shadowed_refs,
-		ArrowFunctionExpression: rewrite_function_shadowed_refs,
-	});
+	);
 }
 
 /**
@@ -708,12 +627,7 @@ function create_index_member_expression(object, index) {
  * @returns {any}
  */
 function create_value_member_expression(identifier) {
-	return create_member_expression(
-		clone_identifier(identifier),
-		{ type: 'Identifier', name: 'value', metadata: { path: [] } },
-		false,
-		identifier,
-	);
+	return create_member_expression(clone_identifier(identifier), 'value', false, identifier);
 }
 
 /**
@@ -724,17 +638,7 @@ function create_value_member_expression(identifier) {
  * @returns {any}
  */
 function create_member_expression(object, property, computed, source_node) {
-	return setLocation(
-		{
-			type: 'MemberExpression',
-			object,
-			property,
-			computed,
-			optional: false,
-			metadata: { path: [] },
-		},
-		source_node,
-	);
+	return builders.member(object, property, computed, false, source_node);
 }
 
 /**
@@ -939,16 +843,7 @@ function has_dom_content_attribute(attributes, name) {
  * @returns {any}
  */
 function create_jsx_attribute(name, value, source_node) {
-	return setLocation(
-		/** @type {any} */ ({
-			type: 'JSXAttribute',
-			name: identifier_to_jsx_name(builders.id(name)),
-			value,
-			shorthand: false,
-			metadata: { path: [] },
-		}),
-		source_node,
-	);
+	return builders.jsx_attribute(builders.jsx_id(name), value, false, source_node);
 }
 
 /**
@@ -957,12 +852,7 @@ function create_jsx_attribute(name, value, source_node) {
  * @returns {any}
  */
 function to_jsx_expression_container(expression, source_node = expression) {
-	void source_node;
-	return {
-		type: 'JSXExpressionContainer',
-		expression,
-		metadata: { path: [] },
-	};
+	return builders.jsx_expression_container(expression, source_node);
 }
 
 /**
@@ -1073,7 +963,7 @@ function ensure_named_import(program, source, name, local = name) {
 		return;
 	}
 
-	program.body.unshift(create_import_declaration(source, [create_import_specifier(name, local)]));
+	program.body.unshift(builders.imports([[name, local, 'value']], source));
 }
 
 /**
@@ -1087,22 +977,6 @@ function create_import_specifier(name, local = name) {
 		imported: builders.id(name),
 		local: builders.id(local),
 		importKind: 'value',
-		metadata: { path: [] },
-	};
-}
-
-/**
- * @param {string} source
- * @param {any[]} specifiers
- * @returns {any}
- */
-function create_import_declaration(source, specifiers) {
-	return {
-		type: 'ImportDeclaration',
-		attributes: [],
-		specifiers,
-		importKind: 'value',
-		source: builders.literal(source),
 		metadata: { path: [] },
 	};
 }

--- a/packages/tsrx-vue/tests/basic.test.js
+++ b/packages/tsrx-vue/tests/basic.test.js
@@ -425,6 +425,25 @@ describe('@tsrx/vue basic', () => {
 		expect(code).toContain('item.value.text');
 	});
 
+	it('does not rewrite shadowed loop params inside nested keyed slot functions', () => {
+		const { code } = compile(
+			`component App({ items, getNew, use }: { items: { id: string, text: string }[], getNew: () => unknown, use: (item: unknown) => void }) {
+				for (const item of items; key item.id) {
+					<button onClick={() => {
+						const item = getNew();
+						use(item);
+					}}>{item.text}</button>
+				}
+			}`,
+			'App.tsrx',
+		);
+
+		expect(code).toContain('const item = getNew();');
+		expect(code).toContain('use(item);');
+		expect(code).toContain('item.value.text');
+		expect(code).not.toContain('use(item.value)');
+	});
+
 	it('compiles indexed keyed for...of statements in component bodies', () => {
 		const { code } = compile(
 			`component App({ items }: { items: { id: string, text: string }[] }) {

--- a/packages/tsrx-vue/tests/basic.test.js
+++ b/packages/tsrx-vue/tests/basic.test.js
@@ -476,6 +476,21 @@ describe('@tsrx/vue basic', () => {
 		expect(code).not.toContain('<Fragment');
 	});
 
+	it('falls back without injecting VaporFor for keyed destructuring patterns it cannot rewrite', () => {
+		const { code } = compile(
+			`component App({ items, keyName }: { items: Array<Record<string, string>>, keyName: string }) {
+				for (const { [keyName]: label } of items) {
+					<div key={label}>{label}</div>
+				}
+			}`,
+			'App.tsrx',
+		);
+
+		expect(code).toContain('.map(({ [keyName]: label }) => {');
+		expect(code).toContain('<div key={label}>{label}</div>');
+		expect(code).not.toContain('VaporFor');
+	});
+
 	it('compiles switch statements in component bodies', () => {
 		const { code } = compile(
 			`component App({ value }) {

--- a/packages/tsrx-vue/tests/basic.test.js
+++ b/packages/tsrx-vue/tests/basic.test.js
@@ -406,7 +406,8 @@ describe('@tsrx/vue basic', () => {
 			'App.tsrx',
 		);
 
-		expect(code).toContain('<template v-for={item in items}><div>{item}</div></template>');
+		expect(code).toContain('<VaporFor in={items}>{(item) => <div>{item}</div>}</VaporFor>');
+		expect(code).toContain("import { defineVaporComponent, VaporFor } from 'vue-jsx-vapor';");
 		expect(code).not.toContain('not yet supported in Vue TSRX');
 	});
 
@@ -420,9 +421,8 @@ describe('@tsrx/vue basic', () => {
 			'App.tsrx',
 		);
 
-		expect(code).toContain('<template v-for={item in items} key={item.id}>');
-		expect(code).toContain('key={item.id}');
-		expect(code).toContain('item.text');
+		expect(code).toContain('<VaporFor in={items} getKey={(item) => item.id}>');
+		expect(code).toContain('item.value.text');
 	});
 
 	it('compiles indexed keyed for...of statements in component bodies', () => {
@@ -435,9 +435,10 @@ describe('@tsrx/vue basic', () => {
 			'App.tsrx',
 		);
 
-		expect(code).toContain('<template v-for={(item, i) in items} key={item.id}>');
-		expect(code).toContain('{i}');
-		expect(code).toContain('item.text');
+		expect(code).toContain('<VaporFor in={items} getKey={(item, i) => item.id}>');
+		expect(code).toContain('{(item, i) => <div>');
+		expect(code).toContain('{i.value}');
+		expect(code).toContain('item.value.text');
 	});
 
 	it('keeps explicit loop keys on single static for...of templates', () => {
@@ -450,7 +451,8 @@ describe('@tsrx/vue basic', () => {
 			'App.tsrx',
 		);
 
-		expect(code).toContain('<template v-for={(item, i) in items} key={i}>');
+		expect(code).toContain('<VaporFor in={items} getKey={(item, i) => i}>');
+		expect(code).toContain('{(item, i) => <div>');
 		expect(code).toContain("<div>{'test'}</div>");
 		expect(code).not.toContain('<div key={i}>');
 		expect(code).not.toContain('<Fragment');
@@ -467,7 +469,8 @@ describe('@tsrx/vue basic', () => {
 			'App.tsrx',
 		);
 
-		expect(code).toContain('<template v-for={(item, i) in items} key={i}>');
+		expect(code).toContain('<VaporFor in={items} getKey={(item, i) => i}>');
+		expect(code).toContain('{(item, i) => <>');
 		expect(code).toContain('App__static1');
 		expect(code).toContain('App__static2');
 		expect(code).not.toContain('<Fragment');

--- a/packages/tsrx/types/jsx-platform.d.ts
+++ b/packages/tsrx/types/jsx-platform.d.ts
@@ -176,7 +176,7 @@ export interface JsxPlatformHooks {
 	 * Optionally replace the default React-style `.map(...)` lowering for a
 	 * `for...of` body after the shared transform has already produced its render
 	 * statements and applied any explicit or implicit keys. Vue uses this to hand
-	 * the loop to the downstream Vapor JSX compiler as a native `v-for` template.
+	 * the loop to the downstream Vapor JSX compiler as a typed `VaporFor` component.
 	 */
 	renderForOf?: (node: any, loopParams: any[], bodyStatements: any[], ctx: any) => any | null;
 	/**

--- a/packages/vite-plugin-vue/package.json
+++ b/packages/vite-plugin-vue/package.json
@@ -29,7 +29,7 @@
     "typescript": "catalog:default",
     "vite": "catalog:default",
     "vue": "3.6.0-beta.10",
-    "vue-jsx-vapor": "^3.2.11"
+    "vue-jsx-vapor": "^3.2.12"
   },
   "files": [
     "src",

--- a/packages/vite-plugin-vue/src/vapor.js
+++ b/packages/vite-plugin-vue/src/vapor.js
@@ -9,8 +9,13 @@ import vueJsxVaporModule from 'vue-jsx-vapor/vite';
  * }) => Plugin[]} VueJsxVaporPlugin
  */
 
+const vueJsxVaporModuleInterop = /** @type {VueJsxVaporPlugin | { default: VueJsxVaporPlugin }} */ (
+	/** @type {unknown} */ (vueJsxVaporModule)
+);
 const vueJsxVapor =
-	typeof vueJsxVaporModule === 'function' ? vueJsxVaporModule : vueJsxVaporModule.default;
+	typeof vueJsxVaporModuleInterop === 'function'
+		? vueJsxVaporModuleInterop
+		: vueJsxVaporModuleInterop.default;
 
 export function tsrxVueVapor() {
 	return vueJsxVapor({

--- a/packages/vite-plugin-vue/src/vapor.js
+++ b/packages/vite-plugin-vue/src/vapor.js
@@ -1,9 +1,6 @@
 /** @import { Plugin } from 'vite' */
 
-import { createRequire } from 'node:module';
-
-const require = createRequire(import.meta.url);
-const vueJsxVaporViteEntry = 'vue-jsx-vapor/vite';
+import vueJsxVaporModule from 'vue-jsx-vapor/vite';
 
 /**
  * @typedef {(options: {
@@ -12,9 +9,6 @@ const vueJsxVaporViteEntry = 'vue-jsx-vapor/vite';
  * }) => Plugin[]} VueJsxVaporPlugin
  */
 
-const vueJsxVaporModule = /** @type {{ default: VueJsxVaporPlugin } | VueJsxVaporPlugin} */ (
-	require(vueJsxVaporViteEntry)
-);
 const vueJsxVapor =
 	typeof vueJsxVaporModule === 'function' ? vueJsxVaporModule : vueJsxVaporModule.default;
 

--- a/packages/vite-plugin-vue/tests/runtime.test.tsrx
+++ b/packages/vite-plugin-vue/tests/runtime.test.tsrx
@@ -387,6 +387,30 @@ component ForKeyedStateApp() {
 	</button>
 }
 
+component ForJsxKeyedStateApp() {
+	const items = ref([
+		{ id: 'a', label: 'Alpha' },
+		{ id: 'b', label: 'Beta' },
+		{ id: 'c', label: 'Gamma' },
+	]);
+
+	for (const item of items.value) {
+		<KeyedRow key={item.id} {item} />
+	}
+
+	<button class="reverse-jsx-keyed" onClick={() => (items.value = [...items.value].reverse())}>
+		{'reverse'}
+	</button>
+	<button
+		class="rename-jsx-keyed-beta"
+		onClick={() => (items.value = items.value.map(
+			(item) => item.id === 'b' ? { ...item, label: 'Bravo' } : item,
+		))}
+	>
+		{'rename'}
+	</button>
+}
+
 component ForIndexKeyedStateApp() {
 	const items = ref([
 		{ id: 'a', label: 'Alpha' },
@@ -400,6 +424,97 @@ component ForIndexKeyedStateApp() {
 
 	<button class="reverse-index-keyed" onClick={() => (items.value = [...items.value].reverse())}>
 		{'reverse'}
+	</button>
+}
+
+component ForJsxIndexKeyedApp() {
+	const items = ref([
+		{ id: 'a', label: 'Alpha' },
+		{ id: 'b', label: 'Beta' },
+		{ id: 'c', label: 'Gamma' },
+	]);
+
+	for (const item of items.value; index i) {
+		<p key={item.id} class={`jsx-index-keyed-row row-${item.id}`}>
+			{`${i}:${item.label}`}
+		</p>
+	}
+
+	<button class="reverse-jsx-index-keyed" onClick={() => (items.value = [...items.value].reverse())}>
+		{'reverse'}
+	</button>
+}
+
+component ForNestedIndexKeyedApp() {
+	const items = ref([
+		{ id: 'a', label: 'Alpha' },
+		{ id: 'b', label: 'Beta' },
+		{ id: 'c', label: 'Gamma' },
+	]);
+
+	for (const item of items.value; index i; key item.id) {
+		<section class={`nested-index-keyed-row row-${item.id}`}>
+			<div>
+				<span>{`${i}:${item.label}`}</span>
+			</div>
+		</section>
+	}
+
+	<button class="reverse-nested-index-keyed" onClick={() => (items.value = [...items.value].reverse())}>
+		{'reverse'}
+	</button>
+	<button
+		class="rename-nested-index-keyed-beta"
+		onClick={() => (items.value = items.value.map(
+			(item) => item.id === 'b' ? { ...item, label: 'Bravo' } : item,
+		))}
+	>
+		{'rename'}
+	</button>
+}
+
+component ForImplicitIndexKeyFragmentApp() {
+	const items = ref(['a', 'b', 'c']);
+
+	for (const item of items.value; index i) {
+		<span class="fragment-index-item">{`${i}:${item}`}</span>
+		<span class="fragment-value-item">{item}</span>
+	}
+
+	<button class="reverse-fragment-index" onClick={() => (items.value = [...items.value].reverse())}>
+		{'reverse'}
+	</button>
+}
+
+component DestructuredKeyedRow(props: { id: string; label: string }) {
+	const count = ref(0);
+
+	<button class={`destructured-keyed-row row-${props.id}`} onClick={() => count.value++}>
+		{`${props.label}:${count.value}`}
+	</button>
+}
+
+component ForDestructuredKeyedStateApp() {
+	const items = ref([
+		{ id: 'a', label: 'Alpha' },
+		{ id: 'b', label: 'Beta' },
+		{ id: 'c', label: 'Gamma' },
+	]);
+
+	for (const { id, label } of items.value; key id) {
+		<DestructuredKeyedRow id={id} label={label} />
+	}
+
+	<button class="reverse-destructured-keyed" onClick={() => (items.value = [...items.value].reverse())}>
+		{'reverse'}
+	</button>
+	<button
+		class="rename-destructured-keyed-beta"
+		onClick={() => (items.value = items.value.map(
+			(item) => item.id === 'b' ? { ...item, label: 'Bravo' } : item,
+		))}
+	>
+		{'rename'}
 	</button>
 }
 
@@ -870,6 +985,28 @@ describe('tsrx-vue runtime', () => {
 		expect(text('.row-b')).toBe('Bravo:1');
 	});
 
+	it('preserves component state when keys come from JSX key attributes', async () => {
+		await render(ForJsxKeyedStateApp);
+		expect(texts('.keyed-row')).toEqual([
+			'Alpha:0',
+			'Beta:0',
+			'Gamma:0',
+		]);
+
+		await click('.row-b');
+		expect(text('.row-b')).toBe('Beta:1');
+
+		await click('.reverse-jsx-keyed');
+		expect(texts('.keyed-row')).toEqual([
+			'Gamma:0',
+			'Beta:1',
+			'Alpha:0',
+		]);
+
+		await click('.rename-jsx-keyed-beta');
+		expect(text('.row-b')).toBe('Bravo:1');
+	});
+
 	it('updates index bindings in keyed for-of loops after reorders', async () => {
 		await render(ForIndexKeyedStateApp);
 		expect(texts('.indexed-keyed-row')).toEqual([
@@ -884,6 +1021,81 @@ describe('tsrx-vue runtime', () => {
 			'1:Beta',
 			'2:Alpha',
 		]);
+	});
+
+	it('updates index bindings when JSX key attributes drive keyed for-of loops', async () => {
+		await render(ForJsxIndexKeyedApp);
+		expect(texts('.jsx-index-keyed-row')).toEqual([
+			'0:Alpha',
+			'1:Beta',
+			'2:Gamma',
+		]);
+
+		await click('.reverse-jsx-index-keyed');
+		expect(texts('.jsx-index-keyed-row')).toEqual([
+			'0:Gamma',
+			'1:Beta',
+			'2:Alpha',
+		]);
+	});
+
+	it('updates keyed item and index reads inside nested loop output', async () => {
+		await render(ForNestedIndexKeyedApp);
+		expect(texts('.nested-index-keyed-row')).toEqual([
+			'0:Alpha',
+			'1:Beta',
+			'2:Gamma',
+		]);
+
+		await click('.reverse-nested-index-keyed');
+		expect(texts('.nested-index-keyed-row')).toEqual([
+			'0:Gamma',
+			'1:Beta',
+			'2:Alpha',
+		]);
+
+		await click('.rename-nested-index-keyed-beta');
+		expect(text('.row-b')).toBe('1:Bravo');
+	});
+
+	it('updates implicit index-keyed fragments after reorders', async () => {
+		await render(ForImplicitIndexKeyFragmentApp);
+		expect(texts('.fragment-index-item')).toEqual([
+			'0:a',
+			'1:b',
+			'2:c',
+		]);
+		expect(texts('.fragment-value-item')).toEqual(['a', 'b', 'c']);
+
+		await click('.reverse-fragment-index');
+		expect(texts('.fragment-index-item')).toEqual([
+			'0:c',
+			'1:b',
+			'2:a',
+		]);
+		expect(texts('.fragment-value-item')).toEqual(['c', 'b', 'a']);
+	});
+
+	it('preserves keyed component state for destructured for-of loop params', async () => {
+		await render(ForDestructuredKeyedStateApp);
+		expect(texts('.destructured-keyed-row')).toEqual([
+			'Alpha:0',
+			'Beta:0',
+			'Gamma:0',
+		]);
+
+		await click('.row-b');
+		expect(text('.row-b')).toBe('Beta:1');
+
+		await click('.reverse-destructured-keyed');
+		expect(texts('.destructured-keyed-row')).toEqual([
+			'Gamma:0',
+			'Beta:1',
+			'Alpha:0',
+		]);
+
+		await click('.rename-destructured-keyed-beta');
+		expect(text('.row-b')).toBe('Bravo:1');
 	});
 
 	it('switches rendered branches reactively', async () => {

--- a/packages/vite-plugin-vue/tests/runtime.test.tsrx
+++ b/packages/vite-plugin-vue/tests/runtime.test.tsrx
@@ -435,12 +435,13 @@ component ForJsxIndexKeyedApp() {
 	]);
 
 	for (const item of items.value; index i) {
-		<p key={item.id} class={`jsx-index-keyed-row row-${item.id}`}>
-			{`${i}:${item.label}`}
-		</p>
+		<p key={item.id} class={`jsx-index-keyed-row row-${item.id}`}>{`${i}:${item.label}`}</p>
 	}
 
-	<button class="reverse-jsx-index-keyed" onClick={() => (items.value = [...items.value].reverse())}>
+	<button
+		class="reverse-jsx-index-keyed"
+		onClick={() => (items.value = [...items.value].reverse())}
+	>
 		{'reverse'}
 	</button>
 }
@@ -460,7 +461,10 @@ component ForNestedIndexKeyedApp() {
 		</section>
 	}
 
-	<button class="reverse-nested-index-keyed" onClick={() => (items.value = [...items.value].reverse())}>
+	<button
+		class="reverse-nested-index-keyed"
+		onClick={() => (items.value = [...items.value].reverse())}
+	>
 		{'reverse'}
 	</button>
 	<button
@@ -502,10 +506,13 @@ component ForDestructuredKeyedStateApp() {
 	]);
 
 	for (const { id, label } of items.value; key id) {
-		<DestructuredKeyedRow id={id} label={label} />
+		<DestructuredKeyedRow {id} {label} />
 	}
 
-	<button class="reverse-destructured-keyed" onClick={() => (items.value = [...items.value].reverse())}>
+	<button
+		class="reverse-destructured-keyed"
+		onClick={() => (items.value = [...items.value].reverse())}
+	>
 		{'reverse'}
 	</button>
 	<button

--- a/packages/vite-plugin-vue/tests/vue-jsx-vapor-shim.js
+++ b/packages/vite-plugin-vue/tests/vue-jsx-vapor-shim.js
@@ -263,6 +263,24 @@ export function createNodes(...values) {
 
 export const defineVaporComponent = defineVaporComponentBase;
 
+export const VaporFor = defineVaporComponentBase(
+	/**
+	 * @param {{ in?: ShimValue, getKey?: (value: ShimValue, key: ShimValue, index?: number) => ShimValue }} props
+	 * @param {{ slots: { default?: (...values: ShimValue[]) => ShimValue } }} context
+	 * @returns {ShimValue}
+	 */
+	(props, { slots }) =>
+		Vue.createFor(
+			() => props.in,
+			(item, key, index) =>
+				slots.default
+					? slots.default(props.getKey === undefined ? item.value : item, key, index)
+					: [],
+			props.getKey === undefined ? (item) => item : props.getKey,
+		),
+	{ props: ['in', 'getKey'] },
+);
+
 /**
  * @param {ShimValue} type
  * @param {ShimValue} props

--- a/packages/vite-plugin-vue/tsconfig.json
+++ b/packages/vite-plugin-vue/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "../tsrx/tsconfig.json",
+  "compilerOptions": {
+    "skipLibCheck": true
+  },
   "include": ["src/**/*", "types/**/*"],
   "exclude": ["tests/**/*"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -316,10 +316,10 @@ importers:
         version: 5.9.3
       vite-plugin-solid:
         specifier: 3.0.0-next.5
-        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.7(@solidjs/signals@2.0.0-beta.7)(solid-js@2.0.0-beta.7))(solid-js@2.0.0-beta.7)(vite@8.0.0(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@24.11.0)(esbuild@0.27.3)(jiti@2.6.1))
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.7(@solidjs/signals@2.0.0-beta.7)(solid-js@2.0.0-beta.7))(solid-js@2.0.0-beta.7)(vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.11.0)(esbuild@0.27.3)(jiti@2.6.1))
       vitest:
         specifier: catalog:default
-        version: 4.1.4(@types/node@24.11.0)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.0(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@24.11.0)(esbuild@0.27.3)(jiti@2.6.1))
+        version: 4.1.4(@types/node@24.11.0)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.11.0)(esbuild@0.27.3)(jiti@2.6.1))
       wait-on:
         specifier: catalog:default
         version: 9.0.5
@@ -451,13 +451,13 @@ importers:
         version: 2.4.2
       tsdown:
         specifier: catalog:default
-        version: 0.20.3(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@typescript/native-preview@7.0.0-dev.20260502.1)(typescript@5.9.3)
+        version: 0.20.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@typescript/native-preview@7.0.0-dev.20260502.1)(typescript@5.9.3)
       type-fest:
         specifier: catalog:default
         version: 5.6.0
       vitest:
         specifier: catalog:default
-        version: 4.1.4(@types/node@25.3.3)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.0(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1))
+        version: 4.1.4(@types/node@25.3.3)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1))
 
   packages/compat-react:
     dependencies:
@@ -492,7 +492,7 @@ importers:
     devDependencies:
       tsdown:
         specifier: catalog:default
-        version: 0.20.3(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@typescript/native-preview@7.0.0-dev.20260502.1)(typescript@5.9.3)
+        version: 0.20.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@typescript/native-preview@7.0.0-dev.20260502.1)(typescript@5.9.3)
 
   packages/eslint-parser:
     dependencies:
@@ -517,7 +517,7 @@ importers:
         version: 24.11.0
       tsdown:
         specifier: catalog:default
-        version: 0.20.3(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@typescript/native-preview@7.0.0-dev.20260502.1)(typescript@5.9.3)
+        version: 0.20.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@typescript/native-preview@7.0.0-dev.20260502.1)(typescript@5.9.3)
       typescript:
         specifier: catalog:default
         version: 5.9.3
@@ -544,13 +544,13 @@ importers:
         version: 10.2.1(jiti@2.6.1)
       tsdown:
         specifier: catalog:default
-        version: 0.20.3(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@typescript/native-preview@7.0.0-dev.20260502.1)(typescript@5.9.3)
+        version: 0.20.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@typescript/native-preview@7.0.0-dev.20260502.1)(typescript@5.9.3)
       typescript:
         specifier: catalog:default
         version: 5.9.3
       vitest:
         specifier: catalog:default
-        version: 4.1.4(@types/node@24.11.0)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.0(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@24.11.0)(esbuild@0.27.3)(jiti@2.6.1))
+        version: 4.1.4(@types/node@24.11.0)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.11.0)(esbuild@0.27.3)(jiti@2.6.1))
 
   packages/intellij-plugin: {}
 
@@ -586,7 +586,7 @@ importers:
         version: link:../tsrx-ripple
       tsdown:
         specifier: catalog:default
-        version: 0.20.3(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@typescript/native-preview@7.0.0-dev.20260502.1)(typescript@5.9.3)
+        version: 0.20.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@typescript/native-preview@7.0.0-dev.20260502.1)(typescript@5.9.3)
 
   packages/nvim-plugin: {}
 
@@ -765,8 +765,8 @@ importers:
         specifier: 3.6.0-beta.10
         version: 3.6.0-beta.10(typescript@5.9.3)
       vue-jsx-vapor:
-        specifier: ^3.2.11
-        version: 3.2.11(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(csstype@3.2.3)(esbuild@0.27.3)(vite@8.0.0(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1))(vue@3.6.0-beta.10(typescript@5.9.3))
+        specifier: ^3.2.12
+        version: 3.2.12(csstype@3.2.3)(esbuild@0.27.3)(vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1))(vue@3.6.0-beta.10(typescript@5.9.3))
 
   packages/sublime-text-plugin:
     devDependencies:
@@ -858,7 +858,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:default
-        version: 4.1.4(@types/node@24.11.0)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.0(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@24.11.0)(esbuild@0.27.3)(jiti@2.6.1))
+        version: 4.1.4(@types/node@24.11.0)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.11.0)(esbuild@0.27.3)(jiti@2.6.1))
 
   packages/tsrx-preact:
     dependencies:
@@ -980,12 +980,15 @@ importers:
       esrap:
         specifier: catalog:default
         version: 2.2.3
+      is-reference:
+        specifier: catalog:default
+        version: 3.0.3
       vue:
         specifier: '>=3.5'
         version: 3.5.29(typescript@5.9.3)
       vue-jsx-vapor:
-        specifier: '>=3.2.10'
-        version: 3.2.10(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(csstype@3.2.3)(esbuild@0.27.3)(vite@8.0.0(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1))(vue@3.5.29(typescript@5.9.3))
+        specifier: '>=3.2.12'
+        version: 3.2.12(csstype@3.2.3)(esbuild@0.27.3)(vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1))(vue@3.5.29(typescript@5.9.3))
       zimmerframe:
         specifier: catalog:default
         version: 1.1.4
@@ -1045,7 +1048,7 @@ importers:
         version: 24.11.0
       tsdown:
         specifier: catalog:default
-        version: 0.20.3(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@typescript/native-preview@7.0.0-dev.20260502.1)(typescript@5.9.3)
+        version: 0.20.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@typescript/native-preview@7.0.0-dev.20260502.1)(typescript@5.9.3)
 
   packages/vite-plugin:
     dependencies:
@@ -1067,7 +1070,7 @@ importers:
         version: 5.6.0
       vite:
         specifier: catalog:default
-        version: 8.0.0(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@24.11.0)(esbuild@0.27.3)(jiti@2.6.1)
+        version: 8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.11.0)(esbuild@0.27.3)(jiti@2.6.1)
 
   packages/vite-plugin-preact:
     dependencies:
@@ -1083,7 +1086,7 @@ importers:
         version: 5.9.3
       vite:
         specifier: catalog:default
-        version: 8.0.0(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)
+        version: 8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)
 
   packages/vite-plugin-react:
     dependencies:
@@ -1117,7 +1120,7 @@ importers:
         version: 5.9.3
       vite:
         specifier: catalog:default
-        version: 8.0.0(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)
+        version: 8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)
 
   packages/vite-plugin-solid:
     dependencies:
@@ -1133,10 +1136,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: catalog:default
-        version: 8.0.0(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)
+        version: 8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)
       vite-plugin-solid:
         specifier: 3.0.0-next.5
-        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.7(@solidjs/signals@2.0.0-beta.7)(solid-js@2.0.0-beta.7))(solid-js@2.0.0-beta.7)(vite@8.0.0(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1))
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.7(@solidjs/signals@2.0.0-beta.7)(solid-js@2.0.0-beta.7))(solid-js@2.0.0-beta.7)(vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1))
 
   packages/vite-plugin-vue:
     dependencies:
@@ -1149,13 +1152,13 @@ importers:
         version: 5.9.3
       vite:
         specifier: catalog:default
-        version: 8.0.0(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)
+        version: 8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)
       vue:
         specifier: 3.6.0-beta.10
         version: 3.6.0-beta.10(typescript@5.9.3)
       vue-jsx-vapor:
-        specifier: ^3.2.11
-        version: 3.2.11(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(csstype@3.2.3)(esbuild@0.27.3)(vite@8.0.0(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1))(vue@3.6.0-beta.10(typescript@5.9.3))
+        specifier: ^3.2.12
+        version: 3.2.12(csstype@3.2.3)(esbuild@0.27.3)(vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1))(vue@3.6.0-beta.10(typescript@5.9.3))
 
   packages/vscode-plugin:
     dependencies:
@@ -1210,7 +1213,7 @@ importers:
         version: 0.5.17
       tsdown:
         specifier: catalog:default
-        version: 0.20.3(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@typescript/native-preview@7.0.0-dev.20260502.1)(typescript@5.9.3)
+        version: 0.20.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@typescript/native-preview@7.0.0-dev.20260502.1)(typescript@5.9.3)
 
   packages/zed-plugin: {}
 
@@ -1246,7 +1249,7 @@ importers:
         version: 5.9.3
       vite:
         specifier: catalog:default
-        version: 8.0.0(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)
+        version: 8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)
 
   playground/ripple:
     dependencies:
@@ -1265,7 +1268,7 @@ importers:
         version: link:../../packages/vite-plugin
       '@tailwindcss/vite':
         specifier: catalog:default
-        version: 4.2.1(vite@8.0.0(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1))
+        version: 4.2.1(vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1))
       '@tsrx/eslint-plugin':
         specifier: workspace:*
         version: link:../../packages/eslint-plugin
@@ -1289,10 +1292,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: catalog:default
-        version: 8.0.0(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)
+        version: 8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)
       vitest:
         specifier: catalog:default
-        version: 4.1.4(@types/node@25.3.3)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.0(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1))
+        version: 4.1.4(@types/node@25.3.3)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1))
 
   playground/solid:
     dependencies:
@@ -1320,10 +1323,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: catalog:default
-        version: 8.0.0(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)
+        version: 8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)
       vite-plugin-solid:
         specifier: 3.0.0-next.5
-        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.7(@solidjs/signals@2.0.0-beta.7)(solid-js@2.0.0-beta.7))(solid-js@2.0.0-beta.7)(vite@8.0.0(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1))
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.7(@solidjs/signals@2.0.0-beta.7)(solid-js@2.0.0-beta.7))(solid-js@2.0.0-beta.7)(vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1))
 
   playground/vue:
     dependencies:
@@ -1345,10 +1348,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: catalog:default
-        version: 8.0.0(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)
+        version: 8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)
       vue-jsx-vapor:
         specifier: ^3.2.10
-        version: 3.2.10(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(csstype@3.2.3)(esbuild@0.27.3)(vite@8.0.0(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1))(vue@3.6.0-beta.8(typescript@5.9.3))
+        version: 3.2.10(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(csstype@3.2.3)(esbuild@0.27.3)(vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1))(vue@3.6.0-beta.8(typescript@5.9.3))
 
   website:
     dependencies:
@@ -1419,7 +1422,7 @@ importers:
         version: 5.9.3
       vite:
         specifier: catalog:default
-        version: 8.0.0(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)
+        version: 8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)
 
   website-tsrx:
     dependencies:
@@ -1489,7 +1492,7 @@ importers:
         version: 5.9.3
       vite:
         specifier: catalog:default
-        version: 8.0.0(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)
+        version: 8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)
 
 packages:
 
@@ -1855,14 +1858,23 @@ packages:
   '@docsearch/js@4.6.0':
     resolution: {integrity: sha512-9/rbgkm/BgTq46cwxIohvSAz3koOFjnPpg0mwkJItAfzKbQIj+310PvwtgUY1YITDuGCag6yOL50GW2DBkaaBw==}
 
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+
   '@emnapi/core@1.8.1':
     resolution: {integrity: sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==}
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
   '@emnapi/runtime@1.8.1':
     resolution: {integrity: sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==}
 
   '@emnapi/wasi-threads@1.1.0':
     resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
   '@esbuild/aix-ppc64@0.27.3':
     resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
@@ -3602,8 +3614,8 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@vue-jsx-vapor/compiler-rs-android-arm-eabi@3.2.11':
-    resolution: {integrity: sha512-V5H7fPMarhIfoINtjeZVNnYCKw8gW5DnjaHjUYJq8PJNNGd1/lsU4dlhZ36NpgAfSFQJ6Y0c9bq9b7wNO7LX8A==}
+  '@vue-jsx-vapor/compiler-rs-android-arm-eabi@3.2.12':
+    resolution: {integrity: sha512-54Qm8zerMdcam0OLkfQXk5i+ppgUNA/s7oyZSwCBI9v7cx6tuBOaCRNZgSqi3SWqZ7GDmTVe05j7cjGaIb/teg==}
     cpu: [arm]
     os: [android]
 
@@ -3612,8 +3624,8 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@vue-jsx-vapor/compiler-rs-android-arm64@3.2.11':
-    resolution: {integrity: sha512-6rxR87vfSKEG7JYsEDc/8PlYbS1Bv6g8tAVtDQ/9IPKZ0X7VyV2a9zf4FnPptB5BoHSNbgxtACmdnrF8MSAAUA==}
+  '@vue-jsx-vapor/compiler-rs-android-arm64@3.2.12':
+    resolution: {integrity: sha512-J0KMV+ZYo2bx6SbWxLBMZJecNuMoY4Abxg71Gl668HV1EzdtU1wvpR+kBMPCJtf6kiqE6F0DBn0gqjvEuCqJ4Q==}
     cpu: [arm64]
     os: [android]
 
@@ -3622,8 +3634,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@vue-jsx-vapor/compiler-rs-darwin-arm64@3.2.11':
-    resolution: {integrity: sha512-f/G1xkXLMfDK6lraDQi0wYLkUnblt4PQ26G8GuiGoAIp9A9rbBMZTOfwMl5kNcCAWeLeJASHXAMAAnvnW9oTQg==}
+  '@vue-jsx-vapor/compiler-rs-darwin-arm64@3.2.12':
+    resolution: {integrity: sha512-hWTMqt2dwkyZtoIXUw8IRNl6R+BzCov1MzC7C/AWYbGesyjVqnmzVWlHRUjZvTGdMVhuBeAnb2dgeexf4yROPw==}
     cpu: [arm64]
     os: [darwin]
 
@@ -3632,8 +3644,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@vue-jsx-vapor/compiler-rs-darwin-x64@3.2.11':
-    resolution: {integrity: sha512-oVGjP1MJqL772Z6jW0XG5FGb0VDAFDvZx0nIQYcehzcKgH4SNJWUvoenTXh+CuKJMPRDbsP0CfXgFxg2Thr90A==}
+  '@vue-jsx-vapor/compiler-rs-darwin-x64@3.2.12':
+    resolution: {integrity: sha512-5bVN/u6144ISI0l4uxStnb3MACVWrqcGW/8SuRaCpu7CS4VJL3sj/cofMT87208Re5NhvhN6643fsibasttFfg==}
     cpu: [x64]
     os: [darwin]
 
@@ -3642,8 +3654,8 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@vue-jsx-vapor/compiler-rs-freebsd-x64@3.2.11':
-    resolution: {integrity: sha512-6tdJuC9piAO3973ad/wB/rR3XD4XiBZtpaBJUmyk8zLAULYsCTu1x4Eol5N4ipHFAMhjVfkrBaoxVj/x+zEz9w==}
+  '@vue-jsx-vapor/compiler-rs-freebsd-x64@3.2.12':
+    resolution: {integrity: sha512-GRx1NILuj3ZJd6O+pMpVpTS6JIS7QOyt/tGrTvuIhEBgR9eEfRPeqBbKFLOIhOcubNYqhQzmyCFVCbPGjbp3SA==}
     cpu: [x64]
     os: [freebsd]
 
@@ -3652,8 +3664,8 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@vue-jsx-vapor/compiler-rs-linux-arm-gnueabihf@3.2.11':
-    resolution: {integrity: sha512-2odpM6pN/2nrT2lRLcrpF5Ii/M2cFfg8ZgowDEPCn9pUXjsS6VZ7NXmycdtTAMQCzX6sob06juCUlbT0Mz7K2Q==}
+  '@vue-jsx-vapor/compiler-rs-linux-arm-gnueabihf@3.2.12':
+    resolution: {integrity: sha512-H5tU/naS99mDkTMGKOdBsU5jFNmyWYEwVYFWoBSW5V4pB3rxQiSkyhGPYhlRMioaqqFH/2+NMyjKgvy3SaGAnQ==}
     cpu: [arm]
     os: [linux]
 
@@ -3662,8 +3674,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@vue-jsx-vapor/compiler-rs-linux-arm64-gnu@3.2.11':
-    resolution: {integrity: sha512-9rmaggjL+1eUfLRxjhxGSAH1x+87g4pT14obu2pdE8nWeipP78JUNZTQsGLbsoOFpCx0wrWa8yq840Q3+z7qIA==}
+  '@vue-jsx-vapor/compiler-rs-linux-arm64-gnu@3.2.12':
+    resolution: {integrity: sha512-v/haft+bVqDLQoW7ePe6HK57PZ/05CRjR+omh0E7R9YYrHn2Jn4vUVdlppnc8VUslNbbtDcLQXl25Q7jBx6TVQ==}
     cpu: [arm64]
     os: [linux]
 
@@ -3672,8 +3684,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@vue-jsx-vapor/compiler-rs-linux-arm64-musl@3.2.11':
-    resolution: {integrity: sha512-3+dxre+yMuwCXFG6fo+cBR6//9mFxth9lTzewSDxd/ojjpG+nsU1zTeRsYIzQ8UJjPtVV9mjR1AGughlzpQdFg==}
+  '@vue-jsx-vapor/compiler-rs-linux-arm64-musl@3.2.12':
+    resolution: {integrity: sha512-d7RvGooGlgiVt0Wjqqn5foh6N/o5VcDqT0UGFUc+S5PFVgFnq/+N9jiniH6MxWByov+xp/QoOY8TVZXdcS2m+A==}
     cpu: [arm64]
     os: [linux]
 
@@ -3682,8 +3694,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@vue-jsx-vapor/compiler-rs-linux-x64-gnu@3.2.11':
-    resolution: {integrity: sha512-GBbZTWWnbv+Z4X3HAQfr3HYvaDdlzrPCXWMmeEGyQ9wtGx6mGEzXYq3AON9hqTBpPBXmi1eTSPYE6J6ikSJFlg==}
+  '@vue-jsx-vapor/compiler-rs-linux-x64-gnu@3.2.12':
+    resolution: {integrity: sha512-JnS9X+qTMT40eWC2daa9dZBusPo9JElvyl8klwx7VzaNqbdzatljqnB59WQuYdoNTRHn7JFot/JVMiS3q5hlrQ==}
     cpu: [x64]
     os: [linux]
 
@@ -3692,8 +3704,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@vue-jsx-vapor/compiler-rs-linux-x64-musl@3.2.11':
-    resolution: {integrity: sha512-/gjWGtztbHZ+bzjIqaJDJdqYWJ1rC5meWttTJuHCYKmXka1Mqbc9zgs+nsR6orE+OG4W2jt2PIPcMvKhWdOZow==}
+  '@vue-jsx-vapor/compiler-rs-linux-x64-musl@3.2.12':
+    resolution: {integrity: sha512-jvpGBeM9krXYANzMysf/ipBSjzQ3qaDVgXSh2u9QqfvGMuOJOsYJO0AYsAmJ0W1wMi2Sjrz/iqz5WVSK8hJh2g==}
     cpu: [x64]
     os: [linux]
 
@@ -3702,8 +3714,8 @@ packages:
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
 
-  '@vue-jsx-vapor/compiler-rs-wasm32-wasi@3.2.11':
-    resolution: {integrity: sha512-20tzL6PpF7+IC+9dElezm24q5os5yvCf7yHWfLpNFELZBIUIlXHezW9zE/wPpvaO2b0UubaaB9LFTAuB5MvIqA==}
+  '@vue-jsx-vapor/compiler-rs-wasm32-wasi@3.2.12':
+    resolution: {integrity: sha512-vo+8p6yIL+rD7hEqnoN2LD1qjzr7gkDIn94k70xHnLpJCRxs+vqftLw7gE37Lf45SC7mjOskh4u60fbh08PU7w==}
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
 
@@ -3712,8 +3724,8 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@vue-jsx-vapor/compiler-rs-win32-arm64-msvc@3.2.11':
-    resolution: {integrity: sha512-Q2hCJ1/HYgk9QMyV9Z83iI/1WM5/8ndsEeuWAikk+u5h6tHizYW0nEoliQrNwb/Tbfr4RnOVFPa145w+oUzIEg==}
+  '@vue-jsx-vapor/compiler-rs-win32-arm64-msvc@3.2.12':
+    resolution: {integrity: sha512-u/343E/C5oesS5Dur5iacjh/W5q/YHDy2bcZneqjBTXSHdSJYEPibXEh/thLtT7aXiRuD19u0IDKRl1Nk3K8sg==}
     cpu: [arm64]
     os: [win32]
 
@@ -3722,8 +3734,8 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@vue-jsx-vapor/compiler-rs-win32-ia32-msvc@3.2.11':
-    resolution: {integrity: sha512-JjW1jj2dgQGvhL25STFMBUhw38qekPQM8Zm3gAVtFli8Wk0XdL7d+aTRbYqEp0PUKKekahlLl4IkVpMUXPPCJw==}
+  '@vue-jsx-vapor/compiler-rs-win32-ia32-msvc@3.2.12':
+    resolution: {integrity: sha512-4v2y4LrODltQ/oGj4EyspdTGsWJVOAYJLb795QXA5ITV/W4UvFat5y23BJCEc/b+ZTsihzq9lV1lzNg/ZZYrTg==}
     cpu: [ia32]
     os: [win32]
 
@@ -3732,16 +3744,16 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@vue-jsx-vapor/compiler-rs-win32-x64-msvc@3.2.11':
-    resolution: {integrity: sha512-FPQ5eYjIK5F2kce2FAhp35BwplxAD7yBVL4L5HAJH36bm/Tdgi2PK+kuIT9TgxfReT3io1U8kSnAfVC7jabTtA==}
+  '@vue-jsx-vapor/compiler-rs-win32-x64-msvc@3.2.12':
+    resolution: {integrity: sha512-01pgM0sY+qnwDS4mn2/3A72rgVwPb3n2croswRjqLMjBE0TRYS8PD69S4+Bgk0IGYgk0xn51yrlp0j2s/asMcA==}
     cpu: [x64]
     os: [win32]
 
   '@vue-jsx-vapor/compiler-rs@3.2.10':
     resolution: {integrity: sha512-YMdQWywc0pX1qRqyy6eAPR2YnEhO2+JRWlv1aveh9E326b34njPEFHKYuaaQRjgY8bGu2martq1Vzk+ongLSKg==}
 
-  '@vue-jsx-vapor/compiler-rs@3.2.11':
-    resolution: {integrity: sha512-Trg/LFqBoRjtZ+ChA8gEB7+EioKndKpvj5LWxzZKdtB70kgGQBmUF67NgsiJH/qUyQmFbr461vu23wieUatY0Q==}
+  '@vue-jsx-vapor/compiler-rs@3.2.12':
+    resolution: {integrity: sha512-QU2sFhr7Jleyp74v3yjcJXbJKuFrBJDn5fbEegEHpxer5EpFdMaPgyZw9b6araZcw/JmyZsOc25XR9CtxmhQaQ==}
 
   '@vue-jsx-vapor/macros@3.2.10':
     resolution: {integrity: sha512-BU8Uw5r8cHufFZOJEzSjPemnLM3llBDtC0Z8XO+keoF1Toyc2uDxV47s7Fa30FzB7B61Vc6iU1I3z99c4hv/8w==}
@@ -3767,8 +3779,8 @@ packages:
       webpack:
         optional: true
 
-  '@vue-jsx-vapor/macros@3.2.11':
-    resolution: {integrity: sha512-p9OZjPBVjMbCPukwAtG0P+PuSkOypOjZmzydPvjuHckKuIkUUT6qQ/tGNBplAHZVpk+QRD8aBnvz/uSKzZRfaw==}
+  '@vue-jsx-vapor/macros@3.2.12':
+    resolution: {integrity: sha512-+bkloyR899qc0eImSjp3B0o6aDFlNkZ5h2zmJ+bSRIxSsWMQZGrs5yFxQJd+HqmDKypbczSsKmRn6BhBxwwo1g==}
     peerDependencies:
       '@nuxt/kit': ^3
       '@nuxt/schema': ^3
@@ -3797,8 +3809,8 @@ packages:
       csstype: ^3.2.3
       vue: 3.6.0-beta.8
 
-  '@vue-jsx-vapor/runtime@3.2.11':
-    resolution: {integrity: sha512-9sR1Imeao/KaAJXC06uP0sCe42PgRa7RVQVrBEfpOa2AWwbR+NaM1CcdidI6gCE0457Fq4cYDRDRRrD44zN1ow==}
+  '@vue-jsx-vapor/runtime@3.2.12':
+    resolution: {integrity: sha512-zTIcevkDwOqGpT7ESNc3NmZpqssrIuMDBmfUSuMN4pdo3TKdGod8gqjL1ldTnADr45Y9chEDhYizmh1Me5Kkhg==}
     peerDependencies:
       csstype: ^3.2.3
       vue: 3.6.0-beta.8
@@ -7081,8 +7093,8 @@ packages:
       webpack:
         optional: true
 
-  vue-jsx-vapor@3.2.11:
-    resolution: {integrity: sha512-5v05gT9MBNDZuZ1jAx9ikBpUdbZPxBE8J6btIg727jHEaT+nAhsvqvQ1itDAzBU1ViIh+wKxNLVcNVa43iyCFw==}
+  vue-jsx-vapor@3.2.12:
+    resolution: {integrity: sha512-+flzOLr5rL8kU8yHiFvP7bx/9uwIqY/Vsj0U967BhpE4/5T0+N5hXI2ujHA65D9lIqh1aKnnUWtJ3vuH3IvzXA==}
     peerDependencies:
       '@nuxt/kit': ^3
       '@nuxt/schema': ^3
@@ -7868,9 +7880,20 @@ snapshots:
 
   '@docsearch/js@4.6.0': {}
 
+  '@emnapi/core@1.10.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/core@1.8.1':
     dependencies:
       '@emnapi/wasi-threads': 1.1.0
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.10.0':
+    dependencies:
       tslib: 2.8.1
     optional: true
 
@@ -7880,6 +7903,11 @@ snapshots:
     optional: true
 
   '@emnapi/wasi-threads@1.1.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -8306,10 +8334,10 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)':
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
-      '@emnapi/core': 1.8.1
-      '@emnapi/runtime': 1.8.1
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.10.1
     optional: true
 
@@ -8580,25 +8608,25 @@ snapshots:
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.9':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.3(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)':
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.5(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)':
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.9(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)':
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.9(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -9004,12 +9032,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.2.1
       '@tailwindcss/oxide-win32-x64-msvc': 4.2.1
 
-  '@tailwindcss/vite@4.2.1(vite@8.0.0(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1))':
+  '@tailwindcss/vite@4.2.1(vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1))':
     dependencies:
       '@tailwindcss/node': 4.2.1
       '@tailwindcss/oxide': 4.2.1
       tailwindcss: 4.2.1
-      vite: 8.0.0(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)
+      vite: 8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)
 
   '@tanstack/query-core@5.100.6': {}
 
@@ -9316,21 +9344,21 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.4(vite@8.0.0(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@24.11.0)(esbuild@0.27.3)(jiti@2.6.1))':
+  '@vitest/mocker@4.1.4(vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.11.0)(esbuild@0.27.3)(jiti@2.6.1))':
     dependencies:
       '@vitest/spy': 4.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.0(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@24.11.0)(esbuild@0.27.3)(jiti@2.6.1)
+      vite: 8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.11.0)(esbuild@0.27.3)(jiti@2.6.1)
 
-  '@vitest/mocker@4.1.4(vite@8.0.0(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1))':
+  '@vitest/mocker@4.1.4(vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1))':
     dependencies:
       '@vitest/spy': 4.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.0(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)
+      vite: 8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)
 
   '@vitest/pretty-format@4.1.4':
     dependencies:
@@ -9473,98 +9501,97 @@ snapshots:
   '@vue-jsx-vapor/compiler-rs-android-arm-eabi@3.2.10':
     optional: true
 
-  '@vue-jsx-vapor/compiler-rs-android-arm-eabi@3.2.11':
+  '@vue-jsx-vapor/compiler-rs-android-arm-eabi@3.2.12':
     optional: true
 
   '@vue-jsx-vapor/compiler-rs-android-arm64@3.2.10':
     optional: true
 
-  '@vue-jsx-vapor/compiler-rs-android-arm64@3.2.11':
+  '@vue-jsx-vapor/compiler-rs-android-arm64@3.2.12':
     optional: true
 
   '@vue-jsx-vapor/compiler-rs-darwin-arm64@3.2.10':
     optional: true
 
-  '@vue-jsx-vapor/compiler-rs-darwin-arm64@3.2.11':
+  '@vue-jsx-vapor/compiler-rs-darwin-arm64@3.2.12':
     optional: true
 
   '@vue-jsx-vapor/compiler-rs-darwin-x64@3.2.10':
     optional: true
 
-  '@vue-jsx-vapor/compiler-rs-darwin-x64@3.2.11':
+  '@vue-jsx-vapor/compiler-rs-darwin-x64@3.2.12':
     optional: true
 
   '@vue-jsx-vapor/compiler-rs-freebsd-x64@3.2.10':
     optional: true
 
-  '@vue-jsx-vapor/compiler-rs-freebsd-x64@3.2.11':
+  '@vue-jsx-vapor/compiler-rs-freebsd-x64@3.2.12':
     optional: true
 
   '@vue-jsx-vapor/compiler-rs-linux-arm-gnueabihf@3.2.10':
     optional: true
 
-  '@vue-jsx-vapor/compiler-rs-linux-arm-gnueabihf@3.2.11':
+  '@vue-jsx-vapor/compiler-rs-linux-arm-gnueabihf@3.2.12':
     optional: true
 
   '@vue-jsx-vapor/compiler-rs-linux-arm64-gnu@3.2.10':
     optional: true
 
-  '@vue-jsx-vapor/compiler-rs-linux-arm64-gnu@3.2.11':
+  '@vue-jsx-vapor/compiler-rs-linux-arm64-gnu@3.2.12':
     optional: true
 
   '@vue-jsx-vapor/compiler-rs-linux-arm64-musl@3.2.10':
     optional: true
 
-  '@vue-jsx-vapor/compiler-rs-linux-arm64-musl@3.2.11':
+  '@vue-jsx-vapor/compiler-rs-linux-arm64-musl@3.2.12':
     optional: true
 
   '@vue-jsx-vapor/compiler-rs-linux-x64-gnu@3.2.10':
     optional: true
 
-  '@vue-jsx-vapor/compiler-rs-linux-x64-gnu@3.2.11':
+  '@vue-jsx-vapor/compiler-rs-linux-x64-gnu@3.2.12':
     optional: true
 
   '@vue-jsx-vapor/compiler-rs-linux-x64-musl@3.2.10':
     optional: true
 
-  '@vue-jsx-vapor/compiler-rs-linux-x64-musl@3.2.11':
+  '@vue-jsx-vapor/compiler-rs-linux-x64-musl@3.2.12':
     optional: true
 
-  '@vue-jsx-vapor/compiler-rs-wasm32-wasi@3.2.10(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)':
+  '@vue-jsx-vapor/compiler-rs-wasm32-wasi@3.2.10(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
     optional: true
 
-  '@vue-jsx-vapor/compiler-rs-wasm32-wasi@3.2.11(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)':
+  '@vue-jsx-vapor/compiler-rs-wasm32-wasi@3.2.12':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
   '@vue-jsx-vapor/compiler-rs-win32-arm64-msvc@3.2.10':
     optional: true
 
-  '@vue-jsx-vapor/compiler-rs-win32-arm64-msvc@3.2.11':
+  '@vue-jsx-vapor/compiler-rs-win32-arm64-msvc@3.2.12':
     optional: true
 
   '@vue-jsx-vapor/compiler-rs-win32-ia32-msvc@3.2.10':
     optional: true
 
-  '@vue-jsx-vapor/compiler-rs-win32-ia32-msvc@3.2.11':
+  '@vue-jsx-vapor/compiler-rs-win32-ia32-msvc@3.2.12':
     optional: true
 
   '@vue-jsx-vapor/compiler-rs-win32-x64-msvc@3.2.10':
     optional: true
 
-  '@vue-jsx-vapor/compiler-rs-win32-x64-msvc@3.2.11':
+  '@vue-jsx-vapor/compiler-rs-win32-x64-msvc@3.2.12':
     optional: true
 
-  '@vue-jsx-vapor/compiler-rs@3.2.10(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)':
+  '@vue-jsx-vapor/compiler-rs@3.2.10(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     optionalDependencies:
       '@vue-jsx-vapor/compiler-rs-android-arm-eabi': 3.2.10
       '@vue-jsx-vapor/compiler-rs-android-arm64': 3.2.10
@@ -9576,7 +9603,7 @@ snapshots:
       '@vue-jsx-vapor/compiler-rs-linux-arm64-musl': 3.2.10
       '@vue-jsx-vapor/compiler-rs-linux-x64-gnu': 3.2.10
       '@vue-jsx-vapor/compiler-rs-linux-x64-musl': 3.2.10
-      '@vue-jsx-vapor/compiler-rs-wasm32-wasi': 3.2.10(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)
+      '@vue-jsx-vapor/compiler-rs-wasm32-wasi': 3.2.10(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       '@vue-jsx-vapor/compiler-rs-win32-arm64-msvc': 3.2.10
       '@vue-jsx-vapor/compiler-rs-win32-ia32-msvc': 3.2.10
       '@vue-jsx-vapor/compiler-rs-win32-x64-msvc': 3.2.10
@@ -9584,39 +9611,24 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  '@vue-jsx-vapor/compiler-rs@3.2.11(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)':
+  '@vue-jsx-vapor/compiler-rs@3.2.12':
     optionalDependencies:
-      '@vue-jsx-vapor/compiler-rs-android-arm-eabi': 3.2.11
-      '@vue-jsx-vapor/compiler-rs-android-arm64': 3.2.11
-      '@vue-jsx-vapor/compiler-rs-darwin-arm64': 3.2.11
-      '@vue-jsx-vapor/compiler-rs-darwin-x64': 3.2.11
-      '@vue-jsx-vapor/compiler-rs-freebsd-x64': 3.2.11
-      '@vue-jsx-vapor/compiler-rs-linux-arm-gnueabihf': 3.2.11
-      '@vue-jsx-vapor/compiler-rs-linux-arm64-gnu': 3.2.11
-      '@vue-jsx-vapor/compiler-rs-linux-arm64-musl': 3.2.11
-      '@vue-jsx-vapor/compiler-rs-linux-x64-gnu': 3.2.11
-      '@vue-jsx-vapor/compiler-rs-linux-x64-musl': 3.2.11
-      '@vue-jsx-vapor/compiler-rs-wasm32-wasi': 3.2.11(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)
-      '@vue-jsx-vapor/compiler-rs-win32-arm64-msvc': 3.2.11
-      '@vue-jsx-vapor/compiler-rs-win32-ia32-msvc': 3.2.11
-      '@vue-jsx-vapor/compiler-rs-win32-x64-msvc': 3.2.11
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
+      '@vue-jsx-vapor/compiler-rs-android-arm-eabi': 3.2.12
+      '@vue-jsx-vapor/compiler-rs-android-arm64': 3.2.12
+      '@vue-jsx-vapor/compiler-rs-darwin-arm64': 3.2.12
+      '@vue-jsx-vapor/compiler-rs-darwin-x64': 3.2.12
+      '@vue-jsx-vapor/compiler-rs-freebsd-x64': 3.2.12
+      '@vue-jsx-vapor/compiler-rs-linux-arm-gnueabihf': 3.2.12
+      '@vue-jsx-vapor/compiler-rs-linux-arm64-gnu': 3.2.12
+      '@vue-jsx-vapor/compiler-rs-linux-arm64-musl': 3.2.12
+      '@vue-jsx-vapor/compiler-rs-linux-x64-gnu': 3.2.12
+      '@vue-jsx-vapor/compiler-rs-linux-x64-musl': 3.2.12
+      '@vue-jsx-vapor/compiler-rs-wasm32-wasi': 3.2.12
+      '@vue-jsx-vapor/compiler-rs-win32-arm64-msvc': 3.2.12
+      '@vue-jsx-vapor/compiler-rs-win32-ia32-msvc': 3.2.12
+      '@vue-jsx-vapor/compiler-rs-win32-x64-msvc': 3.2.12
 
-  '@vue-jsx-vapor/macros@3.2.10(esbuild@0.27.3)(vite@8.0.0(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1))(vue@3.5.29(typescript@5.9.3))':
-    dependencies:
-      hash-sum: 2.0.0
-      magic-string: 0.30.21
-      ts-macro: 0.3.7
-      unplugin: 3.0.0
-      unplugin-utils: 0.3.1
-      vue: 3.5.29(typescript@5.9.3)
-    optionalDependencies:
-      esbuild: 0.27.3
-      vite: 8.0.0(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)
-
-  '@vue-jsx-vapor/macros@3.2.10(esbuild@0.27.3)(vite@8.0.0(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1))(vue@3.6.0-beta.8(typescript@5.9.3))':
+  '@vue-jsx-vapor/macros@3.2.10(esbuild@0.27.3)(vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1))(vue@3.6.0-beta.8(typescript@5.9.3))':
     dependencies:
       hash-sum: 2.0.0
       magic-string: 0.30.21
@@ -9626,9 +9638,21 @@ snapshots:
       vue: 3.6.0-beta.8(typescript@5.9.3)
     optionalDependencies:
       esbuild: 0.27.3
-      vite: 8.0.0(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)
+      vite: 8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)
 
-  '@vue-jsx-vapor/macros@3.2.11(esbuild@0.27.3)(vite@8.0.0(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1))(vue@3.6.0-beta.10(typescript@5.9.3))':
+  '@vue-jsx-vapor/macros@3.2.12(esbuild@0.27.3)(vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1))(vue@3.5.29(typescript@5.9.3))':
+    dependencies:
+      hash-sum: 2.0.0
+      magic-string: 0.30.21
+      ts-macro: 0.3.7
+      unplugin: 3.0.0
+      unplugin-utils: 0.3.1
+      vue: 3.5.29(typescript@5.9.3)
+    optionalDependencies:
+      esbuild: 0.27.3
+      vite: 8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)
+
+  '@vue-jsx-vapor/macros@3.2.12(esbuild@0.27.3)(vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1))(vue@3.6.0-beta.10(typescript@5.9.3))':
     dependencies:
       hash-sum: 2.0.0
       magic-string: 0.30.21
@@ -9638,19 +9662,19 @@ snapshots:
       vue: 3.6.0-beta.10(typescript@5.9.3)
     optionalDependencies:
       esbuild: 0.27.3
-      vite: 8.0.0(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)
-
-  '@vue-jsx-vapor/runtime@3.2.10(csstype@3.2.3)(vue@3.5.29(typescript@5.9.3))':
-    dependencies:
-      csstype: 3.2.3
-      vue: 3.5.29(typescript@5.9.3)
+      vite: 8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)
 
   '@vue-jsx-vapor/runtime@3.2.10(csstype@3.2.3)(vue@3.6.0-beta.8(typescript@5.9.3))':
     dependencies:
       csstype: 3.2.3
       vue: 3.6.0-beta.8(typescript@5.9.3)
 
-  '@vue-jsx-vapor/runtime@3.2.11(csstype@3.2.3)(vue@3.6.0-beta.10(typescript@5.9.3))':
+  '@vue-jsx-vapor/runtime@3.2.12(csstype@3.2.3)(vue@3.5.29(typescript@5.9.3))':
+    dependencies:
+      csstype: 3.2.3
+      vue: 3.5.29(typescript@5.9.3)
+
+  '@vue-jsx-vapor/runtime@3.2.12(csstype@3.2.3)(vue@3.6.0-beta.10(typescript@5.9.3))':
     dependencies:
       csstype: 3.2.3
       vue: 3.6.0-beta.10(typescript@5.9.3)
@@ -12109,7 +12133,7 @@ snapshots:
       devalue: 5.7.1
       esm-env: 1.2.2
 
-  rolldown-plugin-dts@0.22.3(@typescript/native-preview@7.0.0-dev.20260502.1)(rolldown@1.0.0-rc.3(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1))(typescript@5.9.3):
+  rolldown-plugin-dts@0.22.3(@typescript/native-preview@7.0.0-dev.20260502.1)(rolldown@1.0.0-rc.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@5.9.3):
     dependencies:
       '@babel/generator': 8.0.0-rc.2
       '@babel/helper-validator-identifier': 8.0.0-rc.2
@@ -12120,14 +12144,14 @@ snapshots:
       dts-resolver: 2.1.3
       get-tsconfig: 4.13.6
       obug: 2.1.1
-      rolldown: 1.0.0-rc.3(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)
+      rolldown: 1.0.0-rc.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optionalDependencies:
       '@typescript/native-preview': 7.0.0-dev.20260502.1
       typescript: 5.9.3
     transitivePeerDependencies:
       - oxc-resolver
 
-  rolldown@1.0.0-rc.3(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1):
+  rolldown@1.0.0-rc.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
     dependencies:
       '@oxc-project/types': 0.112.0
       '@rolldown/pluginutils': 1.0.0-rc.3
@@ -12142,14 +12166,14 @@ snapshots:
       '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.3
       '@rolldown/binding-linux-x64-musl': 1.0.0-rc.3
       '@rolldown/binding-openharmony-arm64': 1.0.0-rc.3
-      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.3(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.3
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.3
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  rolldown@1.0.0-rc.5(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1):
+  rolldown@1.0.0-rc.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
     dependencies:
       '@oxc-project/types': 0.114.0
       '@rolldown/pluginutils': 1.0.0-rc.5
@@ -12164,14 +12188,14 @@ snapshots:
       '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.5
       '@rolldown/binding-linux-x64-musl': 1.0.0-rc.5
       '@rolldown/binding-openharmony-arm64': 1.0.0-rc.5
-      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.5(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.5
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.5
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  rolldown@1.0.0-rc.9(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1):
+  rolldown@1.0.0-rc.9(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
     dependencies:
       '@oxc-project/types': 0.115.0
       '@rolldown/pluginutils': 1.0.0-rc.9
@@ -12188,7 +12212,7 @@ snapshots:
       '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.9
       '@rolldown/binding-linux-x64-musl': 1.0.0-rc.9
       '@rolldown/binding-openharmony-arm64': 1.0.0-rc.9
-      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.9(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.9(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.9
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.9
     transitivePeerDependencies:
@@ -12724,7 +12748,7 @@ snapshots:
     dependencies:
       muggle-string: 0.4.1
 
-  tsdown@0.20.3(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@typescript/native-preview@7.0.0-dev.20260502.1)(typescript@5.9.3):
+  tsdown@0.20.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@typescript/native-preview@7.0.0-dev.20260502.1)(typescript@5.9.3):
     dependencies:
       ansis: 4.2.0
       cac: 6.7.14
@@ -12734,14 +12758,14 @@ snapshots:
       import-without-cache: 0.2.5
       obug: 2.1.1
       picomatch: 4.0.3
-      rolldown: 1.0.0-rc.3(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)
-      rolldown-plugin-dts: 0.22.3(@typescript/native-preview@7.0.0-dev.20260502.1)(rolldown@1.0.0-rc.3(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1))(typescript@5.9.3)
+      rolldown: 1.0.0-rc.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      rolldown-plugin-dts: 0.22.3(@typescript/native-preview@7.0.0-dev.20260502.1)(rolldown@1.0.0-rc.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@5.9.3)
       semver: 7.7.4
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tree-kill: 1.2.2
       unconfig-core: 7.5.0
-      unrun: 0.2.28(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)
+      unrun: 0.2.28(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -12867,9 +12891,9 @@ snapshots:
       picomatch: 4.0.3
       webpack-virtual-modules: 0.6.2
 
-  unrun@0.2.28(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1):
+  unrun@0.2.28(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
     dependencies:
-      rolldown: 1.0.0-rc.5(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)
+      rolldown: 1.0.0-rc.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -12928,7 +12952,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-plugin-solid@3.0.0-next.5(@solidjs/web@2.0.0-beta.7(@solidjs/signals@2.0.0-beta.7)(solid-js@2.0.0-beta.7))(solid-js@2.0.0-beta.7)(vite@8.0.0(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@24.11.0)(esbuild@0.27.3)(jiti@2.6.1)):
+  vite-plugin-solid@3.0.0-next.5(@solidjs/web@2.0.0-beta.7(@solidjs/signals@2.0.0-beta.7)(solid-js@2.0.0-beta.7))(solid-js@2.0.0-beta.7)(vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.11.0)(esbuild@0.27.3)(jiti@2.6.1)):
     dependencies:
       '@babel/core': 7.29.0
       '@solidjs/web': 2.0.0-beta.7(@solidjs/signals@2.0.0-beta.7)(solid-js@2.0.0-beta.7)
@@ -12937,12 +12961,12 @@ snapshots:
       merge-anything: 5.1.7
       solid-js: 2.0.0-beta.7
       solid-refresh: 0.8.0-next.7(solid-js@2.0.0-beta.7)
-      vite: 8.0.0(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@24.11.0)(esbuild@0.27.3)(jiti@2.6.1)
-      vitefu: 1.1.3(vite@8.0.0(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@24.11.0)(esbuild@0.27.3)(jiti@2.6.1))
+      vite: 8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.11.0)(esbuild@0.27.3)(jiti@2.6.1)
+      vitefu: 1.1.3(vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.11.0)(esbuild@0.27.3)(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-solid@3.0.0-next.5(@solidjs/web@2.0.0-beta.7(@solidjs/signals@2.0.0-beta.7)(solid-js@2.0.0-beta.7))(solid-js@2.0.0-beta.7)(vite@8.0.0(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)):
+  vite-plugin-solid@3.0.0-next.5(@solidjs/web@2.0.0-beta.7(@solidjs/signals@2.0.0-beta.7)(solid-js@2.0.0-beta.7))(solid-js@2.0.0-beta.7)(vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)):
     dependencies:
       '@babel/core': 7.29.0
       '@solidjs/web': 2.0.0-beta.7(@solidjs/signals@2.0.0-beta.7)(solid-js@2.0.0-beta.7)
@@ -12951,8 +12975,8 @@ snapshots:
       merge-anything: 5.1.7
       solid-js: 2.0.0-beta.7
       solid-refresh: 0.8.0-next.7(solid-js@2.0.0-beta.7)
-      vite: 8.0.0(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)
-      vitefu: 1.1.3(vite@8.0.0(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1))
+      vite: 8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)
+      vitefu: 1.1.3(vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -12970,13 +12994,13 @@ snapshots:
       jiti: 2.6.1
       lightningcss: 1.32.0
 
-  vite@8.0.0(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@24.11.0)(esbuild@0.27.3)(jiti@2.6.1):
+  vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.11.0)(esbuild@0.27.3)(jiti@2.6.1):
     dependencies:
       '@oxc-project/runtime': 0.115.0
       lightningcss: 1.32.0
       picomatch: 4.0.3
       postcss: 8.5.8
-      rolldown: 1.0.0-rc.9(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)
+      rolldown: 1.0.0-rc.9(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 24.11.0
@@ -12987,13 +13011,13 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  vite@8.0.0(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1):
+  vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1):
     dependencies:
       '@oxc-project/runtime': 0.115.0
       lightningcss: 1.32.0
       picomatch: 4.0.3
       postcss: 8.5.8
-      rolldown: 1.0.0-rc.9(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)
+      rolldown: 1.0.0-rc.9(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 25.3.3
@@ -13004,13 +13028,13 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  vitefu@1.1.3(vite@8.0.0(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@24.11.0)(esbuild@0.27.3)(jiti@2.6.1)):
+  vitefu@1.1.3(vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.11.0)(esbuild@0.27.3)(jiti@2.6.1)):
     optionalDependencies:
-      vite: 8.0.0(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@24.11.0)(esbuild@0.27.3)(jiti@2.6.1)
+      vite: 8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.11.0)(esbuild@0.27.3)(jiti@2.6.1)
 
-  vitefu@1.1.3(vite@8.0.0(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)):
+  vitefu@1.1.3(vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)):
     optionalDependencies:
-      vite: 8.0.0(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)
+      vite: 8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)
 
   vitepress-plugin-npm-commands@0.9.0(vitepress-plugin-tabs@0.8.0(vitepress@2.0.0-alpha.12(@types/node@25.3.3)(axios@1.15.0)(fuse.js@7.1.0)(jiti@2.6.1)(lightningcss@1.32.0)(postcss@8.5.8)(typescript@5.9.3))(vue@3.6.0-beta.10(typescript@5.9.3)))(vitepress@2.0.0-alpha.12(@types/node@25.3.3)(axios@1.15.0)(fuse.js@7.1.0)(jiti@2.6.1)(lightningcss@1.32.0)(postcss@8.5.8)(typescript@5.9.3)):
     dependencies:
@@ -13071,10 +13095,10 @@ snapshots:
       - universal-cookie
       - yaml
 
-  vitest@4.1.4(@types/node@24.11.0)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.0(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@24.11.0)(esbuild@0.27.3)(jiti@2.6.1)):
+  vitest@4.1.4(@types/node@24.11.0)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.11.0)(esbuild@0.27.3)(jiti@2.6.1)):
     dependencies:
       '@vitest/expect': 4.1.4
-      '@vitest/mocker': 4.1.4(vite@8.0.0(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@24.11.0)(esbuild@0.27.3)(jiti@2.6.1))
+      '@vitest/mocker': 4.1.4(vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.11.0)(esbuild@0.27.3)(jiti@2.6.1))
       '@vitest/pretty-format': 4.1.4
       '@vitest/runner': 4.1.4
       '@vitest/snapshot': 4.1.4
@@ -13091,7 +13115,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 8.0.0(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@24.11.0)(esbuild@0.27.3)(jiti@2.6.1)
+      vite: 8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.11.0)(esbuild@0.27.3)(jiti@2.6.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.11.0
@@ -13099,10 +13123,10 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.4(@types/node@25.3.3)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.0(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)):
+  vitest@4.1.4(@types/node@25.3.3)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)):
     dependencies:
       '@vitest/expect': 4.1.4
-      '@vitest/mocker': 4.1.4(vite@8.0.0(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1))
+      '@vitest/mocker': 4.1.4(vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1))
       '@vitest/pretty-format': 4.1.4
       '@vitest/runner': 4.1.4
       '@vitest/snapshot': 4.1.4
@@ -13119,7 +13143,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 8.0.0(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)
+      vite: 8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.3.3
@@ -13178,29 +13202,10 @@ snapshots:
 
   vscode-uri@3.1.0: {}
 
-  vue-jsx-vapor@3.2.10(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(csstype@3.2.3)(esbuild@0.27.3)(vite@8.0.0(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1))(vue@3.5.29(typescript@5.9.3)):
+  vue-jsx-vapor@3.2.10(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(csstype@3.2.3)(esbuild@0.27.3)(vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1))(vue@3.6.0-beta.8(typescript@5.9.3)):
     dependencies:
-      '@vue-jsx-vapor/compiler-rs': 3.2.10(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)
-      '@vue-jsx-vapor/macros': 3.2.10(esbuild@0.27.3)(vite@8.0.0(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1))(vue@3.5.29(typescript@5.9.3))
-      '@vue-jsx-vapor/runtime': 3.2.10(csstype@3.2.3)(vue@3.5.29(typescript@5.9.3))
-      '@vue/shared': 3.6.0-beta.8
-      pathe: 2.0.3
-      ts-macro: 0.3.7
-      unplugin: 3.0.0
-      unplugin-utils: 0.3.1
-      vue: 3.5.29(typescript@5.9.3)
-    optionalDependencies:
-      esbuild: 0.27.3
-      vite: 8.0.0(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
-      - csstype
-
-  vue-jsx-vapor@3.2.10(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(csstype@3.2.3)(esbuild@0.27.3)(vite@8.0.0(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1))(vue@3.6.0-beta.8(typescript@5.9.3)):
-    dependencies:
-      '@vue-jsx-vapor/compiler-rs': 3.2.10(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)
-      '@vue-jsx-vapor/macros': 3.2.10(esbuild@0.27.3)(vite@8.0.0(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1))(vue@3.6.0-beta.8(typescript@5.9.3))
+      '@vue-jsx-vapor/compiler-rs': 3.2.10(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@vue-jsx-vapor/macros': 3.2.10(esbuild@0.27.3)(vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1))(vue@3.6.0-beta.8(typescript@5.9.3))
       '@vue-jsx-vapor/runtime': 3.2.10(csstype@3.2.3)(vue@3.6.0-beta.8(typescript@5.9.3))
       '@vue/shared': 3.6.0-beta.8
       pathe: 2.0.3
@@ -13210,17 +13215,34 @@ snapshots:
       vue: 3.6.0-beta.8(typescript@5.9.3)
     optionalDependencies:
       esbuild: 0.27.3
-      vite: 8.0.0(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)
+      vite: 8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
       - csstype
 
-  vue-jsx-vapor@3.2.11(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(csstype@3.2.3)(esbuild@0.27.3)(vite@8.0.0(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1))(vue@3.6.0-beta.10(typescript@5.9.3)):
+  vue-jsx-vapor@3.2.12(csstype@3.2.3)(esbuild@0.27.3)(vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1))(vue@3.5.29(typescript@5.9.3)):
     dependencies:
-      '@vue-jsx-vapor/compiler-rs': 3.2.11(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)
-      '@vue-jsx-vapor/macros': 3.2.11(esbuild@0.27.3)(vite@8.0.0(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1))(vue@3.6.0-beta.10(typescript@5.9.3))
-      '@vue-jsx-vapor/runtime': 3.2.11(csstype@3.2.3)(vue@3.6.0-beta.10(typescript@5.9.3))
+      '@vue-jsx-vapor/compiler-rs': 3.2.12
+      '@vue-jsx-vapor/macros': 3.2.12(esbuild@0.27.3)(vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1))(vue@3.5.29(typescript@5.9.3))
+      '@vue-jsx-vapor/runtime': 3.2.12(csstype@3.2.3)(vue@3.5.29(typescript@5.9.3))
+      '@vue/shared': 3.6.0-beta.8
+      pathe: 2.0.3
+      ts-macro: 0.3.7
+      unplugin: 3.0.0
+      unplugin-utils: 0.3.1
+      vue: 3.5.29(typescript@5.9.3)
+    optionalDependencies:
+      esbuild: 0.27.3
+      vite: 8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)
+    transitivePeerDependencies:
+      - csstype
+
+  vue-jsx-vapor@3.2.12(csstype@3.2.3)(esbuild@0.27.3)(vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1))(vue@3.6.0-beta.10(typescript@5.9.3)):
+    dependencies:
+      '@vue-jsx-vapor/compiler-rs': 3.2.12
+      '@vue-jsx-vapor/macros': 3.2.12(esbuild@0.27.3)(vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1))(vue@3.6.0-beta.10(typescript@5.9.3))
+      '@vue-jsx-vapor/runtime': 3.2.12(csstype@3.2.3)(vue@3.6.0-beta.10(typescript@5.9.3))
       '@vue/shared': 3.6.0-beta.8
       pathe: 2.0.3
       ts-macro: 0.3.7
@@ -13229,10 +13251,8 @@ snapshots:
       vue: 3.6.0-beta.10(typescript@5.9.3)
     optionalDependencies:
       esbuild: 0.27.3
-      vite: 8.0.0(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)
+      vite: 8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)
     transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
       - csstype
 
   vue@3.5.29(typescript@5.9.3):


### PR DESCRIPTION
closes #1060


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Vue TSRX `for...of` lowering and keyed-loop semantics (including ref `.value` rewrites) which can affect rendered output and reactivity/state preservation; mitigated by expanded compile/runtime tests.
> 
> **Overview**
> Vue TSRX now lowers `for...of` template loops to the `vue-jsx-vapor` `VaporFor` component (with `in` and optional `getKey`) instead of emitting `<template v-for>`, enabling typed item/key callbacks and improving keyed loop behavior.
> 
> Keyed `for...of` slots are rewritten to match Vapor’s keyed-slot ref shape (reading loop params via `.value`), with additional handling for destructured params, shadowed identifiers in nested functions, and a fallback to the existing `.map(...)` lowering when patterns can’t be safely rewritten.
> 
> The Vue Vite plugin’s `vue-jsx-vapor/vite` bridge is switched to direct ESM import interop, peer/dev floors for `vue-jsx-vapor` are bumped to `>=3.2.12`, and tests/shims are updated/expanded to cover keyed state preservation and index updates across reorders.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81abd7bab8aea7543c258e6958f02169f58da7a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->