### PR TITLE
fix: restore JSX context after inlined tsrx

### DIFF
--- a/.changeset/inline-tsrx-attribute-values.md
+++ b/.changeset/inline-tsrx-attribute-values.md
@@ -1,0 +1,5 @@
+---
+"@tsrx/core": patch
+---
+
+Fix parsing inline `<tsrx>` template fragments inside JSX attribute expression values.

--- a/packages/tsrx/src/plugin.js
+++ b/packages/tsrx/src/plugin.js
@@ -202,6 +202,7 @@ export function TSRXPlugin(config) {
 		// Some parser constructors (e.g. via TS plugins) expose `tokContexts` without `b_stat`.
 		// If we push an undefined context, Acorn's tokenizer will later crash reading `.override`.
 		const b_stat = tc.b_stat || acorn.tokContexts.b_stat;
+		const b_expr = tc.b_expr || acorn.tokContexts.b_expr;
 		const tstt = Parser.acornTypeScript.tokTypes;
 		const tstc = Parser.acornTypeScript.tokContexts;
 
@@ -326,7 +327,7 @@ export function TSRXPlugin(config) {
 
 				const context_index = this.context.length - 1;
 				if (
-					this.context[context_index] === acorn.tokContexts.b_expr &&
+					this.context[context_index] === b_expr &&
 					this.context[context_index - 1] === tstc.tc_oTag
 				) {
 					this.context.pop();

--- a/packages/tsrx/src/plugin.js
+++ b/packages/tsrx/src/plugin.js
@@ -319,6 +319,21 @@ export function TSRXPlugin(config) {
 				}
 			}
 
+			#popJsxAttributeExpressionContextAfterTemplateElement() {
+				if (this.type !== tt.braceR) {
+					return;
+				}
+
+				const context_index = this.context.length - 1;
+				if (
+					this.context[context_index] === acorn.tokContexts.b_expr &&
+					this.context[context_index - 1] === tstc.tc_oTag
+				) {
+					this.context.pop();
+					this.exprAllowed = false;
+				}
+			}
+
 			#isDoubleQuotedTextChildStart() {
 				if (this.#path.findLast((n) => n.type === 'TsxCompat' || n.type === 'Tsx')) {
 					return false;
@@ -1910,9 +1925,18 @@ export function TSRXPlugin(config) {
 					// Use Ripple's parseElement to create a Tsx/Tsrx/TsxCompat node.
 					// Bare fragments (<></>) are shorthand for <tsx>...</tsx>.
 					this.next();
-					return /** @type {import('estree-jsx').JSXElement} */ (
+					const parsed = /** @type {import('estree-jsx').JSXElement} */ (
 						/** @type {unknown} */ (this.parseElement())
 					);
+					this.#popJsxAttributeExpressionContextAfterTemplateElement();
+					return parsed;
+				}
+
+				if (
+					!this.#path.findLast((node) => node.type === 'Component') &&
+					!this.#functionStack.findLast(is_pascal_case_function)
+				) {
+					return super.jsx_parseElement();
 				}
 
 				const code = this.#functionStack.findLast(is_pascal_case_function)

--- a/packages/tsrx/tests/shared/compile.js
+++ b/packages/tsrx/tests/shared/compile.js
@@ -1333,6 +1333,26 @@ export function optionalFn(bar: string, baz?: string) {
 			expect(code).toContain('{"yes"}');
 			expect(code).not.toContain('<tsrx>');
 		});
+
+		it('lowers native TSRX template fragments in component JSX attribute values', () => {
+			const { code } = compile(
+				`component App() { <Card content={<tsrx><span>"Title"</span></tsrx>} /> }`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('{"Title"}');
+			expect(code).not.toContain('<tsrx>');
+		});
+
+		it('lowers native TSRX template fragments in JSX attribute values', () => {
+			const { code } = compile(
+				`class Foo { bar() { return <Card content={<tsrx><span>"Title"</span></tsrx>} />; } }`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('{"Title"}');
+			expect(code).not.toContain('<tsrx>');
+		});
 	});
 
 	describe(`[${name}] lazy destructuring shadowing`, () => {


### PR DESCRIPTION
fixes #1090 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches tokenizer/parser context stack handling around JSX attribute expression parsing; small but could regress JSX/TSX parsing in edge cases.
> 
> **Overview**
> Fixes a parsing bug where inline `<tsrx>...</tsrx>` fragments used inside JSX attribute expression values (e.g. `prop={<tsrx>...</tsrx>}`) could leave Acorn in the wrong token context.
> 
> The plugin now detects when a `<tsrx>`/`<tsx>`/fragment element parse ends at a `}` and pops the extra JSX attribute expression context to keep subsequent tokens parsed correctly, with new regression tests covering both component templates and regular JSX returns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a959cfd85505fa7a1838aa8a3e047eebb842ae16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->