### PR TITLE
fix: chain tsrx vite sourcemaps

### DIFF
--- a/.changeset/tsrx-vite-sourcemaps.md
+++ b/.changeset/tsrx-vite-sourcemaps.md
@@ -1,0 +1,6 @@
+---
+"@tsrx/vite-plugin-react": patch
+"@tsrx/vite-plugin-preact": patch
+---
+
+Chain TSRX compiler source maps through the Vite JSX transform so browser devtools show original `.tsrx` sources instead of generated TSX.

--- a/packages/vite-plugin-preact/src/index.js
+++ b/packages/vite-plugin-preact/src/index.js
@@ -68,15 +68,14 @@ export function tsrxPreact(options = {}) {
 		async transform(/** @type {string} */ code, /** @type {string} */ id) {
 			if (!TSRX_EXTENSION_PATTERN.test(id)) return null;
 
-			const { code: tsx_code, css, map } = compile(code, id, compile_options);
+			let { code: tsx_code, css, map } = compile(code, id, compile_options);
 
 			let source = tsx_code;
-			let input_map = /** @type {any} */ (map);
 			if (css) {
 				css_cache.set(id, css);
 				source = `import ${JSON.stringify(id + CSS_QUERY)};\n${tsx_code}`;
-				if (input_map && typeof input_map.mappings === 'string') {
-					input_map = { ...input_map, mappings: ';' + input_map.mappings };
+				if (map && typeof map.mappings === 'string') {
+					map = { ...map, mappings: ';' + map.mappings };
 				}
 			} else {
 				css_cache.delete(id);
@@ -94,7 +93,7 @@ export function tsrxPreact(options = {}) {
 					},
 					target: 'esnext',
 				},
-				input_map,
+				map,
 			);
 
 			return { code: result.code, map: result.map };

--- a/packages/vite-plugin-preact/src/index.js
+++ b/packages/vite-plugin-preact/src/index.js
@@ -68,25 +68,34 @@ export function tsrxPreact(options = {}) {
 		async transform(/** @type {string} */ code, /** @type {string} */ id) {
 			if (!TSRX_EXTENSION_PATTERN.test(id)) return null;
 
-			const { code: tsx_code, css } = compile(code, id, compile_options);
+			const { code: tsx_code, css, map } = compile(code, id, compile_options);
 
 			let source = tsx_code;
+			let input_map = /** @type {any} */ (map);
 			if (css) {
 				css_cache.set(id, css);
 				source = `import ${JSON.stringify(id + CSS_QUERY)};\n${tsx_code}`;
+				if (input_map && typeof input_map.mappings === 'string') {
+					input_map = { ...input_map, mappings: ';' + input_map.mappings };
+				}
 			} else {
 				css_cache.delete(id);
 			}
 
-			const result = await transformWithOxc(source, id, {
-				lang: 'tsx',
-				sourcemap: true,
-				jsx: {
-					runtime: 'automatic',
-					importSource: jsxImportSource,
+			const result = await transformWithOxc(
+				source,
+				id,
+				{
+					lang: 'tsx',
+					sourcemap: true,
+					jsx: {
+						runtime: 'automatic',
+						importSource: jsxImportSource,
+					},
+					target: 'esnext',
 				},
-				target: 'esnext',
-			});
+				input_map,
+			);
 
 			return { code: result.code, map: result.map };
 		},

--- a/packages/vite-plugin-preact/tests/basic.test.js
+++ b/packages/vite-plugin-preact/tests/basic.test.js
@@ -41,4 +41,19 @@ describe('@tsrx/vite-plugin-preact basic', () => {
 		expect(transformed.code).not.toContain(virtual_id);
 		expect(plugin.load(resolved_id)).toBe('');
 	});
+
+	it('maps the JSX transform output back to the original tsrx source', async () => {
+		const plugin = tsrxPreact();
+		const id = '/virtual/App.tsrx';
+		const source = `export component App() {
+			const message = 'Hello world';
+			<div>{message}</div>
+		}`;
+
+		const transformed = await plugin.transform(source, id);
+
+		expect(transformed).not.toBeNull();
+		expect(/** @type {any} */ (transformed.map).sources).toEqual([id]);
+		expect(/** @type {any} */ (transformed.map).sourcesContent).toEqual([source]);
+	});
 });

--- a/packages/vite-plugin-react/src/index.js
+++ b/packages/vite-plugin-react/src/index.js
@@ -62,15 +62,14 @@ export function tsrxReact(options = {}) {
 		async transform(/** @type {string} */ code, /** @type {string} */ id) {
 			if (!TSRX_EXTENSION_PATTERN.test(id)) return null;
 
-			const { code: tsx_code, css, map } = compile(code, id);
+			let { code: tsx_code, css, map } = compile(code, id);
 
 			let source = tsx_code;
-			let input_map = /** @type {any} */ (map);
 			if (css) {
 				css_cache.set(id, css);
 				source = `import ${JSON.stringify(id + CSS_QUERY)};\n${tsx_code}`;
-				if (input_map && typeof input_map.mappings === 'string') {
-					input_map = { ...input_map, mappings: ';' + input_map.mappings };
+				if (map && typeof map.mappings === 'string') {
+					map = { ...map, mappings: ';' + map.mappings };
 				}
 			} else {
 				css_cache.delete(id);
@@ -88,7 +87,7 @@ export function tsrxReact(options = {}) {
 					},
 					target: 'esnext',
 				},
-				input_map,
+				map,
 			);
 
 			return { code: result.code, map: result.map };

--- a/packages/vite-plugin-react/src/index.js
+++ b/packages/vite-plugin-react/src/index.js
@@ -62,25 +62,34 @@ export function tsrxReact(options = {}) {
 		async transform(/** @type {string} */ code, /** @type {string} */ id) {
 			if (!TSRX_EXTENSION_PATTERN.test(id)) return null;
 
-			const { code: tsx_code, css } = compile(code, id);
+			const { code: tsx_code, css, map } = compile(code, id);
 
 			let source = tsx_code;
+			let input_map = /** @type {any} */ (map);
 			if (css) {
 				css_cache.set(id, css);
 				source = `import ${JSON.stringify(id + CSS_QUERY)};\n${tsx_code}`;
+				if (input_map && typeof input_map.mappings === 'string') {
+					input_map = { ...input_map, mappings: ';' + input_map.mappings };
+				}
 			} else {
 				css_cache.delete(id);
 			}
 
-			const result = await transformWithOxc(source, id, {
-				lang: 'tsx',
-				sourcemap: true,
-				jsx: {
-					runtime: 'automatic',
-					importSource: jsxImportSource,
+			const result = await transformWithOxc(
+				source,
+				id,
+				{
+					lang: 'tsx',
+					sourcemap: true,
+					jsx: {
+						runtime: 'automatic',
+						importSource: jsxImportSource,
+					},
+					target: 'esnext',
 				},
-				target: 'esnext',
-			});
+				input_map,
+			);
 
 			return { code: result.code, map: result.map };
 		},

--- a/packages/vite-plugin-react/tests/basic.test.js
+++ b/packages/vite-plugin-react/tests/basic.test.js
@@ -40,4 +40,19 @@ describe('@tsrx/vite-plugin-react basic', () => {
 		expect(transformed.code).not.toContain(virtual_id);
 		expect(plugin.load(resolved_id)).toBe('');
 	});
+
+	it('maps the JSX transform output back to the original tsrx source', async () => {
+		const plugin = tsrxReact();
+		const id = '/virtual/App.tsrx';
+		const source = `export component App() {
+			const message = 'Hello world';
+			<div>{message}</div>
+		}`;
+
+		const transformed = await plugin.transform(source, id);
+
+		expect(transformed).not.toBeNull();
+		expect(/** @type {any} */ (transformed.map).sources).toEqual([id]);
+		expect(/** @type {any} */ (transformed.map).sourcesContent).toEqual([source]);
+	});
 });

--- a/packages/vite-plugin-solid/src/index.js
+++ b/packages/vite-plugin-solid/src/index.js
@@ -119,25 +119,23 @@ export function tsrxSolid(options = {}) {
 
 			const real_path = to_real_path(id.split('?')[0]);
 			const source = await readFile(real_path, 'utf-8');
-			const { code, css, map } = compile(source, real_path);
+			let { code, css, map } = compile(source, real_path);
 
-			let final_code = code;
-			let final_map = /** @type {any} */ (map);
 			if (css) {
 				css_cache.set(real_path, css);
-				final_code = `import ${JSON.stringify(real_path + CSS_QUERY)};\n${code}`;
+				code = `import ${JSON.stringify(real_path + CSS_QUERY)};\n${code}`;
 				// The prepended import adds one line to the generated output;
 				// shift every mapping down by one line so source positions stay
 				// aligned. In VLQ source maps, each `;` separates generated
 				// lines, so prefixing one `;` offsets all mappings by one line.
-				if (final_map && typeof final_map.mappings === 'string') {
-					final_map = { ...final_map, mappings: ';' + final_map.mappings };
+				if (map && typeof map.mappings === 'string') {
+					map = { ...map, mappings: ';' + map.mappings };
 				}
 			} else {
 				css_cache.delete(real_path);
 			}
 
-			return { code: final_code, map: final_map };
+			return { code, map };
 		},
 
 		handleHotUpdate(ctx) {

--- a/packages/vite-plugin-solid/tests/plugin.test.js
+++ b/packages/vite-plugin-solid/tests/plugin.test.js
@@ -1,3 +1,6 @@
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { tsrxSolid } from '../src/index.js';
 
 /**
@@ -10,6 +13,16 @@ import { tsrxSolid } from '../src/index.js';
  */
 async function fake_plugin_resolve(source) {
 	return { id: source, external: false, moduleSideEffects: true, meta: {} };
+}
+
+/**
+ * @param {import('vite').Plugin} plugin
+ * @param {string} id
+ */
+function call_load(plugin, id) {
+	const hook = typeof plugin.load === 'function' ? plugin.load : plugin.load?.handler;
+	if (!hook) throw new Error('plugin has no load hook');
+	return hook.call(/** @type {any} */ ({}), id);
 }
 
 /**
@@ -66,6 +79,25 @@ describe('@tsrx/vite-plugin-solid routing', () => {
 			const skipped = await call_resolve_id(plugin, '/proj/tests/App.tsrx');
 			expect(resolved_id(matched)).toBe('/proj/src/App.tsrx.tsx');
 			expect(skipped).toBeNull();
+		});
+	});
+
+	describe('source maps', () => {
+		it('maps the compiled output back to the original tsrx source', async () => {
+			const plugin = tsrxSolid();
+			const dir = mkdtempSync(join(tmpdir(), 'tsrx-solid-'));
+			const real_path = join(dir, 'App.tsrx');
+			const source = `export component App() {
+				const message = 'Hello world';
+				<div>{message}</div>
+			}`;
+			writeFileSync(real_path, source);
+
+			const result = await call_load(plugin, real_path + '.tsx');
+
+			expect(result).toBeTruthy();
+			expect(/** @type {any} */ (result).map.sources).toEqual([real_path]);
+			expect(/** @type {any} */ (result).map.sourcesContent).toEqual([source]);
 		});
 	});
 });

--- a/packages/vite-plugin-vue/src/index.js
+++ b/packages/vite-plugin-vue/src/index.js
@@ -176,21 +176,19 @@ function create_tsrx_vue_plugin(options) {
 
 			const realPath = toRealPath(id.split('?')[0]);
 			const source = await readFile(realPath, 'utf-8');
-			const { code, css, map } = compile(source, realPath);
+			let { code, css, map } = compile(source, realPath);
 
-			let finalCode = code;
-			let finalMap = /** @type {any} */ (map);
 			if (css) {
 				cssCache.set(realPath, css);
-				finalCode = `import ${JSON.stringify(realPath + CSS_QUERY)};\n${code}`;
-				if (finalMap && typeof finalMap.mappings === 'string') {
-					finalMap = { ...finalMap, mappings: ';' + finalMap.mappings };
+				code = `import ${JSON.stringify(realPath + CSS_QUERY)};\n${code}`;
+				if (map && typeof map.mappings === 'string') {
+					map = { ...map, mappings: ';' + map.mappings };
 				}
 			} else {
 				cssCache.delete(realPath);
 			}
 
-			return { code: finalCode, map: finalMap };
+			return { code, map };
 		},
 
 		handleHotUpdate(ctx) {

--- a/packages/vite-plugin-vue/tests/plugin.test.js
+++ b/packages/vite-plugin-vue/tests/plugin.test.js
@@ -1,0 +1,44 @@
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { tsrxVue } from '../src/index.js';
+
+/**
+ * @param {import('vite').Plugin} plugin
+ * @param {string} id
+ */
+function call_load(plugin, id) {
+	const hook = typeof plugin.load === 'function' ? plugin.load : plugin.load?.handler;
+	if (!hook) throw new Error('plugin has no load hook');
+	return hook.call(/** @type {any} */ ({}), id);
+}
+
+/**
+ * Pluck the main tsrx-vue plugin (the one with the load hook for `.tsrx.tsx`
+ * virtual ids) out of the array returned by `tsrxVue()`.
+ */
+function get_main_plugin() {
+	const plugins = tsrxVue();
+	const main = plugins.find((p) => p.name === '@tsrx/vite-plugin-vue');
+	if (!main) throw new Error('@tsrx/vite-plugin-vue plugin not found');
+	return main;
+}
+
+describe('@tsrx/vite-plugin-vue source maps', () => {
+	it('maps the compiled output back to the original tsrx source', async () => {
+		const plugin = get_main_plugin();
+		const dir = mkdtempSync(join(tmpdir(), 'tsrx-vue-'));
+		const real_path = join(dir, 'App.tsrx');
+		const source = `export component App() {
+			const message = 'Hello world';
+			<div>{message}</div>
+		}`;
+		writeFileSync(real_path, source);
+
+		const result = await call_load(plugin, real_path + '.tsx');
+
+		expect(result).toBeTruthy();
+		expect(/** @type {any} */ (result).map.sources).toEqual([real_path]);
+		expect(/** @type {any} */ (result).map.sourcesContent).toEqual([source]);
+	});
+});

--- a/packages/vite-plugin/src/index.js
+++ b/packages/vite-plugin/src/index.js
@@ -1,6 +1,6 @@
 /** @import {PackageJson} from 'type-fest' */
 /** @import {Plugin, ResolvedConfig, ViteDevServer} from 'vite' */
-/** @import {RipplePluginOptions, RippleConfigOptions, ResolvedRippleConfig, Route, RenderRoute} from '@ripple-ts/vite-plugin' */
+/** @import {RipplePlugin, RipplePluginOptions, RippleConfigOptions, ResolvedRippleConfig, Route, RenderRoute} from '@ripple-ts/vite-plugin' */
 
 /// <reference types="@tsrx/ripple/types/rpc" />
 
@@ -413,7 +413,7 @@ export function ripple(inlineOptions = {}) {
 		return loadedRippleConfig;
 	}
 
-	/** @type {Plugin[]} */
+	/** @type {[RipplePlugin, ...Plugin[]]} */
 	const plugins = [
 		{
 			name: 'vite-plugin-ripple',
@@ -1248,14 +1248,14 @@ import { hydrate, mount } from 'ripple';
 			transform: {
 				filter: { id: RIPPLE_EXTENSION_PATTERN },
 
-				async handler(code, id, opts) {
+				async handler(source_code, id, opts) {
 					const filename = id.replace(root, '');
 					const ssr = opts?.ssr === true || this.environment.config.consumer === 'server';
 
 					const is_dev = config?.command === 'serve';
 					const current_ripple_config = await get_current_ripple_config();
 
-					const result = await compile(code, filename, {
+					let { code, css, map } = await compile(source_code, filename, {
 						mode: ssr ? 'server' : 'client',
 						dev: is_dev,
 						hmr: is_dev && !ssr,
@@ -1266,17 +1266,17 @@ import { hydrate, mount } from 'ripple';
 					});
 
 					// Track modules with `module server` declarations for RPC (client build only)
-					if (isBuild && !ssr && result.code.includes('_$_.rpc(')) {
+					if (isBuild && !ssr && code.includes('_$_.rpc(')) {
 						serverModuleModules.add(filename);
 					}
 
-					if (result.css) {
+					if (css) {
 						const cssId = createVirtualImportId(filename, root, 'style');
-						cssCache.set(cssId, result.css);
-						result.code += `\nimport ${JSON.stringify(cssId)};\n`;
+						cssCache.set(cssId, css);
+						code += `\nimport ${JSON.stringify(cssId)};\n`;
 					}
 
-					return { code: result.code, map: result.map };
+					return { code, map };
 				},
 			},
 		},

--- a/packages/vite-plugin/tests/transform-source-maps.test.js
+++ b/packages/vite-plugin/tests/transform-source-maps.test.js
@@ -1,0 +1,96 @@
+/** @import {RipplePlugin} from '@ripple-ts/vite-plugin' */
+
+import { describe, it, expect } from 'vitest';
+import path from 'node:path';
+import { ripple } from '@ripple-ts/vite-plugin';
+
+/**
+ * Pull the core ripple plugin out of the plugin array. The narrowed
+ * `name: 'vite-plugin-ripple'` on {@link import('../types/index.js').RipplePlugin}
+ * lets `find` produce a typed result with no cast.
+ *
+ * @returns {RipplePlugin}
+ */
+function get_ripple_plugin() {
+	const [plugin] = ripple({ excludeRippleExternalModules: true });
+	return plugin;
+}
+
+/**
+ * @param {RipplePlugin} plugin
+ * @param {string} root
+ */
+async function init_plugin(plugin, root) {
+	const hook =
+		typeof plugin.configResolved === 'function'
+			? plugin.configResolved
+			: plugin.configResolved?.handler;
+	if (!hook) return;
+	// Bind a stub `this` so we don't trip Vite's hook `this:` constraint.
+	await hook.call(/** @type {any} */ ({}), /** @type {any} */ ({ root, command: 'serve' }));
+}
+
+/**
+ * @param {RipplePlugin} plugin
+ * @param {string} source
+ * @param {string} id
+ */
+async function call_transform(plugin, source, id) {
+	const transform = plugin.transform;
+	if (!transform) throw new Error('plugin has no transform hook');
+	const handler = typeof transform === 'function' ? transform : transform.handler;
+	const ctx = /** @type {any} */ ({
+		environment: { config: { consumer: 'client' } },
+	});
+	return handler.call(ctx, source, id, undefined);
+}
+
+describe('vite-plugin-ripple source maps', () => {
+	it('returns a map that points back to the original .tsrx source', async () => {
+		const plugin = get_ripple_plugin();
+		const root = '/virtual-root';
+		await init_plugin(plugin, root);
+
+		const id = `${root}/App.tsrx`;
+		const source = `export component App() {
+			let message = 'Hello world';
+			<div>{message}</div>
+		}`;
+
+		const result = await call_transform(plugin, source, id);
+
+		expect(result).toBeTruthy();
+		const map = /** @type {any} */ (result).map;
+		// `@tsrx/ripple`'s esrap call uses `path.basename` for `sourceMapSource`,
+		// so `sources` is the bare filename rather than the full id.
+		expect(map.sources).toEqual([path.basename(id)]);
+		expect(map.sourcesContent).toEqual([source]);
+	});
+
+	it('keeps the map valid when a <style> block triggers a virtual css import', async () => {
+		const plugin = get_ripple_plugin();
+		const root = '/virtual-root';
+		await init_plugin(plugin, root);
+
+		const id = `${root}/Styled.tsrx`;
+		const source = `export component Styled() {
+			<div>{'Hello world'}</div>
+
+			<style>
+				.div {
+					color: red;
+				}
+			</style>
+		}`;
+
+		const result = await call_transform(plugin, source, id);
+
+		expect(result).toBeTruthy();
+		const code = /** @type {any} */ (result).code;
+		const map = /** @type {any} */ (result).map;
+		// CSS import is appended (not prepended), so existing mappings stay
+		// aligned and `sourcesContent` still carries the original source.
+		expect(code).toContain('?ripple&type=style&lang.css');
+		expect(map.sourcesContent).toEqual([source]);
+	});
+});

--- a/packages/vite-plugin/types/index.d.ts
+++ b/packages/vite-plugin/types/index.d.ts
@@ -5,7 +5,16 @@ import type { RuntimePrimitives } from '@ripple-ts/adapter';
 // Plugin exports
 // ============================================================================
 
-export function ripple(options?: RipplePluginOptions): Plugin[];
+/**
+ * The core `vite-plugin-ripple` plugin produced by {@link ripple}. The `name`
+ * is narrowed so consumers (and tests) can locate it via `find` without an
+ * `as` cast.
+ */
+export interface RipplePlugin extends Plugin {
+	readonly name: 'vite-plugin-ripple';
+}
+
+export function ripple(options?: RipplePluginOptions): [RipplePlugin, ...Plugin[]];
 export function defineConfig(options: RippleConfigOptions): RippleConfigOptions;
 export function resolveRippleConfig(
 	raw: RippleConfigOptions,

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -173,6 +173,15 @@ export default defineConfig({
 			},
 			{
 				test: {
+					name: 'vite-plugin-vue',
+					include: ['packages/vite-plugin-vue/tests/**/*.test.js'],
+					environment: 'node',
+					globals: true,
+				},
+				plugins: [],
+			},
+			{
+				test: {
 					name: 'tsrx-vue-runtime',
 					include: ['packages/vite-plugin-vue/tests/**/*.test.tsrx'],
 					environment: 'jsdom',


### PR DESCRIPTION
- React and Preact TSRX Vite plugins compiled to TSX and then ran OXC without passing the TSRX compiler map through.
- Pass the compiler map as OXC input, including the existing one-line CSS import offset.
- Add plugin tests that assert the final post-JSX map points at the original `.tsrx` source.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes Vite plugin transform outputs (source maps and CSS-import line offsets), which can affect debugging and tooling behavior across multiple frameworks, though runtime codegen is largely unchanged.
> 
> **Overview**
> **Fixes TSRX source map chaining in Vite plugins** so browser devtools map back to original `.tsrx` sources after the JSX transform.
> 
> React/Preact plugins now pass the compiler-generated source map into `transformWithOxc`, and adjust mappings when a virtual CSS import line is prepended.
> 
> Solid/Vue plugins simplify their `load()` return path while preserving the existing CSS-import mapping offset logic, and new tests were added across `vite-plugin-react`, `vite-plugin-preact`, `vite-plugin-solid`, `vite-plugin-vue`, and `vite-plugin-ripple` to assert `sources`/`sourcesContent` point at the original `.tsrx` input. A small typing change narrows `ripple()`’s first plugin to a `RipplePlugin`, and Vitest is configured to run the new `vite-plugin-vue` unit tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74e00a26c1274130cf04b18b2d6c9f462096372f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->