### PR TITLE
adds <tsrx>...</tsrx> expression fragments for inline native TSRX

### DIFF
--- a/.changeset/tidy-waves-dance.md
+++ b/.changeset/tidy-waves-dance.md
@@ -1,0 +1,11 @@
+---
+"@tsrx/core": minor
+"@tsrx/ripple": minor
+"@tsrx/react": minor
+"@tsrx/preact": minor
+"@tsrx/solid": minor
+"@tsrx/vue": minor
+"@tsrx/prettier-plugin": minor
+---
+
+Add `<tsrx>...</tsrx>` expression fragments for inline native TSRX template values.

--- a/assets/Ripple.tmbundle/Syntaxes/ripple.tmLanguage
+++ b/assets/Ripple.tmbundle/Syntaxes/ripple.tmLanguage
@@ -5260,6 +5260,10 @@
 				</dict>
 				<dict>
 					<key>include</key>
+					<string>#jsx-tag-tsrx</string>
+				</dict>
+				<dict>
+					<key>include</key>
 					<string>#jsx-tag-tsx-react</string>
 				</dict>
 				<dict>
@@ -5317,6 +5321,10 @@
 				<dict>
 					<key>include</key>
 					<string>#jsx-tag-tsx</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#jsx-tag-tsrx</string>
 				</dict>
 				<dict>
 					<key>include</key>
@@ -5954,6 +5962,72 @@
 						<dict>
 							<key>include</key>
 							<string>#jsx-tsx-children</string>
+						</dict>
+					</array>
+				</dict>
+			</array>
+		</dict>
+		<key>jsx-tag-tsrx</key>
+		<dict>
+			<key>begin</key>
+			<string>(?:[ \t]*)(&lt;)(tsrx)(?![^&gt;]*/&gt;)(?=\s*&gt;)</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.tag.begin.js</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>entity.name.tag.js</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>(&lt;/)\s*(tsrx)\s*(&gt;)</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.tag.begin.js</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>entity.name.tag.js</string>
+				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.tag.end.js</string>
+				</dict>
+			</dict>
+			<key>name</key>
+			<string>tsrx.tag.js</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>begin</key>
+					<string>(&gt;)</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.tag.end.js</string>
+						</dict>
+					</dict>
+					<key>contentName</key>
+					<string>meta.jsx.children.js</string>
+					<key>end</key>
+					<string>(?=&lt;/tsrx&gt;)</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>#jsx-children</string>
 						</dict>
 					</array>
 				</dict>
@@ -6913,6 +6987,10 @@
 				<dict>
 					<key>include</key>
 					<string>#jsx-tag-tsx</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#jsx-tag-tsrx</string>
 				</dict>
 				<dict>
 					<key>include</key>

--- a/grammars/textmate/ripple.tmLanguage.json
+++ b/grammars/textmate/ripple.tmLanguage.json
@@ -6241,6 +6241,9 @@
           "include": "#jsx-tag-tsx"
         },
         {
+          "include": "#jsx-tag-tsrx"
+        },
+        {
           "include": "#jsx-tag-tsx-react"
         },
         {
@@ -6462,6 +6465,9 @@
           "include": "#jsx-tag-tsx"
         },
         {
+          "include": "#jsx-tag-tsrx"
+        },
+        {
           "include": "#jsx-tag-tsx-react"
         },
         {
@@ -6558,6 +6564,9 @@
         },
         {
           "include": "#jsx-tag-tsx"
+        },
+        {
+          "include": "#jsx-tag-tsrx"
         },
         {
           "include": "#jsx-tag-tsx-react"
@@ -6806,6 +6815,47 @@
           "patterns": [
             {
               "include": "#jsx-tsx-children"
+            }
+          ]
+        }
+      ]
+    },
+    "jsx-tag-tsrx": {
+      "name": "tsrx.tag.js",
+      "begin": "(?:[ \\t]*)(<)(tsrx)(?![^>]*/>)(?=\\s*>)",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.definition.tag.begin.js"
+        },
+        "2": {
+          "name": "entity.name.tag.js"
+        }
+      },
+      "end": "(</)\\s*(tsrx)\\s*(>)",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.definition.tag.begin.js"
+        },
+        "2": {
+          "name": "entity.name.tag.js"
+        },
+        "3": {
+          "name": "punctuation.definition.tag.end.js"
+        }
+      },
+      "patterns": [
+        {
+          "begin": "(>)",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.definition.tag.end.js"
+            }
+          },
+          "end": "(?=</tsrx>)",
+          "contentName": "meta.jsx.children.js",
+          "patterns": [
+            {
+              "include": "#jsx-children"
             }
           ]
         }

--- a/packages/prettier-plugin/src/index.js
+++ b/packages/prettier-plugin/src/index.js
@@ -2192,6 +2192,10 @@ function printRippleNode(node, path, options, print, args) {
 			nodeContent = printTsxCompat(node, path, options, print);
 			break;
 
+		case 'Tsrx':
+			nodeContent = printTsrx(node, path, options, print);
+			break;
+
 		case 'Tsx':
 			nodeContent = printTsx(node, path, options, print);
 			break;
@@ -5628,6 +5632,51 @@ function printTsx(node, path, options, print) {
 	}
 
 	// Use softline to allow single-line when content fits
+	return group([
+		tagName,
+		indent([softline, join(softline, printedChildren)]),
+		softline,
+		closingTagName,
+	]);
+}
+
+/**
+ * Print a Tsrx node - renders native TSRX template children inside
+ * <tsrx>...</tsrx>.
+ * @param {AST.Tsrx} node - The Tsrx node
+ * @param {AstPath<AST.Tsrx>} path - The AST path
+ * @param {RippleFormatOptions} options - Prettier options
+ * @param {PrintFn} print - Print callback
+ * @returns {Doc}
+ */
+function printTsrx(node, path, options, print) {
+	const tagName = '<tsrx>';
+	const closingTagName = '</tsrx>';
+	const hasChildren = Array.isArray(node.children) && node.children.length > 0;
+
+	if (!hasChildren) {
+		return [tagName, closingTagName];
+	}
+
+	const printedChildren = [];
+
+	for (let i = 0; i < node.children.length; i++) {
+		const child = node.children[i];
+
+		if (child.type === 'JSXText') {
+			const text = child.value.trim();
+			if (!text) continue;
+			printedChildren.push(text);
+		} else {
+			const printedChild = path.call(print, 'children', i);
+			printedChildren.push(printedChild);
+		}
+	}
+
+	if (printedChildren.length === 0) {
+		return [tagName, closingTagName];
+	}
+
 	return group([
 		tagName,
 		indent([softline, join(softline, printedChildren)]),

--- a/packages/prettier-plugin/src/index.test.js
+++ b/packages/prettier-plugin/src/index.test.js
@@ -102,6 +102,22 @@ describe('prettier-plugin', () => {
 			expect(typeof result.cursorOffset).toBe('number');
 		});
 
+		it('should format tsrx expression fragments', async () => {
+			const input = `component App(){const content=<tsrx>const label="Hi";<div>"Hello" {label}</div></tsrx>;{content}}`;
+			const expected = `component App() {
+  const content = <tsrx>
+    const label = 'Hi';
+    <div>
+      "Hello"
+      {label}
+    </div>
+  </tsrx>;
+  {content}
+}`;
+			const result = await format(input, { singleQuote: true });
+			expect(result).toBeWithNewline(expected);
+		});
+
 		it('should format whitespace correctly', async () => {
 			const input = `export component Test(){
         let count=0

--- a/packages/ripple/tests/client/tsx.test.tsrx
+++ b/packages/ripple/tests/client/tsx.test.tsrx
@@ -568,3 +568,74 @@ describe('tsx expression', () => {
 		expect(container.querySelector('.success')).toBeFalsy();
 	});
 });
+
+describe('tsrx expression', () => {
+	it('renders native double-quoted text in an assigned fragment', () => {
+		component App() {
+			const el = <tsrx><div>"Hello world"</div></tsrx>;
+			{el}
+		}
+
+		render(App);
+
+		const div = container.querySelector('div');
+		expect(div).toBeTruthy();
+		expect(div.textContent).toBe('Hello world');
+	});
+
+	it('runs setup statements before native template output', () => {
+		component App() {
+			const el = <tsrx>const label = 'from setup';<div>{label}</div></tsrx>;
+			{el}
+		}
+
+		render(App);
+
+		expect(container.querySelector('div').textContent).toBe('from setup');
+	});
+
+	it('updates reactive expressions inside native fragments', () => {
+		component App() {
+			let &[count] = track(0);
+			const el = <tsrx><div>{'count: ' + count}</div></tsrx>;
+			{el}
+			<button onClick={() => count++}>{'increment'}</button>
+		}
+
+		render(App);
+
+		expect(container.querySelector('div').textContent).toBe('count: 0');
+		container.querySelector('button').click();
+		flushSync();
+		expect(container.querySelector('div').textContent).toBe('count: 1');
+	});
+
+	it('renders native control flow inside an assigned fragment', () => {
+		component App() {
+			const el = <tsrx>
+				if (true) {
+					<span>"visible"</span>
+				}
+			</tsrx>;
+			{el}
+		}
+
+		render(App);
+
+		expect(container.querySelector('span').textContent).toBe('visible');
+	});
+
+	it('renders fragments returned from helpers outside components', () => {
+		function makeFragment(label: string) {
+			return <tsrx><span>{label}</span></tsrx>;
+		}
+
+		component App() {
+			{makeFragment('from helper')}
+		}
+
+		render(App);
+
+		expect(container.querySelector('span').textContent).toBe('from helper');
+	});
+});

--- a/packages/ripple/tests/server/basic.test.tsrx
+++ b/packages/ripple/tests/server/basic.test.tsrx
@@ -40,6 +40,18 @@ second"</pre>
 		);
 	});
 
+	it('renders inline tsrx fragments', async () => {
+		component Basic() {
+			const content = <tsrx>const label = 'Server';<span>{label}</span></tsrx>;
+
+			<div>{content}</div>
+		}
+
+		const { body } = await render(Basic);
+
+		expect(body).toBeHtml('<div><span>Server</span></div>');
+	});
+
 	it('renders tracked state updates', async () => {
 		component Counter() {
 			let &[count] = track(0);

--- a/packages/tsrx-mcp/scripts/generate-docs-index.js
+++ b/packages/tsrx-mcp/scripts/generate-docs-index.js
@@ -49,7 +49,10 @@ export async function generate_docs_index() {
 		'COMPONENT_GRAMMAR',
 		specification_source,
 	);
-	const tsx_grammar = extract_string_array_constant('TSX_GRAMMAR', specification_source);
+	const expression_island_grammar = extract_string_array_constant(
+		'EXPRESSION_ISLAND_GRAMMAR',
+		specification_source,
+	);
 	const template_expression_grammar = extract_string_array_constant(
 		'TEMPLATE_EXPRESSION_GRAMMAR',
 		specification_source,
@@ -75,7 +78,7 @@ Core ideas:
 - component declarations use the component keyword.
 - JSX-like elements can be written as statements inside component bodies.
 - control-flow statements can contain template output.
-- expression-position JSX must use <>...</> or <tsx>...</tsx>.
+- expression-position native TSRX must use <tsrx>...</tsrx>; JSX-style values use <>...</> or <tsx>...</tsx>.
 - lazy destructuring uses &[] and &{} for by-reference bindings.
 
 The core language docs should stay target-neutral. After identifying the active runtime target, use target-specific docs, prompts, or skills for runtime imports, bundler setup, and semantics that are not defined by TSRX itself.
@@ -135,27 +138,38 @@ Source: website-tsrx/src/pages/specification.tsrx#templates`,
 		},
 		{
 			slug: 'tsx-expression-values',
-			title: 'TSX Expression Values',
+			title: 'Expression Values',
 			use_cases:
-				'fragments, tsx tag, pass jsx as prop, return jsx from helper, expression position jsx',
-			content: `# TSX Expression Values
+				'fragments, tsrx tag, tsx tag, pass template as prop, return template from helper, render props, expression position jsx',
+			content: `# Expression Values
 
-Regular template elements in component bodies are statements and have no value. When JSX must be used in expression position, wrap it in \`<>...</>\` or \`<tsx>...</tsx>\`.
+Regular template elements in component bodies are statements and have no value. When native TSRX must be used in expression position, wrap it in \`<tsrx>...</tsrx>\`. When JSX-style children must be used in expression position, wrap them in \`<>...</>\` or \`<tsx>...</tsx>\`.
 
 \`\`\`tsx
 component App() {
-  const title = <><span>"Settings"</span></>;
+  const title = <tsrx><span>"Settings"</span></tsrx>;
 
   <Card title={title} />
 }
 \`\`\`
 
-Use this for assigning JSX to variables, returning JSX from helper functions, or passing JSX as props. Do not write \`const el = <div />\` directly in TSRX component code.
+Native TSRX expression fragments can contain setup statements and template control flow:
+
+\`\`\`tsx
+function badge(label: string) {
+  return <tsrx>
+    const normalized = label.trim();
+    <span class="badge">{normalized}</span>
+  </tsrx>;
+}
+\`\`\`
+
+Use these wrappers for assigning UI to variables, returning UI from helper functions, or passing UI as props. Do not write \`const el = <div />\` directly in TSRX component code.
 
 Specification grammar:
 
 \`\`\`text
-${tsx_grammar}
+${expression_island_grammar}
 \`\`\`
 
 Source: website-tsrx/src/pages/specification.tsrx#tsx-islands`,

--- a/packages/tsrx-mcp/src/generated/docs.js
+++ b/packages/tsrx-mcp/src/generated/docs.js
@@ -11,7 +11,7 @@ export const documentation_sections = [
 		use_cases:
 			'always, introduction, explain tsrx, compare jsx, language model context, runtime targets',
 		content:
-			'# TSRX Overview\n\nTSRX is a TypeScript language extension for authoring declarative UI in .tsrx files. It adds a small set of syntax forms on top of TypeScript, while letting each target compiler define the runtime semantics.\n\nCore ideas:\n- component declarations use the component keyword.\n- JSX-like elements can be written as statements inside component bodies.\n- control-flow statements can contain template output.\n- expression-position JSX must use <>...</> or <tsx>...</tsx>.\n- lazy destructuring uses &[] and &{} for by-reference bindings.\n\nThe core language docs should stay target-neutral. After identifying the active runtime target, use target-specific docs, prompts, or skills for runtime imports, bundler setup, and semantics that are not defined by TSRX itself.\n\nSource: website-tsrx/src/pages/specification.tsrx',
+			'# TSRX Overview\n\nTSRX is a TypeScript language extension for authoring declarative UI in .tsrx files. It adds a small set of syntax forms on top of TypeScript, while letting each target compiler define the runtime semantics.\n\nCore ideas:\n- component declarations use the component keyword.\n- JSX-like elements can be written as statements inside component bodies.\n- control-flow statements can contain template output.\n- expression-position native TSRX must use <tsrx>...</tsrx>; JSX-style values use <>...</> or <tsx>...</tsx>.\n- lazy destructuring uses &[] and &{} for by-reference bindings.\n\nThe core language docs should stay target-neutral. After identifying the active runtime target, use target-specific docs, prompts, or skills for runtime imports, bundler setup, and semantics that are not defined by TSRX itself.\n\nSource: website-tsrx/src/pages/specification.tsrx',
 	},
 	{
 		slug: 'components',
@@ -31,11 +31,11 @@ export const documentation_sections = [
 	},
 	{
 		slug: 'tsx-expression-values',
-		title: 'TSX Expression Values',
+		title: 'Expression Values',
 		use_cases:
-			'fragments, tsx tag, pass jsx as prop, return jsx from helper, expression position jsx',
+			'fragments, tsrx tag, tsx tag, pass template as prop, return template from helper, render props, expression position jsx',
 		content:
-			'# TSX Expression Values\n\nRegular template elements in component bodies are statements and have no value. When JSX must be used in expression position, wrap it in `<>...</>` or `<tsx>...</tsx>`.\n\n```tsx\ncomponent App() {\n  const title = <><span>"Settings"</span></>;\n\n  <Card title={title} />\n}\n```\n\nUse this for assigning JSX to variables, returning JSX from helper functions, or passing JSX as props. Do not write `const el = <div />` directly in TSRX component code.\n\nSpecification grammar:\n\n```text\nTsxElement :\n  <tsx> TsxChildrenopt </tsx>\n\nTsxCompatElement :\n  <tsx: IdentifierName> TsxChildrenopt </tsx: IdentifierName>\n\nTsxFragmentShorthand :\n  <> TsxChildrenopt </>\n```\n\nSource: website-tsrx/src/pages/specification.tsrx#tsx-islands',
+			'# Expression Values\n\nRegular template elements in component bodies are statements and have no value. When native TSRX must be used in expression position, wrap it in `<tsrx>...</tsrx>`. When JSX-style children must be used in expression position, wrap them in `<>...</>` or `<tsx>...</tsx>`.\n\n```tsx\ncomponent App() {\n  const title = <tsrx><span>"Settings"</span></tsrx>;\n\n  <Card title={title} />\n}\n```\n\nNative TSRX expression fragments can contain setup statements and template control flow:\n\n```tsx\nfunction badge(label: string) {\n  return <tsrx>\n    const normalized = label.trim();\n    <span class="badge">{normalized}</span>\n  </tsrx>;\n}\n```\n\nUse these wrappers for assigning UI to variables, returning UI from helper functions, or passing UI as props. Do not write `const el = <div />` directly in TSRX component code.\n\nSpecification grammar:\n\n```text\nTsrxExpression :\n  <tsrx> TemplateChildrenopt </tsrx>\n\nTsxElement :\n  <tsx> TsxChildrenopt </tsx>\n\nTsxCompatElement :\n  <tsx: IdentifierName> TsxChildrenopt </tsx: IdentifierName>\n\nTsxFragmentShorthand :\n  <> TsxChildrenopt </>\n```\n\nSource: website-tsrx/src/pages/specification.tsrx#tsx-islands',
 	},
 	{
 		slug: 'control-flow',

--- a/packages/tsrx-mcp/tests/docs.test.js
+++ b/packages/tsrx-mcp/tests/docs.test.js
@@ -24,6 +24,9 @@ describe('@tsrx/mcp documentation index', () => {
 		expect(find_documentation_section('tsx-expression-values')?.content ?? '').toContain(
 			'TsxElement',
 		);
+		expect(find_documentation_section('tsx-expression-values')?.content ?? '').toContain(
+			'TsrxExpression',
+		);
 	});
 
 	it('documents component loop control-flow rules', () => {

--- a/packages/tsrx-ripple/src/analyze/index.js
+++ b/packages/tsrx-ripple/src/analyze/index.js
@@ -239,6 +239,7 @@ function mark_control_flow_has_template(path) {
 			node.type === 'IfStatement' ||
 			node.type === 'SwitchStatement' ||
 			node.type === 'Tsx' ||
+			node.type === 'Tsrx' ||
 			node.type === 'TsxCompat'
 		) {
 			node.metadata.has_template = true;
@@ -336,6 +337,14 @@ function mark_control_flow_has_continue(path) {
  */
 function is_inside_tsx_context(path) {
 	return path.some((node) => node?.type === 'TsxCompat' || node?.type === 'Tsx');
+}
+
+/**
+ * @param {AnalysisContext['path']} path
+ * @returns {boolean}
+ */
+function is_inside_tsrx_context(path) {
+	return path.some((node) => node?.type === 'Tsrx');
 }
 
 /**
@@ -2110,6 +2119,11 @@ const visitors = {
 		return context.next();
 	},
 
+	Tsrx(_, context) {
+		mark_control_flow_has_template(context.path);
+		return context.next();
+	},
+
 	TsxCompat(node, context) {
 		mark_control_flow_has_template(context.path);
 
@@ -2132,7 +2146,7 @@ const visitors = {
 			error(TEMPLATE_FRAGMENT_ERROR, context.state.analysis.module.filename, node);
 		}
 
-		if (!is_inside_component(context)) {
+		if (!is_inside_component(context) && !is_inside_tsrx_context(context.path)) {
 			error(
 				'Elements cannot be used outside of components',
 				context.state.analysis.module.filename,

--- a/packages/tsrx-ripple/src/transform/client/index.js
+++ b/packages/tsrx-ripple/src/transform/client/index.js
@@ -3105,24 +3105,33 @@ function build_tsrx_to_ts_expression(node, context) {
 
 	/** @type {AST.Statement[]} */
 	const body = [];
-	/** @type {TsrxTsExpression[]} */
-	let trailing_children = [];
+	const has_children = inline_children.some(Boolean);
+	const children_id = has_children ? state.scope.generate('children') : null;
+	if (children_id !== null) {
+		body.push(b.const(b.id(children_id), b.array([])));
+	}
 	for (const statement of statements) {
 		const child = statement_to_tsrx_ts_expression(statement);
 		if (child) {
-			trailing_children.push(child);
-		} else {
-			for (const trailing_child of trailing_children) {
-				body.push(b.stmt(/** @type {AST.Expression} */ (trailing_child)));
+			if (children_id !== null) {
+				body.push(
+					b.stmt(
+						b.call(b.member(b.id(children_id), 'push'), /** @type {AST.Expression} */ (child)),
+					),
+				);
 			}
-			trailing_children = [];
+		} else {
 			body.push(/** @type {AST.Statement} */ (statement));
 		}
 	}
 
 	body.push(
 		b.return(
-			/** @type {AST.Expression} */ (build_tsrx_ts_return_expression(trailing_children)),
+			children_id === null
+				? b.literal(null)
+				: /** @type {AST.Expression} */ (
+						b.jsx_fragment([b.jsx_expression_container(b.id(children_id))])
+					),
 			/** @type {AST.NodeWithLocation} */ (node),
 		),
 	);

--- a/packages/tsrx-ripple/src/transform/client/index.js
+++ b/packages/tsrx-ripple/src/transform/client/index.js
@@ -1437,6 +1437,51 @@ const visitors = {
 		return element;
 	},
 
+	Tsrx(node, context) {
+		const { state, visit } = context;
+
+		// to_ts mode: produce a JSX fragment from native TSRX children.
+		if (state.to_ts) {
+			return build_tsrx_to_ts_expression(node, context);
+		}
+
+		const children_filtered = node.children.filter((child) => {
+			return child != null && child.type !== 'EmptyStatement';
+		});
+		apply_tsrx_css_scoping(children_filtered, state);
+
+		const children_component = b.component(b.id('render_children'), [], children_filtered);
+
+		const element = b.call(
+			'_$_.tsrx_element',
+			/** @type {AST.Expression} */ (
+				visit(children_component, {
+					...state,
+					namespace: state.namespace,
+					is_tsrx_element: true,
+				})
+			),
+		);
+
+		// Template body context: push to template and schedule init
+		if (state.flush_node) {
+			state.template?.push('<!>');
+
+			const id = state.flush_node(false);
+
+			const call = b.call('_$_.expression', id, b.thunk(element));
+			state.init?.push(
+				state.namespace !== DEFAULT_NAMESPACE
+					? b.stmt(b.call('_$_.with_ns', b.literal(state.namespace), b.thunk(call)))
+					: b.stmt(call),
+			);
+			return;
+		}
+
+		// Expression context: return the tsrx_element directly as an expression value
+		return element;
+	},
+
 	Element(node, context) {
 		const { state, visit } = context;
 
@@ -1872,6 +1917,7 @@ const visitors = {
 							child.type === 'ForOfStatement' ||
 							child.type === 'SwitchStatement' ||
 							child.type === 'Tsx' ||
+							child.type === 'Tsrx' ||
 							child.type === 'TsxCompat' ||
 							child.type === 'Html' ||
 							(child.type === 'Element' &&
@@ -2997,6 +3043,92 @@ function join_template(items) {
 }
 
 /**
+ * @typedef {AST.Statement | ESTreeJSX.JSXElement | ESTreeJSX.JSXFragment} TsrxTsStatement
+ * @typedef {AST.Expression | ESTreeJSX.JSXElement | ESTreeJSX.JSXFragment} TsrxTsExpression
+ */
+
+/**
+ * @param {TsrxTsStatement} statement
+ * @returns {TsrxTsExpression | null}
+ */
+function statement_to_tsrx_ts_expression(statement) {
+	if (statement.type === 'ExpressionStatement') {
+		return /** @type {AST.ExpressionStatement} */ (statement).expression;
+	}
+	const node = /** @type {AST.Node} */ (statement);
+	if (node.type === 'JSXElement' || node.type === 'JSXFragment') {
+		return /** @type {ESTreeJSX.JSXElement | ESTreeJSX.JSXFragment} */ (node);
+	}
+	return null;
+}
+
+/**
+ * @param {TsrxTsExpression[]} children
+ * @returns {TsrxTsExpression}
+ */
+function build_tsrx_ts_return_expression(children) {
+	return children.length === 0
+		? b.literal(null)
+		: children.length === 1
+			? children[0]
+			: b.jsx_fragment(/** @type {ESTreeJSX.JSXFragment['children']} */ (children));
+}
+
+/**
+ * Builds a TSX expression for Volar/TypeScript output. Pure template children can
+ * remain inline JSX; fragments with setup statements need an IIFE so declarations
+ * stay in statement position.
+ *
+ * @param {AST.Tsrx} node
+ * @param {VisitorClientContext} context
+ * @returns {TsrxTsExpression}
+ */
+function build_tsrx_to_ts_expression(node, context) {
+	const { state, visit } = context;
+	/** @type {TsrxTsStatement[]} */
+	const init = [];
+	const ts_state = { ...state, init };
+	for (const child of node.children) {
+		transform_ts_child(
+			/** @type {AST.Node} */ (child),
+			/** @type {TransformClientContext} */ ({ visit, state: ts_state }),
+		);
+	}
+	const statements = init.filter((statement) => statement.type !== 'EmptyStatement');
+	const inline_children = statements.map(statement_to_tsrx_ts_expression);
+
+	if (inline_children.every(Boolean)) {
+		return build_tsrx_ts_return_expression(/** @type {TsrxTsExpression[]} */ (inline_children));
+	}
+
+	/** @type {AST.Statement[]} */
+	const body = [];
+	/** @type {TsrxTsExpression[]} */
+	let trailing_children = [];
+	for (const statement of statements) {
+		const child = statement_to_tsrx_ts_expression(statement);
+		if (child) {
+			trailing_children.push(child);
+		} else {
+			for (const trailing_child of trailing_children) {
+				body.push(b.stmt(/** @type {AST.Expression} */ (trailing_child)));
+			}
+			trailing_children = [];
+			body.push(/** @type {AST.Statement} */ (statement));
+		}
+	}
+
+	body.push(
+		b.return(
+			/** @type {AST.Expression} */ (build_tsrx_ts_return_expression(trailing_children)),
+			/** @type {AST.NodeWithLocation} */ (node),
+		),
+	);
+
+	return b.call(b.arrow([], b.block(body)));
+}
+
+/**
  * @param {AST.Node} node
  * @param {TransformClientContext} context
  */
@@ -3403,6 +3535,12 @@ function transform_ts_child(node, context) {
 			return result;
 		}
 		state.init.push(b.stmt(result));
+	} else if (node.type === 'Tsrx') {
+		const result = build_tsrx_to_ts_expression(node, context);
+		if (!state.init) {
+			return result;
+		}
+		state.init.push(b.stmt(/** @type {AST.Expression} */ (result)));
 	} else if (node.type === 'JSXExpressionContainer') {
 		// JSX comments {/* ... */} are JSXExpressionContainer with JSXEmptyExpression
 		// These should be preserved in the output as-is for prettier to handle
@@ -3429,7 +3567,18 @@ function transform_ts_child(node, context) {
 			),
 		);
 	} else {
-		throw new Error('TODO');
+		const result = visit(node, state);
+		if (!state.init) {
+			return result;
+		}
+		if (result && /** @type {AST.Node} */ (result).type !== 'EmptyStatement') {
+			push_statement(
+				/** @type {AST.Statement | AST.Statement[] | AST.Directive | AST.ModuleDeclaration} */ (
+					result
+				),
+				state.init,
+			);
+		}
 	}
 }
 
@@ -3445,6 +3594,7 @@ function is_template_or_control_flow(node) {
 		node.type === 'Text' ||
 		node.type === 'Html' ||
 		node.type === 'Tsx' ||
+		node.type === 'Tsrx' ||
 		node.type === 'TsxCompat' ||
 		node.type === 'IfStatement' ||
 		node.type === 'ForOfStatement' ||
@@ -3537,6 +3687,7 @@ function element_has_dynamic_content(element) {
 			child.type === 'ForOfStatement' ||
 			child.type === 'SwitchStatement' ||
 			child.type === 'Tsx' ||
+			child.type === 'Tsrx' ||
 			child.type === 'TsxCompat' ||
 			child.type === 'Html'
 		) {
@@ -3713,6 +3864,7 @@ function transform_children(children, context) {
 				node.type === 'ForOfStatement' ||
 				node.type === 'SwitchStatement' ||
 				node.type === 'Tsx' ||
+				node.type === 'Tsrx' ||
 				node.type === 'TsxCompat' ||
 				node.type === 'Html' ||
 				(node.type === 'Element' &&
@@ -3997,6 +4149,7 @@ function transform_children(children, context) {
 							child.type === 'ForOfStatement' ||
 							child.type === 'SwitchStatement' ||
 							child.type === 'Tsx' ||
+							child.type === 'Tsrx' ||
 							child.type === 'TsxCompat' ||
 							child.type === 'Html' ||
 							(child.type === 'Element' &&
@@ -4024,7 +4177,7 @@ function transform_children(children, context) {
 						state.init?.push(b.stmt(b.call('_$_.pop', id)));
 					}
 				}
-			} else if (node.type === 'TsxCompat' || node.type === 'Tsx') {
+			} else if (node.type === 'TsxCompat' || node.type === 'Tsx' || node.type === 'Tsrx') {
 				skipped = 0;
 
 				visit(node, {

--- a/packages/tsrx-ripple/src/transform/client/index.js
+++ b/packages/tsrx-ripple/src/transform/client/index.js
@@ -3088,7 +3088,9 @@ function build_tsrx_to_ts_expression(node, context) {
 	/** @type {TsrxTsStatement[]} */
 	const init = [];
 	const ts_state = { ...state, init };
-	for (const child of node.children) {
+	for (const child of node.children.filter((child) => {
+		return child != null && child.type !== 'EmptyStatement';
+	})) {
 		transform_ts_child(
 			/** @type {AST.Node} */ (child),
 			/** @type {TransformClientContext} */ ({ visit, state: ts_state }),

--- a/packages/tsrx-ripple/src/transform/client/index.js
+++ b/packages/tsrx-ripple/src/transform/client/index.js
@@ -3089,6 +3089,7 @@ function build_tsrx_to_ts_expression(node, context) {
 	const init = [];
 	const ts_state = { ...state, init };
 	for (const child of node.children) {
+		if (child == null || child.type === 'EmptyStatement') continue;
 		transform_ts_child(
 			/** @type {AST.Node} */ (child),
 			/** @type {TransformClientContext} */ ({ visit, state: ts_state }),

--- a/packages/tsrx-ripple/src/transform/server/index.js
+++ b/packages/tsrx-ripple/src/transform/server/index.js
@@ -207,6 +207,7 @@ function is_template_or_control_flow(node) {
 		node.type === 'Text' ||
 		node.type === 'Html' ||
 		node.type === 'Tsx' ||
+		node.type === 'Tsrx' ||
 		node.type === 'TsxCompat' ||
 		node.type === 'IfStatement' ||
 		node.type === 'ForOfStatement' ||
@@ -1713,6 +1714,37 @@ const visitors = {
 		const init = [];
 		transform_children(
 			converted_children,
+			/** @type {TransformServerContext} */ ({
+				visit,
+				state: {
+					...state,
+					init,
+				},
+			}),
+		);
+
+		if (state.template_child) {
+			// Template body: push children statements inline
+			if (init.length > 0) {
+				state.init?.push(b.block(init));
+			}
+		} else {
+			// Expression context: return tsrx_element(render_fn)
+			const render_fn = b.function(b.id('render_children'), [], b.block(init));
+			return b.call('_$_.tsrx_element', render_fn);
+		}
+	},
+
+	Tsrx(node, { visit, state }) {
+		const children = node.children.filter(
+			(child) => child != null && child.type !== 'EmptyStatement',
+		);
+		apply_tsrx_css_scoping(children, state);
+
+		/** @type {AST.Statement[]} */
+		const init = [];
+		transform_children(
+			children,
 			/** @type {TransformServerContext} */ ({
 				visit,
 				state: {

--- a/packages/tsrx-ripple/src/utils.js
+++ b/packages/tsrx-ripple/src/utils.js
@@ -545,6 +545,11 @@ export function is_children_template_expression(expression, scope, component_sco
 	}
 
 	const unwrapped = unwrap_template_expression(expression);
+	const unwrapped_node = /** @type {AST.Node} */ (unwrapped);
+
+	if (is_template_fragment_node(unwrapped_node)) {
+		return true;
+	}
 
 	if (unwrapped.type === 'MemberExpression') {
 		let property_name = null;
@@ -573,18 +578,60 @@ export function is_children_template_expression(expression, scope, component_sco
 	}
 
 	if (unwrapped.type !== 'Identifier' || unwrapped.name !== 'children') {
+		if (unwrapped.type === 'Identifier') {
+			const binding = scope.get(unwrapped.name);
+			return is_template_fragment_binding(binding, scope);
+		}
 		return false;
 	}
 
 	const binding = scope.get(unwrapped.name);
 	return (
-		(binding?.declaration_kind === 'param' ||
+		is_template_fragment_binding(binding, scope) ||
+		((binding?.declaration_kind === 'param' ||
 			binding?.kind === 'prop' ||
 			binding?.kind === 'prop_fallback' ||
 			binding?.kind === 'lazy' ||
 			binding?.kind === 'lazy_fallback') &&
-		(component_scope === null || binding.scope === component_scope)
+			(component_scope === null || binding.scope === component_scope))
 	);
+}
+
+/**
+ * @param {AST.Node | null | undefined} node
+ * @returns {boolean}
+ */
+function is_template_fragment_node(node) {
+	return node?.type === 'Tsx' || node?.type === 'Tsrx' || node?.type === 'TsxCompat';
+}
+
+/**
+ * @param {Binding | null | undefined} binding
+ * @param {ScopeInterface} scope
+ * @param {Set<Binding>} [visited]
+ * @returns {boolean}
+ */
+function is_template_fragment_binding(binding, scope, visited = new Set()) {
+	if (!binding || binding.reassigned || visited.has(binding)) {
+		return false;
+	}
+	visited.add(binding);
+
+	const initial = binding.initial;
+	if (!initial) {
+		return false;
+	}
+
+	const initial_node = /** @type {AST.Node} */ (initial);
+	if (is_template_fragment_node(initial_node)) {
+		return true;
+	}
+
+	if (initial_node.type === 'Identifier') {
+		return is_template_fragment_binding(scope.get(initial_node.name), scope, visited);
+	}
+
+	return false;
 }
 
 /**

--- a/packages/tsrx-ripple/tests/basic.test.js
+++ b/packages/tsrx-ripple/tests/basic.test.js
@@ -177,3 +177,26 @@ component App() {
 		);
 	});
 });
+
+describe('@tsrx/ripple <tsrx> Volar output', () => {
+	it('returns children before and after setup statements', () => {
+		const source = `class Foo { bar() { return <tsrx><div>"before"</div> const x = 1; <div>{x}</div></tsrx>; } }`;
+		const result = compile_to_volar_mappings(source, 'App.tsrx', { loose: true });
+		const match = result.code.match(/const ([A-Za-z_$][\w$]*) = \[\];/);
+		expect(match).not.toBeNull();
+
+		const children_id = /** @type {RegExpMatchArray} */ (match)[1];
+		const first_push = result.code.indexOf(`${children_id}.push(<div>`);
+		const declaration = result.code.indexOf('const x = 1;');
+		const second_push = result.code.indexOf(`${children_id}.push(<div>`, first_push + 1);
+		const returned_children = result.code.indexOf(`return <>{${children_id}}</>;`);
+
+		expect(first_push).toBeGreaterThan(-1);
+		expect(declaration).toBeGreaterThan(-1);
+		expect(second_push).toBeGreaterThan(-1);
+		expect(returned_children).toBeGreaterThan(-1);
+		expect(first_push).toBeLessThan(declaration);
+		expect(declaration).toBeLessThan(second_push);
+		expect(second_push).toBeLessThan(returned_children);
+	});
+});

--- a/packages/tsrx-solid/src/transform.js
+++ b/packages/tsrx-solid/src/transform.js
@@ -411,6 +411,8 @@ function to_jsx_child(node, transform_context) {
 			// We're inside a JSX child position by construction; keep `{expr}`
 			// containers wrapped. See helpers.js.
 			return tsx_node_to_jsx_expression(node, true);
+		case 'Tsrx':
+			return tsrx_node_to_jsx_expression(node, transform_context, true);
 		case 'TsxCompat':
 			return tsx_compat_node_to_jsx_expression(node, transform_context, true);
 		case 'Element':
@@ -434,6 +436,40 @@ function to_jsx_child(node, transform_context) {
 		default:
 			return node;
 	}
+}
+
+/**
+ * Lower a `<tsrx>` node's native TSRX template body to a Solid JSX expression.
+ *
+ * @param {any} node
+ * @param {TransformContext} transform_context
+ * @param {boolean} [in_jsx_child]
+ * @returns {any}
+ */
+function tsrx_node_to_jsx_expression(node, transform_context, in_jsx_child = false) {
+	const children = (node.children || []).filter(
+		(/** @type {any} */ child) =>
+			child &&
+			child.type !== 'EmptyStatement' &&
+			(child.type !== 'JSXText' || child.value.trim() !== ''),
+	);
+
+	let expression = body_to_jsx_child(children, transform_context);
+	if (is_branch_arrow(expression)) {
+		expression = b.call(expression);
+	}
+
+	if (
+		in_jsx_child &&
+		expression.type !== 'JSXElement' &&
+		expression.type !== 'JSXFragment' &&
+		expression.type !== 'JSXText' &&
+		expression.type !== 'JSXExpressionContainer'
+	) {
+		return to_jsx_expression_container(expression, node);
+	}
+
+	return expression;
 }
 
 /**

--- a/packages/tsrx/src/plugin.js
+++ b/packages/tsrx/src/plugin.js
@@ -18,7 +18,7 @@ import { error } from './errors.js';
 import { DIAGNOSTIC_CODES } from './diagnostics.js';
 
 const JSX_EXPRESSION_VALUE_ERROR =
-	'JSX elements cannot be used as expressions. Wrap with `<>...</>` or `<tsx>...</tsx>` or use elements as statements within a component.';
+	'JSX elements cannot be used as expressions. Wrap JSX with `<>...</>` or `<tsx>...</tsx>`, wrap TSRX templates with `<tsrx>...</tsrx>`, or use elements as statements within a component.';
 
 /** @type {WeakMap<Record<string, boolean>, Map<string, number>>} */
 const argument_clash_first_positions = new WeakMap();
@@ -325,7 +325,10 @@ export function TSRXPlugin(config) {
 				}
 
 				const parent = this.#path.at(-1);
-				if (!parent || (parent.type !== 'Component' && parent.type !== 'Element')) {
+				if (
+					!parent ||
+					(parent.type !== 'Component' && parent.type !== 'Element' && parent.type !== 'Tsrx')
+				) {
 					return false;
 				}
 
@@ -1809,7 +1812,8 @@ export function TSRXPlugin(config) {
 								ch === 125 &&
 								(this.#path.length === 0 ||
 									this.#path.at(-1)?.type === 'Component' ||
-									this.#path.at(-1)?.type === 'Element')
+									this.#path.at(-1)?.type === 'Element' ||
+									this.#path.at(-1)?.type === 'Tsrx')
 							) {
 								this.#resetTokenStartToCurrentPosition();
 								return original.readToken.call(this, ch);
@@ -1849,7 +1853,9 @@ export function TSRXPlugin(config) {
 			 * Override jsx_parseElement to intercept expression-level JSX.
 			 * This is called by acorn-jsx's parseExprAtom when it encounters <
 			 * in expression position. Bare fragments are treated as shorthand
-			 * for <tsx>...</tsx>; other tags must still use <tsx> or <tsx:*>.
+			 * for <tsx>...</tsx>. <tsrx>...</tsrx> admits native TSRX
+			 * template syntax as an expression value. Other tags must still use
+			 * <tsx>, <tsrx>, or <tsx:*>.
 			 * @type {Parse.Parser['jsx_parseElement']}
 			 */
 			jsx_parseElement() {
@@ -1859,11 +1865,12 @@ export function TSRXPlugin(config) {
 					return super.jsx_parseElement();
 				}
 
-				// Check if the element being parsed IS a <tsx> or <tsx:*> tag
+				// Check if the element being parsed IS a <tsx>, <tsrx>, or <tsx:*> tag
 				// Current token is jsxTagStart, this.end is position after '<'
 				const tag_name_start = this.end;
 				const is_fragment_tag = this.input.charCodeAt(tag_name_start) === 62;
 				const char_after_tsx = this.input.charCodeAt(tag_name_start + 3);
+				const char_after_tsrx = this.input.charCodeAt(tag_name_start + 4);
 				const is_tsx_tag =
 					this.input.startsWith('tsx', tag_name_start) &&
 					(tag_name_start + 3 >= this.input.length ||
@@ -1874,9 +1881,18 @@ export function TSRXPlugin(config) {
 						char_after_tsx === 10 || // newline
 						char_after_tsx === 13 || // carriage return
 						char_after_tsx === 58); // : (tsx:react)
+				const is_tsrx_tag =
+					this.input.startsWith('tsrx', tag_name_start) &&
+					(tag_name_start + 4 >= this.input.length ||
+						char_after_tsrx === 62 || // >
+						char_after_tsrx === 47 || // / (self-closing)
+						char_after_tsrx === 32 || // space
+						char_after_tsrx === 9 || // tab
+						char_after_tsrx === 10 || // newline
+						char_after_tsrx === 13); // carriage return
 
-				if (is_fragment_tag || is_tsx_tag) {
-					// Use Ripple's parseElement to create a Tsx/TsxCompat node.
+				if (is_fragment_tag || is_tsx_tag || is_tsrx_tag) {
+					// Use Ripple's parseElement to create a Tsx/Tsrx/TsxCompat node.
 					// Bare fragments (<></>) are shorthand for <tsx>...</tsx>.
 					this.next();
 					return /** @type {import('estree-jsx').JSXElement} */ (
@@ -1907,7 +1923,9 @@ export function TSRXPlugin(config) {
 				const start = this.start - 1;
 				const position = new acorn.Position(this.curLine, start - this.lineStart);
 
-				const element = /** @type {AST.Element | AST.Tsx | AST.TsxCompat} */ (this.startNode());
+				const element = /** @type {AST.Element | AST.Tsx | AST.Tsrx | AST.TsxCompat} */ (
+					this.startNode()
+				);
 				element.start = start;
 				/** @type {AST.NodeWithLocation} */ (element).loc.start = position;
 				element.metadata = { path: [] };
@@ -1928,6 +1946,11 @@ export function TSRXPlugin(config) {
 					!is_tsx_compat &&
 					open.name.type === 'JSXIdentifier' &&
 					open.name.name === 'tsx';
+				const is_tsrx =
+					!is_fragment &&
+					!is_tsx_compat &&
+					open.name.type === 'JSXIdentifier' &&
+					open.name.name === 'tsrx';
 
 				if (is_tsx_compat) {
 					const namespace_node = /** @type {ESTreeJSX.JSXNamespacedName} */ (open.name);
@@ -1948,6 +1971,15 @@ export function TSRXPlugin(config) {
 						this.raise(
 							open.start,
 							`TSX elements cannot be self-closing. '<tsx />' must have a closing tag '</tsx>'.`,
+						);
+					}
+				} else if (is_tsrx) {
+					/** @type {AST.Tsrx} */ (element).type = 'Tsrx';
+
+					if (open.selfClosing) {
+						this.raise(
+							open.start,
+							`TSRX elements cannot be self-closing. '<tsrx />' must have a closing tag '</tsrx>'.`,
 						);
 					}
 				} else if (is_fragment) {
@@ -1987,7 +2019,7 @@ export function TSRXPlugin(config) {
 					}
 				}
 
-				if (!is_tsx_compat && !is_tsx && !is_fragment) {
+				if (!is_tsx_compat && !is_tsx && !is_tsrx && !is_fragment) {
 					/** @type {AST.Element} */ (element).id = /** @type {AST.Identifier} */ (
 						convert_from_jsx(/** @type {ESTreeJSX.JSXIdentifier} */ (open.name))
 					);
@@ -2181,6 +2213,7 @@ export function TSRXPlugin(config) {
 							parent?.type === 'Component' ||
 							parent?.type === 'Element' ||
 							parent?.type === 'Tsx' ||
+							parent?.type === 'Tsrx' ||
 							parent?.type === 'TsxCompat';
 
 						if (curContext === tstc.tc_expr && !insideTemplate) {
@@ -2249,7 +2282,21 @@ export function TSRXPlugin(config) {
 								this.#popTsxTokenContextBeforeTemplateExpressionChild();
 								this.next();
 							}
-						} else if (this.#path[this.#path.length - 1] === element) {
+						} else if (element.type === 'Tsrx' && this.#path[this.#path.length - 1] === element) {
+							this.#report_broken_markup_error(
+								this.start,
+								"Unclosed tag '<tsrx>'. Expected '</tsrx>' before end of component.",
+							);
+							element.unclosed = true;
+							/** @type {AST.SourceLocation} */ (element.loc).end = {
+								.../** @type {AST.SourceLocation} */ (element.openingElement.loc).end,
+							};
+							element.end = element.openingElement.end;
+							this.#path.pop();
+						} else if (
+							element.type === 'Element' &&
+							this.#path[this.#path.length - 1] === element
+						) {
 							// Check if this element was properly closed
 							const tagName = this.getElementName(element.id);
 							this.#report_broken_markup_error(
@@ -2257,7 +2304,7 @@ export function TSRXPlugin(config) {
 								`Unclosed tag '<${tagName}>'. Expected '</${tagName}>' before end of component.`,
 							);
 							element.unclosed = true;
-							element.loc.end = {
+							/** @type {AST.SourceLocation} */ (element.loc).end = {
 								.../** @type {AST.SourceLocation} */ (element.openingElement.loc).end,
 							};
 							element.end = element.openingElement.end;
@@ -2272,6 +2319,7 @@ export function TSRXPlugin(config) {
 						parent?.type === 'Component' ||
 						parent?.type === 'Element' ||
 						parent?.type === 'Tsx' ||
+						parent?.type === 'Tsrx' ||
 						parent?.type === 'TsxCompat';
 
 					if (curContext === tstc.tc_expr && !insideTemplate) {
@@ -2279,7 +2327,13 @@ export function TSRXPlugin(config) {
 					}
 				}
 
-				if (element.closingElement && !is_tsx_compat && !is_tsx && element.closingElement.name) {
+				if (
+					element.closingElement &&
+					!is_tsx_compat &&
+					!is_tsx &&
+					!is_tsrx &&
+					element.closingElement.name
+				) {
 					/** @type {unknown} */ (element.closingElement.name) = convert_from_jsx(
 						element.closingElement.name,
 					);
@@ -2480,10 +2534,26 @@ export function TSRXPlugin(config) {
 						this.context.pop();
 					}
 					return;
-				} else if (this.type === tstt.jsxTagStart) {
+				} else if (
+					this.type === tstt.jsxTagStart ||
+					(this.input.charCodeAt(this.start) === 60 /* < */ &&
+						this.input.charCodeAt(this.start + 1) === 47) /* / */
+				) {
 					const startPos = this.start;
 					const startLoc = this.startLoc;
-					this.next();
+					if (this.type === tstt.jsxTagStart) {
+						this.next();
+					} else {
+						// A control-flow block inside <tsrx> can leave the tokenizer
+						// in normal JS mode, so `</tsrx>` may arrive as a relational
+						// `<` token. Re-enter JSX closing-tag parsing manually.
+						this.pos = startPos + 1;
+						this.type = tstt.jsxTagStart;
+						this.start = startPos;
+						this.startLoc = startLoc;
+						this.exprAllowed = false;
+						this.next();
+					}
 					if (this.value === '/' || this.type === tt.slash) {
 						// Consume '/'
 						this.next();
@@ -2500,6 +2570,7 @@ export function TSRXPlugin(config) {
 							!currentElement ||
 							(currentElement.type !== 'Element' &&
 								currentElement.type !== 'Tsx' &&
+								currentElement.type !== 'Tsrx' &&
 								currentElement.type !== 'TsxCompat')
 						) {
 							this.raise(this.start, 'Unexpected closing tag');
@@ -2518,6 +2589,12 @@ export function TSRXPlugin(config) {
 									: this.getElementName(closingElement.name);
 						} else if (currentElement.type === 'Tsx') {
 							openingTagName = currentElement.openingElement.name ? 'tsx' : null;
+							closingTagName =
+								closingElement.name?.type === 'JSXNamespacedName'
+									? closingElement.name.namespace.name + ':' + closingElement.name.name.name
+									: this.getElementName(closingElement.name);
+						} else if (currentElement.type === 'Tsrx') {
+							openingTagName = 'tsrx';
 							closingTagName =
 								closingElement.name?.type === 'JSXNamespacedName'
 									? closingElement.name.namespace.name + ':' + closingElement.name.name.name
@@ -2544,7 +2621,12 @@ export function TSRXPlugin(config) {
 								const elem = this.#path[this.#path.length - 1];
 
 								// Stop at non-Element boundaries (Component, etc.)
-								if (elem.type !== 'Element' && elem.type !== 'Tsx' && elem.type !== 'TsxCompat') {
+								if (
+									elem.type !== 'Element' &&
+									elem.type !== 'Tsx' &&
+									elem.type !== 'Tsrx' &&
+									elem.type !== 'TsxCompat'
+								) {
 									break;
 								}
 
@@ -2555,9 +2637,11 @@ export function TSRXPlugin(config) {
 											? elem.openingElement.name
 												? 'tsx'
 												: null
-											: elem.id
-												? this.getElementName(elem.id)
-												: null;
+											: elem.type === 'Tsrx'
+												? 'tsrx'
+												: elem.id
+													? this.getElementName(elem.id)
+													: null;
 
 								// Found matching opening tag
 								if (elemName === closingTagName) {
@@ -2576,12 +2660,19 @@ export function TSRXPlugin(config) {
 						}
 
 						const elementToClose = this.#path[this.#path.length - 1];
-						if (elementToClose && elementToClose.type === 'Element') {
-							const elementToCloseName = /** @type {AST.Element} */ (elementToClose).id
-								? this.getElementName(/** @type {AST.Element} */ (elementToClose).id)
-								: null;
+						if (
+							elementToClose &&
+							(elementToClose.type === 'Element' || elementToClose.type === 'Tsrx')
+						) {
+							const elementToCloseName =
+								elementToClose.type === 'Tsrx'
+									? 'tsrx'
+									: /** @type {AST.Element} */ (elementToClose).id
+										? this.getElementName(/** @type {AST.Element} */ (elementToClose).id)
+										: null;
 							if (elementToCloseName === closingTagName) {
-								/** @type {AST.Element} */ (elementToClose).closingElement = closingElement;
+								/** @type {AST.Element | AST.Tsrx} */ (elementToClose).closingElement =
+									closingElement;
 							}
 						}
 

--- a/packages/tsrx/src/scope.js
+++ b/packages/tsrx/src/scope.js
@@ -127,6 +127,13 @@ export function create_scopes(ast, root, parent, error_options) {
 			next({ scope });
 		},
 
+		Tsrx(node, { state, next }) {
+			const scope = state.scope.child();
+			scopes.set(node, scope);
+
+			next({ scope });
+		},
+
 		TSModuleDeclaration(node, { state, next }) {
 			const is_submodule = node.metadata?.module_keyword === 'module';
 			if (is_submodule && node.id?.type === 'Identifier') {

--- a/packages/tsrx/src/transform/jsx/ast-builders.js
+++ b/packages/tsrx/src/transform/jsx/ast-builders.js
@@ -175,6 +175,7 @@ export function is_jsx_child(node) {
 		t === 'JSXExpressionContainer' ||
 		t === 'JSXText' ||
 		t === 'Tsx' ||
+		t === 'Tsrx' ||
 		t === 'TsxCompat' ||
 		t === 'Element' ||
 		t === 'Text' ||

--- a/packages/tsrx/src/transform/jsx/index.js
+++ b/packages/tsrx/src/transform/jsx/index.js
@@ -390,6 +390,17 @@ export function createJsxTransform(platform) {
 				);
 			},
 
+			Tsrx(node, { next, path, state }) {
+				const inner = /** @type {any} */ (next() ?? node);
+				const in_jsx_child = in_jsx_child_context(path);
+				return /** @type {any} */ (
+					wrap_jsx_setup_declarations(
+						tsrx_node_to_jsx_expression(inner, state, in_jsx_child),
+						in_jsx_child,
+					)
+				);
+			},
+
 			TsxCompat(node, { next, path, state }) {
 				const inner = /** @type {any} */ (next() ?? node);
 				const in_jsx_child = in_jsx_child_context(path);
@@ -3379,6 +3390,8 @@ function to_jsx_child(node, transform_context) {
 			// We're inside a JSX child position by construction, so keep a
 			// JSXExpressionContainer wrapper for bare `{expr}` children.
 			return tsx_node_to_jsx_expression(node, true);
+		case 'Tsrx':
+			return tsrx_node_to_jsx_expression(node, transform_context, true);
 		case 'TsxCompat':
 			return tsx_compat_node_to_jsx_expression(node, transform_context, true);
 		case 'Element':
@@ -3411,6 +3424,59 @@ function to_jsx_child(node, transform_context) {
 		default:
 			return node;
 	}
+}
+
+/**
+ * Lower a `<tsrx>` node's native TSRX template body to a JSX expression.
+ * Unlike `<tsx>`, children have already been parsed and transformed through
+ * the normal TSRX Element/Text/control-flow visitors.
+ *
+ * @param {any} node
+ * @param {TransformContext} transform_context
+ * @param {boolean} [in_jsx_child]
+ * @returns {any}
+ */
+function tsrx_node_to_jsx_expression(node, transform_context, in_jsx_child = false) {
+	const children = (node.children || []).filter(
+		(/** @type {any} */ child) =>
+			child &&
+			child.type !== 'EmptyStatement' &&
+			(child.type !== 'JSXText' || child.value.trim() !== ''),
+	);
+
+	/** @type {any} */
+	let expression;
+	if (children.length === 0) {
+		expression = create_null_literal();
+	} else if (
+		children.every(is_inline_element_child) &&
+		!children_contain_return_semantics(children)
+	) {
+		const saved_inside_element_child = transform_context.inside_element_child;
+		transform_context.inside_element_child = true;
+		try {
+			const render_nodes = children.map((/** @type {any} */ child) =>
+				to_jsx_child(child, transform_context),
+			);
+			expression = build_return_expression(render_nodes) || create_null_literal();
+		} finally {
+			transform_context.inside_element_child = saved_inside_element_child;
+		}
+	} else {
+		expression = statement_body_to_jsx_child(children, transform_context).expression;
+	}
+
+	if (
+		in_jsx_child &&
+		expression.type !== 'JSXElement' &&
+		expression.type !== 'JSXFragment' &&
+		expression.type !== 'JSXText' &&
+		expression.type !== 'JSXExpressionContainer'
+	) {
+		return to_jsx_expression_container(expression, node);
+	}
+
+	return expression;
 }
 
 /**

--- a/packages/tsrx/tests/shared/compile.js
+++ b/packages/tsrx/tests/shared/compile.js
@@ -1281,6 +1281,40 @@ export function optionalFn(bar: string, baz?: string) {
 		});
 	});
 
+	describe(`[${name}] <tsrx> template fragments`, () => {
+		it('lowers native TSRX template text in expression position', () => {
+			const { code } = compile(
+				`class Foo { bar() { return <tsrx><div>"Hello"</div></tsrx>; } }`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('{"Hello"}');
+			expect(code).not.toContain('<tsrx>');
+		});
+
+		it('preserves statements before template output', () => {
+			const { code } = compile(
+				`class Foo { bar() { return <tsrx>const label = 'Hi'; <div>{label}</div></tsrx>; } }`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain("const label = 'Hi';");
+			expect(code).toContain('{label}');
+			expect(code).not.toContain('<tsrx>');
+		});
+
+		it('supports control flow inside native template fragments', () => {
+			const { code } = compile(
+				`class Foo { bar() { return <tsrx>if (true) { <div>"yes"</div> }</tsrx>; } }`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('true');
+			expect(code).toContain('{"yes"}');
+			expect(code).not.toContain('<tsrx>');
+		});
+	});
+
 	describe(`[${name}] lazy destructuring shadowing`, () => {
 		// Lazy `&{ name }` destructuring rewrites `name` to `__lazy0.name` at
 		// component scope, but locals with the same name must shadow — the

--- a/packages/tsrx/tests/shared/source-mappings.js
+++ b/packages/tsrx/tests/shared/source-mappings.js
@@ -712,6 +712,7 @@ component C() {
 				`class Foo { bar() { return <tsrx>"Hello"</tsrx>; } }`,
 				`class Foo { bar() { return <tsrx><div>"a"</div><div>"b"</div></tsrx>; } }`,
 				`class Foo { bar() { return <tsrx>const x = 1; <div>{x}</div></tsrx>; } }`,
+				`class Foo { bar() { return <tsrx>; <div>"ok"</div></tsrx>; } }`,
 				`class Foo { bar() { return <tsrx>if (true) { <div>"yes"</div> }</tsrx>; } }`,
 			];
 			for (const source of sources) {

--- a/packages/tsrx/tests/shared/source-mappings.js
+++ b/packages/tsrx/tests/shared/source-mappings.js
@@ -695,6 +695,31 @@ component C() {
 		});
 	});
 
+	describe(`[${name}] <tsrx> blocks preserve source locations`, () => {
+		it('keeps loc on native template elements inside tsrx blocks', () => {
+			const source = `component C() { <tsrx><div>"hi"</div></tsrx> }`;
+			const result = compile_to_volar_mappings(source, 'App.tsrx', { loose: true });
+			const div_offset = source.indexOf('<div>');
+			const has_div_mapping = result.mappings.some(
+				(/** @type {{ sourceOffsets: number[] }} */ m) => m.sourceOffsets[0] === div_offset + 1,
+			);
+			expect(has_div_mapping).toBe(true);
+		});
+
+		it('does not crash for common native template fragment shapes', () => {
+			const sources = [
+				`class Foo { bar() { return <tsrx>{"Hello"}</tsrx>; } }`,
+				`class Foo { bar() { return <tsrx>"Hello"</tsrx>; } }`,
+				`class Foo { bar() { return <tsrx><div>"a"</div><div>"b"</div></tsrx>; } }`,
+				`class Foo { bar() { return <tsrx>const x = 1; <div>{x}</div></tsrx>; } }`,
+				`class Foo { bar() { return <tsrx>if (true) { <div>"yes"</div> }</tsrx>; } }`,
+			];
+			for (const source of sources) {
+				expect(() => compile_to_volar_mappings(source, 'App.tsrx', { loose: true })).not.toThrow();
+			}
+		});
+	});
+
 	describe(`[${name}] shorthand attribute does not duplicate mapping on the generated name`, () => {
 		it('does not map the synthesized attribute name back to {count}', () => {
 			// `<X {count} />` expands to `<X count={count} />`. The generated

--- a/packages/tsrx/types/index.d.ts
+++ b/packages/tsrx/types/index.d.ts
@@ -205,6 +205,7 @@ declare module 'estree' {
 	interface NodeMap {
 		Component: Component;
 		Tsx: Tsx;
+		Tsrx: Tsrx;
 		TsxCompat: TsxCompat;
 		TSRXExpression: TSRXExpression;
 		Html: Html;
@@ -346,6 +347,16 @@ declare module 'estree' {
 		closingElement: ESTreeJSX.JSXClosingElement;
 	}
 
+	interface Tsrx extends AST.BaseNode {
+		type: 'Tsrx';
+		attributes: Array<any>;
+		children: AST.Node[];
+		selfClosing?: boolean;
+		unclosed?: boolean;
+		openingElement: ESTreeJSX.JSXOpeningElement;
+		closingElement: ESTreeJSX.JSXClosingElement;
+	}
+
 	interface TsxCompat extends AST.BaseNode {
 		type: 'TsxCompat';
 		kind: string;
@@ -479,7 +490,7 @@ declare module 'estree' {
 
 	export type TSRXStatement = AST.Statement | TSESTree.Statement;
 
-	export type NodeWithChildren = AST.Element | AST.Tsx | AST.TsxCompat;
+	export type NodeWithChildren = AST.Element | AST.Tsx | AST.Tsrx | AST.TsxCompat;
 
 	export namespace CSS {
 		export interface BaseNode extends AST.NodeWithMaybeComments {

--- a/packages/tsrx/types/parse.d.ts
+++ b/packages/tsrx/types/parse.d.ts
@@ -1172,7 +1172,7 @@ export namespace Parse {
 		 */
 		parseTopLevel(node: AST.Program): AST.Program;
 
-		parseElement(): AST.Element | AST.Tsx | AST.TsxCompat;
+		parseElement(): AST.Element | AST.Tsx | AST.Tsrx | AST.TsxCompat;
 
 		parseDoubleQuotedTextChild(): AST.TextNode;
 

--- a/website-new/docs/guide/syntax.md
+++ b/website-new/docs/guide/syntax.md
@@ -32,10 +32,11 @@ with that later!
 ## Caveat: Templates Must be within Components
 
 Unlike JSX, Ripple's regular templates are statement-based and can only appear
-within the body of a component. If you need JSX in expression position, use the
-`<tsx>...</tsx>` wrapper covered below. This design keeps normal component
-templates distinct from regular JavaScript logic while still providing an escape
-hatch when you need to store, return, or pass JSX as a value.
+within the body of a component. If you need UI in expression position, use the
+`<tsrx>...</tsrx>`, `<>...</>`, or `<tsx>...</tsx>` wrappers covered below. This
+design keeps normal component templates distinct from regular JavaScript logic
+while still providing an escape hatch when you need to store, return, or pass UI
+as a value.
 
 ```ripple
 // ❌ Wrong - Plain templates outside the component
@@ -75,38 +76,41 @@ component App() {
 }
 ```
 
-## Using `<tsx>` for JSX Expression Values
+## Using `<tsx>` and `<tsrx>` for Expression Values
 
-Use `<tsx>...</tsx>` when JSX needs to exist in expression position rather than as
-a normal template statement. This is useful when you want to assign JSX to a
-variable, return it from a helper, or pass it directly as a prop or child.
+Use an expression island when UI needs to exist in expression position rather
+than as a normal template statement. Reach for `<tsrx>...</tsrx>` when you want
+native Ripple/TSRX template syntax, including double-quoted text children,
+setup statements, and template control flow. Use `<>...</>` or `<tsx>...</tsx>`
+when you want JSX-style children.
 
 ```ripple
-// ✅ Correct - Store JSX in a variable
+// ✅ Correct - Store native TSRX in a variable
 component App() {
-  const title = <tsx>
+  const title = <tsrx>
     <span class="title">
       "Settings"
     </span>
-  </tsx>;
+  </tsrx>;
 
   <header>{title}</header>
 }
 
-// ✅ Correct - Return JSX from a helper function
+// ✅ Correct - Return native TSRX from a helper function
 function createBadge(label: string) {
-  return <tsx>
+  return <tsrx>
+    const normalized = label.trim();
     <span class="badge">
-      {label}
+      {normalized}
     </span>
-  </tsx>;
+  </tsrx>;
 }
 
 component App() {
   {createBadge('New')}
 }
 
-// ✅ Correct - Pass JSX directly as props
+// ✅ Correct - Pass JSX-style values directly as props
 component Card(props: { title: any; children: any }) {
   <section>
     <h2>{props.title}</h2>
@@ -118,25 +122,27 @@ component App() {
   <Card
     title={<tsx>
       <span>
-        "Settings"
+        Settings
       </span>
     </tsx>}
     children={<tsx>
       <p>
-        "Card body"
+        Card body
       </p>
     </tsx>}
   />
 }
 ```
 
-### `<tsx>` vs `<tsx:react>`
+### `<tsrx>` vs `<tsx>` vs `<tsx:react>`
 
-- `<tsx>` keeps Ripple syntax and Ripple rendering semantics.
+- `<tsrx>` keeps native Ripple/TSRX template syntax and Ripple rendering semantics.
+- `<tsx>` and `<>...</>` are JSX-style expression islands.
 - `<tsx:react>` switches to React JSX semantics and requires compat setup.
 
-Use plain `<tsx>` when you want a Ripple renderable value. Use `<tsx:react>` only
-when you are intentionally embedding React.
+Use `<tsrx>` when you want a Ripple renderable value written with normal TSRX
+template rules. Use `<tsx>` or fragment shorthand for JSX-style values. Use
+`<tsx:react>` only when you are intentionally embedding React.
 
 ## Early Returns in Components
 

--- a/website-new/public/llms.txt
+++ b/website-new/public/llms.txt
@@ -119,36 +119,39 @@ component App() {
 
 This design enforces clear separation between component templates and regular JavaScript logic, making code more predictable and easier to analyze.
 
-### Using `<>` or `<tsx>` for JSX Expression Values
+### Using `<>`, `<tsx>`, or `<tsrx>` for Expression Values
 
-**IMPORTANT**: Regular Ripple elements are statement-based and can only appear directly inside component bodies or nested template blocks. If you need to create JSX as a value in expression position, wrap it in `<>...</>` or the equivalent `<tsx>...</tsx>` form.
+**IMPORTANT**: Regular TSRX elements are statement-based and can only appear directly inside component bodies or nested template blocks. If you need to create UI as a value in expression position, wrap it in an expression island.
 
-Use `<>...</>` or `<tsx>...</tsx>` when you need to:
-- assign JSX to a variable
-- return JSX from a helper function
-- pass JSX directly as a prop or `children`
+Use `<tsrx>...</tsrx>` when you want native TSRX template syntax in expression position. Use `<>...</>` or `<tsx>...</tsx>` when you want JSX-style children instead.
+
+Use these wrappers when you need to:
+- assign UI to a variable
+- return UI from a helper function
+- pass UI directly as a prop or `children`
 - build reusable render factories
 
 ```ripple
-// ✅ CORRECT - JSX used as an expression value via fragment shorthand
+// ✅ CORRECT - native TSRX template used as an expression value
 component App() {
-  const title = <><span class="title">Title</span></>;
+  const title = <tsrx><span class="title">"Title"</span></tsrx>;
 
   <div>{title}</div>
 }
 
-// ✅ CORRECT - returning JSX from a helper function
+// ✅ CORRECT - returning a native TSRX fragment from a helper function
 function createBadge(label: string) {
-  return <>
-    <span class="badge">{label}</span>
-  </>;
+  return <tsrx>
+    const normalized = label.trim();
+    <span class="badge">{normalized}</span>
+  </tsrx>;
 }
 
 component App() {
   {createBadge('New')}
 }
 
-// ✅ CORRECT - passing JSX directly as props
+// ✅ CORRECT - passing JSX-style props via fragment shorthand
 component Card(props: { title: any; children: any }) {
   <section>
     <h2>{props.title}</h2>
@@ -165,19 +168,21 @@ component App() {
 ```
 
 **LLM DO:**
-- Use `<>...</>` as the default wrapper when JSX must exist in expression position.
-- Use `<tsx>...</tsx>` when you want the explicit long form; it is equivalent.
-- Treat either form as a renderable value that can be stored, returned, and passed around.
-- Keep using normal Ripple syntax and semantics inside either wrapper.
+- Use `<tsrx>...</tsrx>` when you want normal Ripple/TSRX template syntax in expression position, including double-quoted text children, setup statements, and template control flow.
+- Use `<>...</>` as the default wrapper when JSX-style children must exist in expression position.
+- Use `<tsx>...</tsx>` when you want the explicit long form of the JSX-style wrapper; it is equivalent to `<>...</>`.
+- Treat all three forms as renderable values that can be stored, returned, and passed around.
 
 **LLM DON'T:**
 - Do not write `const el = <div />;` directly in Ripple code.
-- Do not return bare JSX from helper functions without `<>...</>` or `<tsx>...</tsx>`.
+- Do not return bare UI from helper functions without `<tsrx>...</tsrx>`, `<>...</>`, or `<tsx>...</tsx>`.
+- Do not use double-quoted TSRX text children inside `<>...</>` or `<tsx>...</tsx>` when you mean native TSRX text; use `<tsrx>...</tsrx>` instead.
 - Do not confuse plain `<tsx>` with `<tsx:react>`.
 - Do not require React compat for plain `<tsx>`.
 
 **Key distinction:**
-- `<>...</>` / `<tsx>...</tsx>`: expression-form Ripple JSX value
+- `<tsrx>...</tsrx>`: expression-form native Ripple/TSRX template value
+- `<>...</>` / `<tsx>...</tsx>`: expression-form JSX-style value
 - `<tsx:react>`: React compatibility block with React JSX semantics and compat setup
 
 ### ⚠️ Critical: Early Returns Are Guard Exits, Not JSX Returns

--- a/website-tsrx/public/llms.txt
+++ b/website-tsrx/public/llms.txt
@@ -285,7 +285,7 @@ export component Button({ label, onClick }: {
 
 **LLM DON'T:**
 - Do not `return <JSX />` from a component body.
-- Do not assign `.tsrx` JSX to a variable outside a `<>...</>` or `<tsx>...</tsx>` wrapper.
+- Do not assign `.tsrx` UI to a variable outside a `<tsrx>...</tsrx>`, `<>...</>`, or `<tsx>...</tsx>` wrapper.
 - Do not mix `function Component()` and `component Component()` patterns.
 
 ### Statement-based JSX
@@ -325,40 +325,45 @@ quoted JSX attribute values. Use entities such as `&quot;` and `&amp;` for liter
 characters that need escaping; backslashes are literal text and do not escape the
 closing quote.
 
-### Using `<>` or `<tsx>` for JSX values
+### Using `<>`, `<tsx>`, or `<tsrx>` for expression values
 
-When you need JSX in **expression position** — assigning it to a variable,
-passing it as a prop, returning from a helper — wrap it in `<>...</>` or the
-equivalent `<tsx>...</tsx>` form.
+When you need UI in **expression position** — assigning it to a variable,
+passing it as a prop, returning from a helper — wrap it in an expression island.
+Use `<tsrx>...</tsrx>` for native TSRX template syntax. Use `<>...</>` or the
+equivalent `<tsx>...</tsx>` form for JSX-style children.
 
 ```tsrx
 component App() {
-  const title = <><span class="title">"Settings"</span></>;
+  const title = <tsrx><span class="title">"Settings"</span></tsrx>;
   <Card {title} />
 }
 ```
 
 ```tsrx
-// ✅ CORRECT — return JSX from a helper via fragment shorthand
+// ✅ CORRECT — return native TSRX from a helper
 function badge(label: string) {
-  return <><span class="badge">{label}</span></>;
+  return <tsrx>
+    const normalized = label.trim();
+    <span class="badge">{normalized}</span>
+  </tsrx>;
 }
 
-// ✅ CORRECT — pass JSX as a prop via fragment shorthand
+// ✅ CORRECT — pass JSX-style values via fragment shorthand
 <Card
-  title={<><span>"Settings"</span></>}
-  children={<><p>"Body"</p></>}
+  title={<><span>Settings</span></>}
+  children={<><p>Body</p></>}
 />
 ```
 
 **LLM DO:**
-- Use `<>...</>` as the default wrapper when JSX must live in expression position.
-- Use `<tsx>...</tsx>` when you want the explicit long form; it is equivalent.
-- Keep normal TSRX syntax and semantics inside either wrapper.
+- Use `<tsrx>...</tsrx>` when you want normal TSRX template syntax in expression position, including double-quoted text children, setup statements, and template control flow.
+- Use `<>...</>` as the default wrapper when JSX-style children must live in expression position.
+- Use `<tsx>...</tsx>` when you want the explicit long form of the JSX-style wrapper; it is equivalent to `<>...</>`.
 
 **LLM DON'T:**
 - Do not write `const el = <div />;` at the top level of a component.
-- Do not return bare JSX from regular functions without `<>...</>` or `<tsx>...</tsx>`.
+- Do not return bare UI from regular functions without `<tsrx>...</tsrx>`, `<>...</>`, or `<tsx>...</tsx>`.
+- Do not put direct double-quoted TSRX text children inside `<>...</>` or `<tsx>...</tsx>` when you mean native TSRX text; use `<tsrx>...</tsrx>` instead.
 
 ### Text children and expressions: `"..."`, `{ ... }`, `{text ...}`, `{html ...}`
 
@@ -941,7 +946,8 @@ component List<T>({ items, render }: Props<T>) {
 | ------------------------ | ------------------------------------------------ |
 | Component declaration    | `component Name(props: T) { ... }`               |
 | Exported component       | `export component Name(...) { ... }`             |
-| JSX as value             | `const v = <tsx><span /></tsx>;`                 |
+| TSRX as value            | `const v = <tsrx><span>"Hi"</span></tsrx>;`      |
+| JSX as value             | `const v = <tsx><span>Hi</span></tsx>;`          |
 | Text content             | `<p>"literal"</p>`, `<p>{expr}</p>`             |
 | Forced escaped text      | `<span>{text expr}</span>`                       |
 | Raw HTML (Ripple, host-only Vue) | `<article>{html markup}</article>`        |

--- a/website-tsrx/src/pages/docs.tsrx
+++ b/website-tsrx/src/pages/docs.tsrx
@@ -27,7 +27,7 @@ const STATEMENT_HTML = [
 
 const TSX_EXPR_HTML = [
 	'<span class="ln">1</span> <span class="kw">component</span> <span class="fn">App</span><span class="br">(</span><span class="br">)</span> <span class="br">{</span>',
-	'<span class="ln">2</span>   <span class="kw">const</span> <span class="prop">title</span> = <span class="tag">&lt;</span><span class="tag">&gt;</span><span class="tag">&lt;</span><span class="el">span</span> <span class="attr">class</span>=<span class="str">"title"</span><span class="tag">&gt;</span><span class="tbr">{</span><span class="str">\'Settings\'</span><span class="tbr">}</span><span class="tag">&lt;/</span><span class="el">span</span><span class="tag">&gt;</span><span class="tag">&lt;/</span><span class="tag">&gt;</span>;',
+	'<span class="ln">2</span>   <span class="kw">const</span> <span class="prop">title</span> = <span class="tag">&lt;</span><span class="el">tsrx</span><span class="tag">&gt;</span><span class="tag">&lt;</span><span class="el">span</span> <span class="attr">class</span>=<span class="str">"title"</span><span class="tag">&gt;</span><span class="str">"Settings"</span><span class="tag">&lt;/</span><span class="el">span</span><span class="tag">&gt;</span><span class="tag">&lt;/</span><span class="el">tsrx</span><span class="tag">&gt;</span>;',
 	'<span class="ln">3</span>   <span class="tag">&lt;</span><span class="el">Card</span> <span class="tbr">{</span><span class="prop">title</span><span class="tbr">}</span> <span class="tag">/&gt;</span>',
 	'<span class="ln">4</span> <span class="br">}</span>',
 ].join('\n');
@@ -327,10 +327,13 @@ export component DocsPage() {
 							<code>{html STATEMENT_HTML}</code>
 						</pre>
 						<p class="section-body">
-							{'This means you can\'t assign JSX to a variable or return it from a function by default. When you need JSX as a value — to assign it, pass it as a prop, or return it from a helper — wrap it in '}
+							{'This means you can\'t assign JSX to a variable or return it from a function by default. When you need native TSRX as a value — to assign it, pass it as a prop, or return it from a helper — wrap it in '}
+							<code class="inline-code">{'<tsrx>...</tsrx>'}</code>
+							{'. Use '}
 							<code class="inline-code">{'<>...</>'}</code>
-							{' or the explicit '}
-							<code class="inline-code">{'<tsx></tsx>'}</code>
+							{' or '}
+							<code class="inline-code">{'<tsx>...</tsx>'}</code>
+							{' when you want JSX-style children instead'}
 							{':'}
 						</p>
 						<pre class="code-block">

--- a/website-tsrx/src/pages/features.tsrx
+++ b/website-tsrx/src/pages/features.tsrx
@@ -47,7 +47,7 @@ const STATEMENT_HTML = [
 
 const TSX_EXPR_HTML = [
 	'<span class="ln">1</span> <span class="kw">component</span> <span class="fn">App</span><span class="br">(</span><span class="br">)</span> <span class="br">{</span>',
-	'<span class="ln">2</span>   <span class="kw">const</span> <span class="prop">title</span> = <span class="tag">&lt;</span><span class="tag">&gt;</span><span class="tag">&lt;</span><span class="el">span</span> <span class="attr">class</span>=<span class="str">"title"</span><span class="tag">&gt;</span><span class="str">"Settings"</span><span class="tag">&lt;/</span><span class="el">span</span><span class="tag">&gt;</span><span class="tag">&lt;/</span><span class="tag">&gt;</span>;',
+	'<span class="ln">2</span>   <span class="kw">const</span> <span class="prop">title</span> = <span class="tag">&lt;</span><span class="el">tsrx</span><span class="tag">&gt;</span><span class="tag">&lt;</span><span class="el">span</span> <span class="attr">class</span>=<span class="str">"title"</span><span class="tag">&gt;</span><span class="str">"Settings"</span><span class="tag">&lt;/</span><span class="el">span</span><span class="tag">&gt;</span><span class="tag">&lt;/</span><span class="el">tsrx</span><span class="tag">&gt;</span>;',
 	'<span class="ln">3</span>   <span class="tag">&lt;</span><span class="el">Card</span> <span class="tbr">{</span><span class="prop">title</span><span class="tbr">}</span> <span class="tag">/&gt;</span>',
 	'<span class="ln">4</span> <span class="br">}</span>',
 ].join('\n');
@@ -439,10 +439,13 @@ export component FeaturesPage() {
 							<code>{html STATEMENT_HTML}</code>
 						</pre>
 						<p class="section-body">
-							{'This means you can\'t assign JSX to a variable or return it from a function by default. When you need JSX as a value — to assign it, pass it as a prop, or return it from a helper — wrap it in '}
+							{'This means you can\'t assign JSX to a variable or return it from a function by default. When you need native TSRX as a value — to assign it, pass it as a prop, or return it from a helper — wrap it in '}
+							<code class="inline-code">{'<tsrx>...</tsrx>'}</code>
+							{'. Use '}
 							<code class="inline-code">{'<>...</>'}</code>
-							{' or the explicit '}
-							<code class="inline-code">{'<tsx></tsx>'}</code>
+							{' or '}
+							<code class="inline-code">{'<tsx>...</tsx>'}</code>
+							{' when you want JSX-style children instead'}
 							{':'}
 						</p>
 						<pre class="code-block">
@@ -716,11 +719,13 @@ export component FeaturesPage() {
 							<code class="inline-code">{'children={...}'}</code>
 							{' or a named prop like '}
 							<code class="inline-code">{'render={...}'}</code>
-							{'. If that function returns JSX, wrap the JSX in '}
+							{'. If that function returns native TSRX, wrap it in '}
+							<code class="inline-code">{'<tsrx>...</tsrx>'}</code>
+							{'. Use '}
 							<code class="inline-code">{'<>...</>'}</code>
 							{' or '}
 							<code class="inline-code">{'<tsx>...</tsx>'}</code>
-							{' because JSX is statement-based by default.'}
+							{' for JSX-style values.'}
 						</p>
 						<pre class="code-block">
 							<code>{html RENDER_PROPS_HTML}</code>

--- a/website-tsrx/src/pages/specification.tsrx
+++ b/website-tsrx/src/pages/specification.tsrx
@@ -1,6 +1,7 @@
 const MODIFIED_PRODUCTIONS = [
 	'PrimaryExpression :',
 	'  ComponentExpression',
+	'  TsrxExpression',
 	'  TsxExpression',
 	'',
 	'StatementListItem :',
@@ -18,6 +19,9 @@ const MODIFIED_PRODUCTIONS = [
 	'LazyArrayBindingPattern :',
 	'  &[ BindingElementListopt ]',
 	'',
+	'TsrxExpression :',
+	'  <tsrx> TemplateChildrenopt </tsrx>',
+	'',
 	'TsxExpression :',
 	'  <tsx> TsxChildrenopt </tsx>',
 	'  <tsx: IdentifierName> TsxChildrenopt </tsx: IdentifierName>',
@@ -32,7 +36,10 @@ const COMPONENT_GRAMMAR = [
 	'  component BindingIdentifieropt ( FormalParametersopt ) { ComponentBody }',
 ].join('\n');
 
-const TSX_GRAMMAR = [
+const EXPRESSION_ISLAND_GRAMMAR = [
+	'TsrxExpression :',
+	'  <tsrx> TemplateChildrenopt </tsrx>',
+	'',
 	'TsxElement :',
 	'  <tsx> TsxChildrenopt </tsx>',
 	'',
@@ -84,6 +91,7 @@ const AST_NODE_MAPPING = [
 	'JSXAttributeName JSXAttributeInitializeropt -> Attribute',
 	'{ ... AssignmentExpression } in attribute position -> SpreadAttribute',
 	'ref={ AssignmentExpression } -> RefAttribute',
+	'<tsrx> TemplateChildrenopt </tsrx> -> Tsrx',
 	'<tsx> TsxChildrenopt </tsx> -> Tsx',
 	'<> TsxChildrenopt </> -> Tsx',
 	'<tsx: IdentifierName> TsxChildrenopt </tsx: IdentifierName> -> TsxCompat',
@@ -150,6 +158,16 @@ const TEMPLATE_AST_SHAPE = [
 ].join('\n');
 
 const TSX_AST_SHAPE = [
+	'interface Tsrx {',
+	'  type: \'Tsrx\';',
+	'  attributes: Array<any>;',
+	'  children: Node[];',
+	'  openingElement: JSXOpeningElement;',
+	'  closingElement: JSXClosingElement;',
+	'  selfClosing?: boolean;',
+	'  unclosed?: boolean;',
+	'}',
+	'',
 	'interface Tsx {',
 	'  type: \'Tsx\';',
 	'  attributes: Array<any>;',
@@ -207,7 +225,7 @@ const NAV_ITEMS = [
 	{ id: 'productions', label: 'Modified Productions' },
 	{ id: 'components', label: 'Components' },
 	{ id: 'templates', label: 'Template Elements' },
-	{ id: 'tsx-islands', label: 'TSX Islands' },
+	{ id: 'tsx-islands', label: 'Expression Islands' },
 	{ id: 'lazy', label: 'Lazy Destructuring' },
 	{ id: 'style', label: 'Style Syntax' },
 	{ id: 'server-profile', label: 'Server Extensions' },
@@ -221,7 +239,7 @@ export component SpecificationPage() {
 		<title>{'TSRX | Specification'}</title>
 		<meta
 			name="description"
-			content="Draft TSRX language specification: TypeScript-compatible grammar extensions, component syntax, TSX islands, lazy destructuring, style identifiers, and host-defined server extensions."
+			content="Draft TSRX language specification: TypeScript-compatible grammar extensions, component syntax, expression islands, lazy destructuring, style identifiers, and host-defined server extensions."
 		/>
 	</head>
 
@@ -287,7 +305,7 @@ export component SpecificationPage() {
 						<div class="status-panel">
 							<p class="status-chip">{'First-edition scope'}</p>
 							<p class="section-body compact">
-								{'The current draft fixes the syntax and early-error surface for component declarations, statement-oriented template elements, TSX expression islands, lazy destructuring, raw style elements, {style} attribute values, and proposal-aligned submodule declarations.'}
+								{'The current draft fixes the syntax and early-error surface for component declarations, statement-oriented template elements, expression islands, lazy destructuring, raw style elements, {style} attribute values, and proposal-aligned submodule declarations.'}
 							</p>
 						</div>
 					</section>
@@ -308,12 +326,12 @@ export component SpecificationPage() {
 					<section class="doc-section" id="rationale">
 						<h2 class="section-heading">{'Rationale'}</h2>
 						<p class="section-body">
-							{'TSRX exists to define a predictable syntax for component-oriented source code without forcing all tree-shaped UI through the expression positions of JSX. In TSRX, template structure is explicit in the component body, and expression-position UI values are explicit through TSX islands.'}
+							{'TSRX exists to define a predictable syntax for component-oriented source code without forcing all tree-shaped UI through the expression positions of JSX. In TSRX, template structure is explicit in the component body, and expression-position UI values are explicit through TSRX or TSX islands.'}
 						</p>
 						<ul class="spec-list">
 							<li>{'Component bodies may contain element statements directly.'}</li>
 							<li>
-								{'JSX-compatible values remain available, but only through explicit TSX island syntax.'}
+								{'JSX-compatible values remain available, but only through explicit island syntax.'}
 							</li>
 							<li>
 								{'Lazy destructuring is represented as source syntax rather than a host-specific library convention.'}
@@ -475,17 +493,19 @@ export component SpecificationPage() {
 					</section>
 
 					<section class="doc-section" id="tsx-islands">
-						<h2 class="section-heading">{'4.4 TSX Expression Islands'}</h2>
+						<h2 class="section-heading">{'4.4 Expression Islands'}</h2>
 						<p class="section-body">
-							{'TSRX does not admit arbitrary JSX elements in expression position. When a JSX-compatible tree must participate in ordinary expression evaluation, it must be written as a TSX island.'}
+							{'TSRX does not admit arbitrary template or JSX elements in expression position. When a tree must participate in ordinary expression evaluation, it must be written as an expression island. The <tsrx> form keeps native TSRX template children, while TSX islands use JSX-compatible children.'}
 						</p>
 						<pre class="code-block plain">
-							<code>{TSX_GRAMMAR}</code>
+							<code>{EXPRESSION_ISLAND_GRAMMAR}</code>
 						</pre>
 						<p class="section-body">
 							{'The fragment shorthand form is equivalent to a '}
 							<code class="inline-code">{'<tsx>...</tsx>'}</code>
-							{' form in expression position. Compatibility islands through '}
+							{' form in expression position. Native TSRX template islands use '}
+							<code class="inline-code">{'<tsrx>...</tsrx>'}</code>
+							{'. Compatibility islands through '}
 							<code class="inline-code">{'<tsx:kind>'}</code>
 							{' are part of core TSRX syntax, although the meaning of '}
 							<code class="inline-code">{'kind'}</code>
@@ -527,7 +547,7 @@ export component SpecificationPage() {
 						<h2 class="section-heading">{'5 Static Semantics: Early Errors'}</h2>
 						<ul class="spec-list">
 							<li>
-								{'A JSX element other than a TSX island must not appear as a generic ECMAScript expression.'}
+								{'A template or JSX element other than an expression island must not appear as a generic ECMAScript expression.'}
 							</li>
 							<li>
 								{'A JSX fragment must not appear in template position outside a TSX island context.'}
@@ -544,10 +564,12 @@ export component SpecificationPage() {
 							<li>
 								<code class="inline-code">{'<tsx />'}</code>
 								{' and '}
+								<code class="inline-code">{'<tsrx />'}</code>
+								{' and '}
 								<code class="inline-code">{'<tsx:kind />'}</code>
 								{' are not well-formed and must be rejected.'}
 							</li>
-							<li>{'Opening and closing tags for TSX islands must match.'}</li>
+							<li>{'Opening and closing tags for expression islands must match.'}</li>
 							<li>
 								{'{style StringLiteral} must only be used as a whole element attribute value.'}
 							</li>
@@ -658,14 +680,17 @@ export component SpecificationPage() {
 								{' tag, but those details are not part of the general Element shape described here.'}
 							</li>
 						</ul>
-						<h3 class="appendix-heading">{'A.4 TSX island nodes'}</h3>
+						<h3 class="appendix-heading">{'A.4 Expression island nodes'}</h3>
 						<p class="section-body">
-							{'Expression-position TSX islands use distinct node kinds so tools can distinguish ordinary template elements from JSX-compatible subtrees. The fragment shorthand is represented as Tsx, while compatibility islands with an explicit kind are represented as TsxCompat.'}
+							{'Expression-position islands use distinct node kinds so tools can distinguish ordinary template elements, native TSRX subtrees, and JSX-compatible subtrees. The <tsrx> form is represented as Tsrx, the TSX fragment shorthand is represented as Tsx, and compatibility islands with an explicit kind are represented as TsxCompat.'}
 						</p>
 						<pre class="code-block plain">
 							<code>{TSX_AST_SHAPE}</code>
 						</pre>
 						<ul class="spec-list">
+							<li>
+								{'Tsrx corresponds to <tsrx> ... </tsrx> when that form appears in expression position. Its children array follows the native TSRX template-child model.'}
+							</li>
 							<li>
 								{'Tsx corresponds to both <tsx> ... </tsx> and the fragment shorthand <> ... </> when those forms appear in expression position.'}
 							</li>
@@ -673,7 +698,7 @@ export component SpecificationPage() {
 								{'TsxCompat corresponds to <tsx:kind> ... </tsx:kind>, and the kind field stores the compatibility discriminator exactly as parsed.'}
 							</li>
 							<li>
-								{'The children arrays follow the JSX child model inherited from the ESTree JSX node family rather than TSRX template-child normalization.'}
+								{'Tsx and TsxCompat children arrays follow the JSX child model inherited from the ESTree JSX node family rather than TSRX template-child normalization.'}
 							</li>
 							<li>
 								{'openingElement, closingElement, selfClosing, and unclosed serve the same recovery and source-preservation role as on Element nodes.'}

--- a/website/docs/guide/syntax.md
+++ b/website/docs/guide/syntax.md
@@ -32,10 +32,11 @@ with that later!
 ## Caveat: Templates Must be within Components
 
 Unlike JSX, Ripple's regular templates are statement-based and can only appear
-within the body of a component. If you need JSX in expression position, use the
-`<tsx>...</tsx>` wrapper covered below. This design keeps normal component
-templates distinct from regular JavaScript logic while still providing an escape
-hatch when you need to store, return, or pass JSX as a value.
+within the body of a component. If you need UI in expression position, use the
+`<tsrx>...</tsrx>`, `<>...</>`, or `<tsx>...</tsx>` wrappers covered below. This
+design keeps normal component templates distinct from regular JavaScript logic
+while still providing an escape hatch when you need to store, return, or pass UI
+as a value.
 
 ```ripple
 // ❌ Wrong - Plain templates outside the component
@@ -71,38 +72,41 @@ component App() {
 }
 ```
 
-## Using `<tsx>` for JSX Expression Values
+## Using `<tsx>` and `<tsrx>` for Expression Values
 
-Use `<tsx>...</tsx>` when JSX needs to exist in expression position rather than as
-a normal template statement. This is useful when you want to assign JSX to a
-variable, return it from a helper, or pass it directly as a prop or child.
+Use an expression island when UI needs to exist in expression position rather
+than as a normal template statement. Reach for `<tsrx>...</tsrx>` when you want
+native Ripple/TSRX template syntax, including double-quoted text children,
+setup statements, and template control flow. Use `<>...</>` or `<tsx>...</tsx>`
+when you want JSX-style children.
 
 ```ripple
-// ✅ Correct - Store JSX in a variable
+// ✅ Correct - Store native TSRX in a variable
 component App() {
-  const title = <tsx>
+  const title = <tsrx>
     <span class="title">
       "Settings"
     </span>
-  </tsx>;
+  </tsrx>;
 
   <header>{title}</header>
 }
 
-// ✅ Correct - Return JSX from a helper function
+// ✅ Correct - Return native TSRX from a helper function
 function createBadge(label: string) {
-  return <tsx>
+  return <tsrx>
+    const normalized = label.trim();
     <span class="badge">
-      {label}
+      {normalized}
     </span>
-  </tsx>;
+  </tsrx>;
 }
 
 component App() {
   {createBadge('New')}
 }
 
-// ✅ Correct - Pass JSX directly as props
+// ✅ Correct - Pass JSX-style values directly as props
 component Card(props: { title: any; children: any }) {
   <section>
     <h2>{props.title}</h2>
@@ -114,25 +118,27 @@ component App() {
   <Card
     title={<tsx>
       <span>
-        "Settings"
+        Settings
       </span>
     </tsx>}
     children={<tsx>
       <p>
-        "Card body"
+        Card body
       </p>
     </tsx>}
   />
 }
 ```
 
-### `<tsx>` vs `<tsx:react>`
+### `<tsrx>` vs `<tsx>` vs `<tsx:react>`
 
-- `<tsx>` keeps Ripple syntax and Ripple rendering semantics.
+- `<tsrx>` keeps native Ripple/TSRX template syntax and Ripple rendering semantics.
+- `<tsx>` and `<>...</>` are JSX-style expression islands.
 - `<tsx:react>` switches to React JSX semantics and requires compat setup.
 
-Use plain `<tsx>` when you want a Ripple renderable value. Use `<tsx:react>` only
-when you are intentionally embedding React.
+Use `<tsrx>` when you want a Ripple renderable value written with normal TSRX
+template rules. Use `<tsx>` or fragment shorthand for JSX-style values. Use
+`<tsx:react>` only when you are intentionally embedding React.
 
 ## Early Returns in Components
 

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -119,36 +119,39 @@ component App() {
 
 This design enforces clear separation between component templates and regular JavaScript logic, making code more predictable and easier to analyze.
 
-### Using `<>` or `<tsx>` for JSX Expression Values
+### Using `<>`, `<tsx>`, or `<tsrx>` for Expression Values
 
-**IMPORTANT**: Regular Ripple elements are statement-based and can only appear directly inside component bodies or nested template blocks. If you need to create JSX as a value in expression position, wrap it in `<>...</>` or the equivalent `<tsx>...</tsx>` form.
+**IMPORTANT**: Regular TSRX elements are statement-based and can only appear directly inside component bodies or nested template blocks. If you need to create UI as a value in expression position, wrap it in an expression island.
 
-Use `<>...</>` or `<tsx>...</tsx>` when you need to:
-- assign JSX to a variable
-- return JSX from a helper function
-- pass JSX directly as a prop or `children`
+Use `<tsrx>...</tsrx>` when you want native TSRX template syntax in expression position. Use `<>...</>` or `<tsx>...</tsx>` when you want JSX-style children instead.
+
+Use these wrappers when you need to:
+- assign UI to a variable
+- return UI from a helper function
+- pass UI directly as a prop or `children`
 - build reusable render factories
 
 ```ripple
-// ✅ CORRECT - JSX used as an expression value via fragment shorthand
+// ✅ CORRECT - native TSRX template used as an expression value
 component App() {
-  const title = <><span class="title">Title</span></>;
+  const title = <tsrx><span class="title">"Title"</span></tsrx>;
 
   <div>{title}</div>
 }
 
-// ✅ CORRECT - returning JSX from a helper function
+// ✅ CORRECT - returning a native TSRX fragment from a helper function
 function createBadge(label: string) {
-  return <>
-    <span class="badge">{label}</span>
-  </>;
+  return <tsrx>
+    const normalized = label.trim();
+    <span class="badge">{normalized}</span>
+  </tsrx>;
 }
 
 component App() {
   {createBadge('New')}
 }
 
-// ✅ CORRECT - passing JSX directly as props
+// ✅ CORRECT - passing JSX-style props via fragment shorthand
 component Card(props: { title: any; children: any }) {
   <section>
     <h2>{props.title}</h2>
@@ -165,19 +168,21 @@ component App() {
 ```
 
 **LLM DO:**
-- Use `<>...</>` as the default wrapper when JSX must exist in expression position.
-- Use `<tsx>...</tsx>` when you want the explicit long form; it is equivalent.
-- Treat either form as a renderable value that can be stored, returned, and passed around.
-- Keep using normal Ripple syntax and semantics inside either wrapper.
+- Use `<tsrx>...</tsrx>` when you want normal Ripple/TSRX template syntax in expression position, including double-quoted text children, setup statements, and template control flow.
+- Use `<>...</>` as the default wrapper when JSX-style children must exist in expression position.
+- Use `<tsx>...</tsx>` when you want the explicit long form of the JSX-style wrapper; it is equivalent to `<>...</>`.
+- Treat all three forms as renderable values that can be stored, returned, and passed around.
 
 **LLM DON'T:**
 - Do not write `const el = <div />;` directly in Ripple code.
-- Do not return bare JSX from helper functions without `<>...</>` or `<tsx>...</tsx>`.
+- Do not return bare UI from helper functions without `<tsrx>...</tsrx>`, `<>...</>`, or `<tsx>...</tsx>`.
+- Do not use double-quoted TSRX text children inside `<>...</>` or `<tsx>...</tsx>` when you mean native TSRX text; use `<tsrx>...</tsrx>` instead.
 - Do not confuse plain `<tsx>` with `<tsx:react>`.
 - Do not require React compat for plain `<tsx>`.
 
 **Key distinction:**
-- `<>...</>` / `<tsx>...</tsx>`: expression-form Ripple JSX value
+- `<tsrx>...</tsrx>`: expression-form native Ripple/TSRX template value
+- `<>...</>` / `<tsx>...</tsx>`: expression-form JSX-style value
 - `<tsx:react>`: React compatibility block with React JSX semantics and compat setup
 
 ### ⚠️ Critical: Early Returns Are Guard Exits, Not JSX Returns


### PR DESCRIPTION
This should solve so many issues for people who want to use render props, or just want to use functions as components still, because they prefer using the pattern of returning their template instead of the mechanics of `component`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new core syntax form and threads a new `Tsrx` AST node through parsing, analysis, transforms, formatting, and tooling, which can affect compilation/output across runtimes. Risk is mitigated by broad test coverage, but regressions are possible in edge cases around tokenization, scoping, and TS/JSX interop.
> 
> **Overview**
> Adds a new expression-position “native template” island, `<tsrx>...</tsrx>`, allowing TSRX template children (including setup statements and control flow) to be used as a value for assignments, returns, and render props.
> 
> Implements a new `Tsrx` AST node end-to-end: parser/tokenizer support (including non-self-closing and closing-tag recovery), ripple analyzer allowances for elements inside `Tsrx`, client/server transforms emitting `_$_.tsrx_element(...)`, and Volar/TS output lowering that preserves statement ordering via an IIFE when needed. Updates the Prettier plugin, TextMate grammar, types, docs/spec, and adds targeted client/server/formatter/mapping tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50bd42c51c56777408291fe81583238da41d9f1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->