### PR TITLE
fix(prettier): formatting ts conditional types

### DIFF
--- a/.changeset/long-conditional-types.md
+++ b/.changeset/long-conditional-types.md
@@ -1,0 +1,5 @@
+---
+'@tsrx/prettier-plugin': patch
+---
+
+Break long nested TypeScript conditional type aliases across multiple lines when formatting TSRX files.

--- a/packages/prettier-plugin/src/index.js
+++ b/packages/prettier-plugin/src/index.js
@@ -4286,23 +4286,17 @@ function printTSInterfaceBody(node, path, options, print) {
  * @param {AstPath<AST.TSTypeAliasDeclaration>} path - The AST path
  * @param {RippleFormatOptions} options - Prettier options
  * @param {PrintFn} print - Print callback
- * @returns {Doc[]}
+ * @returns {Doc}
  */
 function printTSTypeAliasDeclaration(node, path, options, print) {
 	/** @type {Doc[]} */
-	const parts = [];
-	parts.push('type ');
-	parts.push(node.id.name);
+	const head = ['type ', node.id.name];
 
 	if (node.typeParameters) {
-		parts.push(path.call(print, 'typeParameters'));
+		head.push(path.call(print, 'typeParameters'));
 	}
 
-	parts.push(' = ');
-	parts.push(path.call(print, 'typeAnnotation'));
-	parts.push(semi(options));
-
-	return parts;
+	return group([head, ' =', indent([line, path.call(print, 'typeAnnotation')]), semi(options)]);
 }
 
 /**
@@ -5394,19 +5388,22 @@ function printTSConstructorType(node, path, options, print) {
  * @param {AstPath<AST.TSConditionalType>} path - The AST path
  * @param {RippleFormatOptions} options - Prettier options
  * @param {PrintFn} print - Print callback
- * @returns {Doc[]}
+ * @returns {Doc}
  */
 function printTSConditionalType(node, path, options, print) {
-	/** @type {Doc[]} */
-	const parts = [];
-	parts.push(path.call(print, 'checkType'));
-	parts.push(' extends ');
-	parts.push(path.call(print, 'extendsType'));
-	parts.push(' ? ');
-	parts.push(path.call(print, 'trueType'));
-	parts.push(' : ');
-	parts.push(path.call(print, 'falseType'));
-	return parts;
+	const trueType = path.call(print, 'trueType');
+	const falseType = path.call(print, 'falseType');
+
+	const shouldIndentTrueType = node.trueType.type !== 'TSConditionalType';
+	const shouldIndentFalseType = node.falseType.type !== 'TSConditionalType';
+
+	return group([
+		path.call(print, 'checkType'),
+		' extends ',
+		path.call(print, 'extendsType'),
+		indent([line, '? ', shouldIndentTrueType ? indent(trueType) : trueType]),
+		indent([line, ': ', shouldIndentFalseType ? indent(falseType) : falseType]),
+	]);
 }
 
 /**

--- a/packages/prettier-plugin/src/index.test.js
+++ b/packages/prettier-plugin/src/index.test.js
@@ -3474,6 +3474,20 @@ const items = [] as unknown[];`;
 			expect(result).toBeWithNewline(expected);
 		});
 
+		it('should break long nested TypeScript conditional type aliases', async () => {
+			const input = `type PageModelValue<Value> = Value extends ReadonlySignal<unknown> ? Value : Value extends (...args: any[]) => any ? Value : Value extends object ? { [Key in keyof Value]: PageModelValue<Value[Key]> } : never;`;
+			const expected = `type PageModelValue<Value> =
+  Value extends ReadonlySignal<unknown>
+    ? Value
+    : Value extends (...args: any[]) => any
+      ? Value
+      : Value extends object
+        ? { [Key in keyof Value]: PageModelValue<Value[Key]> }
+        : never;`;
+			const result = await format(input);
+			expect(result).toBeWithNewline(expected);
+		});
+
 		it('should format TypeScript mapped types (TSMappedType)', async () => {
 			const input = `type ReadonlyPartial<T> = { readonly [K in keyof T]?: T[K] }`;
 			const expected = `type ReadonlyPartial<T> = { readonly [K in keyof T]?: T[K] };`;


### PR DESCRIPTION
closes #1133 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core printer output for `TSTypeAliasDeclaration` and `TSConditionalType`, which can alter formatting across many files and may introduce edge-case regressions in TypeScript type printing.
> 
> **Overview**
> Updates the printer to **group and line-break** `type` alias declarations after `=` and to format `TSConditionalType` using multiline `?`/`:` indentation that avoids extra nesting when branches are themselves conditional types.
> 
> Adds a regression test for a long, nested conditional type alias and includes a patch changeset for `@tsrx/prettier-plugin`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b6b726f6d0e8e6cdefccb8ab2869b64fc672e98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->