### PR TITLE
update `Comparison to Other Frameworks` docs

### DIFF
--- a/website-new/docs/comparison.md
+++ b/website-new/docs/comparison.md
@@ -7,7 +7,7 @@ title: Comparison to other frameworks
 ## vs React
 
 - No JSX functions/returns - components use statement-based templates
-- Built-in reactivity with `track` and `@` syntax instead of useState/useEffect
+- Built-in reactivity with `track()` and `&[]` lazy destructuring instead of useState/useEffect
 - Scoped CSS without CSS-in-JS libraries
 - No virtual DOM - fine-grained reactivity
 

--- a/website/docs/comparison.md
+++ b/website/docs/comparison.md
@@ -7,7 +7,7 @@ title: Comparison to other frameworks
 ## vs React
 
 - No JSX functions/returns - components use statement-based templates
-- Built-in reactivity with `track` and `@` syntax instead of useState/useEffect
+- Built-in reactivity with `track()` and `&[]` lazy destructuring instead of useState/useEffect
 - Scoped CSS without CSS-in-JS libraries
 - No virtual DOM - fine-grained reactivity
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change that tweaks wording/formatting of the React reactivity comparison; no runtime or API behavior is affected.
> 
> **Overview**
> Updates the `Comparison to other frameworks` docs (in both `website/docs/comparison.md` and `website-new/docs/comparison.md`) to revise the React section’s reactivity bullet, switching from `track`/`@` wording to `track()` and `&[]` lazy destructuring terminology.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 935082ba74d9524ee633c903581905b387461d61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->