### PR TITLE
fix: root block cleanup, better dom cleanup

### DIFF
--- a/.changeset/honest-hmr-cleanup.md
+++ b/.changeset/honest-hmr-cleanup.md
@@ -1,0 +1,5 @@
+---
+"ripple": patch
+---
+
+Fix client cleanup for HMR-wrapped roots that do not own their DOM range directly.

--- a/packages/ripple/src/runtime/internal/client/blocks.js
+++ b/packages/ripple/src/runtime/internal/client/blocks.js
@@ -188,7 +188,7 @@ export function root(fn, compat) {
 		};
 	}
 
-	return block(ROOT_BLOCK, target_fn, { compat }, create_component_ctx());
+	return block(ROOT_BLOCK, target_fn, { compat, start: null, end: null }, create_component_ctx());
 }
 
 /**
@@ -274,7 +274,7 @@ export function destroy_block_children(parent, remove_dom = false) {
 	var block = parent.first;
 	parent.first = parent.last = null;
 
-	if ((parent.f & CONTAINS_TEARDOWN) !== 0) {
+	if (remove_dom || (parent.f & CONTAINS_TEARDOWN) !== 0) {
 		while (block !== null) {
 			var next = block.next;
 			destroy_block(block, remove_dom);
@@ -456,7 +456,7 @@ export function destroy_block(block, remove_dom = true) {
 		(f & HEAD_BLOCK) !== 0
 	) {
 		var s = block.s;
-		if (s !== null) {
+		if (s !== null && s.start !== null) {
 			remove_block_dom(s.start, s.end);
 			removed = true;
 		}

--- a/packages/ripple/tests/client/basic/basic.hmr.test.tsrx
+++ b/packages/ripple/tests/client/basic/basic.hmr.test.tsrx
@@ -1,5 +1,6 @@
 import { HMR } from '../../../src/runtime/internal/client/constants.js';
 import { hmr } from '../../../src/runtime/internal/client/hmr.js';
+import { effect, flushSync, mount } from 'ripple';
 
 describe('basic client > hmr', () => {
 	it('handles updates before first render', () => {
@@ -15,5 +16,82 @@ describe('basic client > hmr', () => {
 
 		expect(wrapper[HMR].current).toBeUndefined();
 		expect(wrapper[HMR].fn).toBe(updated_component);
+	});
+
+	it('removes DOM when an HMR-wrapped root is unmounted', () => {
+		component App() {
+			<div class="hmr-root">{'hmr root'}</div>
+		}
+
+		const cleanup = mount(hmr(App), { target: container });
+		flushSync();
+
+		expect(container.querySelector('.hmr-root')?.textContent).toBe('hmr root');
+
+		cleanup();
+
+		expect(container.querySelector('.hmr-root')).toBeNull();
+		expect(container.innerHTML).toBe('');
+	});
+
+	it('runs child teardowns when an HMR-wrapped root is unmounted', () => {
+		let teardown_count = 0;
+
+		component Child() {
+			effect(() => {
+				return () => {
+					teardown_count++;
+				};
+			});
+
+			<span class="hmr-child">{'child'}</span>
+		}
+
+		component App() {
+			<Child />
+		}
+
+		const cleanup = mount(hmr(App), { target: container });
+		flushSync();
+
+		expect(container.querySelector('.hmr-child')?.textContent).toBe('child');
+		expect(teardown_count).toBe(0);
+
+		cleanup();
+
+		expect(container.querySelector('.hmr-child')).toBeNull();
+		expect(teardown_count).toBe(1);
+	});
+
+	it('does not double-remove child DOM when the root owns the DOM range', () => {
+		let remove_count = 0;
+		const original_remove = Element.prototype.remove;
+
+		Element.prototype.remove = function () {
+			if (this.classList.contains('owned-root')) {
+				remove_count++;
+			}
+			return original_remove.call(this);
+		};
+
+		try {
+			component App() {
+				<div class="owned-root">
+					<span>{'child'}</span>
+				</div>
+			}
+
+			const cleanup = mount(App, { target: container });
+			flushSync();
+
+			expect(container.querySelector('.owned-root')).not.toBeNull();
+
+			cleanup();
+
+			expect(container.querySelector('.owned-root')).toBeNull();
+			expect(remove_count).toBe(1);
+		} finally {
+			Element.prototype.remove = original_remove;
+		}
 	});
 });


### PR DESCRIPTION
supersedes #1117
fixes #1114 

there were a series of events here that needed fixes.
this now cleanly destroys block and dom. just with the start and end set to null, the dom was still left behind.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core client runtime block-destruction logic; mistakes could cause leaked DOM nodes or skipped/double teardowns during unmount, though covered by new targeted HMR tests.
> 
> **Overview**
> Fixes unmount behavior for HMR-wrapped roots so DOM is reliably removed even when the root block does not directly own a `start`/`end` DOM range.
> 
> Updates `root()`/`destroy_block()` teardown flow to only remove a block’s DOM when the range is defined, and to still recurse into/destroy children when `remove_dom` is requested. Adds client HMR tests covering DOM removal, child teardown execution, and preventing double-removal when the root owns the DOM range.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9425b4d8e4b6db42a5b71459b81c5687d204d802. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->