### PR TITLE
fix(client): handle undefined block.s.start in mount cleanup (#1114)

### DIFF
--- a/.changeset/fix-mount-cleanup-undefined-start.md
+++ b/.changeset/fix-mount-cleanup-undefined-start.md
@@ -1,0 +1,5 @@
+---
+'ripple': patch
+---
+
+Fix `mount()` cleanup throwing `TypeError: Cannot read properties of undefined (reading 'remove')`. A block whose state had an `undefined` start node was skipped by the strict-equality sentinel check in `assign_nodes`, so the cleanup path forwarded `undefined` into `remove_block_dom` and crashed. `assign_nodes` and the `destroy_block` cleanup gate now treat `null` and `undefined` uniformly.

--- a/packages/ripple/src/runtime/internal/client/blocks.js
+++ b/packages/ripple/src/runtime/internal/client/blocks.js
@@ -456,7 +456,7 @@ export function destroy_block(block, remove_dom = true) {
 		(f & HEAD_BLOCK) !== 0
 	) {
 		var s = block.s;
-		if (s !== null) {
+		if (s !== null && s.start != null) {
 			remove_block_dom(s.start, s.end);
 			removed = true;
 		}

--- a/packages/ripple/src/runtime/internal/client/template.js
+++ b/packages/ripple/src/runtime/internal/client/template.js
@@ -23,7 +23,7 @@ export function assign_nodes(start, end) {
 			start,
 			end,
 		};
-	} else if (s.start === null) {
+	} else if (s.start == null) {
 		s.start = start;
 		s.end = end;
 	}

--- a/packages/ripple/tests/client/mount.test.tsrx
+++ b/packages/ripple/tests/client/mount.test.tsrx
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from 'ripple';
+
+describe('mount cleanup', () => {
+	it('cleanup does not throw for a component that renders a DOM element', () => {
+		component Button() {
+			<button type="button">{'Click me'}</button>
+		}
+
+		const target = document.createElement('div');
+		document.body.appendChild(target);
+
+		const cleanup = mount(Button, { target });
+		expect(target.querySelector('button')).toBeTruthy();
+
+		expect(() => cleanup()).not.toThrow();
+		expect(target.querySelector('button')).toBeNull();
+
+		document.body.removeChild(target);
+	});
+});


### PR DESCRIPTION
Fixes #1114.

When a block state is created without DOM nodes assigned yet, `block.s.start` can be `undefined` instead of `null`. The strict-equality sentinel check in `assign_nodes` (`s.start === null`) skipped re-assignment in that case, leaving `s.start` as `undefined`. On cleanup, `destroy_block` then called `remove_block_dom(s.start, s.end)`, and the `while (node !== null)` loop in `remove_block_dom` proceeded with `node = undefined` and crashed on `node.remove()`.

Switched both call sites (`assign_nodes` sentinel check, and the `destroy_block` cleanup gate) to a loose null check (`== null`) so null and undefined are handled identically. Matches the existing guard at `move_block` line 419 in behaviour.

Reproduction is the StackBlitz from the issue: mount any component, call the returned cleanup function, observe the TypeError on main; with the patch, cleanup completes silently.

Added a patch-level changeset for `ripple`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small runtime guard changes to treat `null`/`undefined` start nodes equivalently and a regression test; primary impact is preventing a cleanup crash during unmount.
> 
> **Overview**
> Fixes a `mount()` cleanup crash where a block could carry an `undefined` `s.start` and `destroy_block` would forward it into `remove_block_dom`.
> 
> Updates `assign_nodes` to reassign nodes when `s.start` is *nullish* (`== null`), and tightens the `destroy_block` DOM-removal gate to only call `remove_block_dom` when `s.start` is present. Adds a client test covering `mount()`/cleanup and a patch changeset for `ripple`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d9cf5727019ee6a2a35be2e2a395fe578cc59a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->