### PR TITLE
fix: prettier line breaking for attributes

### DIFF
--- a/.changeset/tidy-attributes-break.md
+++ b/.changeset/tidy-attributes-break.md
@@ -1,0 +1,5 @@
+---
+'@tsrx/prettier-plugin': patch
+---
+
+Break TSX attributes consistently when template-valued TSRX expression props wrap.

--- a/packages/prettier-plugin/src/index.js
+++ b/packages/prettier-plugin/src/index.js
@@ -1687,7 +1687,7 @@ function printRippleNode(node, path, options, print, args) {
 			break;
 
 		case 'ArrowFunctionExpression':
-			nodeContent = printArrowFunction(node, path, options, print);
+			nodeContent = printArrowFunction(node, path, options, print, args);
 			break;
 
 		case 'FunctionExpression':
@@ -2723,9 +2723,10 @@ function printFunctionExpression(node, path, options, print) {
  * @param {AstPath<AST.ArrowFunctionExpression>} path - The AST path
  * @param {RippleFormatOptions} options - Prettier options
  * @param {PrintFn} print - Print callback
+ * @param {PrintArgs} [args] - Additional context arguments
  * @returns {Doc}
  */
-function printArrowFunction(node, path, options, print) {
+function printArrowFunction(node, path, options, print, args) {
 	/** @type {Doc[]} */
 	const parts = [];
 
@@ -2773,20 +2774,41 @@ function printArrowFunction(node, path, options, print) {
 		// For expression bodies, check if we need to wrap in parens
 		// Wrap ObjectExpression, AssignmentExpression, and SequenceExpression in parens
 		// to avoid ambiguity with block statements or to clarify intent
+		const bodyDoc = path.call(print, 'body');
 		if (
 			node.body.type === 'ObjectExpression' ||
 			node.body.type === 'AssignmentExpression' ||
-			node.body.type === 'SequenceExpression'
+			node.body.type === 'SequenceExpression' ||
+			(args?.isInAttribute && isTemplateExpression(node.body))
 		) {
 			parts.push('(');
-			parts.push(path.call(print, 'body'));
+			if (isTemplateExpression(node.body)) {
+				parts.push(indent([hardline, bodyDoc]));
+				parts.push(hardline);
+			} else {
+				parts.push(bodyDoc);
+			}
 			parts.push(')');
 		} else {
-			parts.push(path.call(print, 'body'));
+			parts.push(bodyDoc);
 		}
 	}
 
 	return parts;
+}
+
+/**
+ * Check whether an expression is one of TSRX's template expression wrappers.
+ * @param {AST.Node} node - The node to check
+ * @returns {boolean}
+ */
+function isTemplateExpression(node) {
+	return (
+		node.type === 'Tsx' ||
+		node.type === 'Tsrx' ||
+		node.type === 'JSXElement' ||
+		node.type === 'JSXFragment'
+	);
 }
 
 /**
@@ -5816,12 +5838,15 @@ function printJSXElement(node, path, options, print) {
 	// Format attributes
 	/** @type {Doc} */
 	let attributesDoc = '';
+	let hasBreakingAttribute = false;
 	if (hasAttributes) {
 		/** @type {Doc[]} */
 		const attrs = openingElement.attributes.map(
 			(/** @type {AST.Node} */ attr, /** @type {number} */ i) => {
+				/** @type {Doc} */
+				let attrDoc = '';
 				if (attr.type === 'JSXAttribute') {
-					return path.call(
+					attrDoc = path.call(
 						(attrPath) =>
 							printJSXAttribute(
 								/** @type {ESTreeJSX.JSXAttribute} */ (attrPath.node),
@@ -5834,20 +5859,39 @@ function printJSXElement(node, path, options, print) {
 						i,
 					);
 				} else if (attr.type === 'JSXSpreadAttribute' || attr.type === 'SpreadAttribute') {
-					return ['{...', path.call(print, 'openingElement', 'attributes', i, 'argument'), '}'];
+					attrDoc = ['{...', path.call(print, 'openingElement', 'attributes', i, 'argument'), '}'];
 				}
-				return '';
+				if (!hasBreakingAttribute && attrDoc && willBreak(attrDoc)) {
+					hasBreakingAttribute = true;
+				}
+				return attrDoc;
 			},
 		);
-		attributesDoc = [' ', join(' ', attrs)];
+		const attrLineBreak = options.singleAttributePerLine ? hardline : line;
+		attributesDoc = indent([attrLineBreak, join(attrLineBreak, attrs)]);
 	}
+	const shouldForceBreak = hasBreakingAttribute;
 
 	if (isSelfClosing) {
-		return ['<', tagName, typeArgsDoc, attributesDoc, ' />'];
+		return group(['<', tagName, typeArgsDoc, attributesDoc, hasAttributes ? line : ' ', '/>'], {
+			shouldBreak: shouldForceBreak,
+		});
 	}
 
+	const openingTag = group(
+		[
+			'<',
+			tagName,
+			typeArgsDoc,
+			attributesDoc,
+			hasAttributes && !options.bracketSameLine ? softline : '',
+			'>',
+		],
+		{ shouldBreak: shouldForceBreak },
+	);
+
 	if (!hasChildren) {
-		return ['<', tagName, typeArgsDoc, attributesDoc, '></', tagName, '>'];
+		return [openingTag, '</', tagName, '>'];
 	}
 
 	// Format children - filter out empty text nodes and merge adjacent text nodes
@@ -5891,7 +5935,7 @@ function printJSXElement(node, path, options, print) {
 
 	// Check if content can be inlined (single text node or single expression)
 	if (childrenDocs.length === 1 && typeof childrenDocs[0] === 'string') {
-		return ['<', tagName, typeArgsDoc, attributesDoc, '>', childrenDocs[0], '</', tagName, '>'];
+		return group([openingTag, childrenDocs[0], '</', tagName, '>']);
 	}
 	const meaningfulChildren = node.children.filter(
 		(child) => child.type !== 'JSXText' || child.value.trim(),
@@ -5902,7 +5946,7 @@ function printJSXElement(node, path, options, print) {
 		singleMeaningfulChild?.type === 'JSXExpressionContainer' &&
 		singleMeaningfulChild.expression.type === 'Identifier'
 	) {
-		return ['<', tagName, typeArgsDoc, attributesDoc, '>', childrenDocs[0], '</', tagName, '>'];
+		return group([openingTag, childrenDocs[0], '</', tagName, '>']);
 	}
 
 	// Multiple children or complex children - format with line breaks
@@ -5916,11 +5960,7 @@ function printJSXElement(node, path, options, print) {
 
 	// Build the final element
 	return group([
-		'<',
-		tagName,
-		typeArgsDoc,
-		attributesDoc,
-		'>',
+		openingTag,
 		indent([hardline, ...formattedChildren]),
 		hardline,
 		'</',
@@ -6009,7 +6049,11 @@ function printJSXAttribute(attr, path, options, print) {
 	}
 
 	if (attr.value.type === 'JSXExpressionContainer') {
-		const exprDoc = path.call(print, 'value', 'expression');
+		const exprDoc = path.call(
+			(valuePath) => print(valuePath, { isInAttribute: true }),
+			'value',
+			'expression',
+		);
 		return [name, '={', exprDoc, '}'];
 	}
 

--- a/packages/prettier-plugin/src/index.js
+++ b/packages/prettier-plugin/src/index.js
@@ -2805,6 +2805,7 @@ function printArrowFunction(node, path, options, print, args) {
 function isTemplateExpression(node) {
 	return (
 		node.type === 'Tsx' ||
+		node.type === 'TsxCompat' ||
 		node.type === 'Tsrx' ||
 		node.type === 'JSXElement' ||
 		node.type === 'JSXFragment'

--- a/packages/prettier-plugin/src/index.test.js
+++ b/packages/prettier-plugin/src/index.test.js
@@ -231,6 +231,30 @@ describe('prettier-plugin', () => {
   />
 }`,
 				},
+				{
+					input: `component Test() {
+  <A fallback={(error) => <tsx:react>
+    <B id="xyz" status="error" moreProps={{ a: 1, b: 2 }} value={getErrorMessage(
+      error,
+    )} otherProp={2} />
+  </tsx:react>} />
+}`,
+					expected: `component Test() {
+  <A
+    fallback={(error) => (
+      <tsx:react>
+        <B
+          id="xyz"
+          status="error"
+          moreProps={{ a: 1, b: 2 }}
+          value={getErrorMessage(error)}
+          otherProp={2}
+        />
+      </tsx:react>
+    )}
+  />
+}`,
+				},
 			];
 
 			for (const { input, expected } of cases) {

--- a/packages/prettier-plugin/src/index.test.js
+++ b/packages/prettier-plugin/src/index.test.js
@@ -157,6 +157,88 @@ describe('prettier-plugin', () => {
 			expect(result).toBeWithNewline(expected);
 		});
 
+		it('should break nested TSX element attributes inside expression props', async () => {
+			const cases = [
+				{
+					input: `component Test() {
+  <A fallback={(error) => <>
+    <B id="xyz" status="error" moreProps={{ a: 1, b: 2 }} value={getErrorMessage(
+      error,
+    )} otherProp={2} />
+  </>} />
+}`,
+					expected: `component Test() {
+  <A
+    fallback={(error) => (
+      <>
+        <B
+          id="xyz"
+          status="error"
+          moreProps={{ a: 1, b: 2 }}
+          value={getErrorMessage(error)}
+          otherProp={2}
+        />
+      </>
+    )}
+  />
+}`,
+				},
+				{
+					input: `component Test() {
+  <A fallback={(error) => <tsx>
+    <B id="xyz" status="error" moreProps={{ a: 1, b: 2 }} value={getErrorMessage(
+      error,
+    )} otherProp={2} />
+  </tsx>} />
+}`,
+					expected: `component Test() {
+  <A
+    fallback={(error) => (
+      <tsx>
+        <B
+          id="xyz"
+          status="error"
+          moreProps={{ a: 1, b: 2 }}
+          value={getErrorMessage(error)}
+          otherProp={2}
+        />
+      </tsx>
+    )}
+  />
+}`,
+				},
+				{
+					input: `component Test() {
+  <A fallback={(error) => <tsrx>
+    <B id="xyz" status="error" moreProps={{ a: 1, b: 2 }} value={getErrorMessage(
+      error,
+    )} otherProp={2} />
+  </tsrx>} />
+}`,
+					expected: `component Test() {
+  <A
+    fallback={(error) => (
+      <tsrx>
+        <B
+          id="xyz"
+          status="error"
+          moreProps={{ a: 1, b: 2 }}
+          value={getErrorMessage(error)}
+          otherProp={2}
+        />
+      </tsrx>
+    )}
+  />
+}`,
+				},
+			];
+
+			for (const { input, expected } of cases) {
+				const result = await format(input);
+				expect(result).toBeWithNewline(expected);
+			}
+		});
+
 		it('should format whitespace correctly', async () => {
 			const input = `export component Test(){
         let count=0

--- a/packages/ripple/tests/client/tsx.test.tsrx
+++ b/packages/ripple/tests/client/tsx.test.tsrx
@@ -317,8 +317,12 @@ describe('tsx expression', () => {
 			let &[index] = track(0);
 
 			const el = <tsx>
-				<div id={'item-' + index} class={'item pos-' + index} data-index={index} title={'Item ' +
-					index}>
+				<div
+					id={'item-' + index}
+					class={'item pos-' + index}
+					data-index={index}
+					title={'Item ' + index}
+				>
 					{'Item ' + index}
 				</div>
 			</tsx>;

--- a/packages/vite-plugin-react/tests/runtime.test.tsrx
+++ b/packages/vite-plugin-react/tests/runtime.test.tsrx
@@ -419,9 +419,12 @@ class TsxSpreadRefRenderer {
 		};
 
 		return <tsx>
-			<input {...props} ref={(node: HTMLInputElement | null) => {
-				tsx_explicit_ref_captured = node;
-			}} />
+			<input
+				{...props}
+				ref={(node: HTMLInputElement | null) => {
+					tsx_explicit_ref_captured = node;
+				}}
+			/>
 		</tsx>;
 	}
 }


### PR DESCRIPTION
fixes #1085 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core printing/grouping logic for arrow-function bodies and JSX/TSX attribute layout, which can change formatting output across many files. Behavior is covered by added/updated formatting and runtime tests, but regressions could surface as snapshot diffs for edge cases.
> 
> **Overview**
> Fixes attribute line-breaking in `@tsrx/prettier-plugin` when a JSX/TSX prop is an expression that wraps a template-like value (`<>`, `<tsx>`, `<tsrx>`, etc.). Arrow-function expression bodies in attribute context are now parenthesized and indented consistently, and JSX opening tags are grouped/forced to break when any attribute doc breaks.
> 
> Adds a patch changeset and expands test coverage (including nested template-valued props) while updating existing TSX runtime tests to match the new, more consistent multi-line attribute formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b94a62f0a007dd641d26a7d2873ea6d9cd9857ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->