### PR TITLE
chore: typeOnly flag; regular destructure instead of lazy in typeOnly mode

### DIFF
--- a/.changeset/slimy-trees-dance.md
+++ b/.changeset/slimy-trees-dance.md
@@ -1,0 +1,13 @@
+---
+'@tsrx/preact': patch
+'@tsrx/react': patch
+'@tsrx/solid': patch
+'@tsrx/vue': patch
+'@tsrx/core': patch
+---
+
+Introduces a typeOnly flag to transformers to compile for either production or
+editor support.
+
+Lazy transformations for typeOnly are not skipped, only the & is
+removed to make it look like a regular destructure.

--- a/packages/tsrx-preact/src/index.js
+++ b/packages/tsrx-preact/src/index.js
@@ -69,6 +69,7 @@ export function compile_to_volar_mappings(source, filename, options) {
 		...options,
 		collect: true,
 		loose: !!options?.loose,
+		typeOnly: true,
 		errors,
 		comments,
 	});

--- a/packages/tsrx-react/src/index.js
+++ b/packages/tsrx-react/src/index.js
@@ -64,6 +64,7 @@ export function compile_to_volar_mappings(source, filename, options) {
 		collect: true,
 		loose: !!options?.loose,
 		moduleScopedHookComponents: false,
+		typeOnly: true,
 		errors,
 		comments,
 	});

--- a/packages/tsrx-solid/src/index.js
+++ b/packages/tsrx-solid/src/index.js
@@ -63,6 +63,7 @@ export function compile_to_volar_mappings(source, filename, options) {
 	const transformed = transform(ast, source, filename, {
 		collect: true,
 		loose: !!options?.loose,
+		typeOnly: true,
 		errors,
 		comments,
 	});

--- a/packages/tsrx-solid/src/transform.js
+++ b/packages/tsrx-solid/src/transform.js
@@ -177,7 +177,11 @@ function component_to_function_declaration(component, transform_context) {
 	const params = component.params || [];
 	const body = /** @type {any[]} */ (component.body || []);
 
-	const lazy_bindings = collect_lazy_bindings_from_component(params, body, transform_context);
+	// In type-only mode the lazy rewrite is skipped so destructuring patterns
+	// survive into the virtual TSX and TypeScript can flow real types.
+	const lazy_bindings = transform_context.typeOnly
+		? new Map()
+		: collect_lazy_bindings_from_component(params, body, transform_context);
 
 	// Detect top-level early-return patterns such as `if (cond) { return; }`
 	// and `if (cond) { <p />; return; }`.

--- a/packages/tsrx-vue/src/index.js
+++ b/packages/tsrx-vue/src/index.js
@@ -63,6 +63,7 @@ export function compile_to_volar_mappings(source, filename, options) {
 	const transformed = transform(ast, source, filename, {
 		collect: true,
 		loose: !!options?.loose,
+		typeOnly: true,
 		errors,
 		comments,
 	});

--- a/packages/tsrx/src/transform/jsx/index.js
+++ b/packages/tsrx/src/transform/jsx/index.js
@@ -180,12 +180,15 @@ export function createJsxTransform(platform) {
 			collect,
 			errors: collect ? options?.errors : undefined,
 			comments: options?.comments,
+			typeOnly: !!options?.typeOnly,
 			// Platforms can seed their own tracking state (e.g. solid's
 			// needs_show / needs_for flags) via `hooks.initialState`.
 			...(platform.hooks?.initialState?.() ?? {}),
 		};
 
-		preallocate_lazy_ids(/** @type {any} */ (ast), transform_context);
+		if (!transform_context.typeOnly) {
+			preallocate_lazy_ids(/** @type {any} */ (ast), transform_context);
+		}
 
 		walk(/** @type {any} */ (ast), transform_context, {
 			ReturnStatement(node, { next, path }) {
@@ -442,8 +445,15 @@ export function createJsxTransform(platform) {
 		// declarations, arrow functions, etc.). Component bodies have already been
 		// transformed inside component_to_function_declaration; this catches plain
 		// functions outside components and any lazy patterns in module scope.
+		// In type-only mode, the lazy patterns survive untouched: esrap ignores the
+		// non-standard `lazy` flag, so `&{ a, b }` prints as `{ a, b }`, `let &[a]
+		// = expr` prints as `let [a] = expr`, and the bare statement-level form
+		// `&[x] = expr;` (used when `x` is already declared) prints as `[x] =
+		// expr;` — a valid destructuring assignment to the existing binding.
 		const final_program = /** @type {any} */ (
-			apply_lazy_transforms(/** @type {any} */ (expanded), new Map())
+			transform_context.typeOnly
+				? expanded
+				: apply_lazy_transforms(/** @type {any} */ (expanded), new Map())
 		);
 
 		const result = print(/** @type {any} */ (final_program), tsx_with_ts_locations(), {
@@ -519,7 +529,11 @@ export function component_to_function_declaration(component, transform_context, 
 	// Collect lazy binding info WITHOUT mutating patterns. Stores lazy_id on metadata
 	// for later replacement. Body bindings (count, setCount, etc.) are still in the
 	// original patterns, so collect_statement_bindings during build will find them.
-	const lazy_bindings = collect_lazy_bindings_from_component(params, body, transform_context);
+	// In type-only mode the lazy rewrite is skipped entirely so destructuring
+	// patterns survive into the virtual TSX and TypeScript can flow real types.
+	const lazy_bindings = transform_context.typeOnly
+		? new Map()
+		: collect_lazy_bindings_from_component(params, body, transform_context);
 
 	// Save and set context for this component scope
 	const saved_helper_state = transform_context.helper_state;

--- a/packages/tsrx/tests/shared/source-mappings.js
+++ b/packages/tsrx/tests/shared/source-mappings.js
@@ -464,7 +464,7 @@ component C() {
 	});
 
 	describe(`[${name}] lazy destructuring mappings`, () => {
-		it('maps untyped lazy object param keys and aliased reads into generated property names', () => {
+		it('preserves untyped lazy object patterns so source identifiers map identity-style', () => {
 			const source = `component Hello(&{ a: value, b }) {
 	<>{value}{b}</>
 }`;
@@ -474,14 +474,8 @@ component C() {
 			 * @param {number} sourceOffset
 			 * @param {number} generatedOffset
 			 * @param {number} sourceLength
-			 * @param {number} [generatedLength]
 			 */
-			const mapping_at = (
-				sourceOffset,
-				generatedOffset,
-				sourceLength,
-				generatedLength = sourceLength,
-			) =>
+			const identity_mapping = (sourceOffset, generatedOffset, sourceLength) =>
 				result.mappings.find(
 					(
 						/** @type {{ sourceOffsets: number[], generatedOffsets: number[], lengths: number[], generatedLengths: number[] }} */ mapping,
@@ -489,155 +483,45 @@ component C() {
 						mapping.sourceOffsets[0] === sourceOffset &&
 						mapping.generatedOffsets[0] === generatedOffset &&
 						mapping.lengths[0] === sourceLength &&
-						mapping.generatedLengths[0] === generatedLength,
+						mapping.generatedLengths[0] === sourceLength,
 				);
 
-			const source_key_a_offset = source.indexOf('a: value');
-			const source_key_b_offset = source.indexOf('b })');
-			const source_body_value_offset = source.lastIndexOf('value');
-			const source_body_b_offset = source.lastIndexOf('b');
-			const generated_type_a_offset = result.code.indexOf('{ a: any') + 2;
-			const generated_type_b_offset = result.code.indexOf('b: any');
-			const generated_read_a_offset = result.code.indexOf('__lazy0.a') + '__lazy0.'.length;
-			const generated_read_b_offset = result.code.indexOf('__lazy0.b') + '__lazy0.'.length;
+			expect(result.code).toContain('function Hello({ a: value, b })');
+			// Pattern keys / aliases / shorthand bindings preserved as-is.
+			const src_key_a = source.indexOf('a: value');
+			const src_alias_value = source.indexOf('value, b');
+			const src_param_b = source.indexOf('b })');
+			const src_body_value = source.lastIndexOf('value');
+			const src_body_b = source.lastIndexOf('b');
+			const gen_key_a = result.code.indexOf('a: value');
+			const gen_alias_value = result.code.indexOf('value, b');
+			const gen_param_b = result.code.indexOf('b })');
+			const gen_body_value = result.code.lastIndexOf('value');
+			const gen_body_b = result.code.lastIndexOf('b');
 
-			expect(result.code).toContain('function Hello(__lazy0: { a: any; b: any })');
-			expect(mapping_at(source_key_a_offset, generated_type_a_offset, 'a'.length)).toBeDefined();
-			expect(mapping_at(source_key_b_offset, generated_type_b_offset, 'b'.length)).toBeDefined();
-			expect(
-				mapping_at(source_body_value_offset, generated_read_a_offset, 'value'.length, 'a'.length),
-			).toBeDefined();
-			expect(mapping_at(source_body_b_offset, generated_read_b_offset, 'b'.length)).toBeDefined();
+			expect(identity_mapping(src_key_a, gen_key_a, 'a'.length)).toBeDefined();
+			expect(identity_mapping(src_alias_value, gen_alias_value, 'value'.length)).toBeDefined();
+			expect(identity_mapping(src_param_b, gen_param_b, 'b'.length)).toBeDefined();
+			expect(identity_mapping(src_body_value, gen_body_value, 'value'.length)).toBeDefined();
+			expect(identity_mapping(src_body_b, gen_body_b, 'b'.length)).toBeDefined();
 		});
 
-		it('maps annotated lazy object params to the generated lazy parameter', () => {
+		it('preserves annotated lazy object params with their type annotation intact', () => {
 			const source = `component Hello(&{ a: value, b }: { a: string, b: string }) {
 	<>{value}{b}</>
 }`;
 			const result = compile_to_volar_mappings(source, 'App.tsrx');
-			const source_pattern_offset = source.indexOf('{ a: value, b }');
-			const generated_lazy_offset = result.code.indexOf('__lazy0');
-			const pattern_mapping = result.mappings.find(
-				(
-					/** @type {{ sourceOffsets: number[], generatedOffsets: number[], lengths: number[], generatedLengths: number[] }} */ mapping,
-				) =>
-					mapping.sourceOffsets[0] === source_pattern_offset &&
-					mapping.generatedOffsets[0] === generated_lazy_offset &&
-					mapping.lengths[0] === '{ a: value, b }'.length &&
-					mapping.generatedLengths[0] === '__lazy0'.length,
-			);
 
-			expect(result.code).toContain('function Hello(__lazy0: { a: string; b: string })');
-			expect(pattern_mapping).toBeDefined();
+			expect(result.code).toContain('function Hello({ a: value, b }: { a: string; b: string })');
 		});
 
-		it('rewrites lazy object params in hover text', () => {
-			const source = `component Hello(&{ a: c, b }: { a: string, b: string }) {
-	<>{c}{b}</>
-}`;
-			const result = compile_to_volar_mappings(source, 'App.tsrx');
-			const source_pattern_offset = source.indexOf('{ a: c, b }');
-			const source_name_offset = source.indexOf('Hello');
-			const generated_lazy_offset = result.code.indexOf('__lazy0');
-			const generated_name_offset = result.code.indexOf('Hello');
-			const pattern_mapping = result.mappings.find(
-				(mapping) =>
-					mapping.sourceOffsets[0] === source_pattern_offset &&
-					mapping.generatedOffsets[0] === generated_lazy_offset,
-			);
-			const name_mapping = result.mappings.find(
-				(mapping) =>
-					mapping.sourceOffsets[0] === source_name_offset &&
-					mapping.generatedOffsets[0] === generated_name_offset,
-			);
-			const hover = pattern_mapping?.data.customData.hover;
-			const name_hover = name_mapping?.data.customData.hover;
-
-			expect(typeof hover).toBe('function');
-			if (typeof hover === 'function') {
-				expect(
-					hover(`function Hello(__lazy0: {
-    a: string;
-    b: string;
-}): void`),
-				).toBe(`component Hello(&{
-    a: string;
-    b: string;
-}): void`);
-
-				expect(
-					hover(`(parameter) __lazy0: {
-    a: string;
-    b: string;
-}`),
-				).toBe(`(parameter) &{
-    a: string;
-    b: string;
-}`);
-			}
-
-			expect(typeof name_hover).toBe('function');
-			if (typeof name_hover === 'function') {
-				expect(
-					name_hover(`function Hello(__lazy0: {
-    a: string;
-    b: string;
-}): void`),
-				).toBe(`component Hello(&{
-    a: string;
-    b: string;
-}): void`);
-			}
-		});
-
-		it('rewrites lazy object params in plain function hover text', () => {
+		it('preserves annotated lazy params on plain functions', () => {
 			const source = `function greet(&{ a: c, b }: { a: string, b: string }) {
 	return c + b;
 }`;
 			const result = compile_to_volar_mappings(source, 'App.tsrx');
-			const source_pattern_offset = source.indexOf('{ a: c, b }');
-			const source_name_offset = source.indexOf('greet');
-			const generated_lazy_offset = result.code.indexOf('__lazy0');
-			const generated_name_offset = result.code.indexOf('greet');
-			const pattern_mapping = result.mappings.find(
-				(mapping) =>
-					mapping.sourceOffsets[0] === source_pattern_offset &&
-					mapping.generatedOffsets[0] === generated_lazy_offset,
-			);
-			const name_mapping = result.mappings.find(
-				(mapping) =>
-					mapping.sourceOffsets[0] === source_name_offset &&
-					mapping.generatedOffsets[0] === generated_name_offset,
-			);
-			const param_hover = pattern_mapping?.data.customData.hover;
-			const hover = name_mapping?.data.customData.hover;
 
-			expect(result.code).toContain('function greet(__lazy0: { a: string; b: string })');
-			expect(typeof param_hover).toBe('function');
-			if (typeof param_hover === 'function') {
-				expect(
-					param_hover(`function greet(__lazy0: {
-    a: string;
-    b: string;
-}): string`),
-				).toBe(`function greet(&{
-    a: string;
-    b: string;
-}): string`);
-			}
-
-			expect(typeof hover).toBe('function');
-			if (typeof hover === 'function') {
-				expect(
-					hover(`function greet(__lazy0: {
-    a: string;
-    b: string;
-}): string`),
-				).toBe(`function greet(&{
-    a: string;
-    b: string;
-}): string`);
-			}
+			expect(result.code).toContain('function greet({ a: c, b }: { a: string; b: string })');
 		});
 
 		it('reports repeated lazy param bindings in loose mode without throwing', () => {
@@ -654,7 +538,7 @@ component C() {
 			expect(result.errors[1].message).toBe('Argument name clash');
 			expect(result.errors[1].type).toBe('usage');
 			expect(source.slice(result.errors[1].pos, result.errors[1].end)).toBe('b');
-			expect(result.code).toContain('function greet(__lazy0: { a: string; b: string })');
+			expect(result.code).toContain('function greet({ a: b, b }: { a: string; b: string })');
 		});
 
 		it('reports repeated lazy component param bindings in loose mode without throwing', () => {
@@ -685,7 +569,7 @@ component C() {
 						mapping.lengths[0] === result.errors[1].end - result.errors[1].pos,
 				),
 			).toBeDefined();
-			expect(result.code).toContain('function App(__lazy0: { a: string; b: string })');
+			expect(result.code).toContain('function App({ a: b, b }: { a: string; b: string })');
 		});
 
 		it('reports repeated lazy param bindings with full identifier ranges', () => {

--- a/packages/tsrx/types/jsx-platform.d.ts
+++ b/packages/tsrx/types/jsx-platform.d.ts
@@ -56,6 +56,8 @@ export interface JsxTransformContext {
 	errors: CompileError[] | undefined;
 	/** Module-level comments used to honor `@tsrx-ignore` / `@tsrx-expect-error`. */
 	comments: AST.CommentWithLocation[] | undefined;
+	/** True when emitting a type-only virtual TSX module; preserves lazy destructuring patterns. */
+	typeOnly: boolean;
 }
 
 /**
@@ -94,6 +96,14 @@ export interface JsxTransformOptions {
 	 * can disable it to preserve lexical `typeof` helper prop types.
 	 */
 	moduleScopedHookComponents?: boolean;
+	/**
+	 * Emit a type-only virtual TSX module — output is fed to TypeScript for
+	 * editor diagnostics / completions and never executed. Skips the lazy
+	 * destructuring rewrite (`&{ a, b }` → `__lazy0: { a: any; b: any }`) so
+	 * destructuring patterns survive and TypeScript can flow real types to the
+	 * bindings.
+	 */
+	typeOnly?: boolean;
 }
 
 /**


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes core JSX transform behavior under a new `typeOnly` option and updates editor-tooling compilation paths/tests; mistakes could impact Volar mappings and type-checking output, though runtime compilation paths should remain unchanged.
> 
> **Overview**
> Adds a `typeOnly` option to the core JSX transform context and type definitions so editor tooling can emit a *type-only virtual TSX* module.
> 
> When `typeOnly` is enabled (now used by `compile_to_volar_mappings` in the React/Preact/Solid/Vue packages), the transform skips lazy-destructuring rewrites and lazy-id preallocation so `&{...}` / `&[...]` patterns print as normal destructuring, improving TypeScript type flow and simplifying source mappings. Tests were updated to assert the preserved patterns and identity-style mappings in this mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96c82f095d2d60c3b76c5e8e28c991afe96289c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->