### PR TITLE
fix: align TSRX TextMate grammar naming

### DIFF
--- a/assets/Ripple.tmbundle/Syntaxes/ripple.tmLanguage
+++ b/assets/Ripple.tmbundle/Syntaxes/ripple.tmLanguage
@@ -5372,7 +5372,7 @@
 						</dict>
 					</dict>
 					<key>contentName</key>
-					<string>source.js.embedded.ripple-isolated</string>
+					<string>source.js.embedded.tsrx-isolated</string>
 					<key>end</key>
 					<string>(?=&lt;[a-zA-Z]|&lt;/)</string>
 					<key>endCaptures</key>
@@ -5465,7 +5465,7 @@
 				</dict>
 			</dict>
 			<key>contentName</key>
-			<string>meta.embedded.expression.js source.js.embedded.ripple</string>
+			<string>meta.embedded.expression.js source.js.embedded.tsrx</string>
 			<key>end</key>
 			<string>\}</string>
 			<key>endCaptures</key>
@@ -6314,7 +6314,7 @@
 				</dict>
 			</dict>
 			<key>contentName</key>
-			<string>meta.embedded.expression.js source.js.embedded.ripple</string>
+			<string>meta.embedded.expression.js source.js.embedded.tsrx</string>
 			<key>end</key>
 			<string>\}</string>
 			<key>endCaptures</key>

--- a/grammars/textmate/tsrx.tmLanguage.json
+++ b/grammars/textmate/tsrx.tmLanguage.json
@@ -6526,7 +6526,7 @@
               "name": "punctuation.section.embedded.end.ripple-ts"
             }
           },
-          "contentName": "source.js.embedded.ripple-isolated",
+          "contentName": "source.js.embedded.tsrx-isolated",
           "patterns": [
             {
               "include": "#component-statements"
@@ -6586,7 +6586,7 @@
       ]
     },
     "jsx-evaluated-code": {
-      "contentName": "meta.embedded.expression.js source.js.embedded.ripple",
+      "contentName": "meta.embedded.expression.js source.js.embedded.tsrx",
       "begin": "\\{",
       "end": "\\}",
       "beginCaptures": {
@@ -7078,7 +7078,7 @@
       ]
     },
     "jsx-tsx-evaluated-code": {
-      "contentName": "meta.embedded.expression.js source.js.embedded.ripple",
+      "contentName": "meta.embedded.expression.js source.js.embedded.tsrx",
       "begin": "\\{",
       "end": "\\}",
       "beginCaptures": {

--- a/scripts/regenerate-textmate.js
+++ b/scripts/regenerate-textmate.js
@@ -21,7 +21,7 @@ function writeTargets(targets, sourcePath) {
 const __filename = fileURLToPath(import.meta.url);
 const rootDir = path.join(path.dirname(__filename), '..');
 
-const sourceJson = path.join(rootDir, 'grammars/textmate/ripple.tmLanguage.json');
+const sourceJson = path.join(rootDir, 'grammars/textmate/tsrx.tmLanguage.json');
 const sourcePlist = path.join(rootDir, 'grammars/textmate/info.plist');
 const assetBundleGrammar = path.join(rootDir, 'assets/Ripple.tmbundle/Syntaxes/ripple.tmLanguage');
 

--- a/website-new/src/lib/markdown.js
+++ b/website-new/src/lib/markdown.js
@@ -1,8 +1,8 @@
 import { Marked } from 'marked';
 import { createHighlighter } from 'shiki';
 
-// Import the Ripple TextMate grammar directly (bundled by Vite at build time)
-import ripple_grammar from '../../../grammars/textmate/ripple.tmLanguage.json';
+// Import the TSRX TextMate grammar directly (bundled by Vite at build time)
+import ripple_grammar from '../../../grammars/textmate/tsrx.tmLanguage.json';
 
 /**
  * Escape HTML special characters.

--- a/website-tsrx/src/lib/shiki-codemirror.ts
+++ b/website-tsrx/src/lib/shiki-codemirror.ts
@@ -7,7 +7,7 @@ import {
 } from '@codemirror/view';
 import { type Extension, StateEffect, StateField } from '@codemirror/state';
 import { createHighlighter, type ThemedToken, type Highlighter } from 'shiki';
-import ripple_grammar from '../../../grammars/textmate/ripple.tmLanguage.json';
+import ripple_grammar from '../../../grammars/textmate/tsrx.tmLanguage.json';
 
 const modified_grammar = {
 	...ripple_grammar,

--- a/website/.vitepress/config.js
+++ b/website/.vitepress/config.js
@@ -3,7 +3,7 @@ import { tabsMarkdownPlugin } from 'vitepress-plugin-tabs';
 import { npmCommandsMarkdownPlugin } from 'vitepress-plugin-npm-commands';
 /** @import { DefaultTheme } from 'vitepress'; */
 
-import rippleGrammar from '../../grammars/textmate/ripple.tmLanguage.json';
+import rippleGrammar from '../../grammars/textmate/tsrx.tmLanguage.json';
 const modifiedGrammar = {
 	...rippleGrammar,
 	embeddedLangs: ['jsx', 'tsx', 'css'],


### PR DESCRIPTION
## Summary

- rename the source TextMate grammar from `ripple.tmLanguage.json` to `tsrx.tmLanguage.json`
- update grammar consumers and regeneration script to use the new source path
- replace stale embedded scopes:
  - `source.js.embedded.ripple` -> `source.js.embedded.tsrx`
  - `source.js.embedded.ripple-isolated` -> `source.js.embedded.tsrx-isolated`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates TextMate grammar metadata/scopes and switches consumers to the renamed `tsrx.tmLanguage.json`; no runtime logic changes beyond syntax highlighting inputs.
> 
> **Overview**
> Updates the TextMate grammar naming to consistently use **TSRX**: consumers now import `grammars/textmate/tsrx.tmLanguage.json` instead of `ripple.tmLanguage.json`, and the regeneration script copies from the new source path.
> 
> Also refreshes embedded scope names in the generated grammars (e.g. `source.js.embedded.ripple*` -> `source.js.embedded.tsrx*`) so syntax highlighters/tooling reference the updated scope identifiers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e42caabc9019257d4f210ee00809f89c99b47180. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->