### PR TITLE
docs: document tsrx GitHub highlighting workaround

### DIFF
--- a/website-new/docs/troubleshooting.md
+++ b/website-new/docs/troubleshooting.md
@@ -22,6 +22,19 @@ export component TextBrace() {
 
 Read more: [Syntax](/docs/guide/syntax)
 
+## GitHub does not highlight .tsrx files
+
+GitHub does not currently recognize `.tsrx` files as their own language, so
+source files may render without syntax highlighting. To opt into TSX highlighting
+on GitHub, add this rule to your repository's `.gitattributes` file:
+
+```gitattributes
+*.tsrx linguist-language=TSX
+```
+
+This only changes how GitHub displays `.tsrx` files. It does not affect Ripple
+compilation, editor support, or local tooling.
+
 ## Unexpected token `}`. Did you mean `&rbrace;` or `{"}"}`?
 
 If you've verified that you don't have any unclosed braces and are still

--- a/website/docs/troubleshooting.md
+++ b/website/docs/troubleshooting.md
@@ -22,6 +22,19 @@ export component TextBrace() {
 
 Read more: [Syntax](/docs/guide/syntax)
 
+## GitHub does not highlight .tsrx files
+
+GitHub does not currently recognize `.tsrx` files as their own language, so
+source files may render without syntax highlighting. To opt into TSX highlighting
+on GitHub, add this rule to your repository's `.gitattributes` file:
+
+```gitattributes
+*.tsrx linguist-language=TSX
+```
+
+This only changes how GitHub displays `.tsrx` files. It does not affect Ripple
+compilation, editor support, or local tooling.
+
 ## Unexpected token `}`. Did you mean `&rbrace;` or `{"}"}`?
 
 If you've verified that you don't have any unclosed braces and are still


### PR DESCRIPTION
## Summary

- Adds a troubleshooting note for GitHub `.tsrx` syntax highlighting.
- Shows the `.gitattributes` rule users can add to opt into TSX highlighting on GitHub.
- Clarifies that the workaround only affects GitHub rendering, not Ripple compilation, editor support, or local tooling.

Fixes #1022.

## Testing

- `pnpm exec prettier --check website/docs/troubleshooting.md website-new/docs/troubleshooting.md`

## Notes

- `pnpm install` did not complete fully on this Windows machine because the native `grammars/tree-sitter` install requires the Visual Studio C++ toolset.
- `pnpm format:check` currently reports pre-existing formatting warnings across the fresh upstream checkout, so I validated the changed docs files directly with Prettier instead.
- No changeset was added because this is a docs-only change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs-only change; adds guidance for GitHub rendering and does not affect compilation or runtime behavior.
> 
> **Overview**
> Adds a new troubleshooting section documenting that GitHub doesn’t syntax-highlight `.tsrx` files by default and provides a `.gitattributes` `linguist-language=TSX` workaround.
> 
> Applies the same note to both `website/docs/troubleshooting.md` and `website-new/docs/troubleshooting.md`, clarifying it only changes GitHub display behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce43a262aa3b845b75bd8c46d18c3a6611b553b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->