### PR TITLE
better catch

### DIFF
--- a/.changeset/empty-pending-fallbacks.md
+++ b/.changeset/empty-pending-fallbacks.md
@@ -1,0 +1,8 @@
+---
+'@tsrx/core': patch
+'@tsrx/react': patch
+'@tsrx/preact': patch
+'@tsrx/ripple': patch
+---
+
+Allow empty `pending {}` blocks in component try statements to render a null fallback.

--- a/packages/ripple/tests/client/try.test.tsrx
+++ b/packages/ripple/tests/client/try.test.tsrx
@@ -12,6 +12,40 @@ import {
 } from 'ripple';
 
 describe('try block with catch and pending', () => {
+	it('renders nothing for an empty pending fallback before resolving', async () => {
+		let resolve_value: (value: string) => void = () => {};
+		const promise = new Promise<string>((resolve) => {
+			resolve_value = resolve;
+		});
+
+		component App() {
+			<span class="before">{'before'}</span>
+			try {
+				let &[data] = trackAsync(() => promise);
+				<p class="resolved">{data}</p>
+			} pending {}
+			<span class="after">{'after'}</span>
+		}
+
+		render(App);
+
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		flushSync();
+
+		expect(container.querySelector('.before')?.textContent).toBe('before');
+		expect(container.querySelector('.after')?.textContent).toBe('after');
+		expect(container.querySelector('.resolved')).toBeNull();
+		expect(container.innerHTML).not.toContain('loading');
+
+		resolve_value('resolved value');
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		flushSync();
+
+		expect(container.querySelector('.resolved')?.textContent).toBe('resolved value');
+		expect(container.querySelector('.before')?.textContent).toBe('before');
+		expect(container.querySelector('.after')?.textContent).toBe('after');
+	});
+
 	it('catch block works when a child throws synchronously', async () => {
 		component App() {
 			try {

--- a/packages/ripple/tests/server/try.test.tsrx
+++ b/packages/ripple/tests/server/try.test.tsrx
@@ -1,6 +1,23 @@
 import { trackAsync } from 'ripple';
 
 describe('try block with catch and pending (server)', () => {
+	it('renders resolved content with an empty pending fallback', async () => {
+		component App() {
+			<span>{'before'}</span>
+			try {
+				let &[data] = trackAsync(() => Promise.resolve('resolved value'));
+				<p>{data}</p>
+			} pending {}
+			<span>{'after'}</span>
+		}
+
+		const { body } = await render(App);
+		expect(body).toContain('before');
+		expect(body).toContain('resolved value');
+		expect(body).toContain('after');
+		expect(body).not.toContain('loading');
+	});
+
 	it('catch block works when component throws before await with pending block', async () => {
 		component ThrowingChild() {
 			throw new Error('sync error');

--- a/packages/tsrx-ripple/src/analyze/index.js
+++ b/packages/tsrx-ripple/src/analyze/index.js
@@ -2029,7 +2029,7 @@ const visitors = {
 
 			context.visit(node.pending, state);
 
-			if (!node.metadata.has_template) {
+			if ((node.pending.body || []).length > 0 && !node.metadata.has_template) {
 				error(
 					'Component try statements must contain a template in their "pending" body. Rendering a pending fallback is required to have a template.',
 					state.analysis.module.filename,

--- a/packages/tsrx-ripple/tests/basic.test.js
+++ b/packages/tsrx-ripple/tests/basic.test.js
@@ -17,6 +17,22 @@ runSharedComponentParamsTests({
 	name: 'ripple',
 });
 
+describe('@tsrx/ripple try pending fallbacks', () => {
+	it('allows empty pending blocks as null fallbacks', () => {
+		const { code } = compile(
+			`component App() {
+				try {
+					<div>{'content'}</div>
+				} pending {}
+			}`,
+			'App.tsrx',
+		);
+
+		expect(code).toContain('_$_.try(');
+		expect(code).toContain('template(`<div>content</div>`');
+	});
+});
+
 describe('@tsrx/ripple named ref props', () => {
 	it('wraps named ref props for components', () => {
 		const { code } = compile(

--- a/packages/tsrx/src/transform/jsx/index.js
+++ b/packages/tsrx/src/transform/jsx/index.js
@@ -4164,7 +4164,7 @@ function try_statement_to_jsx_child(node, transform_context) {
 			);
 		}
 		const pending_body = pending.body || [];
-		if (!pending_body.some(is_jsx_child)) {
+		if (pending_body.length > 0 && !pending_body.some(is_jsx_child)) {
 			error(
 				'Component try statements must contain a template in their "pending" body. Rendering a pending fallback is required to have a template.',
 				transform_context.filename,
@@ -4186,7 +4186,10 @@ function try_statement_to_jsx_child(node, transform_context) {
 	if (pending) {
 		transform_context.needs_suspense = true;
 		const pending_body_nodes = pending.body || [];
-		const fallback_content = statement_body_to_jsx_child(pending_body_nodes, transform_context);
+		const fallback_content =
+			pending_body_nodes.length === 0
+				? to_jsx_expression_container(create_null_literal())
+				: statement_body_to_jsx_child(pending_body_nodes, transform_context);
 
 		result = create_jsx_element(
 			'Suspense',

--- a/packages/tsrx/tests/shared/compile.js
+++ b/packages/tsrx/tests/shared/compile.js
@@ -745,6 +745,22 @@ export function runSharedCompileTests({ compile, name, classAttrName }) {
 		});
 	});
 
+	describe(`[${name}] component try pending fallbacks`, () => {
+		it('allows empty pending blocks as null fallbacks', () => {
+			const { code } = compile(
+				`export component App() {
+					try {
+						<div>{'content'}</div>
+					} pending {}
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('fallback={null}');
+			expect(code).toContain("{'content'}");
+		});
+	});
+
 	describe(`[${name}] TypeScript output`, () => {
 		it('collects unclosed tag diagnostics without loose recovery silence', () => {
 			const result = compile(

--- a/packages/vite-plugin-preact/tests/runtime.test.tsrx
+++ b/packages/vite-plugin-preact/tests/runtime.test.tsrx
@@ -1,3 +1,20 @@
+import { lazy } from 'preact/compat';
+import { act } from 'preact/test-utils';
+
+component ResolvedChild(props: { value: string }) {
+	<p class="resolved">{props.value}</p>
+}
+
+component EmptyPendingSuspenseApp(props: {
+	loader: () => Promise<{ default: typeof ResolvedChild }>;
+}) {
+	const LazyChild = lazy(props.loader);
+
+	try {
+		<LazyChild value="hello" />
+	} pending {}
+}
+
 component ForContinueApp() {
 	const items = ['a', '', 'c'];
 
@@ -129,6 +146,22 @@ component NamedRefObjectApp() {
 }
 
 describe('@tsrx/vite-plugin-preact runtime', () => {
+	it('renders nothing for an empty pending fallback then resolves', async () => {
+		let resolve_fn: (mod: { default: typeof ResolvedChild }) => void;
+		const loader = () => new Promise<{ default: typeof ResolvedChild }>((r) => {
+			resolve_fn = r;
+		});
+
+		await render(EmptyPendingSuspenseApp, { loader });
+		expect(container.innerHTML).toBe('');
+		expect(container.querySelector('.resolved')).toBeNull();
+
+		await act(async () => {
+			resolve_fn!({ default: ResolvedChild });
+		});
+		expect(container.querySelector('.resolved')?.textContent).toBe('hello');
+	});
+
 	it('skips for-of iterations with continue', async () => {
 		await render(ForContinueApp);
 		expect(

--- a/packages/vite-plugin-react/tests/runtime.test.tsrx
+++ b/packages/vite-plugin-react/tests/runtime.test.tsrx
@@ -634,6 +634,12 @@ component SuspenseApp(props: { promise: Promise<string> }) {
 	}
 }
 
+component EmptyPendingSuspenseApp(props: { promise: Promise<string> }) {
+	try {
+		<AsyncChild promise={props.promise} />
+	} pending {}
+}
+
 // ── Try/pending/catch: Suspense + ErrorBoundary ──
 
 component SuspenseErrorApp(props: { promise: Promise<string> }) {
@@ -1338,6 +1344,22 @@ describe('tsrx-react runtime', () => {
 		});
 		expect(text('.resolved')).toBe('hello');
 		expect(container.querySelector('.pending')).toBeNull();
+	});
+
+	it('renders nothing for an empty pending fallback then resolves with use()', async () => {
+		let resolve_fn: (value: string) => void;
+		const promise = new Promise<string>((r) => {
+			resolve_fn = r;
+		});
+
+		await render(EmptyPendingSuspenseApp, { promise });
+		expect(container.innerHTML).toBe('');
+		expect(container.querySelector('.resolved')).toBeNull();
+
+		await act(async () => {
+			resolve_fn('hello');
+		});
+		expect(text('.resolved')).toBe('hello');
 	});
 
 	// ── Try/pending/catch: Suspense + ErrorBoundary ──

--- a/packages/vite-plugin-solid/tests/runtime.test.tsrx
+++ b/packages/vite-plugin-solid/tests/runtime.test.tsrx
@@ -541,6 +541,16 @@ component SuspenseApp(props: { loader: () => Promise<{ default: typeof ResolvedC
 	}
 }
 
+component EmptyPendingSuspenseApp(props: {
+	loader: () => Promise<{ default: typeof ResolvedChild }>;
+}) {
+	const LazyChild = lazy(props.loader);
+
+	try {
+		<LazyChild value="hello" />
+	} pending {}
+}
+
 // ── Try/pending/catch: Loading + Errored ──
 
 component SuspenseErrorApp(props: { loader: () => Promise<{ default: typeof ResolvedChild }> }) {
@@ -1172,6 +1182,22 @@ describe('tsrx-solid runtime', () => {
 		await flush();
 		expect(text('.resolved')).toBe('hello');
 		expect(container.querySelector('.pending')).toBeNull();
+	});
+
+	it('renders nothing for an empty pending fallback then resolves (<Loading> + lazy)', async () => {
+		let resolve_fn: (mod: { default: typeof ResolvedChild }) => void;
+		const loader = () => new Promise<{ default: typeof ResolvedChild }>((r) => {
+			resolve_fn = r;
+		});
+
+		await render(EmptyPendingSuspenseApp, { loader });
+		expect(container.innerHTML).toBe('');
+		expect(container.querySelector('.resolved')).toBeNull();
+
+		resolve_fn!({ default: ResolvedChild });
+		await flush();
+		await flush();
+		expect(text('.resolved')).toBe('hello');
 	});
 
 	// ── Try/pending/catch: Loading + Errored ──


### PR DESCRIPTION
Fixes https://github.com/Ripple-TS/ripple/issues/1087

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches compiler analysis/transform logic that affects how `try/pending` blocks compile across `react`/`preact`/`solid`/`ripple`, so regressions could change rendering behavior at runtime. Change is narrow and covered by new client/server/runtime tests for the empty-fallback case.
> 
> **Overview**
> Allows `try { ... } pending {}` in components to compile and render with a **null pending fallback** instead of erroring.
> 
> Updates both the analyzer (`tsrx-ripple`) and JSX transform (`tsrx`) to only require a pending template when the pending body is non-empty, and to emit `fallback={null}` when the pending block is empty. Adds coverage across Ripple client/server tests plus React/Preact/Solid vite-plugin runtime tests, and publishes patch changesets for `@tsrx/core`, `@tsrx/react`, `@tsrx/preact`, and `@tsrx/ripple`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13a40348dfa1b4f66dbf98bafb79e8f6c78acbd1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->