### PR TITLE
fix: return fragments in function inside components

### DIFF
--- a/.changeset/quiet-cameras-return.md
+++ b/.changeset/quiet-cameras-return.md
@@ -1,0 +1,5 @@
+---
+'@tsrx/core': patch
+---
+
+Keep special fragment return values inside component-local functions attached to their return statements.

--- a/packages/tsrx-ripple/tests/basic.test.js
+++ b/packages/tsrx-ripple/tests/basic.test.js
@@ -200,3 +200,54 @@ describe('@tsrx/ripple <tsrx> Volar output', () => {
 		expect(second_push).toBeLessThan(returned_children);
 	});
 });
+
+describe('@tsrx/ripple nested function fragment returns', () => {
+	it('keeps special fragment returns inside component-local functions', () => {
+		const { code } = compile(
+			`export component App() {
+				<div>"App"</div>
+				function FragmentReturn() {
+					return <><div>fragment</div></>;
+				}
+				function TsxReturn() {
+					return <tsx><div>tsx</div></tsx>;
+				}
+				function TsrxReturn() {
+					return <tsrx><div>"tsrx"</div></tsrx>;
+				}
+			}`,
+			'App.tsrx',
+		);
+
+		expect(code).not.toContain('return;');
+		expect(code).toMatch(/function FragmentReturn\(\) {\s+return _\$_.tsrx_element/);
+		expect(code).toMatch(/function TsxReturn\(\) {\s+return _\$_.tsrx_element/);
+		expect(code).toMatch(/function TsrxReturn\(\) {\s+return _\$_.tsrx_element/);
+	});
+
+	it('keeps special fragment returns inside component prop arrow functions', () => {
+		const { code } = compile(
+			`component Child(props) {}
+
+			export component App() {
+				<Child
+					fragment={() => {
+						return <><div>fragment</div></>;
+					}}
+					tsx={() => {
+						return <tsx><div>tsx</div></tsx>;
+					}}
+					tsrx={() => {
+						return <tsrx><div>"tsrx"</div></tsrx>;
+					}}
+				/>
+			}`,
+			'App.tsrx',
+		);
+
+		expect(code).not.toContain('return;');
+		expect(code).toMatch(/fragment: \(\) => {\s+return _\$_.tsrx_element/);
+		expect(code).toMatch(/tsx: \(\) => {\s+return _\$_.tsrx_element/);
+		expect(code).toMatch(/tsrx: \(\) => {\s+return _\$_.tsrx_element/);
+	});
+});

--- a/packages/tsrx/src/plugin.js
+++ b/packages/tsrx/src/plugin.js
@@ -220,6 +220,7 @@ export function TSRXPlugin(config) {
 			#errors = undefined;
 			/** @type {string | null} */
 			#filename = null;
+			#componentDepth = 0;
 			#functionBodyDepth = 0;
 
 			/**
@@ -268,6 +269,14 @@ export function TSRXPlugin(config) {
 					index--;
 				}
 				return null;
+			}
+
+			#isInsideComponent() {
+				return this.#componentDepth > 0;
+			}
+
+			#isInsideComponentTemplate() {
+				return this.#isInsideComponent() && this.#functionBodyDepth === 0;
 			}
 
 			#popTsxTokenContextBeforeTemplateExpressionChild() {
@@ -738,7 +747,7 @@ export function TSRXPlugin(config) {
 
 				if (code === 60) {
 					// < character
-					const inComponent = this.#path.findLast((n) => n.type === 'Component');
+					const inComponent = this.#isInsideComponentTemplate();
 					/** @type {number | null} */
 					let prevNonWhitespaceChar = null;
 
@@ -1094,11 +1103,13 @@ export function TSRXPlugin(config) {
 				this.eat(tt.braceL);
 				node.body = [];
 				this.#path.push(node);
+				this.#componentDepth++;
 
 				try {
 					this.parseTemplateBody(node.body);
 				} finally {
 					this.#functionBodyDepth = parent_function_body_depth;
+					this.#componentDepth--;
 				}
 				this.#path.pop();
 				this.exitScope();
@@ -1322,6 +1333,23 @@ export function TSRXPlugin(config) {
 			parseFunctionBody(node, isArrowFunction, isMethod, forInit, ...args) {
 				this.#functionBodyDepth++;
 				this.#functionStack.push(node);
+				// Inside a component, nested JS function bodies should parse like
+				// ordinary functions, not component template bodies.
+				if (
+					// Only adjust functions declared while parsing a component body.
+					this.#isInsideComponent() &&
+					// A stale JSX expression context means the surrounding template
+					// tokenizer can still treat `<` as template markup.
+					this.context.some((context) => context === tstc.tc_expr) &&
+					// Keep arrows/functions inside JSX tags, such as event handlers,
+					// on the normal JSX attribute parsing path.
+					!this.context.some((context) => context === tstc.tc_oTag || context === tstc.tc_cTag) &&
+					// Only reset statement-level function bodies, not expression
+					// contexts that are actively parsing JSX.
+					this.curContext() === b_stat
+				) {
+					this.context = [b_stat];
+				}
 
 				try {
 					return super.parseFunctionBody(node, isArrowFunction, isMethod, forInit, ...args);

--- a/packages/tsrx/tests/shared/compile.js
+++ b/packages/tsrx/tests/shared/compile.js
@@ -1279,6 +1279,65 @@ export function optionalFn(bar: string, baz?: string) {
 			);
 			expect(code).toContain('return <><div>a</div><div>b</div></>;');
 		});
+
+		it('keeps special fragment returns inside component-local functions', () => {
+			const compat_kind = name === 'solid' ? 'solid' : 'react';
+			const { code } = compile(
+				`export component App() {
+					<div>"App"</div>
+					function FragmentReturn() {
+						return <><div>fragment</div></>;
+					}
+					function TsxReturn() {
+						return <tsx><div>tsx</div></tsx>;
+					}
+					function TsrxReturn() {
+						return <tsrx><div>"tsrx"</div></tsrx>;
+					}
+					function CompatReturn() {
+						return <tsx:${compat_kind}><div>compat</div></tsx:${compat_kind}>;
+					}
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).not.toContain('return;');
+			expect(code).toMatch(/function FragmentReturn\(\) {\s+return <div/);
+			expect(code).toMatch(/function TsxReturn\(\) {\s+return <div/);
+			expect(code).toMatch(/function TsrxReturn\(\) {\s+return <div/);
+			expect(code).toMatch(/function CompatReturn\(\) {\s+return <div/);
+		});
+
+		it('keeps special fragment returns inside component prop arrow functions', () => {
+			const compat_kind = name === 'solid' ? 'solid' : 'react';
+			const { code } = compile(
+				`component Child(props) {}
+
+				export component App() {
+					<Child
+						fragment={() => {
+							return <><div>fragment</div></>;
+						}}
+						tsx={() => {
+							return <tsx><div>tsx</div></tsx>;
+						}}
+						tsrx={() => {
+							return <tsrx><div>"tsrx"</div></tsrx>;
+						}}
+						compat={() => {
+							return <tsx:${compat_kind}><div>compat</div></tsx:${compat_kind}>;
+						}}
+					/>
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).not.toContain('return;');
+			expect(code).toMatch(/fragment=\{\(\) => \{\s+return <div/);
+			expect(code).toMatch(/tsx=\{\(\) => \{\s+return <div/);
+			expect(code).toMatch(/tsrx=\{\(\) => \{\s+return <div/);
+			expect(code).toMatch(/compat=\{\(\) => \{\s+return <div/);
+		});
 	});
 
 	describe(`[${name}] <tsrx> template fragments`, () => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core parsing/tokenizer state for `<` and function bodies inside components, which could affect JSX/TSRX disambiguation in edge cases. Added regression tests reduce the likelihood of broad breakage but parser changes are still moderately risky.
> 
> **Overview**
> Fixes a parser bug where **special fragment-style returns** (`<>...</>`, `<tsx>...</tsx>`, `<tsrx>...</tsrx>`) inside functions defined within a `component` (including render-prop arrow functions) could be mis-parsed/rewritten, leading to incorrect output like stray `return;`.
> 
> The plugin now tracks *component vs nested-function depth* and resets stale JSX expression token context when entering nested function bodies so `<` is treated as normal JSX/TSX in those returns. Adds targeted regression tests for both the Ripple target and the shared core harness, and ships as a patch via changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a73fb9c2fe62e897e1cda83b372cce5bebef2ff7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->