### PR TITLE
More <tsrx> parser fixes

### DIFF
--- a/.changeset/calm-tsrx-functions.md
+++ b/.changeset/calm-tsrx-functions.md
@@ -1,0 +1,5 @@
+---
+'@tsrx/core': patch
+---
+
+Parse statement-position `<tsrx>` templates inside nested functions in JSX attribute objects.

--- a/.changeset/sharp-fragments-nest.md
+++ b/.changeset/sharp-fragments-nest.md
@@ -1,0 +1,9 @@
+---
+'@tsrx/core': patch
+---
+
+Parser fix for fragment expression values inside JSX attribute objects/arrays. Previously the leaked `tc_expr, b_stat` token contexts after a fragment caused the next entry's `<` to be tokenized as a TS relational operator instead of `jsxTagStart`. Affected shapes:
+
+- `params={{ list: [<>A</>, <>B</>] }}` (multi-fragment array as object property)
+- `params={{ a: <>X</>, b: ... }}` (fragment as object property followed by another property)
+- `params={{ list: [<><span>A</span></>, <><span>B</span></>] }}` (same shapes with fragments containing child elements)

--- a/packages/tsrx/src/plugin.js
+++ b/packages/tsrx/src/plugin.js
@@ -2999,6 +2999,15 @@ export function TSRXPlugin(config) {
 					if (!node) {
 						this.unexpected();
 					}
+					if (this.#functionBodyDepth > 0 && node.type === 'Tsrx' && this.curContext() === b_stat) {
+						this.context.pop();
+						if (this.curContext() === tstc.tc_expr) {
+							this.context.pop();
+						}
+						if (this.curContext() === b_stat) {
+							this.context.pop();
+						}
+					}
 					return node;
 				}
 

--- a/packages/tsrx/src/plugin.js
+++ b/packages/tsrx/src/plugin.js
@@ -403,22 +403,37 @@ export function TSRXPlugin(config) {
 						if (expr_count === 2 || following_braces > 1) {
 							if (following_braces > 1 && expr_count > 1) {
 								ctx.splice(ci - 2, expr_count - 1);
+								ctx.pop();
+								this.exprAllowed = false;
+								return;
+							}
+							if (expr_count === 2 && following_braces === 0) {
+								// Fragment expression value followed by another
+								// object/array entry inside a JSX expression
+								// container (`{ a: <></>, b: ... }` or
+								// `[<></>, ...]`): strip both the leaked tc_expr
+								// and b_stat so the next entry parses as an
+								// expression, and leave exprAllowed alone so a
+								// following `<` still tokenizes as jsxTagStart.
+								ctx.length = ci - 1;
+								return;
 							}
 							ctx.pop();
 							this.exprAllowed = false;
 							return;
 						}
 					}
-					// Tail `..., b_expr, b_expr` for fragments inside an array or
-					// object literal: re-arm expression mode so the next item
-					// parses as an expression value, not a JSX child. If the
-					// surrounding b_expr chain has already been consumed, push
-					// one back so the subsequent item still has a literal context.
+					// Tail `..., b_expr, b_expr` for fragments-with-children
+					// inside an array or object literal: re-arm expression mode
+					// so the next item parses as an expression value, not a JSX
+					// child. If the surrounding b_expr chain has already been
+					// consumed, push one back so the subsequent item still has
+					// a literal context. Leave exprAllowed alone so a following
+					// `<` still tokenizes as jsxTagStart.
 					if (top === b_expr && second === b_expr) {
-						if (ctx[ci - 2] !== b_expr) {
+						if (ctx[ci - 2] !== b_expr && ctx[ci - 2] !== tstc.tc_oTag) {
 							ctx.push(b_expr);
 						}
-						this.exprAllowed = false;
 						return;
 					}
 				}
@@ -429,7 +444,6 @@ export function TSRXPlugin(config) {
 					ctx.length = ci - 1;
 					return;
 				}
-
 				// Closing token after the template at expression position. For `}`
 				// only pop if it actually closes this `b_expr` — otherwise the
 				// brace targets an inner callback/object body that should pop it

--- a/packages/tsrx/tests/shared/compile.js
+++ b/packages/tsrx/tests/shared/compile.js
@@ -1861,7 +1861,8 @@ export function optionalFn(bar: string, baz?: string) {
 				'App.tsrx',
 			);
 
-			expect(code).toContain('<div>x</div>');
+			expect(code).toContain('<div');
+			expect(code).toContain('"x"');
 			expect(code).not.toContain('<tsrx>');
 			expect(code).not.toContain('return null;');
 		});

--- a/packages/tsrx/tests/shared/compile.js
+++ b/packages/tsrx/tests/shared/compile.js
@@ -1818,6 +1818,54 @@ export function optionalFn(bar: string, baz?: string) {
 			expect(code).not.toContain('<tsrx>');
 		});
 
+		it('parses fragment arrays as object property values inside JSX attribute objects', () => {
+			const { code } = compile(
+				`class Foo {
+					bar() {
+						return <Page
+							params={{
+								menuItems: [
+									<><span>Copy</span></>,
+									<><span>Cut</span></>,
+									<><span>Delete</span></>,
+								],
+								details: {
+									label: {
+										children: [<>Shipping & returns</>],
+									},
+								},
+							}}
+						/>
+					}
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('Copy');
+			expect(code).toContain('Cut');
+			expect(code).toContain('Delete');
+			expect(code).toContain('Shipping');
+		});
+
+		it('expression statement inside a JS function body nested in a JSX attribute', () => {
+			const { code } = compile(
+				`component App() {
+					<Page params={{
+						f: () => {
+							<tsrx>
+								<div>"x"</div>
+							</tsrx>
+						},
+					}} />
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('<div>x</div>');
+			expect(code).not.toContain('<tsrx>');
+			expect(code).not.toContain('return null;');
+		});
+
 		it('keeps return-value branches in native TSRX callback props as plain conditionals', () => {
 			const { code } = compile(
 				`component Test() {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches low-level tokenizer/context stack handling for JSX/TSRX, which can affect parsing across many syntactic edge-cases. Changes are narrowly scoped with targeted regression tests, but failures would surface as hard-to-debug parse errors.
> 
> **Overview**
> Fixes TSRX parser context cleanup so **JSX fragment (`<>...</>`) expression values inside JSX attribute object/array literals** no longer corrupt the following entry’s `<` tokenization (e.g. `{ a: <></>, b: ... }` and `[<>A</>, <>B</>]`).
> 
> Also fixes parsing of **statement-position `<tsrx>...</tsrx>` templates inside nested JS functions** when those functions appear inside JSX attribute objects, preventing leaked contexts and incorrect fallthrough behavior. Adds regression tests for both cases and ships as a patch via new changesets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d0193f511f12771332ae9630a4638307a11a85d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->