### PR TITLE
fix: more <tsrx> parser expression fixes

### DIFF
--- a/.changeset/vast-areas-allow.md
+++ b/.changeset/vast-areas-allow.md
@@ -1,0 +1,8 @@
+---
+'@tsrx/core': patch
+---
+
+Parser fix for <tsrx> - cleans up the pending token context for }, ), ], plus the callback-return case:
+parenthesized: content={(<tsrx>...</tsrx>)}
+passed as a call arg: content={wrap(<tsrx>...</tsrx>)}
+used as an object property: content={{ child: <tsrx>...</tsrx> }}

--- a/packages/tsrx/src/plugin.js
+++ b/packages/tsrx/src/plugin.js
@@ -320,15 +320,20 @@ export function TSRXPlugin(config) {
 				}
 			}
 
-			#popJsxAttributeExpressionContextAfterTemplateElement() {
-				if (this.type !== tt.braceR) {
+			#popTokenContextsAfterTemplateExpressionElement() {
+				const context_index = this.context.length - 1;
+				if (
+					this.context[context_index] === b_stat &&
+					this.context[context_index - 1] === tstc.tc_expr
+				) {
+					this.context.length = context_index - 1;
 					return;
 				}
 
-				const context_index = this.context.length - 1;
 				if (
-					this.context[context_index] === b_expr &&
-					this.context[context_index - 1] === tstc.tc_oTag
+					(this.type === tt.braceR && this.context[context_index] === b_expr) ||
+					(this.type === tt.parenR && this.context[context_index]?.token === '(') ||
+					(this.type === tt.bracketR && this.context[context_index]?.token === '[')
 				) {
 					this.context.pop();
 					this.exprAllowed = false;
@@ -1929,7 +1934,7 @@ export function TSRXPlugin(config) {
 					const parsed = /** @type {import('estree-jsx').JSXElement} */ (
 						/** @type {unknown} */ (this.parseElement())
 					);
-					this.#popJsxAttributeExpressionContextAfterTemplateElement();
+					this.#popTokenContextsAfterTemplateExpressionElement();
 					return parsed;
 				}
 

--- a/packages/tsrx/tests/shared/compile.js
+++ b/packages/tsrx/tests/shared/compile.js
@@ -1353,6 +1353,46 @@ export function optionalFn(bar: string, baz?: string) {
 			expect(code).toContain('{"Title"}');
 			expect(code).not.toContain('<tsrx>');
 		});
+
+		it('lowers native TSRX template fragments parenthesized in JSX attribute values', () => {
+			const { code } = compile(
+				`class Foo { bar() { return <Card content={(<tsrx><span>"Title"</span></tsrx>)} />; } }`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('{"Title"}');
+			expect(code).not.toContain('<tsrx>');
+		});
+
+		it('lowers native TSRX template fragments passed to calls in JSX attribute values', () => {
+			const { code } = compile(
+				`class Foo { bar() { return <Card content={wrap(<tsrx><span>"Title"</span></tsrx>)} />; } }`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('{"Title"}');
+			expect(code).not.toContain('<tsrx>');
+		});
+
+		it('lowers native TSRX template fragments in object property JSX attribute values', () => {
+			const { code } = compile(
+				`class Foo { bar() { return <Card content={{ child: <tsrx><span>"Title"</span></tsrx> }} />; } }`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('{"Title"}');
+			expect(code).not.toContain('<tsrx>');
+		});
+
+		it('lowers native TSRX template fragments returned from render callback props', () => {
+			const { code } = compile(
+				`class Foo { bar() { return <List render={() => { return <tsrx><span>"Item"</span></tsrx>; }} />; } }`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('{"Item"}');
+			expect(code).not.toContain('<tsrx>');
+		});
 	});
 
 	describe(`[${name}] lazy destructuring shadowing`, () => {


### PR DESCRIPTION
fixes #1094 
fixes other identified use cases

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches low-level parser token-context stack handling for JSX/TSRX boundaries; mistakes here can cause broad parse regressions across many syntactic forms.
> 
> **Overview**
> Fixes `<tsrx>` parsing when used as an *expression* by more aggressively cleaning up Acorn token contexts after parsing a template element, including closing `}`, `)`, and `]` cases and a callback-return shape.
> 
> Adds regression tests covering `<tsrx>` used in JSX attribute expressions when parenthesized, passed as a call argument, nested in an object literal, and returned from a render-prop callback, and publishes the change as a patch via a changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 056f7b1fc7f3a8c30f0bc20dd268ee3a0953f6e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->