### PR TITLE
fix: tsrx return without iife and extra return null

### DIFF
--- a/.changeset/clean-tsrx-returns.md
+++ b/.changeset/clean-tsrx-returns.md
@@ -1,0 +1,9 @@
+---
+'@tsrx/core': patch
+'@tsrx/react': patch
+'@tsrx/preact': patch
+'@tsrx/solid': patch
+'@tsrx/vue': patch
+---
+
+Keep explicit return values in expression-position `<tsrx>` templates out of render control-flow lowering.

--- a/packages/tsrx-solid/src/transform.js
+++ b/packages/tsrx-solid/src/transform.js
@@ -21,6 +21,7 @@ import {
 	captureJsxChild,
 	CREATE_REF_PROP_INTERNAL_NAME,
 	NORMALIZE_SPREAD_PROPS_INTERNAL_NAME,
+	returnValueBodyToExpression as return_value_body_to_expression,
 	tsxNodeToJsxExpression as tsx_node_to_jsx_expression,
 	// Shared AST builders (truly platform-agnostic utilities).
 	clone_expression_node,
@@ -454,6 +455,20 @@ function tsrx_node_to_jsx_expression(node, transform_context, in_jsx_child = fal
 			(child.type !== 'JSXText' || child.value.trim() !== ''),
 	);
 
+	const returned_expression = return_value_body_to_expression(children, node, transform_context);
+	if (returned_expression) {
+		if (
+			in_jsx_child &&
+			returned_expression.type !== 'JSXElement' &&
+			returned_expression.type !== 'JSXFragment' &&
+			returned_expression.type !== 'JSXText' &&
+			returned_expression.type !== 'JSXExpressionContainer'
+		) {
+			return to_jsx_expression_container(returned_expression, node);
+		}
+		return returned_expression;
+	}
+
 	let expression = body_to_jsx_child(children, transform_context);
 	if (is_branch_arrow(expression)) {
 		expression = b.call(expression);
@@ -509,7 +524,7 @@ function body_to_jsx_child(body_nodes, transform_context) {
 	const statements = [];
 	/** @type {any[]} */
 	const children = [];
-	let has_bare_return = false;
+	let has_terminal_return = false;
 	let capture_index = 0;
 	for (const child of body_nodes) {
 		if (is_bare_return_statement(child)) {
@@ -522,7 +537,13 @@ function body_to_jsx_child(body_nodes, transform_context) {
 				loc: child.loc,
 			});
 			children.length = 0;
-			has_bare_return = true;
+			has_terminal_return = true;
+			continue;
+		}
+
+		if (child?.type === 'ReturnStatement' && child.argument != null) {
+			statements.push(child);
+			has_terminal_return = true;
 			continue;
 		}
 
@@ -557,7 +578,7 @@ function body_to_jsx_child(body_nodes, transform_context) {
 	// statements run when (and only when) the branch actually renders.
 	/** @type {any[]} */
 	const block_body = [...statements];
-	if (children.length > 0 || !has_bare_return) {
+	if (children.length > 0 || !has_terminal_return) {
 		block_body.push(
 			/** @type {any} */ ({
 				type: 'ReturnStatement',

--- a/packages/tsrx-vue/tests/basic.test.js
+++ b/packages/tsrx-vue/tests/basic.test.js
@@ -90,6 +90,89 @@ describe('@tsrx/vue basic', () => {
 		expect(code).toContain('return <pre>{__lazy0.count}</pre>;');
 	});
 
+	it('keeps return-value branches in native TSRX callback props as plain conditionals', () => {
+		const { code } = compile(
+			`component Test() {
+				<Page
+					params={{
+						menuAlt: (isAdmin) => <tsrx>
+							if (isAdmin) {
+								return [<>Delete</>, <>Edit</>];
+							} else {
+								return [<>View</>];
+							}
+						</tsrx>,
+						direct: () => <tsrx>
+							return [<>View</>];
+						</tsrx>,
+						bySwitch: (role) => <tsrx>
+							switch (role) {
+								case 'admin':
+									return [<>Edit</>];
+								default:
+									return [<>View</>];
+							}
+						</tsrx>,
+						byForOf: (items) => <tsrx>
+							for (const item of items) {
+								if (item.active) {
+									return [<>{item.label}</>];
+								}
+							}
+
+							return [<>Empty</>];
+						</tsrx>,
+						byTry: (load) => <tsrx>
+							try {
+								return [<>{load()}</>];
+							} catch (error) {
+								return [<>Error</>];
+							}
+						</tsrx>,
+					}}
+				/>
+			}`,
+			'App.tsrx',
+		);
+
+		expect(code).toContain(
+			'menuAlt: (isAdmin) => isAdmin ? [<>Delete</>, <>Edit</>] : [<>View</>]',
+		);
+		expect(code).toContain('direct: () => [<>View</>]');
+		expect(code).toContain('bySwitch: (role) => (() => {');
+		expect(code).toContain('switch (role)');
+		expect(code).toContain('byForOf: (items) => (() => {');
+		expect(code).toContain('for (const item of items)');
+		expect(code).toContain('return [<>Empty</>];');
+		expect(code).toContain('byTry: (load) => (() => {');
+		expect(code).toContain('try {');
+		expect(code).toContain('catch(error)');
+		expect(code).toContain('return [<>Error</>];');
+		expect(code).not.toContain('return null;');
+		expect(code).not.toContain('? (() =>');
+	});
+
+	it('keeps expression child arrays in fragment, tsx, and compat callback props', () => {
+		const { code } = compile(
+			`component Child(props) {}
+
+			component App() {
+				<Child
+					fragment={() => <>{[<>Delete</>, <>Edit</>]}</>}
+					tsx={() => <tsx>{[<>Delete</>, <>Edit</>]}</tsx>}
+					compat={() => <tsx:vue>{[<>Delete</>, <>Edit</>]}</tsx:vue>}
+				/>
+			}`,
+			'App.tsrx',
+		);
+
+		expect(code).toContain('fragment={() => [<>Delete</>, <>Edit</>]}');
+		expect(code).toContain('tsx={() => [<>Delete</>, <>Edit</>]}');
+		expect(code).toContain('compat={() => [<>Delete</>, <>Edit</>]}');
+		expect(code).not.toContain('return null;');
+		expect(code).not.toContain('<tsx>');
+	});
+
 	it('emits scoped CSS and applies the scope hash to host elements', () => {
 		const { code, css, cssHash } = compile(
 			`component App() {

--- a/packages/tsrx/src/index.js
+++ b/packages/tsrx/src/index.js
@@ -149,6 +149,7 @@ export {
 	MERGE_REFS_INTERNAL_NAME,
 	merge_duplicate_refs as mergeDuplicateRefs,
 	NORMALIZE_SPREAD_PROPS_INTERNAL_NAME,
+	return_value_body_to_expression as returnValueBodyToExpression,
 	rewrite_loop_continues_to_bare_returns as rewriteLoopContinuesToBareReturns,
 	to_jsx_attribute as toJsxAttribute,
 	validate_at_most_one_ref_attribute as validateAtMostOneRefAttribute,

--- a/packages/tsrx/src/transform/jsx/index.js
+++ b/packages/tsrx/src/transform/jsx/index.js
@@ -682,7 +682,7 @@ function build_component_statements(body_nodes, transform_context) {
 function build_render_statements(body_nodes, return_null_when_empty, transform_context) {
 	const statements = [];
 	const render_nodes = [];
-	let has_bare_return = false;
+	let has_terminal_return = false;
 
 	// Create a new bindings map so inner-scope bindings from
 	// collect_statement_bindings don't leak to the caller's scope.
@@ -707,7 +707,13 @@ function build_render_statements(body_nodes, return_null_when_empty, transform_c
 		if (is_bare_return_statement(child)) {
 			statements.push(create_component_return_statement(render_nodes, child));
 			render_nodes.length = 0;
-			has_bare_return = true;
+			has_terminal_return = true;
+			continue;
+		}
+
+		if (child?.type === 'ReturnStatement' && child.argument != null) {
+			statements.push(child);
+			has_terminal_return = true;
 			continue;
 		}
 
@@ -968,7 +974,7 @@ function build_render_statements(body_nodes, return_null_when_empty, transform_c
 	}
 
 	const return_arg = build_return_expression(render_nodes);
-	if (return_arg || (return_null_when_empty && !has_bare_return)) {
+	if (return_arg || (return_null_when_empty && !has_terminal_return)) {
 		statements.push({
 			type: 'ReturnStatement',
 			argument: return_arg || { type: 'Literal', value: null, raw: 'null' },
@@ -2761,7 +2767,10 @@ function child_contains_return_semantics(node) {
 		return false;
 	}
 
-	if (node.type === 'ReturnStatement' || is_lone_return_if_statement(node)) {
+	if (
+		(node.type === 'ReturnStatement' && node.argument == null) ||
+		is_lone_return_if_statement(node)
+	) {
 		return true;
 	}
 
@@ -3448,22 +3457,25 @@ function tsrx_node_to_jsx_expression(node, transform_context, in_jsx_child = fal
 	let expression;
 	if (children.length === 0) {
 		expression = create_null_literal();
-	} else if (
-		children.every(is_inline_element_child) &&
-		!children_contain_return_semantics(children)
-	) {
-		const saved_inside_element_child = transform_context.inside_element_child;
-		transform_context.inside_element_child = true;
-		try {
-			const render_nodes = children.map((/** @type {any} */ child) =>
-				to_jsx_child(child, transform_context),
-			);
-			expression = build_return_expression(render_nodes) || create_null_literal();
-		} finally {
-			transform_context.inside_element_child = saved_inside_element_child;
-		}
 	} else {
-		expression = statement_body_to_jsx_child(children, transform_context).expression;
+		expression = return_value_body_to_expression(children, node, transform_context);
+	}
+
+	if (!expression) {
+		if (children.every(is_inline_element_child) && !children_contain_return_semantics(children)) {
+			const saved_inside_element_child = transform_context.inside_element_child;
+			transform_context.inside_element_child = true;
+			try {
+				const render_nodes = children.map((/** @type {any} */ child) =>
+					to_jsx_child(child, transform_context),
+				);
+				expression = build_return_expression(render_nodes) || create_null_literal();
+			} finally {
+				transform_context.inside_element_child = saved_inside_element_child;
+			}
+		} else {
+			expression = statement_body_to_jsx_child(children, transform_context).expression;
+		}
 	}
 
 	if (
@@ -3477,6 +3489,149 @@ function tsrx_node_to_jsx_expression(node, transform_context, in_jsx_child = fal
 	}
 
 	return expression;
+}
+
+/**
+ * Explicit return values inside expression-position `<tsrx>` templates are JavaScript
+ * values, so keep them out of platform render control flow.
+ *
+ * @param {any[]} body_nodes
+ * @param {any} source_node
+ * @param {TransformContext} [transform_context]
+ * @returns {any | null}
+ */
+export function return_value_body_to_expression(body_nodes, source_node, transform_context) {
+	if (!body_contains_top_level_return_value(body_nodes)) return null;
+
+	if (body_nodes.length === 1) {
+		const expression = return_value_statement_to_expression(body_nodes[0], transform_context);
+		if (expression) return expression;
+	}
+
+	return create_statement_iife(body_nodes, source_node, transform_context);
+}
+
+/**
+ * @param {any} node
+ * @param {TransformContext} [transform_context]
+ * @returns {any | null}
+ */
+function return_value_statement_to_expression(node, transform_context) {
+	if (node?.type === 'ReturnStatement' && node.argument != null) {
+		return node.argument;
+	}
+
+	if (node?.type === 'IfStatement') {
+		return return_value_if_statement_to_conditional_expression(node, transform_context);
+	}
+
+	return null;
+}
+
+/**
+ * @param {any} node
+ * @returns {boolean}
+ */
+function body_contains_top_level_return_value(node) {
+	if (!node || typeof node !== 'object') return false;
+
+	if (Array.isArray(node)) {
+		return node.some(body_contains_top_level_return_value);
+	}
+
+	if (node.type === 'ReturnStatement') {
+		return node.argument != null;
+	}
+
+	if (
+		node.type === 'FunctionDeclaration' ||
+		node.type === 'FunctionExpression' ||
+		node.type === 'ArrowFunctionExpression' ||
+		node.type === 'ClassDeclaration' ||
+		node.type === 'ClassExpression' ||
+		node.type === 'Component'
+	) {
+		return false;
+	}
+
+	for (const key of Object.keys(node)) {
+		if (key === 'loc' || key === 'start' || key === 'end' || key === 'metadata') {
+			continue;
+		}
+		if (body_contains_top_level_return_value(node[key])) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/**
+ * @param {any[]} body_nodes
+ * @param {any} source_node
+ * @param {TransformContext} [transform_context]
+ * @returns {any}
+ */
+function create_statement_iife(body_nodes, source_node, transform_context) {
+	return set_generated_expression_loc(
+		b.call(b.arrow([], b.block(body_nodes))),
+		source_node,
+		transform_context,
+	);
+}
+
+/**
+ * @param {any} node
+ * @param {any} source_node
+ * @param {TransformContext} [transform_context]
+ * @returns {any}
+ */
+function set_generated_expression_loc(node, source_node, transform_context) {
+	if (transform_context?.typeOnly || !source_node?.loc) return node;
+	return setLocation(/** @type {any} */ (node), source_node);
+}
+
+/**
+ * @returns {any}
+ */
+function create_undefined_expression() {
+	return b.unary('void', b.literal(0));
+}
+
+/**
+ * @param {any} node
+ * @param {TransformContext} [transform_context]
+ * @returns {any | null}
+ */
+function return_value_block_to_expression(node, transform_context) {
+	const body = node?.type === 'BlockStatement' ? node.body : node ? [node] : [];
+	if (body.length !== 1) return null;
+
+	return return_value_statement_to_expression(body[0], transform_context);
+}
+
+/**
+ * @param {any} node
+ * @param {TransformContext} [transform_context]
+ * @returns {any | null}
+ */
+function return_value_if_statement_to_conditional_expression(node, transform_context) {
+	if (!node || node.type !== 'IfStatement') return null;
+
+	const consequent = return_value_block_to_expression(node.consequent, transform_context);
+	if (!consequent) return null;
+
+	let alternate = create_undefined_expression();
+	if (node.alternate) {
+		alternate = return_value_block_to_expression(node.alternate, transform_context);
+		if (!alternate) return null;
+	}
+
+	return set_generated_expression_loc(
+		b.conditional(node.test, consequent, alternate),
+		node,
+		transform_context,
+	);
 }
 
 /**

--- a/packages/tsrx/tests/shared/compile.js
+++ b/packages/tsrx/tests/shared/compile.js
@@ -9,7 +9,7 @@ import { DIAGNOSTIC_CODES } from '../../src/diagnostics.js';
  * }} CompileHarness
  *
  * @typedef {{
- *   compile_to_volar_mappings: (source: string, filename?: string, options?: any) => { errors: Array<{ code?: string }> },
+ *   compile_to_volar_mappings: (source: string, filename?: string, options?: any) => { code: string, errors: Array<{ code?: string }> },
  *   name: string,
  * }} CompileDiagnosticsHarness
  *
@@ -51,6 +51,40 @@ export function runSharedCompileDiagnosticsTests({ compile_to_volar_mappings, na
 			);
 
 			expect(diagnostic_codes(result)).toContain(DIAGNOSTIC_CODES.JSX_RETURN_IN_COMPONENT);
+		});
+
+		it('keeps return-value native TSRX templates clean in type-only output', () => {
+			const result = compile_to_volar_mappings(
+				`component Test() {
+					<Page
+						params={{
+							menuAlt: (isAdmin) => <tsrx>
+								if (isAdmin) {
+									return [<>Delete</>, <>Edit</>];
+								} else {
+									return [<>View</>];
+								}
+							</tsrx>,
+							bySwitch: (role) => <tsrx>
+								switch (role) {
+									case 'admin':
+										return [<>Edit</>];
+									default:
+										return [<>View</>];
+								}
+							</tsrx>,
+						}}
+					/>
+				}`,
+				'App.tsrx',
+			);
+
+			expect(result.errors).toEqual([]);
+			expect(result.code).toContain(
+				'menuAlt: (isAdmin) => isAdmin ? [<>Delete</>, <>Edit</>] : [<>View</>]',
+			);
+			expect(result.code).toContain('bySwitch: (role) => (() => {');
+			expect(result.code).not.toContain('return null;');
 		});
 	});
 }
@@ -1338,6 +1372,28 @@ export function optionalFn(bar: string, baz?: string) {
 			expect(code).toMatch(/tsrx=\{\(\) => \{\s+return <div/);
 			expect(code).toMatch(/compat=\{\(\) => \{\s+return <div/);
 		});
+
+		it('keeps expression child arrays in fragment, tsx, and compat callback props', () => {
+			const compat_kind = name === 'solid' ? 'solid' : 'react';
+			const { code } = compile(
+				`component Child(props) {}
+
+				export component App() {
+					<Child
+						fragment={() => <>{[<>Delete</>, <>Edit</>]}</>}
+						tsx={() => <tsx>{[<>Delete</>, <>Edit</>]}</tsx>}
+						compat={() => <tsx:${compat_kind}>{[<>Delete</>, <>Edit</>]}</tsx:${compat_kind}>}
+					/>
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('fragment={() => [<>Delete</>, <>Edit</>]}');
+			expect(code).toContain('tsx={() => [<>Delete</>, <>Edit</>]}');
+			expect(code).toContain('compat={() => [<>Delete</>, <>Edit</>]}');
+			expect(code).not.toContain('return null;');
+			expect(code).not.toContain('<tsx>');
+		});
 	});
 
 	describe(`[${name}] <tsrx> template fragments`, () => {
@@ -1451,6 +1507,68 @@ export function optionalFn(bar: string, baz?: string) {
 
 			expect(code).toContain('{"Item"}');
 			expect(code).not.toContain('<tsrx>');
+		});
+
+		it('keeps return-value branches in native TSRX callback props as plain conditionals', () => {
+			const { code } = compile(
+				`component Test() {
+					<Page
+						params={{
+							menuAlt: (isAdmin) => <tsrx>
+								if (isAdmin) {
+									return [<>Delete</>, <>Edit</>];
+								} else {
+									return [<>View</>];
+								}
+							</tsrx>,
+							direct: () => <tsrx>
+								return [<>View</>];
+							</tsrx>,
+							bySwitch: (role) => <tsrx>
+								switch (role) {
+									case 'admin':
+										return [<>Edit</>];
+									default:
+										return [<>View</>];
+								}
+							</tsrx>,
+							byForOf: (items) => <tsrx>
+								for (const item of items) {
+									if (item.active) {
+										return [<>{item.label}</>];
+									}
+								}
+
+								return [<>Empty</>];
+							</tsrx>,
+							byTry: (load) => <tsrx>
+								try {
+									return [<>{load()}</>];
+								} catch (error) {
+									return [<>Error</>];
+								}
+							</tsrx>,
+						}}
+					/>
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain(
+				'menuAlt: (isAdmin) => isAdmin ? [<>Delete</>, <>Edit</>] : [<>View</>]',
+			);
+			expect(code).toContain('direct: () => [<>View</>]');
+			expect(code).toContain('bySwitch: (role) => (() => {');
+			expect(code).toContain('switch (role)');
+			expect(code).toContain('byForOf: (items) => (() => {');
+			expect(code).toContain('for (const item of items)');
+			expect(code).toContain('return [<>Empty</>];');
+			expect(code).toContain('byTry: (load) => (() => {');
+			expect(code).toContain('try {');
+			expect(code).toContain('catch(error)');
+			expect(code).toContain('return [<>Error</>];');
+			expect(code).not.toContain('return null;');
+			expect(code).not.toContain('? (() =>');
 		});
 	});
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core JSX/TSRX lowering logic to treat explicit `return <value>` as an expression result rather than render control-flow, which can affect generated output across multiple targets. Risk is mitigated by added cross-platform tests, but touches central compiler transforms.
> 
> **Overview**
> Ensures expression-position native `<tsrx>` templates that use explicit `return <value>` (including simple `if/else` branches) compile to *plain expressions* (e.g. ternaries or direct values) instead of being lowered into platform render control-flow or extra `return null` fallbacks.
> 
> Adds a new shared helper `returnValueBodyToExpression` in `@tsrx/core` and wires it into both core `<tsrx>` lowering and the Solid transform, while also treating `return <expr>` as a terminal return when building render statements. Expands Vue and shared compile diagnostics tests to cover callback-prop scenarios (if/switch/loop/try) and type-only (Volar) output, and includes a changeset bumping all framework packages as a patch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 416371b4f33d08413aba72dd6f77751166ebfa67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->