### PR TITLE
fix: semicolon-free <tsrx> returns inside callback props

### DIFF
--- a/.changeset/steady-jsx-contexts.md
+++ b/.changeset/steady-jsx-contexts.md
@@ -1,0 +1,9 @@
+---
+'@tsrx/core': patch
+'@tsrx/react': patch
+'@tsrx/preact': patch
+'@tsrx/solid': patch
+'@tsrx/vue': patch
+---
+
+Preserve JSX parser state for semicolon-free native TSRX returns inside callback props.

--- a/packages/tsrx/src/plugin.js
+++ b/packages/tsrx/src/plugin.js
@@ -271,43 +271,6 @@ export function TSRXPlugin(config) {
 				return null;
 			}
 
-			/**
-			 * @param {number} index
-			 */
-			#skipWhitespaceAndComments(index) {
-				while (index < this.input.length) {
-					const ch = this.input.charCodeAt(index);
-					if (ch === 32 || ch === 9 || ch === 10 || ch === 13) {
-						index++;
-					} else if (ch === 47 && this.input.charCodeAt(index + 1) === 42) {
-						const end = this.input.indexOf('*/', index + 2);
-						index = end === -1 ? this.input.length : end + 2;
-					} else if (ch === 47 && this.input.charCodeAt(index + 1) === 47) {
-						index += 2;
-						while (index < this.input.length) {
-							const comment_ch = this.input.charCodeAt(index);
-							if (comment_ch === 10 || comment_ch === 13) break;
-							index++;
-						}
-					} else {
-						break;
-					}
-				}
-				return index;
-			}
-
-			#countFollowingRightBraces() {
-				let index = this.end;
-				let count = 0;
-				while (index < this.input.length) {
-					index = this.#skipWhitespaceAndComments(index);
-					if (this.input.charCodeAt(index) !== 125) break;
-					count++;
-					index++;
-				}
-				return count;
-			}
-
 			#isInsideComponent() {
 				return this.#componentDepth > 0;
 			}
@@ -366,10 +329,99 @@ export function TSRXPlugin(config) {
 				}
 			}
 
-			#popTokenContextsAfterTemplateExpressionElement() {
+			/**
+			 * @param {number} index
+			 * @returns {number}
+			 */
+			#skipWhitespaceAndComments(index) {
+				while (index < this.input.length) {
+					const ch = this.input.charCodeAt(index);
+					if (ch === 32 || ch === 9 || ch === 10 || ch === 13) {
+						index++;
+					} else if (ch === 47 && this.input.charCodeAt(index + 1) === 42) {
+						const end = this.input.indexOf('*/', index + 2);
+						index = end === -1 ? this.input.length : end + 2;
+					} else if (ch === 47 && this.input.charCodeAt(index + 1) === 47) {
+						index += 2;
+						while (index < this.input.length) {
+							const comment_ch = this.input.charCodeAt(index);
+							if (comment_ch === 10 || comment_ch === 13) break;
+							index++;
+						}
+					} else {
+						break;
+					}
+				}
+				return index;
+			}
+
+			/** @returns {number} */
+			#countFollowingRightBraces() {
+				let index = this.end;
+				let count = 0;
+				while (index < this.input.length) {
+					index = this.#skipWhitespaceAndComments(index);
+					if (this.input.charCodeAt(index) !== 125) break;
+					count++;
+					index++;
+				}
+				return count;
+			}
+
+			/**
+			 * @param {AST.Tsx | AST.Tsrx | AST.TsxCompat} node
+			 * @returns {boolean}
+			 */
+			#hasDirectStatementChild(node) {
+				return node.children?.some(
+					(child) => child.type.endsWith('Statement') || child.type === 'VariableDeclaration',
+				);
+			}
+
+			/**
+			 * @param {AST.Tsx | AST.Tsrx | AST.TsxCompat} node
+			 */
+			#popTokenContextsAfterTemplateExpressionElement(node) {
 				const context_index = this.context.length - 1;
 				const following_right_braces =
-					this.type === tt.braceR ? this.#countFollowingRightBraces() : 0;
+					this.type === tt.braceR || this.type === tt.comma ? this.#countFollowingRightBraces() : 0;
+				let expression_contexts_before_template = 0;
+				for (let index = context_index - 2; this.context[index] === b_expr; index--) {
+					expression_contexts_before_template++;
+				}
+
+				// Expression-bodied <tsrx> props can leave an extra statement or
+				// expression context before a following object-property comma.
+				// Statement-bodied templates (`return`, `if`, `switch`, etc.) need
+				// the older JSX-expression cleanup below instead.
+				if (
+					this.type === tt.comma &&
+					this.context[context_index] === b_stat &&
+					this.context[context_index - 1] === tstc.tc_expr &&
+					(expression_contexts_before_template === 2 || following_right_braces > 1) &&
+					!this.#hasDirectStatementChild(node)
+				) {
+					if (following_right_braces > 1 && expression_contexts_before_template > 1) {
+						this.context.splice(context_index - 2, expression_contexts_before_template - 1);
+					}
+					this.context.pop();
+					this.exprAllowed = false;
+					return;
+				}
+
+				if (
+					this.type === tt.comma &&
+					this.context[context_index] === b_expr &&
+					this.context[context_index - 1] === b_expr &&
+					!this.#hasDirectStatementChild(node)
+				) {
+					if (expression_contexts_before_template === 0) {
+						this.context.push(b_expr);
+					}
+					this.exprAllowed = false;
+					return;
+				}
+
 				if (
 					this.context[context_index] === b_stat &&
 					this.context[context_index - 1] === tstc.tc_expr
@@ -2016,7 +2068,9 @@ export function TSRXPlugin(config) {
 					const parsed = /** @type {import('estree-jsx').JSXElement} */ (
 						/** @type {unknown} */ (this.parseElement())
 					);
-					this.#popTokenContextsAfterTemplateExpressionElement();
+					this.#popTokenContextsAfterTemplateExpressionElement(
+						/** @type {AST.Tsx | AST.Tsrx | AST.TsxCompat} */ (/** @type {unknown} */ (parsed)),
+					);
 					return parsed;
 				}
 

--- a/packages/tsrx/src/plugin.js
+++ b/packages/tsrx/src/plugin.js
@@ -382,75 +382,66 @@ export function TSRXPlugin(config) {
 			 * @param {AST.Tsx | AST.Tsrx | AST.TsxCompat} node
 			 */
 			#popTokenContextsAfterTemplateExpressionElement(node) {
-				const context_index = this.context.length - 1;
-				const following_right_braces =
-					this.type === tt.braceR || this.type === tt.comma ? this.#countFollowingRightBraces() : 0;
-				let expression_contexts_before_template = 0;
-				for (let index = context_index - 2; this.context[index] === b_expr; index--) {
-					expression_contexts_before_template++;
-				}
+				const ctx = this.context;
+				const ci = ctx.length - 1;
+				const top = ctx[ci];
+				const second = ctx[ci - 1];
 
-				// Expression-bodied <tsrx> props can leave an extra statement or
-				// expression context before a following object-property comma.
-				// Statement-bodied templates (`return`, `if`, `switch`, etc.) need
-				// the older JSX-expression cleanup below instead.
-				if (
-					this.type === tt.comma &&
-					this.context[context_index] === b_stat &&
-					this.context[context_index - 1] === tstc.tc_expr &&
-					(expression_contexts_before_template === 2 || following_right_braces > 1) &&
-					!this.#hasDirectStatementChild(node)
-				) {
-					if (following_right_braces > 1 && expression_contexts_before_template > 1) {
-						this.context.splice(context_index - 2, expression_contexts_before_template - 1);
+				// Expression-bodied templates (no statement child) followed by `,`
+				// in an object/array literal need surgical fixups; statement-bodied
+				// templates fall through to the JSX-expression-container strip.
+				const has_stmt_child = this.#hasDirectStatementChild(node);
+				if (this.type === tt.comma && !has_stmt_child) {
+					// Tail `..., (b_expr)+, tc_expr, b_stat`: the JSX expression
+					// container leaks an extra `tc_expr, b_stat`. Pop them, and if
+					// the JSX container also closes immediately (`}}` ahead), drop
+					// one of the doubled-up `b_expr` contexts too.
+					if (top === b_stat && second === tstc.tc_expr) {
+						let expr_count = 0;
+						for (let i = ci - 2; ctx[i] === b_expr; i--) expr_count++;
+						const following_braces = this.#countFollowingRightBraces();
+						if (expr_count === 2 || following_braces > 1) {
+							if (following_braces > 1 && expr_count > 1) {
+								ctx.splice(ci - 2, expr_count - 1);
+							}
+							ctx.pop();
+							this.exprAllowed = false;
+							return;
+						}
 					}
-					this.context.pop();
-					this.exprAllowed = false;
-					return;
-				}
-
-				if (
-					this.type === tt.comma &&
-					this.context[context_index] === b_expr &&
-					this.context[context_index - 1] === b_expr &&
-					!this.#hasDirectStatementChild(node)
-				) {
-					if (expression_contexts_before_template === 0) {
-						this.context.push(b_expr);
+					// Tail `..., b_expr, b_expr` for fragments inside an array or
+					// object literal: re-arm expression mode so the next item
+					// parses as an expression value, not a JSX child. If the
+					// surrounding b_expr chain has already been consumed, push
+					// one back so the subsequent item still has a literal context.
+					if (top === b_expr && second === b_expr) {
+						if (ctx[ci - 2] !== b_expr) {
+							ctx.push(b_expr);
+						}
+						this.exprAllowed = false;
+						return;
 					}
-					this.exprAllowed = false;
+				}
+
+				// Inside `{<tsrx>...</tsrx>}` JSX expression container — strip
+				// both the leaked `b_stat` and the container's `tc_expr`.
+				if (top === b_stat && second === tstc.tc_expr) {
+					ctx.length = ci - 1;
 					return;
 				}
 
-				if (
-					this.context[context_index] === b_stat &&
-					this.context[context_index - 1] === tstc.tc_expr
-				) {
-					this.context.length = context_index - 1;
-					return;
-				}
-
-				// When a native <tsrx> expression ends immediately before `}}`, the
-				// first brace can belong to an inner callback/object body, not the
-				// surrounding JSX expression container.
-				if (
-					this.type === tt.braceR &&
-					this.context[context_index] === b_stat &&
-					this.context[context_index - 1] === b_expr &&
-					following_right_braces === 1
-				) {
-					this.context.length = context_index;
-					return;
-				}
-
+				// Closing token after the template at expression position. For `}`
+				// only pop if it actually closes this `b_expr` — otherwise the
+				// brace targets an inner callback/object body that should pop it
+				// naturally on the next token step.
 				if (
 					(this.type === tt.braceR &&
-						this.context[context_index] === b_expr &&
-						(following_right_braces === 0 || this.context[context_index - 1] === b_expr)) ||
-					(this.type === tt.parenR && this.context[context_index]?.token === '(') ||
-					(this.type === tt.bracketR && this.context[context_index]?.token === '[')
+						top === b_expr &&
+						(this.#countFollowingRightBraces() === 0 || second === b_expr)) ||
+					(this.type === tt.parenR && top?.token === '(') ||
+					(this.type === tt.bracketR && top?.token === '[')
 				) {
-					this.context.pop();
+					ctx.pop();
 					this.exprAllowed = false;
 				}
 			}

--- a/packages/tsrx/src/plugin.js
+++ b/packages/tsrx/src/plugin.js
@@ -271,6 +271,43 @@ export function TSRXPlugin(config) {
 				return null;
 			}
 
+			/**
+			 * @param {number} index
+			 */
+			#skipWhitespaceAndComments(index) {
+				while (index < this.input.length) {
+					const ch = this.input.charCodeAt(index);
+					if (ch === 32 || ch === 9 || ch === 10 || ch === 13) {
+						index++;
+					} else if (ch === 47 && this.input.charCodeAt(index + 1) === 42) {
+						const end = this.input.indexOf('*/', index + 2);
+						index = end === -1 ? this.input.length : end + 2;
+					} else if (ch === 47 && this.input.charCodeAt(index + 1) === 47) {
+						index += 2;
+						while (index < this.input.length) {
+							const comment_ch = this.input.charCodeAt(index);
+							if (comment_ch === 10 || comment_ch === 13) break;
+							index++;
+						}
+					} else {
+						break;
+					}
+				}
+				return index;
+			}
+
+			#countFollowingRightBraces() {
+				let index = this.end;
+				let count = 0;
+				while (index < this.input.length) {
+					index = this.#skipWhitespaceAndComments(index);
+					if (this.input.charCodeAt(index) !== 125) break;
+					count++;
+					index++;
+				}
+				return count;
+			}
+
 			#isInsideComponent() {
 				return this.#componentDepth > 0;
 			}
@@ -331,6 +368,8 @@ export function TSRXPlugin(config) {
 
 			#popTokenContextsAfterTemplateExpressionElement() {
 				const context_index = this.context.length - 1;
+				const following_right_braces =
+					this.type === tt.braceR ? this.#countFollowingRightBraces() : 0;
 				if (
 					this.context[context_index] === b_stat &&
 					this.context[context_index - 1] === tstc.tc_expr
@@ -339,8 +378,23 @@ export function TSRXPlugin(config) {
 					return;
 				}
 
+				// When a native <tsrx> expression ends immediately before `}}`, the
+				// first brace can belong to an inner callback/object body, not the
+				// surrounding JSX expression container.
 				if (
-					(this.type === tt.braceR && this.context[context_index] === b_expr) ||
+					this.type === tt.braceR &&
+					this.context[context_index] === b_stat &&
+					this.context[context_index - 1] === b_expr &&
+					following_right_braces === 1
+				) {
+					this.context.length = context_index;
+					return;
+				}
+
+				if (
+					(this.type === tt.braceR &&
+						this.context[context_index] === b_expr &&
+						(following_right_braces === 0 || this.context[context_index - 1] === b_expr)) ||
 					(this.type === tt.parenR && this.context[context_index]?.token === '(') ||
 					(this.type === tt.bracketR && this.context[context_index]?.token === '[')
 				) {

--- a/packages/tsrx/tests/shared/compile.js
+++ b/packages/tsrx/tests/shared/compile.js
@@ -86,6 +86,27 @@ export function runSharedCompileDiagnosticsTests({ compile_to_volar_mappings, na
 			expect(result.code).toContain('bySwitch: (role) => (() => {');
 			expect(result.code).not.toContain('return null;');
 		});
+
+		it('parses native TSRX callback returns in JSX props without semicolons', () => {
+			const result = compile_to_volar_mappings(
+				`class Foo {
+					bar() {
+						return <List
+							render={(item) => {
+								return <tsrx>
+									<span>{item.name}</span>
+								</tsrx>
+							}}
+						/>
+					}
+				}`,
+				'App.tsrx',
+			);
+
+			expect(result.errors).toEqual([]);
+			expect(result.code).not.toContain('<tsrx>');
+			expect(result.code).toContain('item.name');
+		});
 	});
 }
 
@@ -1507,6 +1528,82 @@ export function optionalFn(bar: string, baz?: string) {
 
 			expect(code).toContain('{"Item"}');
 			expect(code).not.toContain('<tsrx>');
+		});
+
+		it('lowers native TSRX template fragments returned from callback props without semicolons', () => {
+			const { code } = compile(
+				`class Foo {
+					bar() {
+						return <List
+							render={(item) => {
+								return <tsrx>
+									<span>{item.name}</span>
+								</tsrx>
+							}}
+						/>
+					}
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('item.name');
+			expect(code).not.toContain('<tsrx>');
+		});
+
+		it('lowers native TSRX template fragments in returned object props without semicolons', () => {
+			const { code } = compile(
+				`class Foo {
+					bar() {
+						return <List
+							render={(item) => {
+								return {
+									child: <tsrx>
+										<span>{item.name}</span>
+									</tsrx>
+								}
+							}}
+						/>
+					}
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('item.name');
+			expect(code).not.toContain('<tsrx>');
+		});
+
+		it('preserves JSX parser state across comments after semicolon-free TSRX returns', () => {
+			const cases = [
+				`class Foo {
+					bar() {
+						return <List
+							render={(item) => {
+								return <tsrx>
+									<span>{item.name}</span>
+								</tsrx> /* block comment */
+							}}
+						/>
+					}
+				}`,
+				`class Foo {
+					bar() {
+						return <List
+							render={(item) => {
+								return <tsrx>
+									<span>{item.name}</span>
+								</tsrx> // line comment
+							}}
+						/>
+					}
+				}`,
+			];
+
+			for (const source of cases) {
+				const { code } = compile(source, 'App.tsrx');
+
+				expect(code).toContain('item.name');
+				expect(code).not.toContain('<tsrx>');
+			}
 		});
 
 		it('keeps return-value branches in native TSRX callback props as plain conditionals', () => {

--- a/packages/tsrx/tests/shared/compile.js
+++ b/packages/tsrx/tests/shared/compile.js
@@ -1572,6 +1572,98 @@ export function optionalFn(bar: string, baz?: string) {
 			expect(code).not.toContain('<tsrx>');
 		});
 
+		it('lowers native TSRX template fragments in nested render props without trailing commas', () => {
+			const cases = [
+				`class Foo {
+					bar() {
+						return <Page
+							params={{
+								details: {
+									render: () => <tsrx>
+										<div>"nested"</div>
+									</tsrx>
+								}
+							}}
+						/>
+					}
+				}`,
+				`class Foo {
+					bar() {
+						return <Page
+							params={{
+								details: {
+									render: () => <tsrx>
+										<div>"nested trailing comma"</div>
+									</tsrx>,
+								},
+							}}
+						/>
+					}
+				}`,
+			];
+
+			for (const source of cases) {
+				const { code } = compile(source, 'App.tsrx');
+
+				expect(code).toContain('nested');
+				expect(code).not.toContain('<tsrx>');
+			}
+		});
+
+		it('lowers native TSRX template fragments in top-level render props', () => {
+			const cases = [
+				[
+					`class Foo {
+					bar() {
+						return <Page
+							params={{
+								render: () => <tsrx>
+									<div>"top"</div>
+								</tsrx>,
+							}}
+						/>
+					}
+				}`,
+					'top',
+				],
+				[
+					`class Foo {
+					bar() {
+						return <Page
+							params={{
+								render: (icon: () => JSX.Element) => <tsrx>
+									<div>"typed top"</div>
+								</tsrx>,
+							}}
+						/>
+					}
+				}`,
+					'typed top',
+				],
+				[
+					`class Foo {
+					bar() {
+						return <Page
+							params={{
+								render: () => <tsrx>
+									return [<>View</>];
+								</tsrx>,
+							}}
+						/>
+					}
+				}`,
+					'View',
+				],
+			];
+
+			for (const [source, expected] of cases) {
+				const { code } = compile(source, 'App.tsrx');
+
+				expect(code).toContain(expected);
+				expect(code).not.toContain('<tsrx>');
+			}
+		});
+
 		it('preserves JSX parser state across comments after semicolon-free TSRX returns', () => {
 			const cases = [
 				`class Foo {
@@ -1604,6 +1696,126 @@ export function optionalFn(bar: string, baz?: string) {
 				expect(code).toContain('item.name');
 				expect(code).not.toContain('<tsrx>');
 			}
+		});
+
+		it('lowers native TSRX template fragments from typed nested render props', () => {
+			const cases = [
+				`class Foo {
+					bar() {
+						return <Page
+							params={{
+								details: {
+									render: (icon: () => JSX.Element) => <tsrx>
+										<div>"typed"</div>
+									</tsrx>,
+								},
+							}}
+						/>
+					}
+				}`,
+				`class Foo {
+					bar() {
+						return <Page
+							params={{
+								details: {
+									render: (tag: string, className: string, icon: () => JSX.Element) => <tsrx>
+										<div>"typed trailing comma"</div>
+									</tsrx>,
+								},
+							}}
+						/>
+					}
+				}`,
+			];
+
+			for (const source of cases) {
+				const { code } = compile(source, 'App.tsrx');
+
+				expect(code).toContain('typed');
+				expect(code).not.toContain('<tsrx>');
+			}
+		});
+
+		it('lowers dynamic native TSRX tags from typed nested render props', () => {
+			const { code } = compile(
+				`class Foo {
+					bar() {
+						return <Page
+							params={{
+								details: {
+									render: (tag: string, className: string, icon: () => JSX.Element) => <tsrx>
+										<@tag class={\`\${className}\${icon ? 'has-icon' : ''}\`}>
+											if (icon) {
+												icon();
+											}
+										</@tag>
+									</tsrx>,
+								},
+							}}
+						/>
+					}
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('className');
+			expect(code).toContain('has-icon');
+			expect(code).toContain('icon()');
+			expect(code).not.toContain('<tsrx>');
+		});
+
+		it('lowers native TSRX templates in complex nested params objects', () => {
+			const { code } = compile(
+				`class Foo {
+					bar() {
+						return <Page
+							params={{
+								title: 'Welcome',
+								header: {
+									class: 'foo',
+									children: <><h1>Big things are coming!</h1></>,
+								},
+								content: <><p>Lorem ipsum...</p></>,
+								menuItems: [
+									<><span>Copy</span></>,
+									<><span>Cut</span></>,
+									<><span>Delete</span></>,
+								],
+								menuAlt: (isAdmin) => <tsrx>
+									if (isAdmin) {
+										return [<>Delete</>, <>Edit</>];
+									} else {
+										return [<>View</>];
+									}
+								</tsrx>,
+								details: {
+									label: {
+										class: 'custom',
+										children: [<>Shipping & returns</>],
+									},
+									leadingIcon: { children: <>icon</> },
+								},
+								details2: {
+									render: (tag: string, className: string, icon: () => JSX.Element) => <tsrx>
+										<@tag class={\`\${className}\${icon ? 'has-icon' : ''}\`}>
+											if (icon) {
+												icon();
+											}
+										</@tag>
+									</tsrx>,
+								},
+							}}
+						/>
+					}
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('Welcome');
+			expect(code).toContain('isAdmin');
+			expect(code).toContain('className');
+			expect(code).toContain('has-icon');
+			expect(code).not.toContain('<tsrx>');
 		});
 
 		it('keeps return-value branches in native TSRX callback props as plain conditionals', () => {


### PR DESCRIPTION
fixes #1100 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches low-level Acorn/JSX token-context manipulation logic; mistakes could cause subtle parse regressions across JSX/TSRX edge cases. Added tests reduce risk but coverage is necessarily finite for tokenizer state bugs.
> 
> **Overview**
> Fixes parsing/lowering of semicolon-free native `<tsrx>...</tsrx>` returns inside JSX callback props (and nested object/array/fragment contexts) by **preserving and selectively repairing JSX tokenizer state** after template-expression elements.
> 
> The plugin now looks ahead past whitespace/comments and uses the parsed template node shape to decide when to pop/restore `b_expr`/`b_stat`/`tc_expr` contexts (including `}}`-ahead and comma/brace/paren/bracket closers). Adds extensive regression tests covering callback returns without semicolons, nested render props, returned objects, and comments after the closing `</tsrx>`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fa18b2f46304fc824517ce60846c530c5d7d5ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->