### PR TITLE
nested lazy destructuring for all tsrx targets

### DIFF
--- a/.changeset/petite-knives-wear.md
+++ b/.changeset/petite-knives-wear.md
@@ -1,0 +1,8 @@
+---
+'@tsrx/vue': patch
+'ripple': patch
+'@tsrx/core': patch
+---
+
+Nested lazy destructuring support for all tsrx targets. Ripple already fully
+supported it.

--- a/packages/ripple/tests/server/lazy-destructuring.test.tsrx
+++ b/packages/ripple/tests/server/lazy-destructuring.test.tsrx
@@ -238,79 +238,132 @@ describe('lazy destructuring', () => {
 	});
 
 	describe('nested lazy destructuring', () => {
-		it('supports nested lazy object inside lazy object as component params', async () => {
+		it('preserves nested lazy object access inside lazy object as component params', async () => {
+			let inner_value = 7;
+
 			component Inner(&{ outer: &{ inner } }: { outer: { inner: number } }) {
-				<pre>{inner}</pre>
+				const before = inner;
+				inner_value = 8;
+				<pre>{`${before}-${inner}`}</pre>
 			}
 
 			component Test() {
-				<Inner outer={{ inner: 7 }} />
+				const outer = {
+					get inner() {
+						return inner_value;
+					},
+				};
+				<Inner {outer} />
 			}
 
 			const { body } = await render(Test);
-			expect(body).toBeHtml('<pre>7</pre>');
+			expect(body).toBeHtml('<pre>7-8</pre>');
 		});
 
-		it('supports nested lazy array inside regular object as component params', async () => {
+		it('preserves nested lazy array access inside regular object as component params', async () => {
+			let first_value = 3;
+			let second_value = 4;
+
 			component Inner({ pair: &[first, second] }: { pair: [number, number] }) {
-				<pre>{`${first}-${second}`}</pre>
+				const before = `${first}-${second}`;
+				first_value = 5;
+				second_value = 6;
+				<pre>{`${before}-${first}-${second}`}</pre>
 			}
 
 			component Test() {
-				<Inner pair={[3, 4]} />
+				const pair = [0, 0] as [number, number];
+				Object.defineProperty(pair, 0, { get: () => first_value });
+				Object.defineProperty(pair, 1, { get: () => second_value });
+				<Inner {pair} />
 			}
 
 			const { body } = await render(Test);
-			expect(body).toBeHtml('<pre>3-4</pre>');
+			expect(body).toBeHtml('<pre>3-4-5-6</pre>');
 		});
 
-		it('supports nested lazy object inside lazy array as function params', async () => {
+		it('preserves nested lazy object access inside lazy array as function params', async () => {
 			component Test() {
+				let name_value = 'Alice';
 				function getName(&[&{ name }]: [{ name: string }]) {
-					return name;
+					const before = name;
+					name_value = 'Bob';
+					return `${before}-${name}`;
 				}
-				<pre>{getName([{ name: 'Alice' }])}</pre>
+				const user = {
+					get name() {
+						return name_value;
+					},
+				};
+				<pre>{getName([user])}</pre>
 			}
 
 			const { body } = await render(Test);
-			expect(body).toBeHtml('<pre>Alice</pre>');
+			expect(body).toBeHtml('<pre>Alice-Bob</pre>');
 		});
 
-		it('supports nested lazy array inside lazy array as function params', async () => {
+		it('preserves nested lazy array access inside lazy array as function params', async () => {
 			component Test() {
+				let first_value = 5;
+				let second_value = 6;
 				function getValues(&[&[a, b]]: [[number, number]]) {
-					return `${a}-${b}`;
+					const before = `${a}-${b}`;
+					first_value = 7;
+					second_value = 8;
+					return `${before}-${a}-${b}`;
 				}
-				<pre>{getValues([[5, 6]])}</pre>
+				const pair = [0, 0] as [number, number];
+				Object.defineProperty(pair, 0, { get: () => first_value });
+				Object.defineProperty(pair, 1, { get: () => second_value });
+				<pre>{getValues([pair])}</pre>
 			}
 
 			const { body } = await render(Test);
-			expect(body).toBeHtml('<pre>5-6</pre>');
+			expect(body).toBeHtml('<pre>5-6-7-8</pre>');
 		});
 
-		it('supports three-level lazy object nesting as component params', async () => {
+		it('preserves three-level lazy object access as component params', async () => {
+			let c_value = 42;
+
 			component Inner(&{ a: &{ b: &{ c } } }: { a: { b: { c: number } } }) {
-				<pre>{c}</pre>
+				const before = c;
+				c_value = 43;
+				<pre>{`${before}-${c}`}</pre>
 			}
 
 			component Test() {
-				<Inner a={{ b: { c: 42 } }} />
+				const a = {
+					b: {
+						get c() {
+							return c_value;
+						},
+					},
+				};
+				<Inner {a} />
 			}
 
 			const { body } = await render(Test);
-			expect(body).toBeHtml('<pre>42</pre>');
+			expect(body).toBeHtml('<pre>42-43</pre>');
 		});
 
-		it('supports nested lazy object inside lazy object as function params', async () => {
+		it('preserves nested lazy object access inside lazy object as function params', async () => {
 			component Test() {
+				let inner_value = 11;
 				function getValue(&{ outer: &{ inner } }: { outer: { inner: number } }) {
-					return inner;
+					const before = inner;
+					inner_value = 12;
+					return `${before}-${inner}`;
 				}
-				<pre>{getValue({ outer: { inner: 11 } })}</pre>
+				const outer = {
+					get inner() {
+						return inner_value;
+					},
+				};
+				<pre>{getValue({ outer })}</pre>
 			}
 
 			const { body } = await render(Test);
-			expect(body).toBeHtml('<pre>11</pre>');
+			expect(body).toBeHtml('<pre>11-12</pre>');
 		});
 
 		it(
@@ -331,27 +384,46 @@ describe('lazy destructuring', () => {
 			},
 		);
 
-		it('supports three-level lazy object nesting as function params', async () => {
+		it('preserves three-level lazy object access as function params', async () => {
 			component Test() {
+				let c_value = 99;
 				function getValue(&{ a: &{ b: &{ c } } }: { a: { b: { c: number } } }) {
-					return c;
+					const before = c;
+					c_value = 100;
+					return `${before}-${c}`;
 				}
-				<pre>{getValue({ a: { b: { c: 99 } } })}</pre>
+				const a = {
+					b: {
+						get c() {
+							return c_value;
+						},
+					},
+				};
+				<pre>{getValue({ a })}</pre>
 			}
 
 			const { body } = await render(Test);
-			expect(body).toBeHtml('<pre>99</pre>');
+			expect(body).toBeHtml('<pre>99-100</pre>');
 		});
 
-		it('supports nested lazy object inside lazy object in const declaration', async () => {
+		it('preserves nested lazy object access inside lazy object in const declaration', async () => {
 			component Test() {
-				const data = { outer: { inner: 5 } };
+				let inner_value = 5;
+				const data = {
+					outer: {
+						get inner() {
+							return inner_value;
+						},
+					},
+				};
 				const &{ outer: &{ inner } } = data;
-				<pre>{inner}</pre>
+				const before = inner;
+				inner_value = 6;
+				<pre>{`${before}-${inner}`}</pre>
 			}
 
 			const { body } = await render(Test);
-			expect(body).toBeHtml('<pre>5</pre>');
+			expect(body).toBeHtml('<pre>5-6</pre>');
 		});
 
 		it('supports nested lazy object inside lazy object in let with writeback', async () => {
@@ -404,26 +476,51 @@ describe('lazy destructuring', () => {
 			expect(body).toBeHtml('<pre>30</pre>');
 		});
 
-		it('supports default values inside nested lazy destructuring', async () => {
+		it('preserves default values inside nested lazy destructuring', async () => {
 			component Test() {
-				const data: { outer: { inner?: number } } = { outer: {} };
+				let inner_value: number | undefined;
+				const data: { outer: { inner?: number } } = {
+					outer: {
+						get inner() {
+							return inner_value;
+						},
+					},
+				};
 				const &{ outer: &{ inner = 42 } } = data;
-				<pre>{inner}</pre>
+				const before = inner;
+				inner_value = 43;
+				<pre>{`${before}-${inner}`}</pre>
 			}
 
 			const { body } = await render(Test);
-			expect(body).toBeHtml('<pre>42</pre>');
+			expect(body).toBeHtml('<pre>42-43</pre>');
 		});
 
-		it('supports multiple sibling nested lazy destructures', async () => {
+		it('preserves multiple sibling nested lazy destructures', async () => {
 			component Test() {
-				const data = { a: { x: 1 }, b: { y: 2 } };
+				let x_value = 1;
+				let y_value = 2;
+				const data = {
+					a: {
+						get x() {
+							return x_value;
+						},
+					},
+					b: {
+						get y() {
+							return y_value;
+						},
+					},
+				};
 				const &{ a: &{ x }, b: &{ y } } = data;
-				<pre>{`${x}-${y}`}</pre>
+				const before = `${x}-${y}`;
+				x_value = 3;
+				y_value = 4;
+				<pre>{`${before}-${x}-${y}`}</pre>
 			}
 
 			const { body } = await render(Test);
-			expect(body).toBeHtml('<pre>1-2</pre>');
+			expect(body).toBeHtml('<pre>1-2-3-4</pre>');
 		});
 
 		it('supports multiple sibling nested lazy destructures with writeback', async () => {

--- a/packages/ripple/tests/server/lazy-destructuring.test.tsrx
+++ b/packages/ripple/tests/server/lazy-destructuring.test.tsrx
@@ -140,7 +140,11 @@ describe('lazy destructuring', () => {
 	it(
 		'preserves lazy getter/setter behavior for RestElement nested destructuring in non-lazy component params',
 		async () => {
-			component Inner({ values: [head, ...&{ 0: first_rest, length: rest_length }] }) {
+			component Inner({
+				values: [head, ...&{ 0: first_rest, length: rest_length }],
+			}: {
+				values: number[];
+			}) {
 				const before = `${first_rest}-${rest_length}`;
 				rest_length = 0;
 				<pre>{`${head}-${before}-${first_rest}-${rest_length}`}</pre>
@@ -159,7 +163,11 @@ describe('lazy destructuring', () => {
 		'preserves lazy getter/setter behavior for RestElement nested destructuring in non-lazy function params',
 		async () => {
 			component Test() {
-				function getInfo({ values: [head, ...&{ 0: first_rest, length: rest_length }] }) {
+				function getInfo({
+					values: [head, ...&{ 0: first_rest, length: rest_length }],
+				}: {
+					values: number[];
+				}) {
 					const before = `${first_rest}-${rest_length}`;
 					rest_length = 0;
 					return `${head}-${before}-${first_rest}-${rest_length}`;
@@ -227,5 +235,208 @@ describe('lazy destructuring', () => {
 
 		const { body } = await render(Test);
 		expect(body).toBeHtml('<pre>10-20</pre>');
+	});
+
+	describe('nested lazy destructuring', () => {
+		it('supports nested lazy object inside lazy object as component params', async () => {
+			component Inner(&{ outer: &{ inner } }: { outer: { inner: number } }) {
+				<pre>{inner}</pre>
+			}
+
+			component Test() {
+				<Inner outer={{ inner: 7 }} />
+			}
+
+			const { body } = await render(Test);
+			expect(body).toBeHtml('<pre>7</pre>');
+		});
+
+		it('supports nested lazy array inside regular object as component params', async () => {
+			component Inner({ pair: &[first, second] }: { pair: [number, number] }) {
+				<pre>{`${first}-${second}`}</pre>
+			}
+
+			component Test() {
+				<Inner pair={[3, 4]} />
+			}
+
+			const { body } = await render(Test);
+			expect(body).toBeHtml('<pre>3-4</pre>');
+		});
+
+		it('supports nested lazy object inside lazy array as function params', async () => {
+			component Test() {
+				function getName(&[&{ name }]: [{ name: string }]) {
+					return name;
+				}
+				<pre>{getName([{ name: 'Alice' }])}</pre>
+			}
+
+			const { body } = await render(Test);
+			expect(body).toBeHtml('<pre>Alice</pre>');
+		});
+
+		it('supports nested lazy array inside lazy array as function params', async () => {
+			component Test() {
+				function getValues(&[&[a, b]]: [[number, number]]) {
+					return `${a}-${b}`;
+				}
+				<pre>{getValues([[5, 6]])}</pre>
+			}
+
+			const { body } = await render(Test);
+			expect(body).toBeHtml('<pre>5-6</pre>');
+		});
+
+		it('supports three-level lazy object nesting as component params', async () => {
+			component Inner(&{ a: &{ b: &{ c } } }: { a: { b: { c: number } } }) {
+				<pre>{c}</pre>
+			}
+
+			component Test() {
+				<Inner a={{ b: { c: 42 } }} />
+			}
+
+			const { body } = await render(Test);
+			expect(body).toBeHtml('<pre>42</pre>');
+		});
+
+		it('supports nested lazy object inside lazy object as function params', async () => {
+			component Test() {
+				function getValue(&{ outer: &{ inner } }: { outer: { inner: number } }) {
+					return inner;
+				}
+				<pre>{getValue({ outer: { inner: 11 } })}</pre>
+			}
+
+			const { body } = await render(Test);
+			expect(body).toBeHtml('<pre>11</pre>');
+		});
+
+		it(
+			'supports nested lazy array inside lazy object as function params with writeback',
+			async () => {
+				component Test() {
+					const obj = { pair: [1, 2] as [number, number] };
+					function bump(&{ pair: &[first, second] }: { pair: [number, number] }) {
+						first = first + 10;
+						second = second + 20;
+					}
+					bump(obj);
+					<pre>{`${obj.pair[0]}-${obj.pair[1]}`}</pre>
+				}
+
+				const { body } = await render(Test);
+				expect(body).toBeHtml('<pre>11-22</pre>');
+			},
+		);
+
+		it('supports three-level lazy object nesting as function params', async () => {
+			component Test() {
+				function getValue(&{ a: &{ b: &{ c } } }: { a: { b: { c: number } } }) {
+					return c;
+				}
+				<pre>{getValue({ a: { b: { c: 99 } } })}</pre>
+			}
+
+			const { body } = await render(Test);
+			expect(body).toBeHtml('<pre>99</pre>');
+		});
+
+		it('supports nested lazy object inside lazy object in const declaration', async () => {
+			component Test() {
+				const data = { outer: { inner: 5 } };
+				const &{ outer: &{ inner } } = data;
+				<pre>{inner}</pre>
+			}
+
+			const { body } = await render(Test);
+			expect(body).toBeHtml('<pre>5</pre>');
+		});
+
+		it('supports nested lazy object inside lazy object in let with writeback', async () => {
+			component Test() {
+				const data = { outer: { inner: 5 } };
+				let &{ outer: &{ inner } } = data;
+				inner = 50;
+				<pre>{data.outer.inner}</pre>
+			}
+
+			const { body } = await render(Test);
+			expect(body).toBeHtml('<pre>50</pre>');
+		});
+
+		it('supports nested lazy array inside lazy object in let with writeback', async () => {
+			component Test() {
+				const data = { pair: [1, 2] as [number, number] };
+				let &{ pair: &[first, second] } = data;
+				first = 100;
+				second = 200;
+				<pre>{`${data.pair[0]}-${data.pair[1]}`}</pre>
+			}
+
+			const { body } = await render(Test);
+			expect(body).toBeHtml('<pre>100-200</pre>');
+		});
+
+		it('supports three-level lazy object nesting in let with writeback', async () => {
+			component Test() {
+				const data = { a: { b: { c: 1 } } };
+				let &{ a: &{ b: &{ c } } } = data;
+				c = 999;
+				<pre>{data.a.b.c}</pre>
+			}
+
+			const { body } = await render(Test);
+			expect(body).toBeHtml('<pre>999</pre>');
+		});
+
+		it('supports compound assignment on deeply nested lazy bindings', async () => {
+			component Test() {
+				const data = { a: { b: { c: 5 } } };
+				let &{ a: &{ b: &{ c } } } = data;
+				c += 10;
+				c *= 2;
+				<pre>{data.a.b.c}</pre>
+			}
+
+			const { body } = await render(Test);
+			expect(body).toBeHtml('<pre>30</pre>');
+		});
+
+		it('supports default values inside nested lazy destructuring', async () => {
+			component Test() {
+				const data: { outer: { inner?: number } } = { outer: {} };
+				const &{ outer: &{ inner = 42 } } = data;
+				<pre>{inner}</pre>
+			}
+
+			const { body } = await render(Test);
+			expect(body).toBeHtml('<pre>42</pre>');
+		});
+
+		it('supports multiple sibling nested lazy destructures', async () => {
+			component Test() {
+				const data = { a: { x: 1 }, b: { y: 2 } };
+				const &{ a: &{ x }, b: &{ y } } = data;
+				<pre>{`${x}-${y}`}</pre>
+			}
+
+			const { body } = await render(Test);
+			expect(body).toBeHtml('<pre>1-2</pre>');
+		});
+
+		it('supports multiple sibling nested lazy destructures with writeback', async () => {
+			component Test() {
+				const data = { a: { x: 1 }, b: { y: 2 } };
+				let &{ a: &{ x }, b: &{ y } } = data;
+				x = 11;
+				y = 22;
+				<pre>{`${data.a.x}-${data.b.y}`}</pre>
+			}
+
+			const { body } = await render(Test);
+			expect(body).toBeHtml('<pre>11-22</pre>');
+		});
 	});
 });

--- a/packages/tsrx-solid/src/transform.js
+++ b/packages/tsrx-solid/src/transform.js
@@ -11,9 +11,7 @@ import {
 	setLocation,
 	addJsxSetupDeclaration as add_jsx_setup_declaration,
 	applyLazyTransforms as apply_lazy_transforms,
-	collectLazyBindingsFromComponent as collect_lazy_bindings_from_component,
 	extractJsxSetupDeclarations as extract_jsx_setup_declarations,
-	replaceLazyParams as replace_lazy_params,
 	rewriteLoopContinuesToBareReturns as rewrite_loop_continues_to_bare_returns,
 	isRefPropExpression as is_ref_prop_expression,
 	isInterleavedBody as is_interleaved_body_core,
@@ -237,12 +235,6 @@ function component_to_function_declaration(component, transform_context, walk_he
 	}
 	transform_context.available_bindings = body_bindings;
 
-	// In type-only mode the lazy rewrite is skipped so destructuring patterns
-	// survive into the virtual TSX and TypeScript can flow real types.
-	const lazy_bindings = transform_context.typeOnly
-		? new Map()
-		: collect_lazy_bindings_from_component(params, body, transform_context);
-
 	// Detect top-level early-return patterns such as `if (cond) { return; }`
 	// and `if (cond) { <p />; return; }`.
 	// Solid components run their body once at setup, so an early `return` would
@@ -368,11 +360,7 @@ function component_to_function_declaration(component, transform_context, walk_he
 		statements.push(b.return(build_return_expression(render_nodes) || b.literal(null)));
 	}
 
-	const final_params = lazy_bindings.size > 0 ? replace_lazy_params(params) : params;
-
 	const body_block = b.block(statements);
-	const final_body =
-		lazy_bindings.size > 0 ? apply_lazy_transforms(body_block, lazy_bindings) : body_block;
 
 	/** @type {AST.FunctionDeclaration | AST.FunctionExpression | AST.ArrowFunctionExpression} */
 	let fn;
@@ -380,17 +368,34 @@ function component_to_function_declaration(component, transform_context, walk_he
 	if (component.id) {
 		fn = b.function_declaration(
 			component.id,
-			final_params,
-			final_body,
+			params,
+			body_block,
 			false,
 			component.typeParameters,
 		);
 	} else if (component.metadata?.arrow) {
-		fn = b.arrow(final_params, final_body, false, component.typeParameters);
+		fn = b.arrow(params, body_block, false, component.typeParameters);
 	} else {
-		fn = b.function(null, final_params, final_body, false, component.typeParameters);
+		fn = b.function(null, params, body_block, false, component.typeParameters);
 	}
 	fn.metadata.is_component = true;
+
+	// `preallocate_lazy_ids` stamped `has_lazy_descendants` on the source
+	// `Component` node; the freshly-built `fn` shares the same params/body
+	// subtree, so propagate the flag so the function-handler's early-return
+	// path can fire for non-lazy components.
+	if (/** @type {any} */ (component).metadata?.has_lazy_descendants) {
+		/** @type {any} */ (fn.metadata).has_lazy_descendants = true;
+	}
+
+	// Apply lazy `&{}` / `&[]` rewrites end-to-end via the function-handler in
+	// `apply_lazy_transforms`. Constant-time fast-path for functions whose
+	// subtrees contain no lazy patterns (flagged ahead of time by
+	// `preallocate_lazy_ids`). In type-only mode the rewrite is skipped so
+	// destructuring patterns survive into the virtual TSX.
+	if (!transform_context.typeOnly) {
+		fn = /** @type {typeof fn} */ (apply_lazy_transforms(fn, new Map()));
+	}
 
 	if (fn.type === 'FunctionDeclaration' && fn.id) {
 		fn.id.metadata = /** @type {AST.Identifier['metadata']} */ ({

--- a/packages/tsrx-solid/src/transform.js
+++ b/packages/tsrx-solid/src/transform.js
@@ -366,13 +366,7 @@ function component_to_function_declaration(component, transform_context, walk_he
 	let fn;
 
 	if (component.id) {
-		fn = b.function_declaration(
-			component.id,
-			params,
-			body_block,
-			false,
-			component.typeParameters,
-		);
+		fn = b.function_declaration(component.id, params, body_block, false, component.typeParameters);
 	} else if (component.metadata?.arrow) {
 		fn = b.arrow(params, body_block, false, component.typeParameters);
 	} else {

--- a/packages/tsrx-vue/tests/basic.test.js
+++ b/packages/tsrx-vue/tests/basic.test.js
@@ -5,6 +5,7 @@ import {
 	runSharedCompileDiagnosticsTests,
 	runSharedComponentLoopControlFlowTests,
 	runSharedComponentParamsTests,
+	runSharedNestedLazyDestructuringTests,
 	runSharedSwitchHelperHoistingTests,
 } from '@tsrx/core/test-harness/compile';
 import { runSharedSourceMappingTests } from '@tsrx/core/test-harness/source-mappings';
@@ -27,6 +28,7 @@ runSharedSwitchHelperHoistingTests({
 	name: 'vue',
 	clientHelperShape: 'module-vapor-component',
 });
+runSharedNestedLazyDestructuringTests({ compile, name: 'vue' });
 
 describe('@tsrx/vue basic', () => {
 	it('wraps named component exports in defineVaporComponent', () => {

--- a/packages/tsrx-vue/tests/basic.test.js
+++ b/packages/tsrx-vue/tests/basic.test.js
@@ -28,7 +28,6 @@ runSharedSwitchHelperHoistingTests({
 	name: 'vue',
 	clientHelperShape: 'module-vapor-component',
 });
-runSharedNestedLazyDestructuringTests({ compile, name: 'vue' });
 
 describe('@tsrx/vue basic', () => {
 	it('wraps named component exports in defineVaporComponent', () => {

--- a/packages/tsrx-vue/tests/basic.test.js
+++ b/packages/tsrx-vue/tests/basic.test.js
@@ -5,7 +5,6 @@ import {
 	runSharedCompileDiagnosticsTests,
 	runSharedComponentLoopControlFlowTests,
 	runSharedComponentParamsTests,
-	runSharedNestedLazyDestructuringTests,
 	runSharedSwitchHelperHoistingTests,
 } from '@tsrx/core/test-harness/compile';
 import { runSharedSourceMappingTests } from '@tsrx/core/test-harness/source-mappings';

--- a/packages/tsrx/src/index.js
+++ b/packages/tsrx/src/index.js
@@ -88,6 +88,7 @@ export {
 	is_class_node as isClassNode,
 	is_component_node as isComponentNode,
 	is_function_node as isFunctionNode,
+	is_function_or_component_node as isFunctionOrComponentNode,
 	is_inside_component as isInsideComponent,
 } from './utils/ast.js';
 
@@ -205,11 +206,9 @@ export {
 export {
 	create_lazy_context as createLazyContext,
 	collect_lazy_bindings as collectLazyBindings,
-	collect_lazy_bindings_from_component as collectLazyBindingsFromComponent,
 	collect_lazy_bindings_from_statements as collectLazyBindingsFromStatements,
 	preallocate_lazy_ids as preallocateLazyIds,
 	apply_lazy_transforms as applyLazyTransforms,
-	replace_lazy_params as replaceLazyParams,
 } from './transform/lazy.js';
 export {
 	find_first_top_level_await as findFirstTopLevelAwait,

--- a/packages/tsrx/src/transform/jsx/index.js
+++ b/packages/tsrx/src/transform/jsx/index.js
@@ -34,12 +34,7 @@ import {
 	jsx_id as build_jsx_id,
 } from '../../utils/builders.js';
 import * as b from '../../utils/builders.js';
-import {
-	apply_lazy_transforms,
-	collect_lazy_bindings_from_component,
-	preallocate_lazy_ids,
-	replace_lazy_params,
-} from '../lazy.js';
+import { apply_lazy_transforms, preallocate_lazy_ids } from '../lazy.js';
 import { find_first_top_level_await_in_component_body } from '../await.js';
 import { prepare_stylesheet_for_render, annotate_component_with_hash } from '../scoping.js';
 import {
@@ -50,7 +45,7 @@ import {
 	validate_component_return_statement,
 	validate_component_unsupported_loop_statement,
 } from '../../analyze/validation.js';
-import { get_component_from_path } from '../../utils/ast.js';
+import { get_component_from_path, is_function_or_component_node } from '../../utils/ast.js';
 import {
 	is_interleaved_body as is_interleaved_body_core,
 	is_capturable_jsx_child,
@@ -646,15 +641,6 @@ export function component_to_function_declaration(component, transform_context, 
 	// Collect param bindings from original patterns (lazy patterns still intact).
 	const param_bindings = collect_param_bindings(params);
 
-	// Collect lazy binding info WITHOUT mutating patterns. Stores lazy_id on metadata
-	// for later replacement. Body bindings (count, setCount, etc.) are still in the
-	// original patterns, so collect_statement_bindings during build will find them.
-	// In type-only mode the lazy rewrite is skipped entirely so destructuring
-	// patterns survive into the virtual TSX and TypeScript can flow real types.
-	const lazy_bindings = transform_context.typeOnly
-		? new Map()
-		: collect_lazy_bindings_from_component(params, body, transform_context);
-
 	// Save and set context for this component scope
 	const saved_helper_state = transform_context.helper_state;
 	const saved_bindings = transform_context.available_bindings;
@@ -662,16 +648,7 @@ export function component_to_function_declaration(component, transform_context, 
 	transform_context.available_bindings = new Map(param_bindings);
 
 	const body_statements = build_component_statements(body, transform_context);
-
-	// Replace lazy param patterns with generated identifiers
-	const final_params = lazy_bindings.size > 0 ? replace_lazy_params(params) : params;
-
-	// Wrap body_statements in a BlockStatement so that apply_lazy_transforms
-	// runs collect_block_shadowed_names and detects body-level declarations
-	// (e.g. `const name = ...`) that shadow lazy binding names.
 	const body_block = b.block(body_statements);
-	const final_body =
-		lazy_bindings.size > 0 ? apply_lazy_transforms(body_block, lazy_bindings) : body_block;
 
 	/** @type {AST.FunctionDeclaration | AST.FunctionExpression | AST.ArrowFunctionExpression} */
 	let fn;
@@ -679,17 +656,37 @@ export function component_to_function_declaration(component, transform_context, 
 	if (component.id) {
 		fn = b.function_declaration(
 			component.id,
-			final_params,
-			final_body,
+			params,
+			body_block,
 			is_async_component,
 			component.typeParameters,
 		);
 	} else if (component.metadata?.arrow) {
-		fn = b.arrow(final_params, final_body, is_async_component, component.typeParameters);
+		fn = b.arrow(params, body_block, is_async_component, component.typeParameters);
 	} else {
-		fn = b.function(null, final_params, final_body, is_async_component, component.typeParameters);
+		fn = b.function(null, params, body_block, is_async_component, component.typeParameters);
 	}
 	/** @type {any} */ (fn.metadata).is_component = true;
+
+	// `preallocate_lazy_ids` stamped `has_lazy_descendants` on the source
+	// `Component` node; the freshly-built `fn` shares the same params/body
+	// subtree, so the flag is equally applicable. Propagating it lets
+	// `apply_lazy_transforms` honor its constant-time early-return path.
+	if (/** @type {any} */ (component).metadata?.has_lazy_descendants) {
+		/** @type {any} */ (fn.metadata).has_lazy_descendants = true;
+	}
+
+	// Apply lazy `&{}` / `&[]` rewrites end-to-end: the function-handler in
+	// `apply_lazy_transforms` collects param bindings, merges with body bindings
+	// discovered by the BlockStatement handler, replaces lazy params with their
+	// `__lazyN` ids, and rewrites every reference. Constant-time fast-path for
+	// functions whose subtrees contain no lazy patterns (flagged ahead of time
+	// by `preallocate_lazy_ids`). In type-only mode the rewrite is skipped so
+	// destructuring patterns survive into the virtual TSX and TypeScript can
+	// flow real types.
+	if (!transform_context.typeOnly) {
+		fn = /** @type {typeof fn} */ (apply_lazy_transforms(fn, new Map()));
+	}
 
 	// Restore context
 	transform_context.helper_state = saved_helper_state;
@@ -2689,7 +2686,7 @@ function validate_hook_outer_assignments_in_node(
 		return;
 	}
 
-	if (is_function_like_node(node)) {
+	if (is_function_or_component_node(node)) {
 		return;
 	}
 
@@ -2831,7 +2828,7 @@ function validate_hook_outer_assignments_in_node(
 function validate_hook_callback_outer_mutations(call_node, shadowed_names, transform_context) {
 	const hook_name = get_hook_callee_name(call_node.callee);
 	for (const argument of call_node.arguments || []) {
-		if (!is_function_like_node(argument)) {
+		if (!is_function_or_component_node(argument)) {
 			continue;
 		}
 		const callback_shadowed_names = create_function_like_shadowed_names(argument, shadowed_names);
@@ -2842,21 +2839,6 @@ function validate_hook_callback_outer_mutations(call_node, shadowed_names, trans
 			hook_name,
 		);
 	}
-}
-
-/**
- * @param {any} node
- * @returns {boolean}
- */
-function is_function_like_node(node) {
-	return (
-		node.type === 'FunctionDeclaration' ||
-		node.type === 'FunctionExpression' ||
-		node.type === 'ArrowFunctionExpression' ||
-		// this is just in case but we should already
-		// have a component replaced with a function node
-		node.type === 'Component'
-	);
 }
 
 /**
@@ -2906,7 +2888,7 @@ function validate_hook_callback_outer_mutations_in_node(
 		return;
 	}
 
-	if (is_function_like_node(node)) {
+	if (is_function_or_component_node(node)) {
 		validate_hook_callback_outer_mutations_in_node(
 			node.body,
 			create_function_like_shadowed_names(node, shadowed_names),

--- a/packages/tsrx/src/transform/lazy.js
+++ b/packages/tsrx/src/transform/lazy.js
@@ -1,24 +1,27 @@
 /** @import * as AST from 'estree' */
 
 import * as b from '../utils/builders.js';
+import { is_function_or_component_node } from '../utils/ast.js';
 
 /**
  * Lazy destructuring transform — framework-agnostic.
  *
- * Shared between `@tsrx/react` and `@tsrx/solid`. Walks an AST and rewrites
- * references to names introduced by `&{ ... }` / `&[ ... ]` destructuring
- * patterns into member-expression accesses on a generated source identifier.
+ * Shared between `@tsrx/react`, `@tsrx/preact`, `@tsrx/solid`, and `@tsrx/vue`.
+ * Walks an AST and rewrites references to names introduced by `&{ ... }` /
+ * `&[ ... ]` destructuring patterns into member-expression accesses on a
+ * generated source identifier.
  *
  * Usage:
  *   1. Create a context with `createLazyContext()` (or provide any object with
  *      a `lazy_next_id: number` field).
  *   2. Run `preallocateLazyIds(root, context)` once over the full program to
- *      assign stable `metadata.lazy_id` values to every lazy pattern.
- *   3. For each function/component scope, collect bindings with
- *      `collectLazyBindingsFromComponent(params, body, context)` and pass the
- *      resulting map into `applyLazyTransforms(body, map)`.
- *   4. If a component declares lazy params, pass its params through
- *      `replaceLazyParams(params)` before emitting.
+ *      assign stable `metadata.lazy_id` values to every lazy pattern and to
+ *      flag function-like nodes whose subtree contains any lazy pattern via
+ *      `metadata.has_lazy_descendants`.
+ *   3. After converting components to functions, call `applyLazyTransforms(fn,
+ *      new Map())` on each top-level function. The function-handler walks the
+ *      whole subtree, collects param + body bindings, replaces lazy patterns
+ *      with their generated identifiers, and rewrites every reference.
  *
  * The transform is purely AST-to-AST and has no framework-specific knowledge.
  */
@@ -273,37 +276,6 @@ function collect_lazy_bindings_at(pattern, source_name, build_parent, lazy_bindi
 }
 
 /**
- * Collect lazy bindings from a component's params and top-level body declarations.
- * Mutates each lazy pattern's `metadata.lazy_id` in place (idempotent if already set).
- *
- * @param {any[]} params
- * @param {any[]} body
- * @param {LazyContext} context
- * @returns {Map<string, LazyBinding>}
- */
-export function collect_lazy_bindings_from_component(params, body, context) {
-	/** @type {Map<string, LazyBinding>} */
-	const lazy_bindings = new Map();
-
-	for (const param of params) {
-		visit_topmost_lazy_patterns(param, (lazy) => {
-			if (!lazy.metadata?.lazy_id) {
-				lazy.metadata = { ...lazy.metadata, lazy_id: generate_lazy_id(context) };
-			}
-			collect_lazy_bindings(lazy, lazy.metadata.lazy_id, lazy_bindings);
-		});
-	}
-
-	// VariableDeclaration lazy patterns already have their `lazy_id` assigned
-	// by `preallocate_lazy_ids` (run once over the whole program by the target
-	// transforms), so `collect_lazy_bindings_from_statements` handles them
-	// alongside the expression-statement assignment form.
-	collect_lazy_bindings_from_statements(body, lazy_bindings);
-
-	return lazy_bindings;
-}
-
-/**
  * Collect lazy bindings from statements at the top level of a block. Reads
  * already-allocated `lazy_id` values from pattern metadata. Handles both
  * `let &[x] = ...` variable declarations and statement-level `&[x] = expr;`
@@ -318,7 +290,6 @@ export function collect_lazy_bindings_from_statements(statements, lazy_bindings)
 			for (const declarator of stmt.declarations || []) {
 				visit_topmost_lazy_patterns(declarator.id, (lazy) => {
 					if (!lazy.metadata?.lazy_id) return;
-					if (lazy_bindings_contains(lazy_bindings, lazy)) return;
 					collect_lazy_bindings(lazy, lazy.metadata.lazy_id, lazy_bindings);
 				});
 			}
@@ -333,29 +304,6 @@ export function collect_lazy_bindings_from_statements(statements, lazy_bindings)
 			});
 		}
 	}
-}
-
-/**
- * @param {Map<string, LazyBinding>} lazy_bindings
- * @param {any} pattern
- * @returns {boolean}
- */
-function lazy_bindings_contains(lazy_bindings, pattern) {
-	if (pattern.type === 'ObjectPattern') {
-		for (const prop of pattern.properties || []) {
-			if (prop.type === 'RestElement') continue;
-			const value = prop.value;
-			const actual = value?.type === 'AssignmentPattern' ? value.left : value;
-			if (actual?.type === 'Identifier' && lazy_bindings.has(actual.name)) return true;
-		}
-	} else if (pattern.type === 'ArrayPattern') {
-		for (const element of pattern.elements || []) {
-			if (!element || element.type === 'RestElement') continue;
-			const actual = element.type === 'AssignmentPattern' ? element.left : element;
-			if (actual?.type === 'Identifier' && lazy_bindings.has(actual.name)) return true;
-		}
-	}
-	return false;
 }
 
 /**
@@ -495,6 +443,10 @@ function replace_lazy_in_pattern(pattern, is_top = true) {
  * e.g. `{ pair: &[a, b] }` allocates an id for the inner `&[a, b]`. Idempotent:
  * skips patterns that already have a `lazy_id`.
  *
+ * Also stamps `metadata.has_lazy_descendants = true` on every function-like
+ * node whose subtree contains any lazy pattern, so `apply_lazy_transforms`
+ * can take a constant-time early-return path for purely non-lazy functions.
+ *
  * @param {any} root
  * @param {LazyContext} context
  */
@@ -507,20 +459,23 @@ export function preallocate_lazy_ids(root, context) {
 		});
 	};
 
-	/** @param {any} node */
+	/**
+	 * @param {any} node
+	 * @returns {boolean} true if `node`'s subtree contains any lazy pattern.
+	 */
 	const visit = (node) => {
-		if (!node || typeof node !== 'object') return;
+		if (!node || typeof node !== 'object') return false;
 		if (Array.isArray(node)) {
-			for (const child of node) visit(child);
-			return;
+			let found = false;
+			for (const child of node) {
+				if (visit(child)) found = true;
+			}
+			return found;
 		}
 
-		if (
-			node.type === 'FunctionDeclaration' ||
-			node.type === 'FunctionExpression' ||
-			node.type === 'ArrowFunctionExpression' ||
-			node.type === 'Component'
-		) {
+		const is_function_like = is_function_or_component_node(node);
+
+		if (is_function_like) {
 			for (const param of node.params || []) {
 				assign_id(param?.type === 'AssignmentPattern' ? param.left : param);
 			}
@@ -538,10 +493,19 @@ export function preallocate_lazy_ids(root, context) {
 			assign_id(node.expression.left);
 		}
 
+		let found =
+			(node.type === 'ObjectPattern' || node.type === 'ArrayPattern') && node.lazy === true;
+
 		for (const key of Object.keys(node)) {
 			if (key === 'loc' || key === 'start' || key === 'end' || key === 'metadata') continue;
-			visit(node[key]);
+			if (visit(node[key])) found = true;
 		}
+
+		if (is_function_like && found) {
+			node.metadata = { ...node.metadata, has_lazy_descendants: true };
+		}
+
+		return found;
 	};
 
 	visit(root);
@@ -597,10 +561,20 @@ export function apply_lazy_transforms(node, lazy_bindings) {
 				? new Map([...outer_minus_shadow, ...own_bindings])
 				: outer_minus_shadow;
 
-		if (inner_bindings.size === 0 && !params_changed && !had_lazy_param) return node;
+		if (
+			inner_bindings.size === 0 &&
+			!params_changed &&
+			!had_lazy_param &&
+			!node.metadata?.has_lazy_descendants
+		) {
+			return node;
+		}
 
-		const new_body =
-			inner_bindings.size > 0 ? apply_lazy_transforms(node.body, inner_bindings) : node.body;
+		// Past the early-return: either we have active lazy bindings, lazy
+		// params to replace, defaults referencing outer lazy, or the body
+		// contains lazy descendants the BlockStatement handler will collect.
+		// In every case the body needs to be walked.
+		const new_body = apply_lazy_transforms(node.body, inner_bindings);
 
 		const final_params_src = params_changed ? new_params : node.params;
 		const final_params = had_lazy_param ? replace_lazy_params(final_params_src) : final_params_src;

--- a/packages/tsrx/src/transform/lazy.js
+++ b/packages/tsrx/src/transform/lazy.js
@@ -196,33 +196,60 @@ function set_lazy_param_binding_mappings(lazy_id, pattern) {
  * Collect lazy bindings from a destructuring pattern.
  *
  * For `&{ name, age }` on source `S`, maps `name` → `S.name`, `age` → `S.age`.
- * For `&[a, b]` on source `S`, maps `a` → `S[0]`, `b` → `S[1]`. Handles nested
- * `AssignmentPattern` (default values); skips `RestElement`.
+ * For `&[a, b]` on source `S`, maps `a` → `S[0]`, `b` → `S[1]`. Recurses into
+ * nested `ObjectPattern` / `ArrayPattern` values so that `&{ outer: &{ inner } }`
+ * on source `S` maps `inner` → `S.outer.inner`, and `&{ pair: &[first, second] }`
+ * maps `first` → `S.pair[0]`. Handles `AssignmentPattern` (default values lost,
+ * but the binding still resolves to the member chain). Skips `RestElement`.
  *
  * @param {any} pattern
  * @param {string} source_name
  * @param {Map<string, LazyBinding>} lazy_bindings
  */
 export function collect_lazy_bindings(pattern, source_name, lazy_bindings) {
+	collect_lazy_bindings_at(
+		pattern,
+		source_name,
+		() => create_generated_identifier(source_name),
+		lazy_bindings,
+	);
+}
+
+/**
+ * Walk a destructure pattern and register a `LazyBinding` for each leaf
+ * `Identifier`, where `build_parent` produces the AST expression that reaches
+ * this pattern's value from the synthesized source identifier. Each nested
+ * level composes its accessor onto `build_parent`, so leaves get the full
+ * member chain (e.g. `source.outer.inner` for `&{ outer: &{ inner } }`).
+ *
+ * @param {any} pattern
+ * @param {string} source_name
+ * @param {(reference?: any) => any} build_parent
+ * @param {Map<string, LazyBinding>} lazy_bindings
+ */
+function collect_lazy_bindings_at(pattern, source_name, build_parent, lazy_bindings) {
 	if (pattern.type === 'ObjectPattern') {
 		for (const prop of pattern.properties || []) {
 			if (prop.type === 'RestElement') continue;
 			const value = prop.value;
 			const actual = value.type === 'AssignmentPattern' ? value.left : value;
+			const key = prop.key;
+			const computed = prop.computed || key.type !== 'Identifier';
+
+			/** @type {(reference?: any) => any} */
+			const build_self = (reference) =>
+				b.member(
+					build_parent(),
+					computed || key.type !== 'Identifier'
+						? { ...key }
+						: create_generated_identifier(key.name, reference, reference?.name),
+					computed,
+				);
+
 			if (actual.type === 'Identifier') {
-				const key = prop.key;
-				const computed = prop.computed || key.type !== 'Identifier';
-				lazy_bindings.set(actual.name, {
-					source_name,
-					read: (reference) =>
-						b.member(
-							create_generated_identifier(source_name),
-							computed || key.type !== 'Identifier'
-								? { ...key }
-								: create_generated_identifier(key.name, reference, reference?.name),
-							computed,
-						),
-				});
+				lazy_bindings.set(actual.name, { source_name, read: build_self });
+			} else if (actual.type === 'ObjectPattern' || actual.type === 'ArrayPattern') {
+				collect_lazy_bindings_at(actual, source_name, build_self, lazy_bindings);
 			}
 		}
 	} else if (pattern.type === 'ArrayPattern') {
@@ -231,12 +258,15 @@ export function collect_lazy_bindings(pattern, source_name, lazy_bindings) {
 			if (!element) continue;
 			if (element.type === 'RestElement') continue;
 			const actual = element.type === 'AssignmentPattern' ? element.left : element;
+			const index = i;
+
+			/** @type {() => any} */
+			const build_self = () => b.member(build_parent(), b.literal(index), true);
+
 			if (actual.type === 'Identifier') {
-				const index = i;
-				lazy_bindings.set(actual.name, {
-					source_name,
-					read: () => b.member(create_generated_identifier(source_name), b.literal(index), true),
-				});
+				lazy_bindings.set(actual.name, { source_name, read: build_self });
+			} else if (actual.type === 'ObjectPattern' || actual.type === 'ArrayPattern') {
+				collect_lazy_bindings_at(actual, source_name, build_self, lazy_bindings);
 			}
 		}
 	}
@@ -256,14 +286,12 @@ export function collect_lazy_bindings_from_component(params, body, context) {
 	const lazy_bindings = new Map();
 
 	for (const param of params) {
-		const pattern = param.type === 'AssignmentPattern' ? param.left : param;
-		if ((pattern.type === 'ObjectPattern' || pattern.type === 'ArrayPattern') && pattern.lazy) {
-			const lazy_name = pattern.metadata?.lazy_id || generate_lazy_id(context);
-			if (!pattern.metadata?.lazy_id) {
-				pattern.metadata = { ...pattern.metadata, lazy_id: lazy_name };
+		visit_topmost_lazy_patterns(param, (lazy) => {
+			if (!lazy.metadata?.lazy_id) {
+				lazy.metadata = { ...lazy.metadata, lazy_id: generate_lazy_id(context) };
 			}
-			collect_lazy_bindings(pattern, lazy_name, lazy_bindings);
-		}
+			collect_lazy_bindings(lazy, lazy.metadata.lazy_id, lazy_bindings);
+		});
 	}
 
 	// VariableDeclaration lazy patterns already have their `lazy_id` assigned
@@ -288,30 +316,21 @@ export function collect_lazy_bindings_from_statements(statements, lazy_bindings)
 	for (const stmt of statements || []) {
 		if (stmt.type === 'VariableDeclaration') {
 			for (const declarator of stmt.declarations || []) {
-				const pattern = declarator.id;
-				if (
-					(pattern?.type === 'ObjectPattern' || pattern?.type === 'ArrayPattern') &&
-					pattern.lazy &&
-					pattern.metadata?.lazy_id &&
-					!lazy_bindings_contains(lazy_bindings, pattern)
-				) {
-					collect_lazy_bindings(pattern, pattern.metadata.lazy_id, lazy_bindings);
-				}
+				visit_topmost_lazy_patterns(declarator.id, (lazy) => {
+					if (!lazy.metadata?.lazy_id) return;
+					if (lazy_bindings_contains(lazy_bindings, lazy)) return;
+					collect_lazy_bindings(lazy, lazy.metadata.lazy_id, lazy_bindings);
+				});
 			}
 		} else if (
 			stmt.type === 'ExpressionStatement' &&
 			stmt.expression?.type === 'AssignmentExpression' &&
-			stmt.expression.operator === '=' &&
-			(stmt.expression.left?.type === 'ObjectPattern' ||
-				stmt.expression.left?.type === 'ArrayPattern') &&
-			stmt.expression.left.lazy &&
-			stmt.expression.left.metadata?.lazy_id
+			stmt.expression.operator === '='
 		) {
-			collect_lazy_bindings(
-				stmt.expression.left,
-				stmt.expression.left.metadata.lazy_id,
-				lazy_bindings,
-			);
+			visit_topmost_lazy_patterns(stmt.expression.left, (lazy) => {
+				if (!lazy.metadata?.lazy_id) return;
+				collect_lazy_bindings(lazy, lazy.metadata.lazy_id, lazy_bindings);
+			});
 		}
 	}
 }
@@ -340,9 +359,141 @@ function lazy_bindings_contains(lazy_bindings, pattern) {
 }
 
 /**
+ * Walk a destructure pattern tree, calling `visit` on every *topmost-lazy*
+ * descendant — a lazy `ObjectPattern` / `ArrayPattern` with no lazy ancestor
+ * within the same pattern tree. Descends through `AssignmentPattern`,
+ * `RestElement`, and non-lazy `ObjectPattern` / `ArrayPattern`. Stops at lazy
+ * patterns: their inner leaves are reached via accessor chains rooted at the
+ * lazy pattern's synthesized id, not by further descent here.
+ *
+ * @param {any} pattern
+ * @param {(node: any) => void} visit
+ */
+function visit_topmost_lazy_patterns(pattern, visit) {
+	if (!pattern || typeof pattern !== 'object') return;
+	if (pattern.type === 'AssignmentPattern') {
+		visit_topmost_lazy_patterns(pattern.left, visit);
+		return;
+	}
+	if (pattern.type === 'RestElement') {
+		visit_topmost_lazy_patterns(pattern.argument, visit);
+		return;
+	}
+	if (pattern.type !== 'ObjectPattern' && pattern.type !== 'ArrayPattern') return;
+
+	if (pattern.lazy) {
+		visit(pattern);
+		return;
+	}
+
+	if (pattern.type === 'ObjectPattern') {
+		for (const prop of pattern.properties || []) {
+			if (prop.type === 'RestElement') visit_topmost_lazy_patterns(prop.argument, visit);
+			else visit_topmost_lazy_patterns(prop.value, visit);
+		}
+	} else {
+		for (const element of pattern.elements || []) {
+			if (element) visit_topmost_lazy_patterns(element, visit);
+		}
+	}
+}
+
+/**
+ * Build the replacement identifier for a lazy pattern. When `is_top` is true
+ * (the pattern is itself a function parameter) we attach the original
+ * `typeAnnotation`, synthesize an object-shaped annotation for untyped object
+ * params so TypeScript sees prop names, and register source-mapping info.
+ * Nested replacements (inside a non-lazy outer destructure) can't carry an
+ * inline type annotation — that's not valid syntax — so they get a plain
+ * identifier with just source-range info.
+ *
+ * @param {any} pattern
+ * @param {boolean} is_top
+ * @returns {any}
+ */
+function build_lazy_id_for_pattern(pattern, is_top) {
+	const pattern_range = get_lazy_pattern_mapping_range(pattern);
+	const lazy_id = pattern_range
+		? create_generated_identifier(
+				pattern.metadata.lazy_id,
+				pattern_range,
+				undefined,
+				pattern_range.source_length,
+			)
+		: create_generated_identifier(pattern.metadata.lazy_id);
+	if (!is_top) return lazy_id;
+	if (pattern.typeAnnotation) {
+		lazy_id.typeAnnotation = pattern.typeAnnotation;
+	} else {
+		const type_annotation = create_lazy_object_type_annotation(pattern);
+		if (type_annotation) lazy_id.typeAnnotation = type_annotation;
+	}
+	set_lazy_param_binding_mappings(lazy_id, pattern);
+	return lazy_id;
+}
+
+/**
+ * Walk a destructure pattern tree and replace every topmost-lazy pattern with
+ * its synthesized id identifier. Non-lazy outer patterns are preserved so a
+ * source like `{ pair: &[a, b] }` becomes `{ pair: __lazy0 }`. The `is_top`
+ * flag is true only when the caller is invoking on a position that itself
+ * binds a single param (so a directly-lazy pattern can carry param-level type
+ * info); recursive descent into child patterns passes `false`.
+ *
+ * @param {any} pattern
+ * @param {boolean} [is_top]
+ * @returns {any}
+ */
+function replace_lazy_in_pattern(pattern, is_top = true) {
+	if (!pattern || typeof pattern !== 'object') return pattern;
+
+	if (pattern.type === 'AssignmentPattern') {
+		const new_left = replace_lazy_in_pattern(pattern.left, is_top);
+		return new_left === pattern.left ? pattern : { ...pattern, left: new_left };
+	}
+	if (pattern.type === 'RestElement') {
+		const new_arg = replace_lazy_in_pattern(pattern.argument, false);
+		return new_arg === pattern.argument ? pattern : { ...pattern, argument: new_arg };
+	}
+	if (pattern.type !== 'ObjectPattern' && pattern.type !== 'ArrayPattern') return pattern;
+
+	if (pattern.lazy && pattern.metadata?.lazy_id) {
+		return build_lazy_id_for_pattern(pattern, is_top);
+	}
+
+	if (pattern.type === 'ObjectPattern') {
+		let changed = false;
+		const new_properties = (pattern.properties || []).map((/** @type {any} */ prop) => {
+			if (prop.type === 'RestElement') {
+				const new_arg = replace_lazy_in_pattern(prop.argument, false);
+				if (new_arg === prop.argument) return prop;
+				changed = true;
+				return { ...prop, argument: new_arg };
+			}
+			const new_value = replace_lazy_in_pattern(prop.value, false);
+			if (new_value === prop.value) return prop;
+			changed = true;
+			return { ...prop, value: new_value };
+		});
+		return changed ? { ...pattern, properties: new_properties } : pattern;
+	}
+
+	let changed = false;
+	const new_elements = (pattern.elements || []).map((/** @type {any} */ element) => {
+		if (!element) return element;
+		const new_element = replace_lazy_in_pattern(element, false);
+		if (new_element !== element) changed = true;
+		return new_element;
+	});
+	return changed ? { ...pattern, elements: new_elements } : pattern;
+}
+
+/**
  * Walk the AST and pre-allocate `lazy_id` metadata on every lazy destructuring
  * pattern: function/component params, variable declarator ids, and statement-level
- * assignment LHS. Idempotent: skips patterns that already have a `lazy_id`.
+ * assignment LHS. Walks into non-lazy outer patterns to find nested lazy ones,
+ * e.g. `{ pair: &[a, b] }` allocates an id for the inner `&[a, b]`. Idempotent:
+ * skips patterns that already have a `lazy_id`.
  *
  * @param {any} root
  * @param {LazyContext} context
@@ -350,16 +501,10 @@ function lazy_bindings_contains(lazy_bindings, pattern) {
 export function preallocate_lazy_ids(root, context) {
 	/** @param {any} pattern */
 	const assign_id = (pattern) => {
-		if (
-			(pattern?.type === 'ObjectPattern' || pattern?.type === 'ArrayPattern') &&
-			pattern.lazy &&
-			!pattern.metadata?.lazy_id
-		) {
-			pattern.metadata = {
-				...pattern.metadata,
-				lazy_id: generate_lazy_id(context),
-			};
-		}
+		visit_topmost_lazy_patterns(pattern, (lazy) => {
+			if (lazy.metadata?.lazy_id) return;
+			lazy.metadata = { ...lazy.metadata, lazy_id: generate_lazy_id(context) };
+		});
 	};
 
 	/** @param {any} node */
@@ -439,15 +584,11 @@ export function apply_lazy_transforms(node, lazy_bindings) {
 		const own_bindings = new Map();
 		let had_lazy_param = false;
 		for (const param of node.params || []) {
-			const pattern = param?.type === 'AssignmentPattern' ? param.left : param;
-			if (
-				(pattern?.type === 'ObjectPattern' || pattern?.type === 'ArrayPattern') &&
-				pattern.lazy &&
-				pattern.metadata?.lazy_id
-			) {
+			visit_topmost_lazy_patterns(param, (lazy) => {
+				if (!lazy.metadata?.lazy_id) return;
 				had_lazy_param = true;
-				collect_lazy_bindings(pattern, pattern.metadata.lazy_id, own_bindings);
-			}
+				collect_lazy_bindings(lazy, lazy.metadata.lazy_id, own_bindings);
+			});
 		}
 
 		// Own bindings override any outer binding with the same name.
@@ -599,6 +740,30 @@ export function apply_lazy_transforms(node, lazy_bindings) {
 		return b.const(lazy_id, init);
 	}
 
+	// Non-lazy outer assignment whose LHS contains nested lazy patterns:
+	// `{ pair: &[a, b] } = obj` → `{ pair: __lazy0 } = obj`. JS reference
+	// semantics carry writes from `__lazy0[0] = x` back into `obj.pair[0]`.
+	if (
+		node.type === 'ExpressionStatement' &&
+		node.expression?.type === 'AssignmentExpression' &&
+		node.expression.operator === '=' &&
+		(node.expression.left?.type === 'ObjectPattern' ||
+			node.expression.left?.type === 'ArrayPattern') &&
+		!node.expression.left.lazy
+	) {
+		const new_left = replace_lazy_in_pattern(node.expression.left);
+		if (new_left !== node.expression.left) {
+			return {
+				...node,
+				expression: {
+					...node.expression,
+					left: new_left,
+					right: apply_lazy_transforms(node.expression.right, lazy_bindings),
+				},
+			};
+		}
+	}
+
 	// AssignmentExpression / UpdateExpression whose target is a lazy identifier.
 	if (
 		node.type === 'AssignmentExpression' &&
@@ -631,6 +796,23 @@ export function apply_lazy_transforms(node, lazy_bindings) {
 			id: lazy_id,
 			init: apply_lazy_transforms(node.init, lazy_bindings),
 		};
+	}
+
+	// Non-lazy outer declarator whose id contains nested lazy patterns:
+	// `let { pair: &[a, b] } = data` → `let { pair: __lazy0 } = data`.
+	if (
+		node.type === 'VariableDeclarator' &&
+		(node.id?.type === 'ObjectPattern' || node.id?.type === 'ArrayPattern') &&
+		!node.id.lazy
+	) {
+		const new_id = replace_lazy_in_pattern(node.id);
+		if (new_id !== node.id) {
+			return {
+				...node,
+				id: new_id,
+				init: apply_lazy_transforms(node.init, lazy_bindings),
+			};
+		}
 	}
 
 	// Shorthand object properties `{ name }` → `{ name: __lazy0.name }`.
@@ -758,38 +940,19 @@ function remove_shadowed(lazy_bindings, shadowed) {
 
 /**
  * Replace any lazy `&{}` / `&[]` patterns in a parameter list with their
- * generated lazy identifiers. Leaves non-lazy params untouched.
+ * generated lazy identifiers, including patterns nested inside non-lazy outer
+ * patterns. For `({ pair: &[a, b] })` returns `({ pair: __lazy0 })`. Leaves
+ * params without any lazy descendants untouched.
  *
  * @param {any[]} params
  * @returns {any[]}
  */
 export function replace_lazy_params(params) {
 	return params.map((param) => {
-		const pattern = param.type === 'AssignmentPattern' ? param.left : param;
-		if (
-			(pattern.type === 'ObjectPattern' || pattern.type === 'ArrayPattern') &&
-			pattern.lazy &&
-			pattern.metadata?.lazy_id
-		) {
-			const pattern_range = get_lazy_pattern_mapping_range(pattern);
-			const lazy_id = pattern_range
-				? create_generated_identifier(
-						pattern.metadata.lazy_id,
-						pattern_range,
-						undefined,
-						pattern_range.source_length,
-					)
-				: create_generated_identifier(pattern.metadata.lazy_id);
-			if (pattern.typeAnnotation) {
-				lazy_id.typeAnnotation = pattern.typeAnnotation;
-			} else {
-				const type_annotation = create_lazy_object_type_annotation(pattern);
-				if (type_annotation) lazy_id.typeAnnotation = type_annotation;
-			}
-			set_lazy_param_binding_mappings(lazy_id, pattern);
-			if (param.type === 'AssignmentPattern') return { ...param, left: lazy_id };
-			return lazy_id;
+		if (param.type === 'AssignmentPattern') {
+			const new_left = replace_lazy_in_pattern(param.left);
+			return new_left === param.left ? param : { ...param, left: new_left };
 		}
-		return param;
+		return replace_lazy_in_pattern(param);
 	});
 }

--- a/packages/tsrx/src/utils/ast.js
+++ b/packages/tsrx/src/utils/ast.js
@@ -36,6 +36,19 @@ export function is_function_node(node) {
  * @param {AST.Node} node
  * @returns {boolean}
  */
+export function is_function_or_component_node(node) {
+	return (
+		node.type === 'FunctionDeclaration' ||
+		node.type === 'FunctionExpression' ||
+		node.type === 'ArrowFunctionExpression' ||
+		node.type === 'Component'
+	);
+}
+
+/**
+ * @param {AST.Node} node
+ * @returns {boolean}
+ */
 export function is_class_node(node) {
 	return node.type === 'ClassExpression' || node.type === 'ClassDeclaration';
 }

--- a/packages/tsrx/tests/shared/compile.js
+++ b/packages/tsrx/tests/shared/compile.js
@@ -1337,6 +1337,7 @@ export function runSharedClassComponentDeclarationTests({
  */
 export function runSharedCompileTests({ compile, name, classAttrName }) {
 	runSharedComponentLoopControlFlowTests({ compile, name });
+	runSharedNestedLazyDestructuringTests({ compile, name });
 
 	describe(`[${name}] component export shapes`, () => {
 		// `component X()` maps to `function X()` identically on every target
@@ -2831,8 +2832,6 @@ export function optionalFn(bar: string, baz?: string) {
 			expect(code).not.toMatch(/console\.log\(__lazy0\.name\)/);
 		});
 	});
-
-	runSharedNestedLazyDestructuringTests({ compile, name });
 
 	describe(`[${name}] interleaved statements and JSX children`, () => {
 		// When a mutation sits between JSX siblings, each child has to be

--- a/packages/tsrx/tests/shared/compile.js
+++ b/packages/tsrx/tests/shared/compile.js
@@ -1332,6 +1332,7 @@ export function runSharedClassComponentDeclarationTests({
  * Shared compile-output regressions. These assert observable properties of
  * the generated code (not source-map structure) that every JSX target should
  * satisfy across whatever `transformElement` hook the platform wires in.
+ * Vue should be excluded from running these
  *
  * @param {CompileHarness} harness
  */

--- a/packages/tsrx/tests/shared/compile.js
+++ b/packages/tsrx/tests/shared/compile.js
@@ -132,6 +132,222 @@ export function runSharedCompileDiagnosticsTests({ compile_to_volar_mappings, na
 }
 
 /**
+ * Nested `&{...}` / `&[...]` patterns must chain accessors through every lazy
+ * level: a reference to the inner binding becomes the full member path through
+ * the synthesized parent identifier, and assignments to it write back through
+ * that same path. These tests are framework-agnostic — every target that
+ * supports the lazy `&` syntax should exercise them.
+ *
+ * @param {Pick<CompileHarness, 'compile' | 'name'>} harness
+ */
+export function runSharedNestedLazyDestructuringTests({ compile, name }) {
+	describe(`[${name}] nested lazy destructuring`, () => {
+		it('transforms nested lazy object inside lazy object in component params', () => {
+			const { code } = compile(
+				`export component App(&{ outer: &{ inner } }: { outer: { inner: number } }) {
+					<div>{inner}</div>
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('function App(__lazy0: { outer: { inner: number } })');
+			expect(code).toContain('__lazy0.outer.inner');
+			// Bare `inner` must not leak through (any identifier use except as a
+			// property key — a property key is followed by `:`).
+			expect(code).not.toMatch(/[^.]\binner\b(?!:)/);
+		});
+
+		it('transforms nested lazy array inside lazy object in component params', () => {
+			const { code } = compile(
+				`export component App(&{ pair: &[first, second] }: { pair: [number, number] }) {
+					<div>{first}{second}</div>
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('function App(__lazy0: { pair: [number, number] })');
+			expect(code).toContain('__lazy0.pair[0]');
+			expect(code).toContain('__lazy0.pair[1]');
+		});
+
+		it('transforms nested lazy object inside lazy array in function params', () => {
+			const { code } = compile(
+				`export function getName(&[&{ name }]: [{ name: string }]) {
+					return name;
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('function getName(__lazy0: [{ name: string }])');
+			expect(code).toContain('__lazy0[0].name');
+		});
+
+		it('transforms three-level nested lazy object in component params', () => {
+			const { code } = compile(
+				`export component App(&{ a: &{ b: &{ c } } }: { a: { b: { c: number } } }) {
+					<div>{c}</div>
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('function App(__lazy0: { a: { b: { c: number } } })');
+			expect(code).toContain('__lazy0.a.b.c');
+		});
+
+		it('transforms nested lazy in variable declaration with writeback', () => {
+			const { code } = compile(
+				`export component App() {
+					const data = { outer: { inner: 5 } };
+					let &{ outer: &{ inner } } = data;
+					inner = 99;
+					<div>{data.outer.inner}</div>
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('let __lazy0 = data');
+			expect(code).toContain('__lazy0.outer.inner = 99');
+			// Plain (non-lazy) destructure of `inner` must not leak through.
+			expect(code).not.toContain('{ outer: { inner } } = data');
+		});
+
+		it('transforms nested lazy array-in-object in variable declaration with writeback', () => {
+			const { code } = compile(
+				`export component App() {
+					const data = { pair: [1, 2] as [number, number] };
+					let &{ pair: &[first, second] } = data;
+					first = 100;
+					second = 200;
+					<div>{data.pair[0]}{data.pair[1]}</div>
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('let __lazy0 = data');
+			expect(code).toContain('__lazy0.pair[0] = 100');
+			expect(code).toContain('__lazy0.pair[1] = 200');
+		});
+
+		it('transforms nested lazy in function params with writeback', () => {
+			const { code } = compile(
+				`export function bump(&{ pair: &[first, second] }: { pair: [number, number] }) {
+					first = first + 10;
+					second = second + 20;
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('function bump(__lazy0: { pair: [number, number] })');
+			expect(code).toContain('__lazy0.pair[0] = __lazy0.pair[0] + 10');
+			expect(code).toContain('__lazy0.pair[1] = __lazy0.pair[1] + 20');
+		});
+
+		it('transforms compound assignment through nested lazy chain', () => {
+			const { code } = compile(
+				`export component App() {
+					const data = { a: { b: { c: 5 } } };
+					let &{ a: &{ b: &{ c } } } = data;
+					c += 10;
+					c *= 2;
+					<div>{data.a.b.c}</div>
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('let __lazy0 = data');
+			expect(code).toContain('__lazy0.a.b.c += 10');
+			expect(code).toContain('__lazy0.a.b.c *= 2');
+		});
+
+		// Lazy `&` markers can appear at any depth — the outer pattern need not
+		// be lazy. The non-lazy outer destructure is preserved; only the lazy
+		// nested pattern is replaced with its synthesized id.
+
+		it('replaces lazy pattern nested inside non-lazy object component param', () => {
+			const { code } = compile(
+				`export component App({ something: &[first, second] }: { something: [number, number] }) {
+					<div>{first}{second}</div>
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('function App({ something: __lazy0 }');
+			expect(code).toContain('__lazy0[0]');
+			expect(code).toContain('__lazy0[1]');
+			// The inner lazy pattern must not survive as a real destructure.
+			expect(code).not.toContain('[first, second]');
+		});
+
+		it('replaces lazy pattern nested inside non-lazy array component param', () => {
+			const { code } = compile(
+				`export component App([head, &{ inner }]: [number, { inner: number }]) {
+					<div>{head}{inner}</div>
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('function App([head, __lazy0]');
+			expect(code).toContain('__lazy0.inner');
+			expect(code).not.toContain('{ inner }');
+		});
+
+		it('replaces lazy pattern nested inside non-lazy function param with writeback', () => {
+			const { code } = compile(
+				`export function bump({ pair: &[first, second] }: { pair: [number, number] }) {
+					first = 100;
+					second = 200;
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('function bump({ pair: __lazy0 }');
+			expect(code).toContain('__lazy0[0] = 100');
+			expect(code).toContain('__lazy0[1] = 200');
+		});
+
+		it('replaces lazy pattern nested inside non-lazy let declaration with writeback', () => {
+			const { code } = compile(
+				`export component App() {
+					const data = { outer: { inner: 5 } };
+					let { outer: &{ inner } } = data;
+					inner = 99;
+					<div>{data.outer.inner}</div>
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('let { outer: __lazy0 } = data');
+			expect(code).toContain('__lazy0.inner = 99');
+		});
+
+		it('replaces multiple sibling lazy patterns nested in non-lazy outer', () => {
+			const { code } = compile(
+				`export component App({ a: &{ x }, b: &{ y } }: { a: { x: number }, b: { y: number } }) {
+					<div>{x}{y}</div>
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toMatch(/\{\s*a:\s*__lazy0,\s*b:\s*__lazy1\s*\}/);
+			expect(code).toContain('__lazy0.x');
+			expect(code).toContain('__lazy1.y');
+		});
+
+		it('replaces deeply nested lazy pattern through multiple non-lazy levels', () => {
+			const { code } = compile(
+				`export component App({ a: { b: &{ c } } }: { a: { b: { c: number } } }) {
+					<div>{c}</div>
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('function App({ a: { b: __lazy0 } }');
+			expect(code).toContain('__lazy0.c');
+		});
+	});
+}
+
+/**
  * @param {Pick<CompileHarness, 'compile' | 'name'>} harness
  */
 export function runSharedFragmentExpressionRenderTests({ compile, name }) {
@@ -2615,6 +2831,8 @@ export function optionalFn(bar: string, baz?: string) {
 			expect(code).not.toMatch(/console\.log\(__lazy0\.name\)/);
 		});
 	});
+
+	runSharedNestedLazyDestructuringTests({ compile, name });
 
 	describe(`[${name}] interleaved statements and JSX children`, () => {
 		// When a mutation sits between JSX siblings, each child has to be

--- a/packages/tsrx/types/index.d.ts
+++ b/packages/tsrx/types/index.d.ts
@@ -92,6 +92,7 @@ interface FunctionMetaData extends BaseNodeMetaData {
 	is_component?: boolean;
 	is_method?: boolean;
 	tracked?: boolean;
+	has_lazy_descendants?: boolean;
 }
 
 // Strip parent, loc, and range from TSESTree nodes to match @sveltejs/acorn-typescript output


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core AST rewriting for lazy destructuring (including param/variable/assignment handling) and updates Solid/Vue integration paths, which could affect generated output and writeback semantics across targets.
> 
> **Overview**
> Adds **nested lazy destructuring** support for `&{}` / `&[]` patterns so inner bindings rewrite to full member-access chains (and preserve writeback) across all TSRX targets.
> 
> Refactors lazy rewriting to run end-to-end via `apply_lazy_transforms` on function/component nodes (with a new `has_lazy_descendants` fast-path flag), removing per-component lazy binding collection/replacement hooks and updating Solid/Vue transforms accordingly.
> 
> Expands coverage with new shared compile harness tests plus extensive Ripple runtime tests for nested getter/setter behavior, defaults, sibling patterns, deep nesting, and compound assignments; adds a patch changeset for `@tsrx/core`, `@tsrx/vue`, and `ripple`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4876fcb08f8a770c844b042027a5ec0f3802980c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->