### PR TITLE
fix: tsx tsrx nesting in ripple, prettier, types

### DIFF
--- a/.changeset/gentle-nested-mappings.md
+++ b/.changeset/gentle-nested-mappings.md
@@ -1,0 +1,7 @@
+---
+"@tsrx/ripple": patch
+"@tsrx/core": patch
+"ripple": patch
+---
+
+Parse nested `<tsrx>` islands inside `<tsx>` expression containers as native TSRX so setup declarations and references keep Volar mappings.

--- a/.changeset/gentle-nested-mappings.md
+++ b/.changeset/gentle-nested-mappings.md
@@ -4,4 +4,4 @@
 "ripple": patch
 ---
 
-Parse nested `<tsrx>` islands inside `<tsx>` expression containers as native TSRX so setup declarations and references keep Volar mappings.
+Parse nested `<tsrx>` islands inside `<tsx>` expression containers as native TSRX so setup declarations and references keep Volar mappings, and hydrate deeply nested `<tsx>`/`<tsrx>` expression values without skipping server markers.

--- a/.changeset/mixed-collection-hydration.md
+++ b/.changeset/mixed-collection-hydration.md
@@ -1,0 +1,5 @@
+---
+'ripple': patch
+---
+
+Avoid duplicating plain text when hydrating mixed TSRX collection values.

--- a/.changeset/nested-template-return-calls.md
+++ b/.changeset/nested-template-return-calls.md
@@ -1,0 +1,5 @@
+---
+'@tsrx/ripple': patch
+---
+
+Render calls to helper functions with nested `<tsx>` or `<tsrx>` returns as template expressions during SSR.

--- a/.changeset/nested-tsrx-tsx-to-ts.md
+++ b/.changeset/nested-tsrx-tsx-to-ts.md
@@ -1,0 +1,13 @@
+---
+"@tsrx/ripple": patch
+"ripple": patch
+"@ripple-ts/vscode-plugin": patch
+---
+
+Fix to_ts output for nested `<tsrx>` islands inside `<tsx>` blocks.
+
+Type JSX expression values as `TSRXElement` so IntelliSense reports assigned
+TSX/TSRX fragments as renderable values instead of `void`.
+
+Fix TextMate highlighting for nested `<tsrx>` and `<tsx>` tags inside JSX
+expression containers.

--- a/.changeset/nested-tsx-tsrx-values.md
+++ b/.changeset/nested-tsx-tsrx-values.md
@@ -1,0 +1,6 @@
+---
+'@tsrx/ripple': patch
+'ripple': patch
+---
+
+Render nested `<tsx>` and `<tsrx>` expression values, including arrays returned from JSX-style expressions.

--- a/.changeset/quiet-comments-breathe.md
+++ b/.changeset/quiet-comments-breathe.md
@@ -1,0 +1,5 @@
+---
+'@tsrx/prettier-plugin': patch
+---
+
+Preserve comments before TSRX expressions that follow nested `<tsx>` and `<tsrx>` blocks, and keep nested `<tsx>` initializer semicolons attached.

--- a/assets/Ripple.tmbundle/Syntaxes/ripple.tmLanguage
+++ b/assets/Ripple.tmbundle/Syntaxes/ripple.tmLanguage
@@ -5294,6 +5294,30 @@
 				</dict>
 				<dict>
 					<key>include</key>
+					<string>#jsx-tag-tsx</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#jsx-tag-tsrx</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#jsx-tag-tsx-react</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#jsx-tsx-tag-fragment</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#jsx-tag-without-attributes-in-expression</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#jsx-tag-in-expression</string>
+				</dict>
+				<dict>
+					<key>include</key>
 					<string>#expressionWithoutIdentifiers</string>
 				</dict>
 				<dict>
@@ -6256,6 +6280,22 @@
 				<dict>
 					<key>include</key>
 					<string>#jsx-ref-modifier</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#jsx-tag-tsx</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#jsx-tag-tsrx</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#jsx-tag-tsx-react</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#jsx-tsx-tag-fragment</string>
 				</dict>
 				<dict>
 					<key>include</key>

--- a/grammars/textmate/ripple.tmLanguage.json
+++ b/grammars/textmate/ripple.tmLanguage.json
@@ -6544,6 +6544,24 @@
           "include": "#jsx-ref-modifier"
         },
         {
+          "include": "#jsx-tag-tsx"
+        },
+        {
+          "include": "#jsx-tag-tsrx"
+        },
+        {
+          "include": "#jsx-tag-tsx-react"
+        },
+        {
+          "include": "#jsx-tsx-tag-fragment"
+        },
+        {
+          "include": "#jsx-tag-without-attributes-in-expression"
+        },
+        {
+          "include": "#jsx-tag-in-expression"
+        },
+        {
           "include": "#expressionWithoutIdentifiers"
         },
         {
@@ -7104,6 +7122,18 @@
         },
         {
           "include": "#jsx-ref-modifier"
+        },
+        {
+          "include": "#jsx-tag-tsx"
+        },
+        {
+          "include": "#jsx-tag-tsrx"
+        },
+        {
+          "include": "#jsx-tag-tsx-react"
+        },
+        {
+          "include": "#jsx-tsx-tag-fragment"
         },
         {
           "include": "#jsx-tsx-tag-in-expression"

--- a/grammars/tree-sitter/queries/injections.scm
+++ b/grammars/tree-sitter/queries/injections.scm
@@ -24,6 +24,13 @@
   (#eq? @_tsx_name "tsx")
   (#set! injection.language "tsx"))
 
+; TSRX islands keep Ripple syntax, including when nested inside a TSX island.
+((jsx_element
+  open_tag: (jsx_opening_element
+    name: (jsx_element_name (identifier) @_tsrx_name))) @injection.content
+  (#eq? @_tsrx_name "tsrx")
+  (#set! injection.language "ripple"))
+
 ((jsx_element
   open_tag: (jsx_opening_element
     name: (jsx_element_name

--- a/packages/nvim-plugin/queries/ripple/injections.scm
+++ b/packages/nvim-plugin/queries/ripple/injections.scm
@@ -24,6 +24,13 @@
   (#eq? @_tsx_name "tsx")
   (#set! injection.language "tsx"))
 
+; TSRX islands keep Ripple syntax, including when nested inside a TSX island.
+((jsx_element
+  open_tag: (jsx_opening_element
+    name: (jsx_element_name (identifier) @_tsrx_name))) @injection.content
+  (#eq? @_tsrx_name "tsrx")
+  (#set! injection.language "ripple"))
+
 ((jsx_element
   open_tag: (jsx_opening_element
     name: (jsx_element_name

--- a/packages/prettier-plugin/src/index.js
+++ b/packages/prettier-plugin/src/index.js
@@ -718,11 +718,13 @@ function printRippleNode(node, path, options, print, args) {
 	const isInlineContext = args && args.isInlineContext;
 	const suppressLeadingComments = args && args.suppressLeadingComments;
 	const suppressExpressionLeadingComments = args && args.suppressExpressionLeadingComments;
+	const parentNode = /** @type {AST.Node | null} */ (path.getParentNode());
 
 	// For TSRXExpression, Text, and Html nodes, don't add leading comments here - they should be handled
-	// as separate children within the element, not as part of the expression
+	// as separate children within elements, not as part of the expression.
 	const shouldSkipLeadingComments =
-		node.type === 'TSRXExpression' || node.type === 'Text' || node.type === 'Html';
+		parentNode?.type === 'Element' &&
+		(node.type === 'TSRXExpression' || node.type === 'Text' || node.type === 'Html');
 
 	// Handle leading comments
 	if (node.leadingComments && !shouldSkipLeadingComments && !suppressLeadingComments) {
@@ -5930,6 +5932,24 @@ function printJSXElement(node, path, options, print) {
 			// Accumulate text content, preserving spaces between words
 			const trimmed = child.value.trim();
 			if (trimmed) {
+				const nextChild = node.children[i + 1];
+				const afterNextChild = node.children[i + 2];
+				const nextText = afterNextChild?.type === 'JSXText' ? afterNextChild.value.trim() : '';
+				if (
+					tagName === 'tsrx' &&
+					trimmed.endsWith('=') &&
+					nextChild?.type === 'JSXElement' &&
+					nextText === ';'
+				) {
+					if (currentText) {
+						childrenDocs.push(currentText);
+						currentText = '';
+					}
+					childrenDocs.push([trimmed, ' ', path.call(print, 'children', i + 1), ';']);
+					i += 2;
+					continue;
+				}
+
 				if (currentText) {
 					currentText += ' ' + trimmed;
 				} else {

--- a/packages/prettier-plugin/src/index.test.js
+++ b/packages/prettier-plugin/src/index.test.js
@@ -200,6 +200,49 @@ describe('prettier-plugin', () => {
 			expect(result).toBeWithNewline(expected);
 		});
 
+		it('should preserve comments before expressions after nested tsx and tsrx blocks', async () => {
+			const input = `component App() {
+	const content = <tsx>
+		{<tsrx>
+			const nested =
+			<tsx>
+				<span class="nested-tsx">
+					{'inside nested tsx'}
+				</span>
+			</tsx>
+			;
+			<div class="native">{nested}</div>
+		</tsrx>}
+	</tsx>;
+
+	// const content = <tsrx>
+	// 	<div>{hey()}</div>
+	// </tsrx>;
+
+	{content}
+}`;
+			const expected = `component App() {
+  const content = <tsx>
+    {<tsrx>
+      const nested = <tsx>
+        <span class="nested-tsx">
+          {'inside nested tsx'}
+        </span>
+      </tsx>;
+      <div class="native">{nested}</div>
+    </tsrx>}
+  </tsx>;
+
+  // const content = <tsrx>
+  // 	<div>{hey()}</div>
+  // </tsrx>;
+
+  {content}
+}`;
+			const result = await format(input, { singleQuote: true });
+			expect(result).toBeWithNewline(expected);
+		});
+
 		it('should break nested TSX element attributes inside expression props', async () => {
 			const cases = [
 				{

--- a/packages/ripple/package.json
+++ b/packages/ripple/package.json
@@ -78,6 +78,8 @@
     "@tsrx/ripple": "workspace:*"
   },
   "devDependencies": {
+    "@types/estree": "catalog:default",
+    "@types/estree-jsx": "catalog:default",
     "@types/node": "catalog:default"
   }
 }

--- a/packages/ripple/src/jsx-runtime.d.ts
+++ b/packages/ripple/src/jsx-runtime.d.ts
@@ -1,9 +1,10 @@
-import type { AddEventObject } from '#public';
+import type { AddEventObject, TSRXElement } from '#public';
 import type { Nullable } from '#helpers';
 
 /**
  * Ripple JSX Runtime Type Definitions
- * Ripple components are imperative and don't return JSX elements
+ * Ripple components are imperative, but JSX expressions still represent
+ * renderable TSRX values when used in expression positions.
  */
 
 // Ripple components don't return JSX elements - they're imperative
@@ -17,13 +18,13 @@ export function jsx(
 	type: string | ComponentType<any>,
 	props?: any,
 	key?: string | number | null,
-): void;
+): TSRXElement;
 
 export function rsx(
 	type: string | ComponentType<any>,
 	props?: any,
 	key?: string | number | null,
-): void;
+): TSRXElement;
 
 /**
  * Create a JSX element with static children (optimization for multiple children)
@@ -33,13 +34,13 @@ export function jsxs(
 	type: string | ComponentType<any>,
 	props?: any,
 	key?: string | number | null,
-): void;
+): TSRXElement;
 
 /**
  * JSX Fragment component
- * In Ripple, fragments are imperative and don't return anything
+ * Ripple fragments are renderable expression values.
  */
-export function Fragment(props: { children?: any }): void;
+export function Fragment(props: { children?: any }): TSRXElement;
 
 export type ClassValue = string | import('clsx').ClassArray | import('clsx').ClassDictionary;
 
@@ -819,8 +820,8 @@ interface SVGTextAttributes {
 // Global JSX namespace for TypeScript
 declare global {
 	namespace JSX {
-		// In Ripple, JSX expressions don't return elements - they're imperative
-		type Element = void;
+		type Element = TSRXElement;
+		type ElementType = keyof IntrinsicElements | ComponentType<any>;
 
 		interface IntrinsicElements {
 			// Document metadata

--- a/packages/ripple/src/runtime/element.js
+++ b/packages/ripple/src/runtime/element.js
@@ -1,5 +1,3 @@
-import { is_array } from '@tsrx/core/runtime/language-helpers';
-
 const TSRX_ELEMENT = Symbol.for('ripple.element');
 
 /**
@@ -26,25 +24,6 @@ export function tsrx_element(render) {
  */
 export function is_tsrx_element(value) {
 	return value != null && value[TSRX_ELEMENT] === true;
-}
-
-/**
- * @param {any} value
- * @returns {boolean}
- */
-export function is_tsrx_collection(value) {
-	if (!is_array(value)) {
-		return false;
-	}
-
-	for (var i = 0; i < value.length; i++) {
-		var item = value[i];
-		if (is_tsrx_element(item) || is_tsrx_collection(item)) {
-			return true;
-		}
-	}
-
-	return false;
 }
 
 /**

--- a/packages/ripple/src/runtime/element.js
+++ b/packages/ripple/src/runtime/element.js
@@ -1,3 +1,5 @@
+import { is_array } from '@tsrx/core/runtime/language-helpers';
+
 const TSRX_ELEMENT = Symbol.for('ripple.element');
 
 /**
@@ -31,7 +33,7 @@ export function is_tsrx_element(value) {
  * @returns {boolean}
  */
 export function is_tsrx_collection(value) {
-	if (!Array.isArray(value)) {
+	if (!is_array(value)) {
 		return false;
 	}
 

--- a/packages/ripple/src/runtime/element.js
+++ b/packages/ripple/src/runtime/element.js
@@ -28,6 +28,25 @@ export function is_tsrx_element(value) {
 
 /**
  * @param {any} value
+ * @returns {boolean}
+ */
+export function is_tsrx_collection(value) {
+	if (!Array.isArray(value)) {
+		return false;
+	}
+
+	for (var i = 0; i < value.length; i++) {
+		var item = value[i];
+		if (is_tsrx_element(item) || is_tsrx_collection(item)) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/**
+ * @param {any} value
  * @returns {any}
  */
 export function normalize_children(value) {

--- a/packages/ripple/src/runtime/internal/client/expression.js
+++ b/packages/ripple/src/runtime/internal/client/expression.js
@@ -109,7 +109,7 @@ export function expression(node, get_value) {
 	render(() => {
 		var next_value = get_value();
 		var next_is_collection = is_tsrx_collection(next_value);
-		var next_is_element = is_tsrx_element(next_value) || next_is_collection;
+		var next_is_element = next_is_collection || is_tsrx_element(next_value);
 		var is_hydration_marker = hydrating && anchor.nodeType === COMMENT_NODE;
 
 		if (is_hydration_marker) {

--- a/packages/ripple/src/runtime/internal/client/expression.js
+++ b/packages/ripple/src/runtime/internal/client/expression.js
@@ -1,5 +1,6 @@
 /** @import { Block } from '#client' */
 
+import { is_array } from '@tsrx/core/runtime/language-helpers';
 import { branch, destroy_block, render } from './blocks.js';
 import { BRANCH_BLOCK, UNINITIALIZED } from './constants.js';
 import { create_text, get_next_sibling } from './operations.js';
@@ -7,7 +8,7 @@ import { assign_nodes } from './template.js';
 import { active_block } from './runtime.js';
 import { hydrate_node, hydrating, set_hydrate_node } from './hydration.js';
 import { COMMENT_NODE, HYDRATION_END, HYDRATION_START, TEXT_NODE } from '../../../constants.js';
-import { is_tsrx_element, is_tsrx_collection } from '../../element.js';
+import { is_tsrx_element } from '../../element.js';
 
 /**
  * Finds the nearest enclosing BRANCH_BLOCK in the block hierarchy.
@@ -57,7 +58,7 @@ function render_tsrx_collection_items(value, anchor, block) {
 
 		if (is_tsrx_element(item)) {
 			item.render(anchor, block);
-		} else if (is_tsrx_collection(item)) {
+		} else if (is_array(item)) {
 			render_tsrx_collection_items(item, anchor, block);
 		} else if (item != null) {
 			render_tsrx_collection_text(item + '', anchor);
@@ -135,7 +136,7 @@ export function expression(node, get_value) {
 
 	render(() => {
 		var next_value = get_value();
-		var next_is_collection = is_tsrx_collection(next_value);
+		var next_is_collection = is_array(next_value);
 		var next_is_element = next_is_collection || is_tsrx_element(next_value);
 		var is_hydration_marker = hydrating && anchor.nodeType === COMMENT_NODE;
 

--- a/packages/ripple/src/runtime/internal/client/expression.js
+++ b/packages/ripple/src/runtime/internal/client/expression.js
@@ -182,7 +182,7 @@ export function expression(node, get_value) {
 			var parent_branch = find_enclosing_branch(active_block);
 
 			child_block = branch(() => {
-				var block = active_block;
+				var block = /** @type {Block} */ (active_block);
 				if (next_is_collection) {
 					render_tsrx_collection(next_value, end ?? anchor, block);
 				} else {

--- a/packages/ripple/src/runtime/internal/client/expression.js
+++ b/packages/ripple/src/runtime/internal/client/expression.js
@@ -3,6 +3,7 @@
 import { branch, destroy_block, render } from './blocks.js';
 import { BRANCH_BLOCK, UNINITIALIZED } from './constants.js';
 import { create_text, get_next_sibling } from './operations.js';
+import { assign_nodes } from './template.js';
 import { active_block } from './runtime.js';
 import { hydrating, set_hydrate_node } from './hydration.js';
 import { COMMENT_NODE, HYDRATION_END, HYDRATION_START, TEXT_NODE } from '../../../constants.js';
@@ -21,6 +22,60 @@ function find_enclosing_branch(block) {
 		block = block.p;
 	}
 	return null;
+}
+
+/**
+ * @param {any} value
+ * @returns {boolean}
+ */
+function is_tsrx_collection(value) {
+	if (!Array.isArray(value)) {
+		return false;
+	}
+
+	for (var i = 0; i < value.length; i++) {
+		var item = value[i];
+		if (is_tsrx_element(item) || is_tsrx_collection(item)) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/**
+ * @param {any[]} value
+ * @param {ChildNode} anchor
+ * @param {Block} block
+ * @returns {void}
+ */
+function render_tsrx_collection(value, anchor, block) {
+	var start = document.createComment('');
+	var end = document.createComment('');
+
+	anchor.before(start, end);
+	assign_nodes(start, end);
+	render_tsrx_collection_items(value, end, block);
+}
+
+/**
+ * @param {any[]} value
+ * @param {ChildNode} anchor
+ * @param {Block} block
+ * @returns {void}
+ */
+function render_tsrx_collection_items(value, anchor, block) {
+	for (var i = 0; i < value.length; i++) {
+		var item = value[i];
+
+		if (is_tsrx_element(item)) {
+			item.render(anchor, block);
+		} else if (is_tsrx_collection(item)) {
+			render_tsrx_collection_items(item, anchor, block);
+		} else if (item != null) {
+			anchor.before(create_text(item + ''));
+		}
+	}
 }
 
 /**
@@ -47,7 +102,8 @@ export function expression(node, get_value) {
 
 	render(() => {
 		var next_value = get_value();
-		var next_is_element = is_tsrx_element(next_value);
+		var next_is_collection = is_tsrx_collection(next_value);
+		var next_is_element = is_tsrx_element(next_value) || next_is_collection;
 		var is_hydration_marker = hydrating && anchor.nodeType === COMMENT_NODE;
 
 		if (is_hydration_marker) {
@@ -94,7 +150,11 @@ export function expression(node, get_value) {
 
 			child_block = branch(() => {
 				var block = active_block;
-				next_value.render(end ?? anchor, block);
+				if (next_is_collection) {
+					render_tsrx_collection(next_value, end ?? anchor, block);
+				} else {
+					next_value.render(end ?? anchor, block);
+				}
 			});
 
 			// Update parent branch's s.start to include content inserted before anchor.

--- a/packages/ripple/src/runtime/internal/client/expression.js
+++ b/packages/ripple/src/runtime/internal/client/expression.js
@@ -7,7 +7,7 @@ import { assign_nodes } from './template.js';
 import { active_block } from './runtime.js';
 import { hydrate_node, hydrating, set_hydrate_node } from './hydration.js';
 import { COMMENT_NODE, HYDRATION_END, HYDRATION_START, TEXT_NODE } from '../../../constants.js';
-import { is_tsrx_element } from '../../element.js';
+import { is_tsrx_element, is_tsrx_collection } from '../../element.js';
 
 /**
  * Finds the nearest enclosing BRANCH_BLOCK in the block hierarchy.
@@ -22,25 +22,6 @@ function find_enclosing_branch(block) {
 		block = block.p;
 	}
 	return null;
-}
-
-/**
- * @param {any} value
- * @returns {boolean}
- */
-function is_tsrx_collection(value) {
-	if (!Array.isArray(value)) {
-		return false;
-	}
-
-	for (var i = 0; i < value.length; i++) {
-		var item = value[i];
-		if (is_tsrx_element(item) || is_tsrx_collection(item)) {
-			return true;
-		}
-	}
-
-	return false;
 }
 
 /**
@@ -79,9 +60,55 @@ function render_tsrx_collection_items(value, anchor, block) {
 		} else if (is_tsrx_collection(item)) {
 			render_tsrx_collection_items(item, anchor, block);
 		} else if (item != null) {
-			anchor.before(create_text(item + ''));
+			render_tsrx_collection_text(item + '', anchor);
 		}
 	}
+}
+
+/**
+ * @param {string} value
+ * @param {ChildNode} anchor
+ * @returns {void}
+ */
+function render_tsrx_collection_text(value, anchor) {
+	if (!hydrating) {
+		anchor.before(create_text(value));
+		return;
+	}
+
+	var node = hydrate_node;
+
+	if (node?.nodeType === TEXT_NODE) {
+		var current_value = /** @type {Text} */ (node).nodeValue ?? '';
+
+		if (current_value !== value) {
+			/** @type {Text} */ (node).nodeValue = value;
+
+			if (current_value.startsWith(value)) {
+				var remaining = current_value.slice(value.length);
+
+				if (remaining !== '') {
+					var remaining_text = create_text(remaining);
+					/** @type {ChildNode} */ (node).after(remaining_text);
+					set_hydrate_node(remaining_text);
+					return;
+				}
+			}
+		}
+
+		set_hydrate_node(get_next_sibling(node) ?? anchor);
+		return;
+	}
+
+	var new_text = create_text(value);
+
+	if (node !== null && node !== anchor) {
+		/** @type {ChildNode} */ (node).before(new_text);
+	} else {
+		anchor.before(new_text);
+	}
+
+	set_hydrate_node(node ?? anchor);
 }
 
 /**

--- a/packages/ripple/src/runtime/internal/client/expression.js
+++ b/packages/ripple/src/runtime/internal/client/expression.js
@@ -5,7 +5,7 @@ import { BRANCH_BLOCK, UNINITIALIZED } from './constants.js';
 import { create_text, get_next_sibling } from './operations.js';
 import { assign_nodes } from './template.js';
 import { active_block } from './runtime.js';
-import { hydrating, set_hydrate_node } from './hydration.js';
+import { hydrate_node, hydrating, set_hydrate_node } from './hydration.js';
 import { COMMENT_NODE, HYDRATION_END, HYDRATION_START, TEXT_NODE } from '../../../constants.js';
 import { is_tsrx_element } from '../../element.js';
 
@@ -50,6 +50,12 @@ function is_tsrx_collection(value) {
  * @returns {void}
  */
 function render_tsrx_collection(value, anchor, block) {
+	if (hydrating) {
+		assign_nodes(/** @type {Node} */ (hydrate_node ?? anchor), anchor);
+		render_tsrx_collection_items(value, anchor, block);
+		return;
+	}
+
 	var start = document.createComment('');
 	var end = document.createComment('');
 

--- a/packages/ripple/src/runtime/internal/client/template.js
+++ b/packages/ripple/src/runtime/internal/client/template.js
@@ -1,6 +1,9 @@
 /** @import { Block } from '#client' */
 
 import {
+	COMMENT_NODE,
+	HYDRATION_END,
+	HYDRATION_START,
 	TEMPLATE_FRAGMENT,
 	TEMPLATE_USE_IMPORT_NODE,
 	TEMPLATE_SVG_NAMESPACE,
@@ -177,6 +180,10 @@ export function append(anchor, dom, skip_advance) {
 			if (s !== null) {
 				s.end = /** @type {Node} */ (hydrate_node);
 			}
+
+			if (is_after_hydration_block(dom, hydrate_node)) {
+				return;
+			}
 		}
 
 		// Only advance if there's a next sibling. At the end of a component's
@@ -185,6 +192,44 @@ export function append(anchor, dom, skip_advance) {
 		return;
 	}
 	anchor.before(/** @type {Node} */ (dom));
+}
+
+/**
+ * @param {Node} start
+ * @param {Node | null} target
+ * @returns {boolean}
+ */
+function is_after_hydration_block(start, target) {
+	if (
+		target === null ||
+		start.nodeType !== COMMENT_NODE ||
+		/** @type {Comment} */ (start).data !== HYDRATION_START
+	) {
+		return false;
+	}
+
+	var current = get_next_sibling(start);
+	var depth = 0;
+
+	while (current !== null && current !== target) {
+		if (current.nodeType === COMMENT_NODE) {
+			var data = /** @type {Comment} */ (current).data;
+
+			if (data === HYDRATION_START) {
+				depth += 1;
+			} else if (data === HYDRATION_END) {
+				if (depth === 0) {
+					return true;
+				}
+
+				depth -= 1;
+			}
+		}
+
+		current = get_next_sibling(current);
+	}
+
+	return false;
 }
 
 export function text(data = '') {

--- a/packages/ripple/src/runtime/internal/server/index.js
+++ b/packages/ripple/src/runtime/internal/server/index.js
@@ -38,7 +38,12 @@ import {
 import { clsx } from 'clsx';
 import { create_ref_prop } from '@tsrx/core/runtime/ref';
 import { BLOCK_CLOSE, BLOCK_OPEN } from '../../../constants.js';
-import { is_tsrx_element, normalize_children, tsrx_element } from '../../element.js';
+import {
+	is_tsrx_element,
+	normalize_children,
+	tsrx_element,
+	is_tsrx_collection,
+} from '../../element.js';
 import {
 	is_tag_valid_with_parent,
 	is_tag_valid_with_ancestor,
@@ -82,25 +87,6 @@ export class TrackAsyncRunError extends Error {
 }
 
 export function noop() {}
-
-/**
- * @param {any} value
- * @returns {boolean}
- */
-function is_tsrx_collection(value) {
-	if (!Array.isArray(value)) {
-		return false;
-	}
-
-	for (var i = 0; i < value.length; i++) {
-		var item = value[i];
-		if (is_tsrx_element(item) || is_tsrx_collection(item)) {
-			return true;
-		}
-	}
-
-	return false;
-}
 
 /**
  * @param {any[]} value

--- a/packages/ripple/src/runtime/internal/server/index.js
+++ b/packages/ripple/src/runtime/internal/server/index.js
@@ -85,6 +85,43 @@ export function noop() {}
 
 /**
  * @param {any} value
+ * @returns {boolean}
+ */
+function is_tsrx_collection(value) {
+	if (!Array.isArray(value)) {
+		return false;
+	}
+
+	for (var i = 0; i < value.length; i++) {
+		var item = value[i];
+		if (is_tsrx_element(item) || is_tsrx_collection(item)) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/**
+ * @param {any[]} value
+ * @returns {void}
+ */
+function render_tsrx_collection(value) {
+	for (var i = 0; i < value.length; i++) {
+		var item = value[i];
+
+		if (is_tsrx_element(item)) {
+			item.render({});
+		} else if (is_tsrx_collection(item)) {
+			render_tsrx_collection(item);
+		} else if (item != null) {
+			output_push(escape(item));
+		}
+	}
+}
+
+/**
+ * @param {any} value
  * @returns {void}
  */
 export function render_expression(value) {
@@ -92,6 +129,8 @@ export function render_expression(value) {
 
 	if (is_tsrx_element(value)) {
 		value.render({});
+	} else if (is_tsrx_collection(value)) {
+		render_tsrx_collection(value);
 	} else {
 		output_push(escape(value ?? ''));
 	}

--- a/packages/ripple/src/runtime/internal/server/index.js
+++ b/packages/ripple/src/runtime/internal/server/index.js
@@ -28,7 +28,7 @@ import {
 } from '../client/constants.js';
 import { DEV } from 'esm-env';
 import { is_ripple_object } from '../client/utils.js';
-import { array_slice } from '@tsrx/core/runtime/language-helpers';
+import { array_slice, is_array } from '@tsrx/core/runtime/language-helpers';
 import {
 	escape,
 	escape_script,
@@ -38,12 +38,7 @@ import {
 import { clsx } from 'clsx';
 import { create_ref_prop } from '@tsrx/core/runtime/ref';
 import { BLOCK_CLOSE, BLOCK_OPEN } from '../../../constants.js';
-import {
-	is_tsrx_element,
-	normalize_children,
-	tsrx_element,
-	is_tsrx_collection,
-} from '../../element.js';
+import { is_tsrx_element, normalize_children, tsrx_element } from '../../element.js';
 import {
 	is_tag_valid_with_parent,
 	is_tag_valid_with_ancestor,
@@ -98,7 +93,7 @@ function render_tsrx_collection(value) {
 
 		if (is_tsrx_element(item)) {
 			item.render({});
-		} else if (is_tsrx_collection(item)) {
+		} else if (is_array(item)) {
 			render_tsrx_collection(item);
 		} else if (item != null) {
 			output_push(escape(item));
@@ -115,7 +110,7 @@ export function render_expression(value) {
 
 	if (is_tsrx_element(value)) {
 		value.render({});
-	} else if (is_tsrx_collection(value)) {
+	} else if (is_array(value)) {
 		render_tsrx_collection(value);
 	} else {
 		output_push(escape(value ?? ''));

--- a/packages/ripple/tests/client/basic/basic.collections.test.tsrx
+++ b/packages/ripple/tests/client/basic/basic.collections.test.tsrx
@@ -173,4 +173,39 @@ describe('basic client > collections', () => {
 		expect(frame.querySelectorAll('.middle')).toHaveLength(1);
 		expect(countCommentNodes(frame)).toBe(initialCommentCount);
 	});
+
+	it('flattens nested primitive arrays inside mixed tsrx collections', () => {
+		component App() {
+			<div class="frame">
+				{<tsx>
+					{[
+						'start:',
+						['one', 2, true, null, false],
+						<strong>
+							{'!'}
+						</strong>,
+						':end',
+					]}
+				</tsx>}
+			</div>
+		}
+
+		render(App);
+
+		expect(container.querySelector('.frame').textContent).toBe('start:one2truefalse!:end');
+	});
+
+	it('flattens direct primitive array expressions', () => {
+		component App() {
+			const items = ['start:', ['one', 2], null, true, false, ':end'];
+
+			<div class="frame">{['start:', ['one', 2], null, true, false, ':end']}</div>
+			<div class="bound-frame">{items}</div>
+		}
+
+		render(App);
+
+		expect(container.querySelector('.frame').textContent).toBe('start:one2truefalse:end');
+		expect(container.querySelector('.bound-frame').textContent).toBe('start:one2truefalse:end');
+	});
 });

--- a/packages/ripple/tests/client/basic/basic.collections.test.tsrx
+++ b/packages/ripple/tests/client/basic/basic.collections.test.tsrx
@@ -208,4 +208,22 @@ describe('basic client > collections', () => {
 		expect(container.querySelector('.frame').textContent).toBe('start:one2truefalse:end');
 		expect(container.querySelector('.bound-frame').textContent).toBe('start:one2truefalse:end');
 	});
+
+	it('flattens conditional primitive array expressions', () => {
+		component App() {
+			const condition = true;
+			const ternary_items = condition
+				? ['start:', ['one', 2], null, true, false, ':end']
+				: ['fallback'];
+			const logical_items = condition && ['start:', ['one', 2], null, true, false, ':end'];
+
+			<div class="ternary-frame">{ternary_items}</div>
+			<div class="logical-frame">{logical_items}</div>
+		}
+
+		render(App);
+
+		expect(container.querySelector('.ternary-frame').textContent).toBe('start:one2truefalse:end');
+		expect(container.querySelector('.logical-frame').textContent).toBe('start:one2truefalse:end');
+	});
 });

--- a/packages/ripple/tests/client/basic/basic.collections.test.tsrx
+++ b/packages/ripple/tests/client/basic/basic.collections.test.tsrx
@@ -2,6 +2,17 @@ import { RippleArray, flushSync, track } from 'ripple';
 import { TRACKED_ARRAY } from '../../../src/runtime/internal/client/constants.js';
 
 describe('basic client > collections', () => {
+	function countCommentNodes(node: Node) {
+		const walker = document.createTreeWalker(node, NodeFilter.SHOW_COMMENT);
+		let count = 0;
+
+		while (walker.nextNode()) {
+			count++;
+		}
+
+		return count;
+	}
+
 	it('renders with simple reactive objects', () => {
 		component Basic() {
 			let &[user] = track({
@@ -105,5 +116,61 @@ describe('basic client > collections', () => {
 
 		expect(pre1.textContent).toBe('4');
 		expect(pre2.textContent).toBe('2');
+	});
+
+	it('cleans up mixed tsrx collection sentinels and trailing text on rerender', () => {
+		component App() {
+			let &[primary] = track(true);
+
+			<div class="frame">
+				{<tsx>
+					{primary
+						? [
+								'first:',
+								<strong class="middle">
+									{'one'}
+								</strong>,
+								':tail',
+							]
+						: [
+								'second:',
+								<strong class="middle">
+									{'two'}
+								</strong>,
+								':done',
+							]}
+				</tsx>}
+			</div>
+			<button
+				onClick={() => {
+					primary = !primary;
+				}}
+			>
+				{'toggle'}
+			</button>
+		}
+
+		render(App);
+
+		const frame = container.querySelector('.frame');
+		const button = container.querySelector('button');
+		const initialCommentCount = countCommentNodes(frame);
+
+		expect(frame.textContent).toBe('first:one:tail');
+		expect(frame.querySelectorAll('.middle')).toHaveLength(1);
+
+		button.click();
+		flushSync();
+
+		expect(frame.textContent).toBe('second:two:done');
+		expect(frame.querySelectorAll('.middle')).toHaveLength(1);
+		expect(countCommentNodes(frame)).toBe(initialCommentCount);
+
+		button.click();
+		flushSync();
+
+		expect(frame.textContent).toBe('first:one:tail');
+		expect(frame.querySelectorAll('.middle')).toHaveLength(1);
+		expect(countCommentNodes(frame)).toBe(initialCommentCount);
 	});
 });

--- a/packages/ripple/tests/client/compiler/compiler.basic.test.tsrx
+++ b/packages/ripple/tests/client/compiler/compiler.basic.test.tsrx
@@ -350,6 +350,25 @@ const Inline = component(props) {
 		expect(result).not.toContain('const Inline = (__anchor, props, __block) => {');
 	});
 
+	it('emits function calls with nested template returns as expressions in client output', () => {
+		const source = `
+component App() {
+	function make(flag) {
+		if (flag) {
+			return <tsx><span>{'nested'}</span></tsx>;
+		}
+
+		return null;
+	}
+
+	<div>{make(true)}</div>
+}
+`;
+		const result = compile(source, 'nested-template-return.tsrx', { mode: 'client' }).code;
+
+		expect(result).toContain('_$_.expression(expression, () => make(true))');
+	});
+
 	// 	it(
 	// 		'imports and uses only obfuscated Tracked imports when encountering only shorthand syntax',
 	// 		() => {

--- a/packages/ripple/tests/client/compiler/compiler.basic.test.tsrx
+++ b/packages/ripple/tests/client/compiler/compiler.basic.test.tsrx
@@ -460,6 +460,69 @@ component App() {
 		expect(track_result).not.toContain('lazy0');
 	});
 
+	it('lowers nested tsrx inside tsx in to_ts output', () => {
+		const source = `
+component App() {
+	const content = <tsx>
+		{<tsrx>
+			const nested = <tsx>
+				<span class="nested-tsx">
+					{'inside nested tsx'}
+				</span>
+			</tsx>;
+			<div class="native">{nested}</div>
+		</tsrx>}
+	</tsx>;
+
+	{content}
+}
+`;
+		const result = compile_to_volar_mappings(source, 'test.tsrx').code;
+
+		expect(result).not.toContain('<tsrx>');
+		expect(result).not.toContain('</tsrx>');
+		expect(result).not.toContain('<tsx>');
+		expect(result).not.toContain('</tsx>');
+		expect(result).toContain('const nested = <>');
+		expect(result).toContain('children.push(<div class="native">');
+	});
+
+	it('maps identifiers from nested tsrx inside tsx in to_ts output', () => {
+		const source = `
+component App() {
+	const content = <tsx>
+		{<tsrx>
+			const nested = <tsx>
+				<span class="nested-tsx">
+					{'inside nested tsx'}
+				</span>
+			</tsx>;
+			<div class="native">{nested}</div>
+		</tsrx>}
+	</tsx>;
+
+	{content}
+}
+`;
+		const result = compile_to_volar_mappings(source, 'test.tsrx', { loose: true });
+		const source_declaration = source.indexOf('nested =');
+		const source_reference = source.indexOf('nested}</div>');
+		const generated_declaration = result.code.indexOf('const nested') + 'const '.length;
+		const generated_reference = result.code.indexOf('nested;', generated_declaration);
+
+		function find_mapping(source_offset: number, generated_offset: number) {
+			return result.mappings.find(
+				(mapping) => mapping.sourceOffsets[0] === source_offset &&
+					mapping.generatedOffsets[0] === generated_offset &&
+					mapping.lengths[0] === 'nested'.length &&
+					mapping.generatedLengths[0] === 'nested'.length,
+			);
+		}
+
+		expect(find_mapping(source_declaration, generated_declaration)).toBeDefined();
+		expect(find_mapping(source_reference, generated_reference)).toBeDefined();
+	});
+
 	it('preserves optional markers in to_ts TypeScript output', () => {
 		const source = `
 export type OptionalTuple = [bar: string, baz?: string];

--- a/packages/ripple/tests/client/tsx.test.tsrx
+++ b/packages/ripple/tests/client/tsx.test.tsrx
@@ -503,6 +503,114 @@ describe('tsx expression', () => {
 		expect(button.querySelector('.btn-label').textContent).toBe('Save');
 	});
 
+	it('renders deeply nested tsx and tsrx expression values', () => {
+		function makeFragment(label: string) {
+			return <tsrx>
+				<span class="label">{label}</span>
+				const test = <tsx>
+					{[1, 2, 3, 4].map(
+						(item) => <tsx>
+							{<tsrx>
+								<div class="helper-item">{item}</div>
+							</tsrx>}
+						</tsx>,
+					)}
+				</tsx>;
+				{test}
+			</tsrx>;
+		}
+
+		component App() {
+			{<tsx>{[1, 2, 3].map((item) => <div class="app-item">{item}</div>)}</tsx>}
+			{makeFragment('from helper')}
+		}
+
+		render(App);
+
+		expect(
+			Array.from(container.querySelectorAll('.app-item')).map((node) => node.textContent),
+		).toEqual([
+			'1',
+			'2',
+			'3',
+		]);
+		expect(container.querySelector('.label').textContent).toBe('from helper');
+		expect(
+			Array.from(container.querySelectorAll('.helper-item')).map((node) => node.textContent),
+		).toEqual(['1', '2', '3', '4']);
+	});
+
+	it('renders tsrx nested directly inside a top-level tsx expression value', () => {
+		component App() {
+			const content = <tsx>
+				<section class="outer">
+					{<tsrx>
+						<div class="inner">
+							{'from tsrx'}
+						</div>
+					</tsrx>}
+				</section>
+			</tsx>;
+
+			{content}
+		}
+
+		render(App);
+
+		const outer = container.querySelector('.outer');
+		expect(outer).toBeTruthy();
+		expect(outer.querySelector('.inner').textContent).toBe('from tsrx');
+	});
+
+	it('renders nested elements from tsrx inside a top-level tsx value', () => {
+		component App() {
+			const content = <tsx>
+				<div class="wrapper">
+					{<tsrx>
+						<section class="native">
+							<span class="nested-tsrx">
+								{'inside nested tsrx'}
+							</span>
+						</section>
+					</tsrx>}
+				</div>
+			</tsx>;
+
+			{content}
+		}
+
+		render(App);
+
+		const native = container.querySelector('.native');
+		expect(native).toBeTruthy();
+		expect(native.querySelector('.nested-tsrx').textContent).toBe('inside nested tsrx');
+	});
+
+	it('renders tsx declared inside tsrx nested from a top-level tsx value', () => {
+		component App() {
+			const content = <tsx>
+				{<tsrx>
+					const nested =
+					<tsx>
+						<span class="nested-tsx">
+							{'inside nested tsx'}
+						</span>
+					</tsx>
+					;
+					<div class="native">{nested}</div>
+				</tsrx>}
+			</tsx>;
+
+			{content}
+		}
+
+		render(App);
+
+		const native = container.querySelector('.native');
+		expect(native).toBeTruthy();
+		expect(native.querySelector('.nested-tsx').textContent).toBe('inside nested tsx');
+	});
+
 	it('renders tsx as prop with fallback in component', () => {
 		component Alert(&{ icon, message }: { icon?: any; message: string }) {
 			<div class="alert">

--- a/packages/ripple/tests/client/tsx.test.tsrx
+++ b/packages/ripple/tests/client/tsx.test.tsrx
@@ -590,13 +590,11 @@ describe('tsx expression', () => {
 		component App() {
 			const content = <tsx>
 				{<tsrx>
-					const nested =
-					<tsx>
+					const nested = <tsx>
 						<span class="nested-tsx">
 							{'inside nested tsx'}
 						</span>
-					</tsx>
-					;
+					</tsx>;
 					<div class="native">{nested}</div>
 				</tsrx>}
 			</tsx>;

--- a/packages/ripple/tests/hydration/basic.test.js
+++ b/packages/ripple/tests/hydration/basic.test.js
@@ -60,6 +60,54 @@ describe('hydration > basic', () => {
 		expect(container.innerHTML).toBeHtml('<div>42</div><span>COMPUTED</span>');
 	});
 
+	it('hydrates deeply nested tsx and tsrx expression values', async () => {
+		await hydrateComponent(
+			ServerComponents.NestedTsxTsrxExpressionValues,
+			ClientComponents.NestedTsxTsrxExpressionValues,
+		);
+
+		expect(
+			Array.from(container.querySelectorAll('.app-item')).map((node) => node.textContent),
+		).toEqual(['1', '2', '3']);
+		expect(container.querySelector('.label')?.textContent).toBe('from helper');
+		expect(
+			Array.from(container.querySelectorAll('.helper-item')).map((node) => node.textContent),
+		).toEqual(['1', '2', '3', '4']);
+	});
+
+	it('hydrates tsrx nested directly inside a top-level tsx expression value', async () => {
+		await hydrateComponent(
+			ServerComponents.NestedTsrxInsideTopLevelTsxExpression,
+			ClientComponents.NestedTsrxInsideTopLevelTsxExpression,
+		);
+
+		const outer = container.querySelector('.outer');
+		expect(outer).toBeTruthy();
+		expect(outer?.querySelector('.inner')?.textContent).toBe('from tsrx');
+	});
+
+	it('hydrates nested elements from tsrx inside a top-level tsx value', async () => {
+		await hydrateComponent(
+			ServerComponents.NestedTsrxElementsInsideTopLevelTsxValue,
+			ClientComponents.NestedTsrxElementsInsideTopLevelTsxValue,
+		);
+
+		const native = container.querySelector('.native');
+		expect(native).toBeTruthy();
+		expect(native?.querySelector('.nested-tsrx')?.textContent).toBe('inside nested tsrx');
+	});
+
+	it('hydrates tsx declared inside tsrx nested from a top-level tsx value', async () => {
+		await hydrateComponent(
+			ServerComponents.TsxDeclaredInsideNestedTsrxFromTopLevelTsx,
+			ClientComponents.TsxDeclaredInsideNestedTsrxFromTopLevelTsx,
+		);
+
+		const native = container.querySelector('.native');
+		expect(native).toBeTruthy();
+		expect(native?.querySelector('.nested-tsx')?.textContent).toBe('inside nested tsx');
+	});
+
 	it('restores text children after hydrating away initial server text', async () => {
 		await hydrateComponent(
 			ServerComponents.TextPropWithToggle,

--- a/packages/ripple/tests/hydration/basic.test.js
+++ b/packages/ripple/tests/hydration/basic.test.js
@@ -110,6 +110,28 @@ describe('hydration > basic', () => {
 		expect(collection?.querySelector('.primitive-tail')?.textContent).toBe(' ok');
 	});
 
+	it('hydrates dynamic array values returned from calls without comma stringification', async () => {
+		await hydrateComponent(
+			ServerComponents.DynamicArrayFromCall,
+			ClientComponents.DynamicArrayFromCall,
+		);
+
+		expect(container.querySelector('.dynamic-array-call')?.textContent).toBe(
+			'start:one2truefalse:end',
+		);
+	});
+
+	it('hydrates dynamic array values from tracked state without comma stringification', async () => {
+		await hydrateComponent(
+			ServerComponents.DynamicArrayFromTrack,
+			ClientComponents.DynamicArrayFromTrack,
+		);
+
+		expect(container.querySelector('.dynamic-array-track')?.textContent).toBe(
+			'start:one2truefalse:end',
+		);
+	});
+
 	it('hydrates tsrx nested directly inside a top-level tsx expression value', async () => {
 		await hydrateComponent(
 			ServerComponents.NestedTsrxInsideTopLevelTsxExpression,

--- a/packages/ripple/tests/hydration/basic.test.js
+++ b/packages/ripple/tests/hydration/basic.test.js
@@ -132,6 +132,28 @@ describe('hydration > basic', () => {
 		);
 	});
 
+	it('hydrates dynamic array values from conditionals without comma stringification', async () => {
+		await hydrateComponent(
+			ServerComponents.DynamicArrayFromConditional,
+			ClientComponents.DynamicArrayFromConditional,
+		);
+
+		expect(container.querySelector('.dynamic-array-conditional')?.textContent).toBe(
+			'start:one2truefalse:end',
+		);
+	});
+
+	it('hydrates dynamic array values from logical expressions without comma stringification', async () => {
+		await hydrateComponent(
+			ServerComponents.DynamicArrayFromLogical,
+			ClientComponents.DynamicArrayFromLogical,
+		);
+
+		expect(container.querySelector('.dynamic-array-logical')?.textContent).toBe(
+			'start:one2truefalse:end',
+		);
+	});
+
 	it('hydrates tsrx nested directly inside a top-level tsx expression value', async () => {
 		await hydrateComponent(
 			ServerComponents.NestedTsrxInsideTopLevelTsxExpression,

--- a/packages/ripple/tests/hydration/basic.test.js
+++ b/packages/ripple/tests/hydration/basic.test.js
@@ -75,6 +75,41 @@ describe('hydration > basic', () => {
 		).toEqual(['1', '2', '3', '4']);
 	});
 
+	it('hydrates mixed tsrx collection text without duplicating server text', async () => {
+		await hydrateComponent(
+			ServerComponents.MixedTsrxCollectionText,
+			ClientComponents.MixedTsrxCollectionText,
+		);
+
+		const collection = container.querySelector('.mixed-collection');
+		expect(collection?.textContent).toBe('alpha beta gamma delta epsilon zeta');
+		expect(collection?.querySelector('.middle')?.textContent).toBe('beta');
+		expect(collection?.querySelector('.tail')?.textContent).toBe('epsilon');
+	});
+
+	it('hydrates split mixed collection text when the client updates a coalesced server text segment', async () => {
+		await hydrateComponent(
+			ServerComponents.MixedTsrxCollectionSplitServerText,
+			ClientComponents.MixedTsrxCollectionSplitClientText,
+		);
+
+		const collection = container.querySelector('.mixed-collection-split');
+		expect(collection?.textContent).toBe('alpha beta gamma changed epsilon zeta');
+		expect(collection?.querySelector('.middle')?.textContent).toBe('beta');
+		expect(collection?.querySelector('.tail')?.textContent).toBe('epsilon');
+	});
+
+	it('hydrates primitive mixed collection text with client/server text differences', async () => {
+		await hydrateComponent(
+			ServerComponents.MixedTsrxCollectionPrimitiveServerText,
+			ClientComponents.MixedTsrxCollectionPrimitiveClientText,
+		);
+
+		const collection = container.querySelector('.mixed-collection-primitive');
+		expect(collection?.textContent).toBe('count: 2 / false ok');
+		expect(collection?.querySelector('.primitive-tail')?.textContent).toBe(' ok');
+	});
+
 	it('hydrates tsrx nested directly inside a top-level tsx expression value', async () => {
 		await hydrateComponent(
 			ServerComponents.NestedTsrxInsideTopLevelTsxExpression,

--- a/packages/ripple/tests/hydration/compiled/client/basic.js
+++ b/packages/ripple/tests/hydration/compiled/client/basic.js
@@ -22,33 +22,51 @@ var root_12 = _$_.template(`<span class="label"> </span><!>`, 1, 2);
 var root_18 = _$_.template(`<div class="app-item"> </div>`, 0);
 var root_19 = _$_.template(` `, 1, 1);
 var root_20 = _$_.template(`<!><!>`, 1, 2);
-var root_23 = _$_.template(`<div class="inner">from tsrx</div>`, 0);
-var root_22 = _$_.template(`<!>`, 1, 1);
-var root_21 = _$_.template(`<section class="outer"> </section>`, 0);
-var root_24 = _$_.template(`<!>`, 1, 1);
-var root_27 = _$_.template(`<section class="native"><span class="nested-tsrx">inside nested tsrx</span></section>`, 0);
-var root_26 = _$_.template(`<!>`, 1, 1);
-var root_25 = _$_.template(`<div class="wrapper"> </div>`, 0);
-var root_28 = _$_.template(`<!>`, 1, 1);
-var root_29 = _$_.template(`<span class="nested-tsx">inside nested tsx</span>`, 0);
-var root_30 = _$_.template(`<div class="native"><!></div>`, 0);
-var root_31 = _$_.template(`<!>`, 1, 1);
-var root_32 = _$_.template(`<!>`, 1, 1);
-var root_33 = _$_.template(`<div class="text-prop"><!></div>`, 0);
-var root_34 = _$_.template(`<!><button class="show-text">Show</button>`, 1, 2);
-var root_35 = _$_.template(`<h1 class="sr-only">heading</h1><p class="subtitle">first paragraph</p><p class="subtitle">second paragraph</p>`, 1, 3);
-var root_36 = _$_.template(`<!><span class="sibling1"> </span><span class="sibling2"> </span>`, 1, 3);
-var root_37 = _$_.template(`<h1 class="sr-only">Ripple</h1><img src="/images/logo.png" alt="Logo" class="logo"><p class="subtitle">the elegant TypeScript UI framework</p>`, 1, 3);
-var root_39 = _$_.template(`<a href="/playground" class="playground-link">Playground</a>`, 0);
-var root_38 = _$_.template(`<div class="social-links"><a href="https://github.com" class="github-link">GitHub</a><a href="https://discord.com" class="discord-link">Discord</a><!></div>`, 0);
-var root_40 = _$_.template(`<main><div class="container"><!></div></main>`, 0);
-var root_41 = _$_.template(`<div class="content"><p>Some content here</p></div>`, 0);
-var root_43 = _$_.template(`<!><!><!><!>`, 1, 4);
+var root_21 = _$_.template(`<strong class="middle">beta</strong>`, 0);
+var root_22 = _$_.template(`<em class="tail">epsilon</em>`, 0);
+var root_23 = _$_.template(` `, 1, 1);
+var root_24 = _$_.template(`<div class="mixed-collection"><!></div>`, 0);
+var root_25 = _$_.template(`<strong class="middle">beta</strong>`, 0);
+var root_26 = _$_.template(`<em class="tail">epsilon</em>`, 0);
+var root_27 = _$_.template(` `, 1, 1);
+var root_28 = _$_.template(`<div class="mixed-collection-split"><!></div>`, 0);
+var root_29 = _$_.template(`<strong class="middle">beta</strong>`, 0);
+var root_30 = _$_.template(`<em class="tail">epsilon</em>`, 0);
+var root_31 = _$_.template(` `, 1, 1);
+var root_32 = _$_.template(`<div class="mixed-collection-split"><!></div>`, 0);
+var root_33 = _$_.template(`<span class="primitive-tail"> ok</span>`, 0);
+var root_34 = _$_.template(` `, 1, 1);
+var root_35 = _$_.template(`<div class="mixed-collection-primitive"><!></div>`, 0);
+var root_36 = _$_.template(`<span class="primitive-tail"> ok</span>`, 0);
+var root_37 = _$_.template(` `, 1, 1);
+var root_38 = _$_.template(`<div class="mixed-collection-primitive"><!></div>`, 0);
+var root_41 = _$_.template(`<div class="inner">from tsrx</div>`, 0);
+var root_40 = _$_.template(`<!>`, 1, 1);
+var root_39 = _$_.template(`<section class="outer"> </section>`, 0);
 var root_42 = _$_.template(`<!>`, 1, 1);
-var root_44 = _$_.template(`<footer class="last-child">I am the last child</footer>`, 0);
-var root_45 = _$_.template(`<div class="wrapper"><h1>Header</h1><p>Some content</p><!></div>`, 0);
-var root_46 = _$_.template(`<div class="inner"><span>Inner text</span><!></div>`, 0);
-var root_47 = _$_.template(`<section class="outer"><h2>Section title</h2><!></section>`, 0);
+var root_45 = _$_.template(`<section class="native"><span class="nested-tsrx">inside nested tsrx</span></section>`, 0);
+var root_44 = _$_.template(`<!>`, 1, 1);
+var root_43 = _$_.template(`<div class="wrapper"> </div>`, 0);
+var root_46 = _$_.template(`<!>`, 1, 1);
+var root_47 = _$_.template(`<span class="nested-tsx">inside nested tsx</span>`, 0);
+var root_48 = _$_.template(`<div class="native"><!></div>`, 0);
+var root_49 = _$_.template(`<!>`, 1, 1);
+var root_50 = _$_.template(`<!>`, 1, 1);
+var root_51 = _$_.template(`<div class="text-prop"><!></div>`, 0);
+var root_52 = _$_.template(`<!><button class="show-text">Show</button>`, 1, 2);
+var root_53 = _$_.template(`<h1 class="sr-only">heading</h1><p class="subtitle">first paragraph</p><p class="subtitle">second paragraph</p>`, 1, 3);
+var root_54 = _$_.template(`<!><span class="sibling1"> </span><span class="sibling2"> </span>`, 1, 3);
+var root_55 = _$_.template(`<h1 class="sr-only">Ripple</h1><img src="/images/logo.png" alt="Logo" class="logo"><p class="subtitle">the elegant TypeScript UI framework</p>`, 1, 3);
+var root_57 = _$_.template(`<a href="/playground" class="playground-link">Playground</a>`, 0);
+var root_56 = _$_.template(`<div class="social-links"><a href="https://github.com" class="github-link">GitHub</a><a href="https://discord.com" class="discord-link">Discord</a><!></div>`, 0);
+var root_58 = _$_.template(`<main><div class="container"><!></div></main>`, 0);
+var root_59 = _$_.template(`<div class="content"><p>Some content here</p></div>`, 0);
+var root_61 = _$_.template(`<!><!><!><!>`, 1, 4);
+var root_60 = _$_.template(`<!>`, 1, 1);
+var root_62 = _$_.template(`<footer class="last-child">I am the last child</footer>`, 0);
+var root_63 = _$_.template(`<div class="wrapper"><h1>Header</h1><p>Some content</p><!></div>`, 0);
+var root_64 = _$_.template(`<div class="inner"><span>Inner text</span><!></div>`, 0);
+var root_65 = _$_.template(`<section class="outer"><h2>Section title</h2><!></section>`, 0);
 
 import { track } from 'ripple';
 
@@ -299,26 +317,222 @@ export function NestedTsxTsrxExpressionValues(__anchor, _, __block) {
 	_$_.pop_component();
 }
 
+export function MixedTsrxCollectionText(__anchor, _, __block) {
+	_$_.push_component();
+
+	const content = _$_.tsrx_element(function render_children(__anchor, __block) {
+		var fragment_12 = root_23();
+		var expression_12 = _$_.first_child_frag(fragment_12, true);
+
+		_$_.expression(expression_12, () => [
+			'alpha ',
+			_$_.tsrx_element(function render_children(__anchor, __block) {
+				var strong = root_21();
+
+				_$_.append(__anchor, strong);
+			}),
+			' gamma ',
+			[
+				'delta ',
+				_$_.tsrx_element(function render_children(__anchor, __block) {
+					var em = root_22();
+
+					_$_.append(__anchor, em);
+				}),
+				' zeta'
+			]
+		]);
+
+		_$_.append(__anchor, fragment_12);
+	});
+
+	var div_10 = root_24();
+
+	{
+		var expression_13 = _$_.child(div_10);
+
+		_$_.expression(expression_13, () => content);
+		_$_.pop(div_10);
+	}
+
+	_$_.append(__anchor, div_10);
+	_$_.pop_component();
+}
+
+export function MixedTsrxCollectionSplitServerText(__anchor, _, __block) {
+	_$_.push_component();
+
+	const content = _$_.tsrx_element(function render_children(__anchor, __block) {
+		var fragment_13 = root_27();
+		var expression_14 = _$_.first_child_frag(fragment_13, true);
+
+		_$_.expression(expression_14, () => [
+			'alpha ',
+			_$_.tsrx_element(function render_children(__anchor, __block) {
+				var strong_1 = root_25();
+
+				_$_.append(__anchor, strong_1);
+			}),
+			' gamma ',
+			[
+				'delta ',
+				_$_.tsrx_element(function render_children(__anchor, __block) {
+					var em_1 = root_26();
+
+					_$_.append(__anchor, em_1);
+				}),
+				' zeta'
+			]
+		]);
+
+		_$_.append(__anchor, fragment_13);
+	});
+
+	var div_11 = root_28();
+
+	{
+		var expression_15 = _$_.child(div_11);
+
+		_$_.expression(expression_15, () => content);
+		_$_.pop(div_11);
+	}
+
+	_$_.append(__anchor, div_11);
+	_$_.pop_component();
+}
+
+export function MixedTsrxCollectionSplitClientText(__anchor, _, __block) {
+	_$_.push_component();
+
+	const content = _$_.tsrx_element(function render_children(__anchor, __block) {
+		var fragment_14 = root_31();
+		var expression_16 = _$_.first_child_frag(fragment_14, true);
+
+		_$_.expression(expression_16, () => [
+			'alpha ',
+			_$_.tsrx_element(function render_children(__anchor, __block) {
+				var strong_2 = root_29();
+
+				_$_.append(__anchor, strong_2);
+			}),
+			' gamma ',
+			[
+				'changed ',
+				_$_.tsrx_element(function render_children(__anchor, __block) {
+					var em_2 = root_30();
+
+					_$_.append(__anchor, em_2);
+				}),
+				' zeta'
+			]
+		]);
+
+		_$_.append(__anchor, fragment_14);
+	});
+
+	var div_12 = root_32();
+
+	{
+		var expression_17 = _$_.child(div_12);
+
+		_$_.expression(expression_17, () => content);
+		_$_.pop(div_12);
+	}
+
+	_$_.append(__anchor, div_12);
+	_$_.pop_component();
+}
+
+export function MixedTsrxCollectionPrimitiveServerText(__anchor, _, __block) {
+	_$_.push_component();
+
+	const content = _$_.tsrx_element(function render_children(__anchor, __block) {
+		var fragment_15 = root_34();
+		var expression_18 = _$_.first_child_frag(fragment_15, true);
+
+		_$_.expression(expression_18, () => [
+			'count: ',
+			1,
+			' / ',
+			true,
+			_$_.tsrx_element(function render_children(__anchor, __block) {
+				var span_4 = root_33();
+
+				_$_.append(__anchor, span_4);
+			})
+		]);
+
+		_$_.append(__anchor, fragment_15);
+	});
+
+	var div_13 = root_35();
+
+	{
+		var expression_19 = _$_.child(div_13);
+
+		_$_.expression(expression_19, () => content);
+		_$_.pop(div_13);
+	}
+
+	_$_.append(__anchor, div_13);
+	_$_.pop_component();
+}
+
+export function MixedTsrxCollectionPrimitiveClientText(__anchor, _, __block) {
+	_$_.push_component();
+
+	const content = _$_.tsrx_element(function render_children(__anchor, __block) {
+		var fragment_16 = root_37();
+		var expression_20 = _$_.first_child_frag(fragment_16, true);
+
+		_$_.expression(expression_20, () => [
+			'count: ',
+			2,
+			' / ',
+			false,
+			_$_.tsrx_element(function render_children(__anchor, __block) {
+				var span_5 = root_36();
+
+				_$_.append(__anchor, span_5);
+			})
+		]);
+
+		_$_.append(__anchor, fragment_16);
+	});
+
+	var div_14 = root_38();
+
+	{
+		var expression_21 = _$_.child(div_14);
+
+		_$_.expression(expression_21, () => content);
+		_$_.pop(div_14);
+	}
+
+	_$_.append(__anchor, div_14);
+	_$_.pop_component();
+}
+
 export function NestedTsrxInsideTopLevelTsxExpression(__anchor, _, __block) {
 	_$_.push_component();
 
 	const content = _$_.tsrx_element(function render_children(__anchor, __block) {
-		var section_1 = root_21();
+		var section_1 = root_39();
 
 		{
-			var expression_12 = _$_.child(section_1, true);
+			var expression_22 = _$_.child(section_1, true);
 
-			_$_.expression(expression_12, () => _$_.tsrx_element(function render_children(__anchor, __block) {
-				var fragment_12 = root_22();
-				var node_6 = _$_.first_child_frag(fragment_12);
+			_$_.expression(expression_22, () => _$_.tsrx_element(function render_children(__anchor, __block) {
+				var fragment_17 = root_40();
+				var node_6 = _$_.first_child_frag(fragment_17);
 
 				_$_.expression(node_6, () => _$_.tsrx_element(function render_children(__anchor, __block) {
-					var div_10 = root_23();
+					var div_15 = root_41();
 
-					_$_.append(__anchor, div_10);
+					_$_.append(__anchor, div_15);
 				}));
 
-				_$_.append(__anchor, fragment_12);
+				_$_.append(__anchor, fragment_17);
 			}));
 
 			_$_.pop(section_1);
@@ -327,11 +541,11 @@ export function NestedTsrxInsideTopLevelTsxExpression(__anchor, _, __block) {
 		_$_.append(__anchor, section_1);
 	});
 
-	var fragment_13 = root_24();
-	var expression_13 = _$_.first_child_frag(fragment_13);
+	var fragment_18 = root_42();
+	var expression_23 = _$_.first_child_frag(fragment_18);
 
-	_$_.expression(expression_13, () => content);
-	_$_.append(__anchor, fragment_13);
+	_$_.expression(expression_23, () => content);
+	_$_.append(__anchor, fragment_18);
 	_$_.pop_component();
 }
 
@@ -339,35 +553,35 @@ export function NestedTsrxElementsInsideTopLevelTsxValue(__anchor, _, __block) {
 	_$_.push_component();
 
 	const content = _$_.tsrx_element(function render_children(__anchor, __block) {
-		var div_11 = root_25();
+		var div_16 = root_43();
 
 		{
-			var expression_14 = _$_.child(div_11, true);
+			var expression_24 = _$_.child(div_16, true);
 
-			_$_.expression(expression_14, () => _$_.tsrx_element(function render_children(__anchor, __block) {
-				var fragment_14 = root_26();
-				var node_7 = _$_.first_child_frag(fragment_14);
+			_$_.expression(expression_24, () => _$_.tsrx_element(function render_children(__anchor, __block) {
+				var fragment_19 = root_44();
+				var node_7 = _$_.first_child_frag(fragment_19);
 
 				_$_.expression(node_7, () => _$_.tsrx_element(function render_children(__anchor, __block) {
-					var section_2 = root_27();
+					var section_2 = root_45();
 
 					_$_.append(__anchor, section_2);
 				}));
 
-				_$_.append(__anchor, fragment_14);
+				_$_.append(__anchor, fragment_19);
 			}));
 
-			_$_.pop(div_11);
+			_$_.pop(div_16);
 		}
 
-		_$_.append(__anchor, div_11);
+		_$_.append(__anchor, div_16);
 	});
 
-	var fragment_15 = root_28();
-	var expression_15 = _$_.first_child_frag(fragment_15);
+	var fragment_20 = root_46();
+	var expression_25 = _$_.first_child_frag(fragment_20);
 
-	_$_.expression(expression_15, () => content);
-	_$_.append(__anchor, fragment_15);
+	_$_.expression(expression_25, () => content);
+	_$_.append(__anchor, fragment_20);
 	_$_.pop_component();
 }
 
@@ -375,52 +589,52 @@ export function TsxDeclaredInsideNestedTsrxFromTopLevelTsx(__anchor, _, __block)
 	_$_.push_component();
 
 	const content = _$_.tsrx_element(function render_children(__anchor, __block) {
-		var fragment_16 = root_31();
-		var expression_17 = _$_.first_child_frag(fragment_16);
+		var fragment_21 = root_49();
+		var expression_27 = _$_.first_child_frag(fragment_21);
 
-		_$_.expression(expression_17, () => _$_.tsrx_element(function render_children(__anchor, __block) {
+		_$_.expression(expression_27, () => _$_.tsrx_element(function render_children(__anchor, __block) {
 			const nested = _$_.tsrx_element(function render_children(__anchor, __block) {
-				var span_4 = root_29();
+				var span_6 = root_47();
 
-				_$_.append(__anchor, span_4);
+				_$_.append(__anchor, span_6);
 			});
 
-			var div_12 = root_30();
+			var div_17 = root_48();
 
 			{
-				var expression_16 = _$_.child(div_12);
+				var expression_26 = _$_.child(div_17);
 
-				_$_.expression(expression_16, () => nested);
-				_$_.pop(div_12);
+				_$_.expression(expression_26, () => nested);
+				_$_.pop(div_17);
 			}
 
-			_$_.append(__anchor, div_12);
+			_$_.append(__anchor, div_17);
 		}));
 
-		_$_.append(__anchor, fragment_16);
+		_$_.append(__anchor, fragment_21);
 	});
 
-	var fragment_17 = root_32();
-	var expression_18 = _$_.first_child_frag(fragment_17);
+	var fragment_22 = root_50();
+	var expression_28 = _$_.first_child_frag(fragment_22);
 
-	_$_.expression(expression_18, () => content);
-	_$_.append(__anchor, fragment_17);
+	_$_.expression(expression_28, () => content);
+	_$_.append(__anchor, fragment_22);
 	_$_.pop_component();
 }
 
 function TextProp(__anchor, __props, __block) {
 	_$_.push_component();
 
-	var div_13 = root_33();
+	var div_18 = root_51();
 
 	{
-		var expression_19 = _$_.child(div_13);
+		var expression_29 = _$_.child(div_18);
 
-		_$_.expression(expression_19, () => __props.children);
-		_$_.pop(div_13);
+		_$_.expression(expression_29, () => __props.children);
+		_$_.pop(div_18);
 	}
 
-	_$_.append(__anchor, div_13);
+	_$_.append(__anchor, div_18);
 	_$_.pop_component();
 }
 
@@ -428,8 +642,8 @@ export function TextPropWithToggle(__anchor, _, __block) {
 	_$_.push_component();
 
 	let lazy = _$_.track(false, __block, 'b5de6402');
-	var fragment_18 = root_34();
-	var node_8 = _$_.first_child_frag(fragment_18);
+	var fragment_23 = root_52();
+	var node_8 = _$_.first_child_frag(fragment_23);
 
 	TextProp(
 		node_8,
@@ -444,17 +658,17 @@ export function TextPropWithToggle(__anchor, _, __block) {
 	var button_1 = _$_.sibling(node_8);
 
 	button_1.__click = () => _$_.set(lazy, true);
-	_$_.append(__anchor, fragment_18);
+	_$_.append(__anchor, fragment_23);
 	_$_.pop_component();
 }
 
 function StaticHeader(__anchor, _, __block) {
 	_$_.push_component();
 
-	var fragment_19 = root_35();
+	var fragment_24 = root_53();
 
 	_$_.next(2);
-	_$_.append(__anchor, fragment_19, true);
+	_$_.append(__anchor, fragment_24, true);
 	_$_.pop_component();
 }
 
@@ -462,57 +676,57 @@ export function StaticChildWithSiblings(__anchor, _, __block) {
 	_$_.push_component();
 
 	const foo = 'bar';
-	var fragment_20 = root_36();
-	var node_9 = _$_.first_child_frag(fragment_20);
+	var fragment_25 = root_54();
+	var node_9 = _$_.first_child_frag(fragment_25);
 
 	StaticHeader(node_9, {}, _$_.active_block);
 
-	var span_5 = _$_.sibling(node_9);
+	var span_7 = _$_.sibling(node_9);
 
 	{
-		var expression_20 = _$_.child(span_5, true);
+		var expression_30 = _$_.child(span_7, true);
 
-		_$_.expression(expression_20, () => foo);
-		_$_.pop(span_5);
+		_$_.expression(expression_30, () => foo);
+		_$_.pop(span_7);
 	}
 
-	var span_6 = _$_.sibling(span_5);
+	var span_8 = _$_.sibling(span_7);
 
 	{
-		var expression_21 = _$_.child(span_6, true);
+		var expression_31 = _$_.child(span_8, true);
 
-		_$_.expression(expression_21, () => foo);
-		_$_.pop(span_6);
+		_$_.expression(expression_31, () => foo);
+		_$_.pop(span_8);
 	}
 
 	_$_.next();
-	_$_.append(__anchor, fragment_20, true);
+	_$_.append(__anchor, fragment_25, true);
 	_$_.pop_component();
 }
 
 function Header(__anchor, _, __block) {
 	_$_.push_component();
 
-	var fragment_21 = root_37();
+	var fragment_26 = root_55();
 
 	_$_.next(2);
-	_$_.append(__anchor, fragment_21, true);
+	_$_.append(__anchor, fragment_26, true);
 	_$_.pop_component();
 }
 
 function Actions(__anchor, { playgroundVisible = false }, __block) {
 	_$_.push_component();
 
-	var div_14 = root_38();
+	var div_19 = root_56();
 
 	{
-		var a_2 = _$_.child(div_14);
+		var a_2 = _$_.child(div_19);
 		var a_1 = _$_.sibling(a_2);
 		var node_10 = _$_.sibling(a_1);
 
 		{
 			var consequent = (__anchor) => {
-				var a_3 = root_39();
+				var a_3 = root_57();
 
 				_$_.append(__anchor, a_3);
 			};
@@ -522,26 +736,26 @@ function Actions(__anchor, { playgroundVisible = false }, __block) {
 			});
 		}
 
-		_$_.pop(div_14);
+		_$_.pop(div_19);
 	}
 
-	_$_.append(__anchor, div_14);
+	_$_.append(__anchor, div_19);
 	_$_.pop_component();
 }
 
 function Layout(__anchor, { children }, __block) {
 	_$_.push_component();
 
-	var main_1 = root_40();
+	var main_1 = root_58();
 
 	{
-		var div_15 = _$_.child(main_1);
+		var div_20 = _$_.child(main_1);
 
 		{
-			var expression_22 = _$_.child(div_15);
+			var expression_32 = _$_.child(div_20);
 
-			_$_.expression(expression_22, () => children);
-			_$_.pop(div_15);
+			_$_.expression(expression_32, () => children);
+			_$_.pop(div_20);
 		}
 	}
 
@@ -552,24 +766,24 @@ function Layout(__anchor, { children }, __block) {
 function Content(__anchor, _, __block) {
 	_$_.push_component();
 
-	var div_16 = root_41();
+	var div_21 = root_59();
 
-	_$_.append(__anchor, div_16);
+	_$_.append(__anchor, div_21);
 	_$_.pop_component();
 }
 
 export function WebsiteIndex(__anchor, _, __block) {
 	_$_.push_component();
 
-	var fragment_22 = root_42();
-	var node_11 = _$_.first_child_frag(fragment_22);
+	var fragment_27 = root_60();
+	var node_11 = _$_.first_child_frag(fragment_27);
 
 	Layout(
 		node_11,
 		{
 			children: _$_.tsrx_element(function render_children(__anchor, __block) {
-				var fragment_23 = root_43();
-				var node_12 = _$_.first_child_frag(fragment_23);
+				var fragment_28 = root_61();
+				var node_12 = _$_.first_child_frag(fragment_28);
 
 				Header(node_12, {}, _$_.active_block);
 
@@ -584,20 +798,20 @@ export function WebsiteIndex(__anchor, _, __block) {
 				var node_15 = _$_.sibling(node_14);
 
 				Actions(node_15, { playgroundVisible: false }, _$_.active_block);
-				_$_.append(__anchor, fragment_23);
+				_$_.append(__anchor, fragment_28);
 			})
 		},
 		_$_.active_block
 	);
 
-	_$_.append(__anchor, fragment_22);
+	_$_.append(__anchor, fragment_27);
 	_$_.pop_component();
 }
 
 function LastChild(__anchor, _, __block) {
 	_$_.push_component();
 
-	var footer_1 = root_44();
+	var footer_1 = root_62();
 
 	_$_.append(__anchor, footer_1);
 	_$_.pop_component();
@@ -606,42 +820,42 @@ function LastChild(__anchor, _, __block) {
 export function ComponentAsLastSibling(__anchor, _, __block) {
 	_$_.push_component();
 
-	var div_17 = root_45();
+	var div_22 = root_63();
 
 	{
-		var h1_1 = _$_.child(div_17);
+		var h1_1 = _$_.child(div_22);
 		var p_1 = _$_.sibling(h1_1);
 		var node_16 = _$_.sibling(p_1);
 
 		LastChild(node_16, {}, _$_.active_block);
-		_$_.pop(div_17);
+		_$_.pop(div_22);
 	}
 
-	_$_.append(__anchor, div_17);
+	_$_.append(__anchor, div_22);
 	_$_.pop_component();
 }
 
 function InnerContent(__anchor, _, __block) {
 	_$_.push_component();
 
-	var div_18 = root_46();
+	var div_23 = root_64();
 
 	{
-		var span_7 = _$_.child(div_18);
-		var node_17 = _$_.sibling(span_7);
+		var span_9 = _$_.child(div_23);
+		var node_17 = _$_.sibling(span_9);
 
 		LastChild(node_17, {}, _$_.active_block);
-		_$_.pop(div_18);
+		_$_.pop(div_23);
 	}
 
-	_$_.append(__anchor, div_18);
+	_$_.append(__anchor, div_23);
 	_$_.pop_component();
 }
 
 export function NestedComponentAsLastSibling(__anchor, _, __block) {
 	_$_.push_component();
 
-	var section_3 = root_47();
+	var section_3 = root_65();
 
 	{
 		var h2_1 = _$_.child(section_3);

--- a/packages/ripple/tests/hydration/compiled/client/basic.js
+++ b/packages/ripple/tests/hydration/compiled/client/basic.js
@@ -42,33 +42,35 @@ var root_37 = _$_.template(` `, 1, 1);
 var root_38 = _$_.template(`<div class="mixed-collection-primitive"><!></div>`, 0);
 var root_39 = _$_.template(`<div class="dynamic-array-call"> </div>`, 0);
 var root_40 = _$_.template(`<div class="dynamic-array-track"> </div>`, 0);
-var root_43 = _$_.template(`<div class="inner">from tsrx</div>`, 0);
-var root_42 = _$_.template(`<!>`, 1, 1);
-var root_41 = _$_.template(`<section class="outer"> </section>`, 0);
+var root_41 = _$_.template(`<div class="dynamic-array-conditional"> </div>`, 0);
+var root_42 = _$_.template(`<div class="dynamic-array-logical"> </div>`, 0);
+var root_45 = _$_.template(`<div class="inner">from tsrx</div>`, 0);
 var root_44 = _$_.template(`<!>`, 1, 1);
-var root_47 = _$_.template(`<section class="native"><span class="nested-tsrx">inside nested tsrx</span></section>`, 0);
+var root_43 = _$_.template(`<section class="outer"> </section>`, 0);
 var root_46 = _$_.template(`<!>`, 1, 1);
-var root_45 = _$_.template(`<div class="wrapper"> </div>`, 0);
+var root_49 = _$_.template(`<section class="native"><span class="nested-tsrx">inside nested tsrx</span></section>`, 0);
 var root_48 = _$_.template(`<!>`, 1, 1);
-var root_49 = _$_.template(`<span class="nested-tsx">inside nested tsx</span>`, 0);
-var root_50 = _$_.template(`<div class="native"><!></div>`, 0);
-var root_51 = _$_.template(`<!>`, 1, 1);
-var root_52 = _$_.template(`<!>`, 1, 1);
-var root_53 = _$_.template(`<div class="text-prop"><!></div>`, 0);
-var root_54 = _$_.template(`<!><button class="show-text">Show</button>`, 1, 2);
-var root_55 = _$_.template(`<h1 class="sr-only">heading</h1><p class="subtitle">first paragraph</p><p class="subtitle">second paragraph</p>`, 1, 3);
-var root_56 = _$_.template(`<!><span class="sibling1"> </span><span class="sibling2"> </span>`, 1, 3);
-var root_57 = _$_.template(`<h1 class="sr-only">Ripple</h1><img src="/images/logo.png" alt="Logo" class="logo"><p class="subtitle">the elegant TypeScript UI framework</p>`, 1, 3);
-var root_59 = _$_.template(`<a href="/playground" class="playground-link">Playground</a>`, 0);
-var root_58 = _$_.template(`<div class="social-links"><a href="https://github.com" class="github-link">GitHub</a><a href="https://discord.com" class="discord-link">Discord</a><!></div>`, 0);
-var root_60 = _$_.template(`<main><div class="container"><!></div></main>`, 0);
-var root_61 = _$_.template(`<div class="content"><p>Some content here</p></div>`, 0);
-var root_63 = _$_.template(`<!><!><!><!>`, 1, 4);
-var root_62 = _$_.template(`<!>`, 1, 1);
-var root_64 = _$_.template(`<footer class="last-child">I am the last child</footer>`, 0);
-var root_65 = _$_.template(`<div class="wrapper"><h1>Header</h1><p>Some content</p><!></div>`, 0);
-var root_66 = _$_.template(`<div class="inner"><span>Inner text</span><!></div>`, 0);
-var root_67 = _$_.template(`<section class="outer"><h2>Section title</h2><!></section>`, 0);
+var root_47 = _$_.template(`<div class="wrapper"> </div>`, 0);
+var root_50 = _$_.template(`<!>`, 1, 1);
+var root_51 = _$_.template(`<span class="nested-tsx">inside nested tsx</span>`, 0);
+var root_52 = _$_.template(`<div class="native"><!></div>`, 0);
+var root_53 = _$_.template(`<!>`, 1, 1);
+var root_54 = _$_.template(`<!>`, 1, 1);
+var root_55 = _$_.template(`<div class="text-prop"><!></div>`, 0);
+var root_56 = _$_.template(`<!><button class="show-text">Show</button>`, 1, 2);
+var root_57 = _$_.template(`<h1 class="sr-only">heading</h1><p class="subtitle">first paragraph</p><p class="subtitle">second paragraph</p>`, 1, 3);
+var root_58 = _$_.template(`<!><span class="sibling1"> </span><span class="sibling2"> </span>`, 1, 3);
+var root_59 = _$_.template(`<h1 class="sr-only">Ripple</h1><img src="/images/logo.png" alt="Logo" class="logo"><p class="subtitle">the elegant TypeScript UI framework</p>`, 1, 3);
+var root_61 = _$_.template(`<a href="/playground" class="playground-link">Playground</a>`, 0);
+var root_60 = _$_.template(`<div class="social-links"><a href="https://github.com" class="github-link">GitHub</a><a href="https://discord.com" class="discord-link">Discord</a><!></div>`, 0);
+var root_62 = _$_.template(`<main><div class="container"><!></div></main>`, 0);
+var root_63 = _$_.template(`<div class="content"><p>Some content here</p></div>`, 0);
+var root_65 = _$_.template(`<!><!><!><!>`, 1, 4);
+var root_64 = _$_.template(`<!>`, 1, 1);
+var root_66 = _$_.template(`<footer class="last-child">I am the last child</footer>`, 0);
+var root_67 = _$_.template(`<div class="wrapper"><h1>Header</h1><p>Some content</p><!></div>`, 0);
+var root_68 = _$_.template(`<div class="inner"><span>Inner text</span><!></div>`, 0);
+var root_69 = _$_.template(`<section class="outer"><h2>Section title</h2><!></section>`, 0);
 
 import { track } from 'ripple';
 
@@ -553,23 +555,63 @@ export function DynamicArrayFromTrack(__anchor, _, __block) {
 	_$_.pop_component();
 }
 
+export function DynamicArrayFromConditional(__anchor, _, __block) {
+	_$_.push_component();
+
+	const condition = true;
+
+	const items = condition
+		? ['start:', ['one', 2], true, null, false, ':end']
+		: ['fallback'];
+
+	var div_17 = root_41();
+
+	{
+		var expression_24 = _$_.child(div_17);
+
+		_$_.expression(expression_24, () => items);
+		_$_.pop(div_17);
+	}
+
+	_$_.append(__anchor, div_17);
+	_$_.pop_component();
+}
+
+export function DynamicArrayFromLogical(__anchor, _, __block) {
+	_$_.push_component();
+
+	const condition = true;
+	const items = condition && ['start:', ['one', 2], true, null, false, ':end'];
+	var div_18 = root_42();
+
+	{
+		var expression_25 = _$_.child(div_18);
+
+		_$_.expression(expression_25, () => items);
+		_$_.pop(div_18);
+	}
+
+	_$_.append(__anchor, div_18);
+	_$_.pop_component();
+}
+
 export function NestedTsrxInsideTopLevelTsxExpression(__anchor, _, __block) {
 	_$_.push_component();
 
 	const content = _$_.tsrx_element(function render_children(__anchor, __block) {
-		var section_1 = root_41();
+		var section_1 = root_43();
 
 		{
-			var expression_24 = _$_.child(section_1);
+			var expression_26 = _$_.child(section_1);
 
-			_$_.expression(expression_24, () => _$_.tsrx_element(function render_children(__anchor, __block) {
-				var fragment_17 = root_42();
+			_$_.expression(expression_26, () => _$_.tsrx_element(function render_children(__anchor, __block) {
+				var fragment_17 = root_44();
 				var node_6 = _$_.first_child_frag(fragment_17);
 
 				_$_.expression(node_6, () => _$_.tsrx_element(function render_children(__anchor, __block) {
-					var div_17 = root_43();
+					var div_19 = root_45();
 
-					_$_.append(__anchor, div_17);
+					_$_.append(__anchor, div_19);
 				}));
 
 				_$_.append(__anchor, fragment_17);
@@ -581,10 +623,10 @@ export function NestedTsrxInsideTopLevelTsxExpression(__anchor, _, __block) {
 		_$_.append(__anchor, section_1);
 	});
 
-	var fragment_18 = root_44();
-	var expression_25 = _$_.first_child_frag(fragment_18);
+	var fragment_18 = root_46();
+	var expression_27 = _$_.first_child_frag(fragment_18);
 
-	_$_.expression(expression_25, () => content);
+	_$_.expression(expression_27, () => content);
 	_$_.append(__anchor, fragment_18);
 	_$_.pop_component();
 }
@@ -593,17 +635,17 @@ export function NestedTsrxElementsInsideTopLevelTsxValue(__anchor, _, __block) {
 	_$_.push_component();
 
 	const content = _$_.tsrx_element(function render_children(__anchor, __block) {
-		var div_18 = root_45();
+		var div_20 = root_47();
 
 		{
-			var expression_26 = _$_.child(div_18);
+			var expression_28 = _$_.child(div_20);
 
-			_$_.expression(expression_26, () => _$_.tsrx_element(function render_children(__anchor, __block) {
-				var fragment_19 = root_46();
+			_$_.expression(expression_28, () => _$_.tsrx_element(function render_children(__anchor, __block) {
+				var fragment_19 = root_48();
 				var node_7 = _$_.first_child_frag(fragment_19);
 
 				_$_.expression(node_7, () => _$_.tsrx_element(function render_children(__anchor, __block) {
-					var section_2 = root_47();
+					var section_2 = root_49();
 
 					_$_.append(__anchor, section_2);
 				}));
@@ -611,16 +653,16 @@ export function NestedTsrxElementsInsideTopLevelTsxValue(__anchor, _, __block) {
 				_$_.append(__anchor, fragment_19);
 			}));
 
-			_$_.pop(div_18);
+			_$_.pop(div_20);
 		}
 
-		_$_.append(__anchor, div_18);
+		_$_.append(__anchor, div_20);
 	});
 
-	var fragment_20 = root_48();
-	var expression_27 = _$_.first_child_frag(fragment_20);
+	var fragment_20 = root_50();
+	var expression_29 = _$_.first_child_frag(fragment_20);
 
-	_$_.expression(expression_27, () => content);
+	_$_.expression(expression_29, () => content);
 	_$_.append(__anchor, fragment_20);
 	_$_.pop_component();
 }
@@ -629,35 +671,35 @@ export function TsxDeclaredInsideNestedTsrxFromTopLevelTsx(__anchor, _, __block)
 	_$_.push_component();
 
 	const content = _$_.tsrx_element(function render_children(__anchor, __block) {
-		var fragment_21 = root_51();
-		var expression_29 = _$_.first_child_frag(fragment_21);
+		var fragment_21 = root_53();
+		var expression_31 = _$_.first_child_frag(fragment_21);
 
-		_$_.expression(expression_29, () => _$_.tsrx_element(function render_children(__anchor, __block) {
+		_$_.expression(expression_31, () => _$_.tsrx_element(function render_children(__anchor, __block) {
 			const nested = _$_.tsrx_element(function render_children(__anchor, __block) {
-				var span_6 = root_49();
+				var span_6 = root_51();
 
 				_$_.append(__anchor, span_6);
 			});
 
-			var div_19 = root_50();
+			var div_21 = root_52();
 
 			{
-				var expression_28 = _$_.child(div_19);
+				var expression_30 = _$_.child(div_21);
 
-				_$_.expression(expression_28, () => nested);
-				_$_.pop(div_19);
+				_$_.expression(expression_30, () => nested);
+				_$_.pop(div_21);
 			}
 
-			_$_.append(__anchor, div_19);
+			_$_.append(__anchor, div_21);
 		}));
 
 		_$_.append(__anchor, fragment_21);
 	});
 
-	var fragment_22 = root_52();
-	var expression_30 = _$_.first_child_frag(fragment_22);
+	var fragment_22 = root_54();
+	var expression_32 = _$_.first_child_frag(fragment_22);
 
-	_$_.expression(expression_30, () => content);
+	_$_.expression(expression_32, () => content);
 	_$_.append(__anchor, fragment_22);
 	_$_.pop_component();
 }
@@ -665,16 +707,16 @@ export function TsxDeclaredInsideNestedTsrxFromTopLevelTsx(__anchor, _, __block)
 function TextProp(__anchor, __props, __block) {
 	_$_.push_component();
 
-	var div_20 = root_53();
+	var div_22 = root_55();
 
 	{
-		var expression_31 = _$_.child(div_20);
+		var expression_33 = _$_.child(div_22);
 
-		_$_.expression(expression_31, () => __props.children);
-		_$_.pop(div_20);
+		_$_.expression(expression_33, () => __props.children);
+		_$_.pop(div_22);
 	}
 
-	_$_.append(__anchor, div_20);
+	_$_.append(__anchor, div_22);
 	_$_.pop_component();
 }
 
@@ -682,7 +724,7 @@ export function TextPropWithToggle(__anchor, _, __block) {
 	_$_.push_component();
 
 	let lazy_1 = _$_.track(false, __block, '1ba81c3b');
-	var fragment_23 = root_54();
+	var fragment_23 = root_56();
 	var node_8 = _$_.first_child_frag(fragment_23);
 
 	TextProp(
@@ -705,7 +747,7 @@ export function TextPropWithToggle(__anchor, _, __block) {
 function StaticHeader(__anchor, _, __block) {
 	_$_.push_component();
 
-	var fragment_24 = root_55();
+	var fragment_24 = root_57();
 
 	_$_.next(2);
 	_$_.append(__anchor, fragment_24, true);
@@ -716,7 +758,7 @@ export function StaticChildWithSiblings(__anchor, _, __block) {
 	_$_.push_component();
 
 	const foo = 'bar';
-	var fragment_25 = root_56();
+	var fragment_25 = root_58();
 	var node_9 = _$_.first_child_frag(fragment_25);
 
 	StaticHeader(node_9, {}, _$_.active_block);
@@ -724,18 +766,18 @@ export function StaticChildWithSiblings(__anchor, _, __block) {
 	var span_7 = _$_.sibling(node_9);
 
 	{
-		var expression_32 = _$_.child(span_7);
+		var expression_34 = _$_.child(span_7);
 
-		_$_.expression(expression_32, () => foo);
+		_$_.expression(expression_34, () => foo);
 		_$_.pop(span_7);
 	}
 
 	var span_8 = _$_.sibling(span_7);
 
 	{
-		var expression_33 = _$_.child(span_8);
+		var expression_35 = _$_.child(span_8);
 
-		_$_.expression(expression_33, () => foo);
+		_$_.expression(expression_35, () => foo);
 		_$_.pop(span_8);
 	}
 
@@ -747,7 +789,7 @@ export function StaticChildWithSiblings(__anchor, _, __block) {
 function Header(__anchor, _, __block) {
 	_$_.push_component();
 
-	var fragment_26 = root_57();
+	var fragment_26 = root_59();
 
 	_$_.next(2);
 	_$_.append(__anchor, fragment_26, true);
@@ -757,16 +799,16 @@ function Header(__anchor, _, __block) {
 function Actions(__anchor, { playgroundVisible = false }, __block) {
 	_$_.push_component();
 
-	var div_21 = root_58();
+	var div_23 = root_60();
 
 	{
-		var a_2 = _$_.child(div_21);
+		var a_2 = _$_.child(div_23);
 		var a_1 = _$_.sibling(a_2);
 		var node_10 = _$_.sibling(a_1);
 
 		{
 			var consequent = (__anchor) => {
-				var a_3 = root_59();
+				var a_3 = root_61();
 
 				_$_.append(__anchor, a_3);
 			};
@@ -776,26 +818,26 @@ function Actions(__anchor, { playgroundVisible = false }, __block) {
 			});
 		}
 
-		_$_.pop(div_21);
+		_$_.pop(div_23);
 	}
 
-	_$_.append(__anchor, div_21);
+	_$_.append(__anchor, div_23);
 	_$_.pop_component();
 }
 
 function Layout(__anchor, { children }, __block) {
 	_$_.push_component();
 
-	var main_1 = root_60();
+	var main_1 = root_62();
 
 	{
-		var div_22 = _$_.child(main_1);
+		var div_24 = _$_.child(main_1);
 
 		{
-			var expression_34 = _$_.child(div_22);
+			var expression_36 = _$_.child(div_24);
 
-			_$_.expression(expression_34, () => children);
-			_$_.pop(div_22);
+			_$_.expression(expression_36, () => children);
+			_$_.pop(div_24);
 		}
 	}
 
@@ -806,23 +848,23 @@ function Layout(__anchor, { children }, __block) {
 function Content(__anchor, _, __block) {
 	_$_.push_component();
 
-	var div_23 = root_61();
+	var div_25 = root_63();
 
-	_$_.append(__anchor, div_23);
+	_$_.append(__anchor, div_25);
 	_$_.pop_component();
 }
 
 export function WebsiteIndex(__anchor, _, __block) {
 	_$_.push_component();
 
-	var fragment_27 = root_62();
+	var fragment_27 = root_64();
 	var node_11 = _$_.first_child_frag(fragment_27);
 
 	Layout(
 		node_11,
 		{
 			children: _$_.tsrx_element(function render_children(__anchor, __block) {
-				var fragment_28 = root_63();
+				var fragment_28 = root_65();
 				var node_12 = _$_.first_child_frag(fragment_28);
 
 				Header(node_12, {}, _$_.active_block);
@@ -851,7 +893,7 @@ export function WebsiteIndex(__anchor, _, __block) {
 function LastChild(__anchor, _, __block) {
 	_$_.push_component();
 
-	var footer_1 = root_64();
+	var footer_1 = root_66();
 
 	_$_.append(__anchor, footer_1);
 	_$_.pop_component();
@@ -860,42 +902,42 @@ function LastChild(__anchor, _, __block) {
 export function ComponentAsLastSibling(__anchor, _, __block) {
 	_$_.push_component();
 
-	var div_24 = root_65();
+	var div_26 = root_67();
 
 	{
-		var h1_1 = _$_.child(div_24);
+		var h1_1 = _$_.child(div_26);
 		var p_1 = _$_.sibling(h1_1);
 		var node_16 = _$_.sibling(p_1);
 
 		LastChild(node_16, {}, _$_.active_block);
-		_$_.pop(div_24);
+		_$_.pop(div_26);
 	}
 
-	_$_.append(__anchor, div_24);
+	_$_.append(__anchor, div_26);
 	_$_.pop_component();
 }
 
 function InnerContent(__anchor, _, __block) {
 	_$_.push_component();
 
-	var div_25 = root_66();
+	var div_27 = root_68();
 
 	{
-		var span_9 = _$_.child(div_25);
+		var span_9 = _$_.child(div_27);
 		var node_17 = _$_.sibling(span_9);
 
 		LastChild(node_17, {}, _$_.active_block);
-		_$_.pop(div_25);
+		_$_.pop(div_27);
 	}
 
-	_$_.append(__anchor, div_25);
+	_$_.append(__anchor, div_27);
 	_$_.pop_component();
 }
 
 export function NestedComponentAsLastSibling(__anchor, _, __block) {
 	_$_.push_component();
 
-	var section_3 = root_67();
+	var section_3 = root_69();
 
 	{
 		var h2_1 = _$_.child(section_3);

--- a/packages/ripple/tests/hydration/compiled/client/basic.js
+++ b/packages/ripple/tests/hydration/compiled/client/basic.js
@@ -40,33 +40,35 @@ var root_35 = _$_.template(`<div class="mixed-collection-primitive"><!></div>`, 
 var root_36 = _$_.template(`<span class="primitive-tail"> ok</span>`, 0);
 var root_37 = _$_.template(` `, 1, 1);
 var root_38 = _$_.template(`<div class="mixed-collection-primitive"><!></div>`, 0);
-var root_41 = _$_.template(`<div class="inner">from tsrx</div>`, 0);
-var root_40 = _$_.template(`<!>`, 1, 1);
-var root_39 = _$_.template(`<section class="outer"> </section>`, 0);
+var root_39 = _$_.template(`<div class="dynamic-array-call"> </div>`, 0);
+var root_40 = _$_.template(`<div class="dynamic-array-track"> </div>`, 0);
+var root_43 = _$_.template(`<div class="inner">from tsrx</div>`, 0);
 var root_42 = _$_.template(`<!>`, 1, 1);
-var root_45 = _$_.template(`<section class="native"><span class="nested-tsrx">inside nested tsrx</span></section>`, 0);
+var root_41 = _$_.template(`<section class="outer"> </section>`, 0);
 var root_44 = _$_.template(`<!>`, 1, 1);
-var root_43 = _$_.template(`<div class="wrapper"> </div>`, 0);
+var root_47 = _$_.template(`<section class="native"><span class="nested-tsrx">inside nested tsrx</span></section>`, 0);
 var root_46 = _$_.template(`<!>`, 1, 1);
-var root_47 = _$_.template(`<span class="nested-tsx">inside nested tsx</span>`, 0);
-var root_48 = _$_.template(`<div class="native"><!></div>`, 0);
-var root_49 = _$_.template(`<!>`, 1, 1);
-var root_50 = _$_.template(`<!>`, 1, 1);
-var root_51 = _$_.template(`<div class="text-prop"><!></div>`, 0);
-var root_52 = _$_.template(`<!><button class="show-text">Show</button>`, 1, 2);
-var root_53 = _$_.template(`<h1 class="sr-only">heading</h1><p class="subtitle">first paragraph</p><p class="subtitle">second paragraph</p>`, 1, 3);
-var root_54 = _$_.template(`<!><span class="sibling1"> </span><span class="sibling2"> </span>`, 1, 3);
-var root_55 = _$_.template(`<h1 class="sr-only">Ripple</h1><img src="/images/logo.png" alt="Logo" class="logo"><p class="subtitle">the elegant TypeScript UI framework</p>`, 1, 3);
-var root_57 = _$_.template(`<a href="/playground" class="playground-link">Playground</a>`, 0);
-var root_56 = _$_.template(`<div class="social-links"><a href="https://github.com" class="github-link">GitHub</a><a href="https://discord.com" class="discord-link">Discord</a><!></div>`, 0);
-var root_58 = _$_.template(`<main><div class="container"><!></div></main>`, 0);
-var root_59 = _$_.template(`<div class="content"><p>Some content here</p></div>`, 0);
-var root_61 = _$_.template(`<!><!><!><!>`, 1, 4);
-var root_60 = _$_.template(`<!>`, 1, 1);
-var root_62 = _$_.template(`<footer class="last-child">I am the last child</footer>`, 0);
-var root_63 = _$_.template(`<div class="wrapper"><h1>Header</h1><p>Some content</p><!></div>`, 0);
-var root_64 = _$_.template(`<div class="inner"><span>Inner text</span><!></div>`, 0);
-var root_65 = _$_.template(`<section class="outer"><h2>Section title</h2><!></section>`, 0);
+var root_45 = _$_.template(`<div class="wrapper"> </div>`, 0);
+var root_48 = _$_.template(`<!>`, 1, 1);
+var root_49 = _$_.template(`<span class="nested-tsx">inside nested tsx</span>`, 0);
+var root_50 = _$_.template(`<div class="native"><!></div>`, 0);
+var root_51 = _$_.template(`<!>`, 1, 1);
+var root_52 = _$_.template(`<!>`, 1, 1);
+var root_53 = _$_.template(`<div class="text-prop"><!></div>`, 0);
+var root_54 = _$_.template(`<!><button class="show-text">Show</button>`, 1, 2);
+var root_55 = _$_.template(`<h1 class="sr-only">heading</h1><p class="subtitle">first paragraph</p><p class="subtitle">second paragraph</p>`, 1, 3);
+var root_56 = _$_.template(`<!><span class="sibling1"> </span><span class="sibling2"> </span>`, 1, 3);
+var root_57 = _$_.template(`<h1 class="sr-only">Ripple</h1><img src="/images/logo.png" alt="Logo" class="logo"><p class="subtitle">the elegant TypeScript UI framework</p>`, 1, 3);
+var root_59 = _$_.template(`<a href="/playground" class="playground-link">Playground</a>`, 0);
+var root_58 = _$_.template(`<div class="social-links"><a href="https://github.com" class="github-link">GitHub</a><a href="https://discord.com" class="discord-link">Discord</a><!></div>`, 0);
+var root_60 = _$_.template(`<main><div class="container"><!></div></main>`, 0);
+var root_61 = _$_.template(`<div class="content"><p>Some content here</p></div>`, 0);
+var root_63 = _$_.template(`<!><!><!><!>`, 1, 4);
+var root_62 = _$_.template(`<!>`, 1, 1);
+var root_64 = _$_.template(`<footer class="last-child">I am the last child</footer>`, 0);
+var root_65 = _$_.template(`<div class="wrapper"><h1>Header</h1><p>Some content</p><!></div>`, 0);
+var root_66 = _$_.template(`<div class="inner"><span>Inner text</span><!></div>`, 0);
+var root_67 = _$_.template(`<section class="outer"><h2>Section title</h2><!></section>`, 0);
 
 import { track } from 'ripple';
 
@@ -172,7 +174,7 @@ export function Greeting(__anchor, props, __block) {
 	var div_6 = root_9();
 
 	{
-		var expression = _$_.child(div_6, true);
+		var expression = _$_.child(div_6);
 
 		_$_.expression(expression, () => 'Hello ' + _$_.with_scope(__block, () => String(props.name)));
 		_$_.pop(div_6);
@@ -202,7 +204,7 @@ export function ExpressionContent(__anchor, _, __block) {
 	var div_7 = _$_.first_child_frag(fragment_4);
 
 	{
-		var expression_1 = _$_.child(div_7, true);
+		var expression_1 = _$_.child(div_7);
 
 		_$_.expression(expression_1, () => value);
 		_$_.pop(div_7);
@@ -211,7 +213,7 @@ export function ExpressionContent(__anchor, _, __block) {
 	var span_2 = _$_.sibling(div_7);
 
 	{
-		var expression_2 = _$_.child(span_2, true);
+		var expression_2 = _$_.child(span_2);
 
 		_$_.expression(expression_2, () => _$_.with_scope(__block, () => label.toUpperCase()));
 		_$_.pop(span_2);
@@ -230,7 +232,7 @@ function makeNestedTsxTsrxFragment(label) {
 		var span_3 = _$_.first_child_frag(fragment_5);
 
 		{
-			var expression_3 = _$_.child(span_3, true);
+			var expression_3 = _$_.child(span_3);
 
 			_$_.expression(expression_3, () => label);
 			_$_.pop(span_3);
@@ -238,7 +240,7 @@ function makeNestedTsxTsrxFragment(label) {
 
 		const test = _$_.tsrx_element(function render_children(__anchor, __block) {
 			var fragment_9 = root_17();
-			var expression_6 = _$_.first_child_frag(fragment_9, true);
+			var expression_6 = _$_.first_child_frag(fragment_9);
 
 			_$_.expression(expression_6, () => _$_.with_scope(__block, () => [1, 2, 3, 4].map((item) => _$_.tsrx_element(function render_children(__anchor, __block) {
 				var fragment_6 = root_13();
@@ -246,7 +248,7 @@ function makeNestedTsxTsrxFragment(label) {
 
 				_$_.expression(node_5, () => _$_.tsrx_element(function render_children(__anchor, __block) {
 					var fragment_8 = root_16();
-					var expression_5 = _$_.first_child_frag(fragment_8, true);
+					var expression_5 = _$_.first_child_frag(fragment_8);
 
 					_$_.expression(expression_5, () => _$_.tsrx_element(function render_children(__anchor, __block) {
 						var fragment_7 = root_14();
@@ -256,7 +258,7 @@ function makeNestedTsxTsrxFragment(label) {
 							var div_8 = root_15();
 
 							{
-								var expression_4 = _$_.child(div_8, true);
+								var expression_4 = _$_.child(div_8);
 
 								_$_.expression(expression_4, () => item);
 								_$_.pop(div_8);
@@ -292,13 +294,13 @@ export function NestedTsxTsrxExpressionValues(__anchor, _, __block) {
 
 	_$_.expression(expression_10, () => _$_.tsrx_element(function render_children(__anchor, __block) {
 		var fragment_10 = root_19();
-		var expression_9 = _$_.first_child_frag(fragment_10, true);
+		var expression_9 = _$_.first_child_frag(fragment_10);
 
 		_$_.expression(expression_9, () => _$_.with_scope(__block, () => [1, 2, 3].map((item) => _$_.tsrx_element(function render_children(__anchor, __block) {
 			var div_9 = root_18();
 
 			{
-				var expression_8 = _$_.child(div_9, true);
+				var expression_8 = _$_.child(div_9);
 
 				_$_.expression(expression_8, () => item);
 				_$_.pop(div_9);
@@ -322,7 +324,7 @@ export function MixedTsrxCollectionText(__anchor, _, __block) {
 
 	const content = _$_.tsrx_element(function render_children(__anchor, __block) {
 		var fragment_12 = root_23();
-		var expression_12 = _$_.first_child_frag(fragment_12, true);
+		var expression_12 = _$_.first_child_frag(fragment_12);
 
 		_$_.expression(expression_12, () => [
 			'alpha ',
@@ -364,7 +366,7 @@ export function MixedTsrxCollectionSplitServerText(__anchor, _, __block) {
 
 	const content = _$_.tsrx_element(function render_children(__anchor, __block) {
 		var fragment_13 = root_27();
-		var expression_14 = _$_.first_child_frag(fragment_13, true);
+		var expression_14 = _$_.first_child_frag(fragment_13);
 
 		_$_.expression(expression_14, () => [
 			'alpha ',
@@ -406,7 +408,7 @@ export function MixedTsrxCollectionSplitClientText(__anchor, _, __block) {
 
 	const content = _$_.tsrx_element(function render_children(__anchor, __block) {
 		var fragment_14 = root_31();
-		var expression_16 = _$_.first_child_frag(fragment_14, true);
+		var expression_16 = _$_.first_child_frag(fragment_14);
 
 		_$_.expression(expression_16, () => [
 			'alpha ',
@@ -448,7 +450,7 @@ export function MixedTsrxCollectionPrimitiveServerText(__anchor, _, __block) {
 
 	const content = _$_.tsrx_element(function render_children(__anchor, __block) {
 		var fragment_15 = root_34();
-		var expression_18 = _$_.first_child_frag(fragment_15, true);
+		var expression_18 = _$_.first_child_frag(fragment_15);
 
 		_$_.expression(expression_18, () => [
 			'count: ',
@@ -483,7 +485,7 @@ export function MixedTsrxCollectionPrimitiveClientText(__anchor, _, __block) {
 
 	const content = _$_.tsrx_element(function render_children(__anchor, __block) {
 		var fragment_16 = root_37();
-		var expression_20 = _$_.first_child_frag(fragment_16, true);
+		var expression_20 = _$_.first_child_frag(fragment_16);
 
 		_$_.expression(expression_20, () => [
 			'count: ',
@@ -513,23 +515,61 @@ export function MixedTsrxCollectionPrimitiveClientText(__anchor, _, __block) {
 	_$_.pop_component();
 }
 
+function createPrimitiveItems() {
+	return ['start:', ['one', 2], true, null, false, ':end'];
+}
+
+export function DynamicArrayFromCall(__anchor, _, __block) {
+	_$_.push_component();
+
+	const items = _$_.with_scope(__block, createPrimitiveItems);
+	var div_15 = root_39();
+
+	{
+		var expression_22 = _$_.child(div_15);
+
+		_$_.expression(expression_22, () => items);
+		_$_.pop(div_15);
+	}
+
+	_$_.append(__anchor, div_15);
+	_$_.pop_component();
+}
+
+export function DynamicArrayFromTrack(__anchor, _, __block) {
+	_$_.push_component();
+
+	let lazy = _$_.track(['start:', ['one', 2], true, null, false, ':end'], __block, 'b5de6402');
+	var div_16 = root_40();
+
+	{
+		var expression_23 = _$_.child(div_16);
+
+		_$_.expression(expression_23, () => _$_.get(lazy));
+		_$_.pop(div_16);
+	}
+
+	_$_.append(__anchor, div_16);
+	_$_.pop_component();
+}
+
 export function NestedTsrxInsideTopLevelTsxExpression(__anchor, _, __block) {
 	_$_.push_component();
 
 	const content = _$_.tsrx_element(function render_children(__anchor, __block) {
-		var section_1 = root_39();
+		var section_1 = root_41();
 
 		{
-			var expression_22 = _$_.child(section_1, true);
+			var expression_24 = _$_.child(section_1);
 
-			_$_.expression(expression_22, () => _$_.tsrx_element(function render_children(__anchor, __block) {
-				var fragment_17 = root_40();
+			_$_.expression(expression_24, () => _$_.tsrx_element(function render_children(__anchor, __block) {
+				var fragment_17 = root_42();
 				var node_6 = _$_.first_child_frag(fragment_17);
 
 				_$_.expression(node_6, () => _$_.tsrx_element(function render_children(__anchor, __block) {
-					var div_15 = root_41();
+					var div_17 = root_43();
 
-					_$_.append(__anchor, div_15);
+					_$_.append(__anchor, div_17);
 				}));
 
 				_$_.append(__anchor, fragment_17);
@@ -541,10 +581,10 @@ export function NestedTsrxInsideTopLevelTsxExpression(__anchor, _, __block) {
 		_$_.append(__anchor, section_1);
 	});
 
-	var fragment_18 = root_42();
-	var expression_23 = _$_.first_child_frag(fragment_18);
+	var fragment_18 = root_44();
+	var expression_25 = _$_.first_child_frag(fragment_18);
 
-	_$_.expression(expression_23, () => content);
+	_$_.expression(expression_25, () => content);
 	_$_.append(__anchor, fragment_18);
 	_$_.pop_component();
 }
@@ -553,17 +593,17 @@ export function NestedTsrxElementsInsideTopLevelTsxValue(__anchor, _, __block) {
 	_$_.push_component();
 
 	const content = _$_.tsrx_element(function render_children(__anchor, __block) {
-		var div_16 = root_43();
+		var div_18 = root_45();
 
 		{
-			var expression_24 = _$_.child(div_16, true);
+			var expression_26 = _$_.child(div_18);
 
-			_$_.expression(expression_24, () => _$_.tsrx_element(function render_children(__anchor, __block) {
-				var fragment_19 = root_44();
+			_$_.expression(expression_26, () => _$_.tsrx_element(function render_children(__anchor, __block) {
+				var fragment_19 = root_46();
 				var node_7 = _$_.first_child_frag(fragment_19);
 
 				_$_.expression(node_7, () => _$_.tsrx_element(function render_children(__anchor, __block) {
-					var section_2 = root_45();
+					var section_2 = root_47();
 
 					_$_.append(__anchor, section_2);
 				}));
@@ -571,16 +611,16 @@ export function NestedTsrxElementsInsideTopLevelTsxValue(__anchor, _, __block) {
 				_$_.append(__anchor, fragment_19);
 			}));
 
-			_$_.pop(div_16);
+			_$_.pop(div_18);
 		}
 
-		_$_.append(__anchor, div_16);
+		_$_.append(__anchor, div_18);
 	});
 
-	var fragment_20 = root_46();
-	var expression_25 = _$_.first_child_frag(fragment_20);
+	var fragment_20 = root_48();
+	var expression_27 = _$_.first_child_frag(fragment_20);
 
-	_$_.expression(expression_25, () => content);
+	_$_.expression(expression_27, () => content);
 	_$_.append(__anchor, fragment_20);
 	_$_.pop_component();
 }
@@ -589,35 +629,35 @@ export function TsxDeclaredInsideNestedTsrxFromTopLevelTsx(__anchor, _, __block)
 	_$_.push_component();
 
 	const content = _$_.tsrx_element(function render_children(__anchor, __block) {
-		var fragment_21 = root_49();
-		var expression_27 = _$_.first_child_frag(fragment_21);
+		var fragment_21 = root_51();
+		var expression_29 = _$_.first_child_frag(fragment_21);
 
-		_$_.expression(expression_27, () => _$_.tsrx_element(function render_children(__anchor, __block) {
+		_$_.expression(expression_29, () => _$_.tsrx_element(function render_children(__anchor, __block) {
 			const nested = _$_.tsrx_element(function render_children(__anchor, __block) {
-				var span_6 = root_47();
+				var span_6 = root_49();
 
 				_$_.append(__anchor, span_6);
 			});
 
-			var div_17 = root_48();
+			var div_19 = root_50();
 
 			{
-				var expression_26 = _$_.child(div_17);
+				var expression_28 = _$_.child(div_19);
 
-				_$_.expression(expression_26, () => nested);
-				_$_.pop(div_17);
+				_$_.expression(expression_28, () => nested);
+				_$_.pop(div_19);
 			}
 
-			_$_.append(__anchor, div_17);
+			_$_.append(__anchor, div_19);
 		}));
 
 		_$_.append(__anchor, fragment_21);
 	});
 
-	var fragment_22 = root_50();
-	var expression_28 = _$_.first_child_frag(fragment_22);
+	var fragment_22 = root_52();
+	var expression_30 = _$_.first_child_frag(fragment_22);
 
-	_$_.expression(expression_28, () => content);
+	_$_.expression(expression_30, () => content);
 	_$_.append(__anchor, fragment_22);
 	_$_.pop_component();
 }
@@ -625,31 +665,31 @@ export function TsxDeclaredInsideNestedTsrxFromTopLevelTsx(__anchor, _, __block)
 function TextProp(__anchor, __props, __block) {
 	_$_.push_component();
 
-	var div_18 = root_51();
+	var div_20 = root_53();
 
 	{
-		var expression_29 = _$_.child(div_18);
+		var expression_31 = _$_.child(div_20);
 
-		_$_.expression(expression_29, () => __props.children);
-		_$_.pop(div_18);
+		_$_.expression(expression_31, () => __props.children);
+		_$_.pop(div_20);
 	}
 
-	_$_.append(__anchor, div_18);
+	_$_.append(__anchor, div_20);
 	_$_.pop_component();
 }
 
 export function TextPropWithToggle(__anchor, _, __block) {
 	_$_.push_component();
 
-	let lazy = _$_.track(false, __block, 'b5de6402');
-	var fragment_23 = root_52();
+	let lazy_1 = _$_.track(false, __block, '1ba81c3b');
+	var fragment_23 = root_54();
 	var node_8 = _$_.first_child_frag(fragment_23);
 
 	TextProp(
 		node_8,
 		{
 			get children() {
-				return _$_.normalize_children(_$_.get(lazy) ? 'hello' : '');
+				return _$_.normalize_children(_$_.get(lazy_1) ? 'hello' : '');
 			}
 		},
 		_$_.active_block
@@ -657,7 +697,7 @@ export function TextPropWithToggle(__anchor, _, __block) {
 
 	var button_1 = _$_.sibling(node_8);
 
-	button_1.__click = () => _$_.set(lazy, true);
+	button_1.__click = () => _$_.set(lazy_1, true);
 	_$_.append(__anchor, fragment_23);
 	_$_.pop_component();
 }
@@ -665,7 +705,7 @@ export function TextPropWithToggle(__anchor, _, __block) {
 function StaticHeader(__anchor, _, __block) {
 	_$_.push_component();
 
-	var fragment_24 = root_53();
+	var fragment_24 = root_55();
 
 	_$_.next(2);
 	_$_.append(__anchor, fragment_24, true);
@@ -676,7 +716,7 @@ export function StaticChildWithSiblings(__anchor, _, __block) {
 	_$_.push_component();
 
 	const foo = 'bar';
-	var fragment_25 = root_54();
+	var fragment_25 = root_56();
 	var node_9 = _$_.first_child_frag(fragment_25);
 
 	StaticHeader(node_9, {}, _$_.active_block);
@@ -684,18 +724,18 @@ export function StaticChildWithSiblings(__anchor, _, __block) {
 	var span_7 = _$_.sibling(node_9);
 
 	{
-		var expression_30 = _$_.child(span_7, true);
+		var expression_32 = _$_.child(span_7);
 
-		_$_.expression(expression_30, () => foo);
+		_$_.expression(expression_32, () => foo);
 		_$_.pop(span_7);
 	}
 
 	var span_8 = _$_.sibling(span_7);
 
 	{
-		var expression_31 = _$_.child(span_8, true);
+		var expression_33 = _$_.child(span_8);
 
-		_$_.expression(expression_31, () => foo);
+		_$_.expression(expression_33, () => foo);
 		_$_.pop(span_8);
 	}
 
@@ -707,7 +747,7 @@ export function StaticChildWithSiblings(__anchor, _, __block) {
 function Header(__anchor, _, __block) {
 	_$_.push_component();
 
-	var fragment_26 = root_55();
+	var fragment_26 = root_57();
 
 	_$_.next(2);
 	_$_.append(__anchor, fragment_26, true);
@@ -717,16 +757,16 @@ function Header(__anchor, _, __block) {
 function Actions(__anchor, { playgroundVisible = false }, __block) {
 	_$_.push_component();
 
-	var div_19 = root_56();
+	var div_21 = root_58();
 
 	{
-		var a_2 = _$_.child(div_19);
+		var a_2 = _$_.child(div_21);
 		var a_1 = _$_.sibling(a_2);
 		var node_10 = _$_.sibling(a_1);
 
 		{
 			var consequent = (__anchor) => {
-				var a_3 = root_57();
+				var a_3 = root_59();
 
 				_$_.append(__anchor, a_3);
 			};
@@ -736,26 +776,26 @@ function Actions(__anchor, { playgroundVisible = false }, __block) {
 			});
 		}
 
-		_$_.pop(div_19);
+		_$_.pop(div_21);
 	}
 
-	_$_.append(__anchor, div_19);
+	_$_.append(__anchor, div_21);
 	_$_.pop_component();
 }
 
 function Layout(__anchor, { children }, __block) {
 	_$_.push_component();
 
-	var main_1 = root_58();
+	var main_1 = root_60();
 
 	{
-		var div_20 = _$_.child(main_1);
+		var div_22 = _$_.child(main_1);
 
 		{
-			var expression_32 = _$_.child(div_20);
+			var expression_34 = _$_.child(div_22);
 
-			_$_.expression(expression_32, () => children);
-			_$_.pop(div_20);
+			_$_.expression(expression_34, () => children);
+			_$_.pop(div_22);
 		}
 	}
 
@@ -766,23 +806,23 @@ function Layout(__anchor, { children }, __block) {
 function Content(__anchor, _, __block) {
 	_$_.push_component();
 
-	var div_21 = root_59();
+	var div_23 = root_61();
 
-	_$_.append(__anchor, div_21);
+	_$_.append(__anchor, div_23);
 	_$_.pop_component();
 }
 
 export function WebsiteIndex(__anchor, _, __block) {
 	_$_.push_component();
 
-	var fragment_27 = root_60();
+	var fragment_27 = root_62();
 	var node_11 = _$_.first_child_frag(fragment_27);
 
 	Layout(
 		node_11,
 		{
 			children: _$_.tsrx_element(function render_children(__anchor, __block) {
-				var fragment_28 = root_61();
+				var fragment_28 = root_63();
 				var node_12 = _$_.first_child_frag(fragment_28);
 
 				Header(node_12, {}, _$_.active_block);
@@ -811,7 +851,7 @@ export function WebsiteIndex(__anchor, _, __block) {
 function LastChild(__anchor, _, __block) {
 	_$_.push_component();
 
-	var footer_1 = root_62();
+	var footer_1 = root_64();
 
 	_$_.append(__anchor, footer_1);
 	_$_.pop_component();
@@ -820,42 +860,42 @@ function LastChild(__anchor, _, __block) {
 export function ComponentAsLastSibling(__anchor, _, __block) {
 	_$_.push_component();
 
-	var div_22 = root_63();
+	var div_24 = root_65();
 
 	{
-		var h1_1 = _$_.child(div_22);
+		var h1_1 = _$_.child(div_24);
 		var p_1 = _$_.sibling(h1_1);
 		var node_16 = _$_.sibling(p_1);
 
 		LastChild(node_16, {}, _$_.active_block);
-		_$_.pop(div_22);
+		_$_.pop(div_24);
 	}
 
-	_$_.append(__anchor, div_22);
+	_$_.append(__anchor, div_24);
 	_$_.pop_component();
 }
 
 function InnerContent(__anchor, _, __block) {
 	_$_.push_component();
 
-	var div_23 = root_64();
+	var div_25 = root_66();
 
 	{
-		var span_9 = _$_.child(div_23);
+		var span_9 = _$_.child(div_25);
 		var node_17 = _$_.sibling(span_9);
 
 		LastChild(node_17, {}, _$_.active_block);
-		_$_.pop(div_23);
+		_$_.pop(div_25);
 	}
 
-	_$_.append(__anchor, div_23);
+	_$_.append(__anchor, div_25);
 	_$_.pop_component();
 }
 
 export function NestedComponentAsLastSibling(__anchor, _, __block) {
 	_$_.push_component();
 
-	var section_3 = root_65();
+	var section_3 = root_67();
 
 	{
 		var h2_1 = _$_.child(section_3);

--- a/packages/ripple/tests/hydration/compiled/client/basic.js
+++ b/packages/ripple/tests/hydration/compiled/client/basic.js
@@ -13,21 +13,42 @@ var root_8 = _$_.template(`<!><!>`, 1, 2);
 var root_9 = _$_.template(`<div> </div>`, 0);
 var root_10 = _$_.template(`<!>`, 1, 1);
 var root_11 = _$_.template(`<div> </div><span> </span>`, 1, 2);
-var root_12 = _$_.template(`<div class="text-prop"><!></div>`, 0);
-var root_13 = _$_.template(`<!><button class="show-text">Show</button>`, 1, 2);
-var root_14 = _$_.template(`<h1 class="sr-only">heading</h1><p class="subtitle">first paragraph</p><p class="subtitle">second paragraph</p>`, 1, 3);
-var root_15 = _$_.template(`<!><span class="sibling1"> </span><span class="sibling2"> </span>`, 1, 3);
-var root_16 = _$_.template(`<h1 class="sr-only">Ripple</h1><img src="/images/logo.png" alt="Logo" class="logo"><p class="subtitle">the elegant TypeScript UI framework</p>`, 1, 3);
-var root_18 = _$_.template(`<a href="/playground" class="playground-link">Playground</a>`, 0);
-var root_17 = _$_.template(`<div class="social-links"><a href="https://github.com" class="github-link">GitHub</a><a href="https://discord.com" class="discord-link">Discord</a><!></div>`, 0);
-var root_19 = _$_.template(`<main><div class="container"><!></div></main>`, 0);
-var root_20 = _$_.template(`<div class="content"><p>Some content here</p></div>`, 0);
-var root_22 = _$_.template(`<!><!><!><!>`, 1, 4);
-var root_21 = _$_.template(`<!>`, 1, 1);
-var root_23 = _$_.template(`<footer class="last-child">I am the last child</footer>`, 0);
-var root_24 = _$_.template(`<div class="wrapper"><h1>Header</h1><p>Some content</p><!></div>`, 0);
-var root_25 = _$_.template(`<div class="inner"><span>Inner text</span><!></div>`, 0);
-var root_26 = _$_.template(`<section class="outer"><h2>Section title</h2><!></section>`, 0);
+var root_15 = _$_.template(`<div class="helper-item"> </div>`, 0);
+var root_14 = _$_.template(`<!>`, 1, 1);
+var root_16 = _$_.template(` `, 1, 1);
+var root_13 = _$_.template(`<!>`, 1, 1);
+var root_17 = _$_.template(` `, 1, 1);
+var root_12 = _$_.template(`<span class="label"> </span><!>`, 1, 2);
+var root_18 = _$_.template(`<div class="app-item"> </div>`, 0);
+var root_19 = _$_.template(` `, 1, 1);
+var root_20 = _$_.template(`<!><!>`, 1, 2);
+var root_23 = _$_.template(`<div class="inner">from tsrx</div>`, 0);
+var root_22 = _$_.template(`<!>`, 1, 1);
+var root_21 = _$_.template(`<section class="outer"> </section>`, 0);
+var root_24 = _$_.template(`<!>`, 1, 1);
+var root_27 = _$_.template(`<section class="native"><span class="nested-tsrx">inside nested tsrx</span></section>`, 0);
+var root_26 = _$_.template(`<!>`, 1, 1);
+var root_25 = _$_.template(`<div class="wrapper"> </div>`, 0);
+var root_28 = _$_.template(`<!>`, 1, 1);
+var root_29 = _$_.template(`<span class="nested-tsx">inside nested tsx</span>`, 0);
+var root_30 = _$_.template(`<div class="native"><!></div>`, 0);
+var root_31 = _$_.template(`<!>`, 1, 1);
+var root_32 = _$_.template(`<!>`, 1, 1);
+var root_33 = _$_.template(`<div class="text-prop"><!></div>`, 0);
+var root_34 = _$_.template(`<!><button class="show-text">Show</button>`, 1, 2);
+var root_35 = _$_.template(`<h1 class="sr-only">heading</h1><p class="subtitle">first paragraph</p><p class="subtitle">second paragraph</p>`, 1, 3);
+var root_36 = _$_.template(`<!><span class="sibling1"> </span><span class="sibling2"> </span>`, 1, 3);
+var root_37 = _$_.template(`<h1 class="sr-only">Ripple</h1><img src="/images/logo.png" alt="Logo" class="logo"><p class="subtitle">the elegant TypeScript UI framework</p>`, 1, 3);
+var root_39 = _$_.template(`<a href="/playground" class="playground-link">Playground</a>`, 0);
+var root_38 = _$_.template(`<div class="social-links"><a href="https://github.com" class="github-link">GitHub</a><a href="https://discord.com" class="discord-link">Discord</a><!></div>`, 0);
+var root_40 = _$_.template(`<main><div class="container"><!></div></main>`, 0);
+var root_41 = _$_.template(`<div class="content"><p>Some content here</p></div>`, 0);
+var root_43 = _$_.template(`<!><!><!><!>`, 1, 4);
+var root_42 = _$_.template(`<!>`, 1, 1);
+var root_44 = _$_.template(`<footer class="last-child">I am the last child</footer>`, 0);
+var root_45 = _$_.template(`<div class="wrapper"><h1>Header</h1><p>Some content</p><!></div>`, 0);
+var root_46 = _$_.template(`<div class="inner"><span>Inner text</span><!></div>`, 0);
+var root_47 = _$_.template(`<section class="outer"><h2>Section title</h2><!></section>`, 0);
 
 import { track } from 'ripple';
 
@@ -183,19 +204,223 @@ export function ExpressionContent(__anchor, _, __block) {
 	_$_.pop_component();
 }
 
+function makeNestedTsxTsrxFragment(label) {
+	var __block = _$_.scope();
+
+	return _$_.tsrx_element(function render_children(__anchor, __block) {
+		var fragment_5 = root_12();
+		var span_3 = _$_.first_child_frag(fragment_5);
+
+		{
+			var expression_3 = _$_.child(span_3, true);
+
+			_$_.expression(expression_3, () => label);
+			_$_.pop(span_3);
+		}
+
+		const test = _$_.tsrx_element(function render_children(__anchor, __block) {
+			var fragment_9 = root_17();
+			var expression_6 = _$_.first_child_frag(fragment_9, true);
+
+			_$_.expression(expression_6, () => _$_.with_scope(__block, () => [1, 2, 3, 4].map((item) => _$_.tsrx_element(function render_children(__anchor, __block) {
+				var fragment_6 = root_13();
+				var node_5 = _$_.first_child_frag(fragment_6);
+
+				_$_.expression(node_5, () => _$_.tsrx_element(function render_children(__anchor, __block) {
+					var fragment_8 = root_16();
+					var expression_5 = _$_.first_child_frag(fragment_8, true);
+
+					_$_.expression(expression_5, () => _$_.tsrx_element(function render_children(__anchor, __block) {
+						var fragment_7 = root_14();
+						var node_4 = _$_.first_child_frag(fragment_7);
+
+						_$_.expression(node_4, () => _$_.tsrx_element(function render_children(__anchor, __block) {
+							var div_8 = root_15();
+
+							{
+								var expression_4 = _$_.child(div_8, true);
+
+								_$_.expression(expression_4, () => item);
+								_$_.pop(div_8);
+							}
+
+							_$_.append(__anchor, div_8);
+						}));
+
+						_$_.append(__anchor, fragment_7);
+					}));
+
+					_$_.append(__anchor, fragment_8);
+				}));
+
+				_$_.append(__anchor, fragment_6);
+			}))));
+
+			_$_.append(__anchor, fragment_9);
+		});
+
+		var expression_7 = _$_.sibling(span_3);
+
+		_$_.expression(expression_7, () => test);
+		_$_.append(__anchor, fragment_5);
+	});
+}
+
+export function NestedTsxTsrxExpressionValues(__anchor, _, __block) {
+	_$_.push_component();
+
+	var fragment_11 = root_20();
+	var expression_10 = _$_.first_child_frag(fragment_11);
+
+	_$_.expression(expression_10, () => _$_.tsrx_element(function render_children(__anchor, __block) {
+		var fragment_10 = root_19();
+		var expression_9 = _$_.first_child_frag(fragment_10, true);
+
+		_$_.expression(expression_9, () => _$_.with_scope(__block, () => [1, 2, 3].map((item) => _$_.tsrx_element(function render_children(__anchor, __block) {
+			var div_9 = root_18();
+
+			{
+				var expression_8 = _$_.child(div_9, true);
+
+				_$_.expression(expression_8, () => item);
+				_$_.pop(div_9);
+			}
+
+			_$_.append(__anchor, div_9);
+		}))));
+
+		_$_.append(__anchor, fragment_10);
+	}));
+
+	var expression_11 = _$_.sibling(expression_10);
+
+	_$_.expression(expression_11, () => _$_.with_scope(__block, () => makeNestedTsxTsrxFragment('from helper')));
+	_$_.append(__anchor, fragment_11);
+	_$_.pop_component();
+}
+
+export function NestedTsrxInsideTopLevelTsxExpression(__anchor, _, __block) {
+	_$_.push_component();
+
+	const content = _$_.tsrx_element(function render_children(__anchor, __block) {
+		var section_1 = root_21();
+
+		{
+			var expression_12 = _$_.child(section_1, true);
+
+			_$_.expression(expression_12, () => _$_.tsrx_element(function render_children(__anchor, __block) {
+				var fragment_12 = root_22();
+				var node_6 = _$_.first_child_frag(fragment_12);
+
+				_$_.expression(node_6, () => _$_.tsrx_element(function render_children(__anchor, __block) {
+					var div_10 = root_23();
+
+					_$_.append(__anchor, div_10);
+				}));
+
+				_$_.append(__anchor, fragment_12);
+			}));
+
+			_$_.pop(section_1);
+		}
+
+		_$_.append(__anchor, section_1);
+	});
+
+	var fragment_13 = root_24();
+	var expression_13 = _$_.first_child_frag(fragment_13);
+
+	_$_.expression(expression_13, () => content);
+	_$_.append(__anchor, fragment_13);
+	_$_.pop_component();
+}
+
+export function NestedTsrxElementsInsideTopLevelTsxValue(__anchor, _, __block) {
+	_$_.push_component();
+
+	const content = _$_.tsrx_element(function render_children(__anchor, __block) {
+		var div_11 = root_25();
+
+		{
+			var expression_14 = _$_.child(div_11, true);
+
+			_$_.expression(expression_14, () => _$_.tsrx_element(function render_children(__anchor, __block) {
+				var fragment_14 = root_26();
+				var node_7 = _$_.first_child_frag(fragment_14);
+
+				_$_.expression(node_7, () => _$_.tsrx_element(function render_children(__anchor, __block) {
+					var section_2 = root_27();
+
+					_$_.append(__anchor, section_2);
+				}));
+
+				_$_.append(__anchor, fragment_14);
+			}));
+
+			_$_.pop(div_11);
+		}
+
+		_$_.append(__anchor, div_11);
+	});
+
+	var fragment_15 = root_28();
+	var expression_15 = _$_.first_child_frag(fragment_15);
+
+	_$_.expression(expression_15, () => content);
+	_$_.append(__anchor, fragment_15);
+	_$_.pop_component();
+}
+
+export function TsxDeclaredInsideNestedTsrxFromTopLevelTsx(__anchor, _, __block) {
+	_$_.push_component();
+
+	const content = _$_.tsrx_element(function render_children(__anchor, __block) {
+		var fragment_16 = root_31();
+		var expression_17 = _$_.first_child_frag(fragment_16);
+
+		_$_.expression(expression_17, () => _$_.tsrx_element(function render_children(__anchor, __block) {
+			const nested = _$_.tsrx_element(function render_children(__anchor, __block) {
+				var span_4 = root_29();
+
+				_$_.append(__anchor, span_4);
+			});
+
+			var div_12 = root_30();
+
+			{
+				var expression_16 = _$_.child(div_12);
+
+				_$_.expression(expression_16, () => nested);
+				_$_.pop(div_12);
+			}
+
+			_$_.append(__anchor, div_12);
+		}));
+
+		_$_.append(__anchor, fragment_16);
+	});
+
+	var fragment_17 = root_32();
+	var expression_18 = _$_.first_child_frag(fragment_17);
+
+	_$_.expression(expression_18, () => content);
+	_$_.append(__anchor, fragment_17);
+	_$_.pop_component();
+}
+
 function TextProp(__anchor, __props, __block) {
 	_$_.push_component();
 
-	var div_8 = root_12();
+	var div_13 = root_33();
 
 	{
-		var expression_3 = _$_.child(div_8);
+		var expression_19 = _$_.child(div_13);
 
-		_$_.expression(expression_3, () => __props.children);
-		_$_.pop(div_8);
+		_$_.expression(expression_19, () => __props.children);
+		_$_.pop(div_13);
 	}
 
-	_$_.append(__anchor, div_8);
+	_$_.append(__anchor, div_13);
 	_$_.pop_component();
 }
 
@@ -203,11 +428,11 @@ export function TextPropWithToggle(__anchor, _, __block) {
 	_$_.push_component();
 
 	let lazy = _$_.track(false, __block, 'b5de6402');
-	var fragment_5 = root_13();
-	var node_4 = _$_.first_child_frag(fragment_5);
+	var fragment_18 = root_34();
+	var node_8 = _$_.first_child_frag(fragment_18);
 
 	TextProp(
-		node_4,
+		node_8,
 		{
 			get children() {
 				return _$_.normalize_children(_$_.get(lazy) ? 'hello' : '');
@@ -216,20 +441,20 @@ export function TextPropWithToggle(__anchor, _, __block) {
 		_$_.active_block
 	);
 
-	var button_1 = _$_.sibling(node_4);
+	var button_1 = _$_.sibling(node_8);
 
 	button_1.__click = () => _$_.set(lazy, true);
-	_$_.append(__anchor, fragment_5);
+	_$_.append(__anchor, fragment_18);
 	_$_.pop_component();
 }
 
 function StaticHeader(__anchor, _, __block) {
 	_$_.push_component();
 
-	var fragment_6 = root_14();
+	var fragment_19 = root_35();
 
 	_$_.next(2);
-	_$_.append(__anchor, fragment_6, true);
+	_$_.append(__anchor, fragment_19, true);
 	_$_.pop_component();
 }
 
@@ -237,86 +462,86 @@ export function StaticChildWithSiblings(__anchor, _, __block) {
 	_$_.push_component();
 
 	const foo = 'bar';
-	var fragment_7 = root_15();
-	var node_5 = _$_.first_child_frag(fragment_7);
+	var fragment_20 = root_36();
+	var node_9 = _$_.first_child_frag(fragment_20);
 
-	StaticHeader(node_5, {}, _$_.active_block);
+	StaticHeader(node_9, {}, _$_.active_block);
 
-	var span_3 = _$_.sibling(node_5);
+	var span_5 = _$_.sibling(node_9);
 
 	{
-		var expression_4 = _$_.child(span_3, true);
+		var expression_20 = _$_.child(span_5, true);
 
-		_$_.expression(expression_4, () => foo);
-		_$_.pop(span_3);
+		_$_.expression(expression_20, () => foo);
+		_$_.pop(span_5);
 	}
 
-	var span_4 = _$_.sibling(span_3);
+	var span_6 = _$_.sibling(span_5);
 
 	{
-		var expression_5 = _$_.child(span_4, true);
+		var expression_21 = _$_.child(span_6, true);
 
-		_$_.expression(expression_5, () => foo);
-		_$_.pop(span_4);
+		_$_.expression(expression_21, () => foo);
+		_$_.pop(span_6);
 	}
 
 	_$_.next();
-	_$_.append(__anchor, fragment_7, true);
+	_$_.append(__anchor, fragment_20, true);
 	_$_.pop_component();
 }
 
 function Header(__anchor, _, __block) {
 	_$_.push_component();
 
-	var fragment_8 = root_16();
+	var fragment_21 = root_37();
 
 	_$_.next(2);
-	_$_.append(__anchor, fragment_8, true);
+	_$_.append(__anchor, fragment_21, true);
 	_$_.pop_component();
 }
 
 function Actions(__anchor, { playgroundVisible = false }, __block) {
 	_$_.push_component();
 
-	var div_9 = root_17();
+	var div_14 = root_38();
 
 	{
-		var a_2 = _$_.child(div_9);
+		var a_2 = _$_.child(div_14);
 		var a_1 = _$_.sibling(a_2);
-		var node_6 = _$_.sibling(a_1);
+		var node_10 = _$_.sibling(a_1);
 
 		{
 			var consequent = (__anchor) => {
-				var a_3 = root_18();
+				var a_3 = root_39();
 
 				_$_.append(__anchor, a_3);
 			};
 
-			_$_.if(node_6, (__render) => {
+			_$_.if(node_10, (__render) => {
 				if (playgroundVisible) __render(consequent);
 			});
 		}
 
-		_$_.pop(div_9);
+		_$_.pop(div_14);
 	}
 
-	_$_.append(__anchor, div_9);
+	_$_.append(__anchor, div_14);
 	_$_.pop_component();
 }
 
 function Layout(__anchor, { children }, __block) {
 	_$_.push_component();
 
-	var main_1 = root_19();
+	var main_1 = root_40();
 
 	{
-		var div_10 = _$_.child(main_1);
+		var div_15 = _$_.child(main_1);
 
 		{
-			var expression_6 = _$_.child(div_10);
+			var expression_22 = _$_.child(div_15);
 
-			_$_.expression(expression_6, () => children);
-			_$_.pop(div_10);
+			_$_.expression(expression_22, () => children);
+			_$_.pop(div_15);
 		}
 	}
 
@@ -327,52 +552,52 @@ function Layout(__anchor, { children }, __block) {
 function Content(__anchor, _, __block) {
 	_$_.push_component();
 
-	var div_11 = root_20();
+	var div_16 = root_41();
 
-	_$_.append(__anchor, div_11);
+	_$_.append(__anchor, div_16);
 	_$_.pop_component();
 }
 
 export function WebsiteIndex(__anchor, _, __block) {
 	_$_.push_component();
 
-	var fragment_9 = root_21();
-	var node_7 = _$_.first_child_frag(fragment_9);
+	var fragment_22 = root_42();
+	var node_11 = _$_.first_child_frag(fragment_22);
 
 	Layout(
-		node_7,
+		node_11,
 		{
 			children: _$_.tsrx_element(function render_children(__anchor, __block) {
-				var fragment_10 = root_22();
-				var node_8 = _$_.first_child_frag(fragment_10);
+				var fragment_23 = root_43();
+				var node_12 = _$_.first_child_frag(fragment_23);
 
-				Header(node_8, {}, _$_.active_block);
+				Header(node_12, {}, _$_.active_block);
 
-				var node_9 = _$_.sibling(node_8);
+				var node_13 = _$_.sibling(node_12);
 
-				Actions(node_9, { playgroundVisible: true }, _$_.active_block);
+				Actions(node_13, { playgroundVisible: true }, _$_.active_block);
 
-				var node_10 = _$_.sibling(node_9);
+				var node_14 = _$_.sibling(node_13);
 
-				Content(node_10, {}, _$_.active_block);
+				Content(node_14, {}, _$_.active_block);
 
-				var node_11 = _$_.sibling(node_10);
+				var node_15 = _$_.sibling(node_14);
 
-				Actions(node_11, { playgroundVisible: false }, _$_.active_block);
-				_$_.append(__anchor, fragment_10);
+				Actions(node_15, { playgroundVisible: false }, _$_.active_block);
+				_$_.append(__anchor, fragment_23);
 			})
 		},
 		_$_.active_block
 	);
 
-	_$_.append(__anchor, fragment_9);
+	_$_.append(__anchor, fragment_22);
 	_$_.pop_component();
 }
 
 function LastChild(__anchor, _, __block) {
 	_$_.push_component();
 
-	var footer_1 = root_23();
+	var footer_1 = root_44();
 
 	_$_.append(__anchor, footer_1);
 	_$_.pop_component();
@@ -381,52 +606,52 @@ function LastChild(__anchor, _, __block) {
 export function ComponentAsLastSibling(__anchor, _, __block) {
 	_$_.push_component();
 
-	var div_12 = root_24();
+	var div_17 = root_45();
 
 	{
-		var h1_1 = _$_.child(div_12);
+		var h1_1 = _$_.child(div_17);
 		var p_1 = _$_.sibling(h1_1);
-		var node_12 = _$_.sibling(p_1);
+		var node_16 = _$_.sibling(p_1);
 
-		LastChild(node_12, {}, _$_.active_block);
-		_$_.pop(div_12);
+		LastChild(node_16, {}, _$_.active_block);
+		_$_.pop(div_17);
 	}
 
-	_$_.append(__anchor, div_12);
+	_$_.append(__anchor, div_17);
 	_$_.pop_component();
 }
 
 function InnerContent(__anchor, _, __block) {
 	_$_.push_component();
 
-	var div_13 = root_25();
+	var div_18 = root_46();
 
 	{
-		var span_5 = _$_.child(div_13);
-		var node_13 = _$_.sibling(span_5);
+		var span_7 = _$_.child(div_18);
+		var node_17 = _$_.sibling(span_7);
 
-		LastChild(node_13, {}, _$_.active_block);
-		_$_.pop(div_13);
+		LastChild(node_17, {}, _$_.active_block);
+		_$_.pop(div_18);
 	}
 
-	_$_.append(__anchor, div_13);
+	_$_.append(__anchor, div_18);
 	_$_.pop_component();
 }
 
 export function NestedComponentAsLastSibling(__anchor, _, __block) {
 	_$_.push_component();
 
-	var section_1 = root_26();
+	var section_3 = root_47();
 
 	{
-		var h2_1 = _$_.child(section_1);
-		var node_14 = _$_.sibling(h2_1);
+		var h2_1 = _$_.child(section_3);
+		var node_18 = _$_.sibling(h2_1);
 
-		InnerContent(node_14, {}, _$_.active_block);
-		_$_.pop(section_1);
+		InnerContent(node_18, {}, _$_.active_block);
+		_$_.pop(section_3);
 	}
 
-	_$_.append(__anchor, section_1);
+	_$_.append(__anchor, section_3);
 	_$_.pop_component();
 }
 

--- a/packages/ripple/tests/hydration/compiled/client/events.js
+++ b/packages/ripple/tests/hydration/compiled/client/events.js
@@ -27,7 +27,7 @@ export function ClickCounter(__anchor, _, __block) {
 		var span_1 = _$_.sibling(button_1);
 
 		{
-			var expression = _$_.child(span_1, true);
+			var expression = _$_.child(span_1);
 
 			_$_.expression(expression, () => _$_.get(lazy));
 			_$_.pop(span_1);
@@ -54,7 +54,7 @@ export function IncrementDecrement(__anchor, _, __block) {
 		var span_2 = _$_.sibling(button_2);
 
 		{
-			var expression_1 = _$_.child(span_2, true);
+			var expression_1 = _$_.child(span_2);
 
 			_$_.expression(expression_1, () => _$_.get(lazy_1));
 			_$_.pop(span_2);
@@ -92,7 +92,7 @@ export function MultipleEvents(__anchor, _, __block) {
 		var span_3 = _$_.sibling(button_4);
 
 		{
-			var expression_2 = _$_.child(span_3, true);
+			var expression_2 = _$_.child(span_3);
 
 			_$_.expression(expression_2, () => _$_.get(lazy_2));
 			_$_.pop(span_3);
@@ -101,7 +101,7 @@ export function MultipleEvents(__anchor, _, __block) {
 		var span_4 = _$_.sibling(span_3);
 
 		{
-			var expression_3 = _$_.child(span_4, true);
+			var expression_3 = _$_.child(span_4);
 
 			_$_.expression(expression_3, () => _$_.get(lazy_3));
 			_$_.pop(span_4);
@@ -133,7 +133,7 @@ export function MultiStateUpdate(__anchor, _, __block) {
 		var span_5 = _$_.sibling(button_5);
 
 		{
-			var expression_4 = _$_.child(span_5, true);
+			var expression_4 = _$_.child(span_5);
 
 			_$_.expression(expression_4, () => _$_.get(lazy_4));
 			_$_.pop(span_5);
@@ -142,7 +142,7 @@ export function MultiStateUpdate(__anchor, _, __block) {
 		var span_6 = _$_.sibling(span_5);
 
 		{
-			var expression_5 = _$_.child(span_6, true);
+			var expression_5 = _$_.child(span_6);
 
 			_$_.expression(expression_5, () => _$_.get(lazy_5));
 			_$_.pop(span_6);
@@ -167,7 +167,7 @@ export function ToggleButton(__anchor, _, __block) {
 		};
 
 		{
-			var expression_6 = _$_.child(button_6, true);
+			var expression_6 = _$_.child(button_6);
 
 			_$_.expression(expression_6, () => _$_.get(lazy_6) ? 'ON' : 'OFF');
 			_$_.pop(button_6);
@@ -186,7 +186,7 @@ export function ChildButton(__anchor, props, __block) {
 	_$_.render_event('Click', button_7, () => props.onClick);
 
 	{
-		var expression_7 = _$_.child(button_7, true);
+		var expression_7 = _$_.child(button_7);
 
 		_$_.expression(expression_7, () => props.label);
 		_$_.pop(button_7);
@@ -219,7 +219,7 @@ export function ParentWithChildButton(__anchor, _, __block) {
 		var span_7 = _$_.sibling(node);
 
 		{
-			var expression_8 = _$_.child(span_7, true);
+			var expression_8 = _$_.child(span_7);
 
 			_$_.expression(expression_8, () => _$_.get(lazy_7));
 			_$_.pop(span_7);

--- a/packages/ripple/tests/hydration/compiled/client/for.js
+++ b/packages/ripple/tests/hydration/compiled/client/for.js
@@ -80,7 +80,7 @@ export function StaticForLoop(__anchor, _, __block) {
 				var li_1 = root_1();
 
 				{
-					var expression = _$_.child(li_1, true);
+					var expression = _$_.child(li_1);
 
 					_$_.expression(expression, () => item);
 					_$_.pop(li_1);
@@ -112,7 +112,7 @@ export function ForLoopWithIndex(__anchor, _, __block) {
 				var li_2 = root_3();
 
 				{
-					var expression_1 = _$_.child(li_2, true);
+					var expression_1 = _$_.child(li_2);
 
 					_$_.expression(expression_1, () => `${_$_.get(i)}: ${item}`);
 					_$_.pop(li_2);
@@ -149,7 +149,7 @@ export function KeyedForLoop(__anchor, _, __block) {
 				var li_3 = root_5();
 
 				{
-					var expression_2 = _$_.child(li_3, true);
+					var expression_2 = _$_.child(li_3);
 
 					_$_.expression(expression_2, () => _$_.get(pattern).name);
 					_$_.pop(li_3);
@@ -189,7 +189,7 @@ export function ReactiveForLoopAdd(__anchor, _, __block) {
 				var li_4 = root_7();
 
 				{
-					var expression_3 = _$_.child(li_4, true);
+					var expression_3 = _$_.child(li_4);
 
 					_$_.expression(expression_3, () => item);
 					_$_.pop(li_4);
@@ -229,7 +229,7 @@ export function ReactiveForLoopRemove(__anchor, _, __block) {
 				var li_5 = root_9();
 
 				{
-					var expression_4 = _$_.child(li_5, true);
+					var expression_4 = _$_.child(li_5);
 
 					_$_.expression(expression_4, () => item);
 					_$_.pop(li_5);
@@ -265,7 +265,7 @@ export function ForLoopInteractive(__anchor, _, __block) {
 					var span_1 = _$_.child(div_2);
 
 					{
-						var expression_5 = _$_.child(span_1, true);
+						var expression_5 = _$_.child(span_1);
 
 						_$_.expression(expression_5, () => count);
 						_$_.pop(span_1);
@@ -318,7 +318,7 @@ export function NestedForLoop(__anchor, _, __block) {
 							var span_2 = root_14();
 
 							{
-								var expression_6 = _$_.child(span_2, true);
+								var expression_6 = _$_.child(span_2);
 
 								_$_.expression(expression_6, () => cell);
 								_$_.pop(span_2);
@@ -366,7 +366,7 @@ export function EmptyForLoop(__anchor, _, __block) {
 				var span_3 = root_16();
 
 				{
-					var expression_7 = _$_.child(span_3, true);
+					var expression_7 = _$_.child(span_3);
 
 					_$_.expression(expression_7, () => item);
 					_$_.pop(span_3);
@@ -405,7 +405,7 @@ export function ForLoopComplexObjects(__anchor, _, __block) {
 					var span_4 = _$_.child(div_7);
 
 					{
-						var expression_8 = _$_.child(span_4, true);
+						var expression_8 = _$_.child(span_4);
 
 						_$_.expression(expression_8, () => _$_.get(pattern_1).name);
 						_$_.pop(span_4);
@@ -414,7 +414,7 @@ export function ForLoopComplexObjects(__anchor, _, __block) {
 					var span_5 = _$_.sibling(span_4);
 
 					{
-						var expression_9 = _$_.child(span_5, true);
+						var expression_9 = _$_.child(span_5);
 
 						_$_.expression(expression_9, () => _$_.get(pattern_1).role);
 						_$_.pop(span_5);
@@ -468,7 +468,7 @@ export function KeyedForLoopReorder(__anchor, _, __block) {
 				var li_6 = root_20();
 
 				{
-					var expression_10 = _$_.child(li_6, true);
+					var expression_10 = _$_.child(li_6);
 
 					_$_.expression(expression_10, () => _$_.get(pattern_2).name);
 					_$_.pop(li_6);
@@ -513,7 +513,7 @@ export function KeyedForLoopUpdate(__anchor, _, __block) {
 				var li_7 = root_22();
 
 				{
-					var expression_11 = _$_.child(li_7, true);
+					var expression_11 = _$_.child(li_7);
 
 					_$_.expression(expression_11, () => _$_.get(pattern_3).name);
 					_$_.pop(li_7);
@@ -560,7 +560,7 @@ export function ForLoopMixedOperations(__anchor, _, __block) {
 				_$_.set_class(li_8, `item-${item}`, void 0, true);
 
 				{
-					var expression_12 = _$_.child(li_8, true);
+					var expression_12 = _$_.child(li_8);
 
 					_$_.expression(expression_12, () => item);
 					_$_.pop(li_8);
@@ -611,7 +611,7 @@ export function ForLoopInsideIf(__anchor, _, __block) {
 						var li_9 = root_27();
 
 						{
-							var expression_13 = _$_.child(li_9, true);
+							var expression_13 = _$_.child(li_9);
 
 							_$_.expression(expression_13, () => item);
 							_$_.pop(li_9);
@@ -658,7 +658,7 @@ export function ForLoopEmptyToPopulated(__anchor, _, __block) {
 				var li_10 = root_29();
 
 				{
-					var expression_14 = _$_.child(li_10, true);
+					var expression_14 = _$_.child(li_10);
 
 					_$_.expression(expression_14, () => item);
 					_$_.pop(li_10);
@@ -698,7 +698,7 @@ export function ForLoopPopulatedToEmpty(__anchor, _, __block) {
 				var li_11 = root_31();
 
 				{
-					var expression_15 = _$_.child(li_11, true);
+					var expression_15 = _$_.child(li_11);
 
 					_$_.expression(expression_15, () => item);
 					_$_.pop(li_11);
@@ -754,7 +754,7 @@ export function NestedForLoopReactive(__anchor, _, __block) {
 							var span_6 = root_34();
 
 							{
-								var expression_16 = _$_.child(span_6, true);
+								var expression_16 = _$_.child(span_6);
 
 								_$_.expression(expression_16, () => cell);
 								_$_.pop(span_6);
@@ -822,7 +822,7 @@ export function ForLoopDeeplyNested(__anchor, _, __block) {
 					var h2_1 = _$_.child(div_11);
 
 					{
-						var expression_17 = _$_.child(h2_1, true);
+						var expression_17 = _$_.child(h2_1);
 
 						_$_.expression(expression_17, () => _$_.get(pattern_4).name);
 						_$_.pop(h2_1);
@@ -840,7 +840,7 @@ export function ForLoopDeeplyNested(__anchor, _, __block) {
 								var h3_1 = _$_.child(div_12);
 
 								{
-									var expression_18 = _$_.child(h3_1, true);
+									var expression_18 = _$_.child(h3_1);
 
 									_$_.expression(expression_18, () => _$_.get(pattern_5).name);
 									_$_.pop(h3_1);
@@ -856,7 +856,7 @@ export function ForLoopDeeplyNested(__anchor, _, __block) {
 											var li_12 = root_38();
 
 											{
-												var expression_19 = _$_.child(li_12, true);
+												var expression_19 = _$_.child(li_12);
 
 												_$_.expression(expression_19, () => member);
 												_$_.pop(li_12);
@@ -922,7 +922,7 @@ export function ForLoopIndexUpdate(__anchor, _, __block) {
 				var li_13 = root_40();
 
 				{
-					var expression_20 = _$_.child(li_13, true);
+					var expression_20 = _$_.child(li_13);
 
 					_$_.expression(expression_20, () => `[${_$_.get(i)}] ${item}`);
 					_$_.pop(li_13);
@@ -979,7 +979,7 @@ export function KeyedForLoopWithIndex(__anchor, _, __block) {
 				var li_14 = root_42();
 
 				{
-					var expression_21 = _$_.child(li_14, true);
+					var expression_21 = _$_.child(li_14);
 
 					_$_.expression(expression_21, () => `[${_$_.get(i)}] ${_$_.get(pattern_6).id}: ${_$_.get(pattern_6).value}`);
 					_$_.pop(li_14);
@@ -1036,7 +1036,7 @@ export function ForLoopWithSiblings(__anchor, _, __block) {
 				_$_.set_class(div_14, `item-${item}`, void 0, true);
 
 				{
-					var expression_22 = _$_.child(div_14, true);
+					var expression_22 = _$_.child(div_14);
 
 					_$_.expression(expression_22, () => item);
 					_$_.pop(div_14);
@@ -1123,7 +1123,7 @@ function TodoItem(__anchor, props, __block) {
 		var span_7 = _$_.sibling(input_1);
 
 		{
-			var expression_23 = _$_.child(span_7, true);
+			var expression_23 = _$_.child(span_7);
 
 			_$_.expression(expression_23, () => props.text);
 			_$_.pop(span_7);
@@ -1171,7 +1171,7 @@ export function ForLoopSingleItem(__anchor, _, __block) {
 				var li_15 = root_49();
 
 				{
-					var expression_24 = _$_.child(li_15, true);
+					var expression_24 = _$_.child(li_15);
 
 					_$_.expression(expression_24, () => item);
 					_$_.pop(li_15);
@@ -1212,7 +1212,7 @@ export function ForLoopAddAtBeginning(__anchor, _, __block) {
 				_$_.set_class(li_16, `item-${item}`, void 0, true);
 
 				{
-					var expression_25 = _$_.child(li_16, true);
+					var expression_25 = _$_.child(li_16);
 
 					_$_.expression(expression_25, () => item);
 					_$_.pop(li_16);
@@ -1257,7 +1257,7 @@ export function ForLoopAddInMiddle(__anchor, _, __block) {
 				_$_.set_class(li_17, `item-${item}`, void 0, true);
 
 				{
-					var expression_26 = _$_.child(li_17, true);
+					var expression_26 = _$_.child(li_17);
 
 					_$_.expression(expression_26, () => item);
 					_$_.pop(li_17);
@@ -1299,7 +1299,7 @@ export function ForLoopRemoveFromMiddle(__anchor, _, __block) {
 				_$_.set_class(li_18, `item-${item}`, void 0, true);
 
 				{
-					var expression_27 = _$_.child(li_18, true);
+					var expression_27 = _$_.child(li_18);
 
 					_$_.expression(expression_27, () => item);
 					_$_.pop(li_18);
@@ -1332,7 +1332,7 @@ export function ForLoopLargeList(__anchor, _, __block) {
 				var li_19 = root_57();
 
 				{
-					var expression_28 = _$_.child(li_19, true);
+					var expression_28 = _$_.child(li_19);
 
 					_$_.expression(expression_28, () => item);
 					_$_.pop(li_19);
@@ -1380,7 +1380,7 @@ export function ForLoopSwap(__anchor, _, __block) {
 				_$_.set_class(li_20, `item-${item}`, void 0, true);
 
 				{
-					var expression_29 = _$_.child(li_20, true);
+					var expression_29 = _$_.child(li_20);
 
 					_$_.expression(expression_29, () => item);
 					_$_.pop(li_20);
@@ -1422,7 +1422,7 @@ export function ForLoopReverse(__anchor, _, __block) {
 				_$_.set_class(li_21, `item-${item}`, void 0, true);
 
 				{
-					var expression_30 = _$_.child(li_21, true);
+					var expression_30 = _$_.child(li_21);
 
 					_$_.expression(expression_30, () => item);
 					_$_.pop(li_21);

--- a/packages/ripple/tests/hydration/compiled/client/head.js
+++ b/packages/ripple/tests/hydration/compiled/client/head.js
@@ -40,7 +40,7 @@ export function ReactiveTitle(__anchor, _, __block) {
 		var span_1 = _$_.child(div_2);
 
 		{
-			var expression = _$_.child(span_1, true);
+			var expression = _$_.child(span_1);
 
 			_$_.expression(expression, () => _$_.get(lazy));
 			_$_.pop(span_1);
@@ -81,7 +81,7 @@ export function ReactiveMetaTags(__anchor, _, __block) {
 	var div_4 = root_4();
 
 	{
-		var expression_1 = _$_.child(div_4, true);
+		var expression_1 = _$_.child(div_4);
 
 		_$_.expression(expression_1, () => _$_.get(lazy_1));
 		_$_.pop(div_4);
@@ -106,7 +106,7 @@ export function TitleWithTemplate(__anchor, _, __block) {
 	var div_5 = root_6();
 
 	{
-		var expression_2 = _$_.child(div_5, true);
+		var expression_2 = _$_.child(div_5);
 
 		_$_.expression(expression_2, () => _$_.get(lazy_2));
 		_$_.pop(div_5);
@@ -143,7 +143,7 @@ export function ConditionalTitle(__anchor, _, __block) {
 	var div_7 = root_8();
 
 	{
-		var expression_3 = _$_.child(div_7, true);
+		var expression_3 = _$_.child(div_7);
 
 		_$_.expression(expression_3, () => _$_.get(lazy_4));
 		_$_.pop(div_7);
@@ -170,7 +170,7 @@ export function ComputedTitle(__anchor, _, __block) {
 		var span_2 = _$_.child(div_8);
 
 		{
-			var expression_4 = _$_.child(span_2, true);
+			var expression_4 = _$_.child(span_2);
 
 			_$_.expression(expression_4, () => _$_.get(lazy_5));
 			_$_.pop(span_2);

--- a/packages/ripple/tests/hydration/compiled/client/html.js
+++ b/packages/ripple/tests/hydration/compiled/client/html.js
@@ -485,7 +485,7 @@ export function DocLayout(
 						var a_2 = _$_.child(nav_1);
 
 						{
-							var expression_2 = _$_.child(a_2, true);
+							var expression_2 = _$_.child(a_2);
 
 							_$_.expression(expression_2, () => nextLink.text);
 							_$_.pop(a_2);
@@ -533,7 +533,7 @@ export function DocLayout(
 										var a_3 = _$_.child(li_1);
 
 										{
-											var expression_3 = _$_.child(a_3, true);
+											var expression_3 = _$_.child(a_3);
 
 											_$_.expression(expression_3, () => item.text);
 											_$_.pop(a_3);
@@ -845,7 +845,7 @@ function NavItem(__anchor, { href, text: label, active = false }, __block) {
 			var span_1 = _$_.child(a_4);
 
 			{
-				var expression_8 = _$_.child(span_1, true);
+				var expression_8 = _$_.child(span_1);
 
 				_$_.expression(expression_8, () => label);
 				_$_.pop(span_1);
@@ -872,7 +872,7 @@ function SidebarSection(__anchor, { title, children }, __block) {
 			var h2_2 = _$_.child(div_29);
 
 			{
-				var expression_9 = _$_.child(h2_2, true);
+				var expression_9 = _$_.child(h2_2);
 
 				_$_.expression(expression_9, () => title);
 				_$_.pop(h2_2);
@@ -1398,7 +1398,7 @@ function DocsLayoutInner(
 										var a_5 = _$_.child(nav_4);
 
 										{
-											var expression_14 = _$_.child(a_5, true);
+											var expression_14 = _$_.child(a_5);
 
 											_$_.expression(expression_14, () => nextLink.text);
 											_$_.pop(a_5);
@@ -1595,7 +1595,7 @@ function DocsLayoutExact(
 													var span_2 = _$_.child(a_7);
 
 													{
-														var expression_16 = _$_.child(span_2, true);
+														var expression_16 = _$_.child(span_2);
 
 														_$_.expression(expression_16, () => prevLink.text);
 														_$_.pop(span_2);
@@ -1630,7 +1630,7 @@ function DocsLayoutExact(
 													var span_4 = _$_.child(a_8);
 
 													{
-														var expression_17 = _$_.child(span_4, true);
+														var expression_17 = _$_.child(span_4);
 
 														_$_.expression(expression_17, () => nextLink.text);
 														_$_.pop(span_4);
@@ -1689,7 +1689,7 @@ function DocsLayoutExact(
 												var a_9 = root_76();
 
 												{
-													var expression_18 = _$_.child(a_9, true);
+													var expression_18 = _$_.child(a_9);
 
 													_$_.expression(expression_18, () => item.text);
 													_$_.pop(a_9);

--- a/packages/ripple/tests/hydration/compiled/client/if-children.js
+++ b/packages/ripple/tests/hydration/compiled/client/if-children.js
@@ -69,7 +69,7 @@ export function ChildItem(__anchor, { text: label }, __block) {
 	var div_4 = root_2();
 
 	{
-		var expression_1 = _$_.child(div_4, true);
+		var expression_1 = _$_.child(div_4);
 
 		_$_.expression(expression_1, () => label);
 		_$_.pop(div_4);
@@ -364,7 +364,7 @@ export function DomChildrenThenStaticSiblings(__anchor, _, __block) {
 			var li_1 = _$_.child(ul_1);
 
 			{
-				var expression_3 = _$_.child(li_1, true);
+				var expression_3 = _$_.child(li_1);
 
 				_$_.expression(expression_3, () => 'Item count: ' + _$_.with_scope(__block, () => String(_$_.get(lazy_6))));
 				_$_.pop(li_1);

--- a/packages/ripple/tests/hydration/compiled/client/mixed-control-flow.js
+++ b/packages/ripple/tests/hydration/compiled/client/mixed-control-flow.js
@@ -65,7 +65,7 @@ export function MixedControlFlowStatic(__anchor, _, __block) {
 										var div_1 = root_4();
 
 										{
-											var expression = _$_.child(div_1, true);
+											var expression = _$_.child(div_1);
 
 											_$_.expression(expression, () => `A-${_$_.get(pattern).id}`);
 											_$_.pop(div_1);
@@ -102,7 +102,7 @@ export function MixedControlFlowStatic(__anchor, _, __block) {
 										var div_3 = root_7();
 
 										{
-											var expression_1 = _$_.child(div_3, true);
+											var expression_1 = _$_.child(div_3);
 
 											_$_.expression(expression_1, () => `B-${_$_.get(pattern).id}`);
 											_$_.pop(div_3);
@@ -215,7 +215,7 @@ export function MixedControlFlowReactive(__anchor, _, __block) {
 										var p_1 = root_13();
 
 										{
-											var expression_2 = _$_.child(p_1, true);
+											var expression_2 = _$_.child(p_1);
 
 											_$_.expression(expression_2, () => `A:${_$_.get(pattern_1).label}`);
 											_$_.pop(p_1);
@@ -248,7 +248,7 @@ export function MixedControlFlowReactive(__anchor, _, __block) {
 										var p_3 = root_16();
 
 										{
-											var expression_3 = _$_.child(p_3, true);
+											var expression_3 = _$_.child(p_3);
 
 											_$_.expression(expression_3, () => `B:${_$_.get(pattern_1).label}`);
 											_$_.pop(p_3);
@@ -349,7 +349,7 @@ export function MixedControlFlowAsyncPending(__anchor, _, __block) {
 									_$_.set_class(div_7, `pending-row pending-row-${row}`, void 0, true);
 
 									{
-										var expression_4 = _$_.child(div_7, true);
+										var expression_4 = _$_.child(div_7);
 
 										_$_.expression(expression_4, () => `pending ${row}`);
 										_$_.pop(div_7);
@@ -407,7 +407,7 @@ function AsyncRow(__anchor, { label }, __block) {
 	var div_9 = root_25();
 
 	{
-		var expression_5 = _$_.child(div_9, true);
+		var expression_5 = _$_.child(div_9);
 
 		_$_.expression(expression_5, () => _$_.get(lazy_3));
 		_$_.pop(div_9);

--- a/packages/ripple/tests/hydration/compiled/client/nested-control-flow.js
+++ b/packages/ripple/tests/hydration/compiled/client/nested-control-flow.js
@@ -92,7 +92,7 @@ export function ForIf(__anchor, _, __block) {
 						var li_1 = root_2();
 
 						{
-							var expression = _$_.child(li_1, true);
+							var expression = _$_.child(li_1);
 
 							_$_.expression(expression, () => _$_.get(pattern).label);
 							_$_.pop(li_1);
@@ -148,7 +148,7 @@ export function ForSwitch(__anchor, _, __block) {
 						var li_2 = _$_.first_child_frag(fragment_2);
 
 						{
-							var expression_1 = _$_.child(li_2, true);
+							var expression_1 = _$_.child(li_2);
 
 							_$_.expression(expression_1, () => `A-${_$_.get(pattern_1).id}`);
 							_$_.pop(li_2);
@@ -165,7 +165,7 @@ export function ForSwitch(__anchor, _, __block) {
 						var li_3 = root_6();
 
 						{
-							var expression_2 = _$_.child(li_3, true);
+							var expression_2 = _$_.child(li_3);
 
 							_$_.expression(expression_2, () => `B-${_$_.get(pattern_1).id}`);
 							_$_.pop(li_3);
@@ -347,7 +347,7 @@ export function ForIfSwitchSingle(__anchor, _, __block) {
 								var li_4 = _$_.first_child_frag(fragment_9);
 
 								{
-									var expression_3 = _$_.child(li_4, true);
+									var expression_3 = _$_.child(li_4);
 
 									_$_.expression(expression_3, () => `A-${_$_.get(pattern_2).id}`);
 									_$_.pop(li_4);
@@ -364,7 +364,7 @@ export function ForIfSwitchSingle(__anchor, _, __block) {
 								var li_5 = root_19();
 
 								{
-									var expression_4 = _$_.child(li_5, true);
+									var expression_4 = _$_.child(li_5);
 
 									_$_.expression(expression_4, () => `D-${_$_.get(pattern_2).id}`);
 									_$_.pop(li_5);
@@ -442,7 +442,7 @@ export function ForIfSwitchMulti(__anchor, _, __block) {
 								var li_6 = _$_.first_child_frag(fragment_12);
 
 								{
-									var expression_5 = _$_.child(li_6, true);
+									var expression_5 = _$_.child(li_6);
 
 									_$_.expression(expression_5, () => `A-${_$_.get(pattern_3).id}`);
 									_$_.pop(li_6);
@@ -459,7 +459,7 @@ export function ForIfSwitchMulti(__anchor, _, __block) {
 								var li_7 = root_24();
 
 								{
-									var expression_6 = _$_.child(li_7, true);
+									var expression_6 = _$_.child(li_7);
 
 									_$_.expression(expression_6, () => `B-${_$_.get(pattern_3).id}`);
 									_$_.pop(li_7);
@@ -538,7 +538,7 @@ export function ForIfSwitchWithDisabled(__anchor, _, __block) {
 								var li_8 = _$_.first_child_frag(fragment_15);
 
 								{
-									var expression_7 = _$_.child(li_8, true);
+									var expression_7 = _$_.child(li_8);
 
 									_$_.expression(expression_7, () => `A-${_$_.get(pattern_4).id}`);
 									_$_.pop(li_8);
@@ -555,7 +555,7 @@ export function ForIfSwitchWithDisabled(__anchor, _, __block) {
 								var li_9 = root_29();
 
 								{
-									var expression_8 = _$_.child(li_9, true);
+									var expression_8 = _$_.child(li_9);
 
 									_$_.expression(expression_8, () => `B-${_$_.get(pattern_4).id}`);
 									_$_.pop(li_9);
@@ -689,7 +689,7 @@ export function ForSwitchTry(__anchor, _, __block) {
 								var li_10 = root_38();
 
 								{
-									var expression_9 = _$_.child(li_10, true);
+									var expression_9 = _$_.child(li_10);
 
 									_$_.expression(expression_9, () => `A-${_$_.get(pattern_5).id}`);
 									_$_.pop(li_10);
@@ -706,7 +706,7 @@ export function ForSwitchTry(__anchor, _, __block) {
 								var li_11 = root_39();
 
 								{
-									var expression_10 = _$_.child(li_11, true);
+									var expression_10 = _$_.child(li_11);
 
 									_$_.expression(expression_10, () => `pending ${_$_.get(pattern_5).id}`);
 									_$_.pop(li_11);
@@ -733,7 +733,7 @@ export function ForSwitchTry(__anchor, _, __block) {
 								var li_12 = root_41();
 
 								{
-									var expression_11 = _$_.child(li_12, true);
+									var expression_11 = _$_.child(li_12);
 
 									_$_.expression(expression_11, () => `B-${_$_.get(pattern_5).id}`);
 									_$_.pop(li_12);
@@ -750,7 +750,7 @@ export function ForSwitchTry(__anchor, _, __block) {
 								var li_13 = root_42();
 
 								{
-									var expression_12 = _$_.child(li_13, true);
+									var expression_12 = _$_.child(li_13);
 
 									_$_.expression(expression_12, () => `pending ${_$_.get(pattern_5).id}`);
 									_$_.pop(li_13);
@@ -820,7 +820,7 @@ export function ForIfTry(__anchor, _, __block) {
 								var li_14 = root_46();
 
 								{
-									var expression_13 = _$_.child(li_14, true);
+									var expression_13 = _$_.child(li_14);
 
 									_$_.expression(expression_13, () => `item-${_$_.get(pattern_6).id}`);
 									_$_.pop(li_14);
@@ -837,7 +837,7 @@ export function ForIfTry(__anchor, _, __block) {
 								var li_15 = root_47();
 
 								{
-									var expression_14 = _$_.child(li_15, true);
+									var expression_14 = _$_.child(li_15);
 
 									_$_.expression(expression_14, () => `pending ${_$_.get(pattern_6).id}`);
 									_$_.pop(li_15);
@@ -902,7 +902,7 @@ export function ForIfSwitchTrySingle(__anchor, _, __block) {
 										var li_16 = root_52();
 
 										{
-											var expression_15 = _$_.child(li_16, true);
+											var expression_15 = _$_.child(li_16);
 
 											_$_.expression(expression_15, () => `A-${_$_.get(pattern_7).id}`);
 											_$_.pop(li_16);
@@ -919,7 +919,7 @@ export function ForIfSwitchTrySingle(__anchor, _, __block) {
 										var li_17 = root_53();
 
 										{
-											var expression_16 = _$_.child(li_17, true);
+											var expression_16 = _$_.child(li_17);
 
 											_$_.expression(expression_16, () => `pending ${_$_.get(pattern_7).id}`);
 											_$_.pop(li_17);
@@ -946,7 +946,7 @@ export function ForIfSwitchTrySingle(__anchor, _, __block) {
 										var li_18 = root_55();
 
 										{
-											var expression_17 = _$_.child(li_18, true);
+											var expression_17 = _$_.child(li_18);
 
 											_$_.expression(expression_17, () => `D-${_$_.get(pattern_7).id}`);
 											_$_.pop(li_18);
@@ -963,7 +963,7 @@ export function ForIfSwitchTrySingle(__anchor, _, __block) {
 										var li_19 = root_56();
 
 										{
-											var expression_18 = _$_.child(li_19, true);
+											var expression_18 = _$_.child(li_19);
 
 											_$_.expression(expression_18, () => `pending ${_$_.get(pattern_7).id}`);
 											_$_.pop(li_19);
@@ -1050,7 +1050,7 @@ export function ForIfSwitchTryMulti(__anchor, _, __block) {
 										var li_20 = root_61();
 
 										{
-											var expression_19 = _$_.child(li_20, true);
+											var expression_19 = _$_.child(li_20);
 
 											_$_.expression(expression_19, () => `A-${_$_.get(pattern_8).id}`);
 											_$_.pop(li_20);
@@ -1067,7 +1067,7 @@ export function ForIfSwitchTryMulti(__anchor, _, __block) {
 										var li_21 = root_62();
 
 										{
-											var expression_20 = _$_.child(li_21, true);
+											var expression_20 = _$_.child(li_21);
 
 											_$_.expression(expression_20, () => `pending ${_$_.get(pattern_8).id}`);
 											_$_.pop(li_21);
@@ -1094,7 +1094,7 @@ export function ForIfSwitchTryMulti(__anchor, _, __block) {
 										var li_22 = root_64();
 
 										{
-											var expression_21 = _$_.child(li_22, true);
+											var expression_21 = _$_.child(li_22);
 
 											_$_.expression(expression_21, () => `B-${_$_.get(pattern_8).id}`);
 											_$_.pop(li_22);
@@ -1111,7 +1111,7 @@ export function ForIfSwitchTryMulti(__anchor, _, __block) {
 										var li_23 = root_65();
 
 										{
-											var expression_22 = _$_.child(li_23, true);
+											var expression_22 = _$_.child(li_23);
 
 											_$_.expression(expression_22, () => `pending ${_$_.get(pattern_8).id}`);
 											_$_.pop(li_23);

--- a/packages/ripple/tests/hydration/compiled/client/reactivity.js
+++ b/packages/ripple/tests/hydration/compiled/client/reactivity.js
@@ -17,7 +17,7 @@ export function TrackedState(__anchor, _, __block) {
 	var div_1 = root();
 
 	{
-		var expression = _$_.child(div_1, true);
+		var expression = _$_.child(div_1);
 
 		_$_.expression(expression, () => _$_.get(lazy));
 		_$_.pop(div_1);
@@ -37,7 +37,7 @@ export function CounterWithInitial(__anchor, props, __block) {
 		var span_1 = _$_.child(div_2);
 
 		{
-			var expression_1 = _$_.child(span_1, true);
+			var expression_1 = _$_.child(span_1);
 
 			_$_.expression(expression_1, () => _$_.get(lazy_1));
 			_$_.pop(span_1);
@@ -68,7 +68,7 @@ export function ComputedValues(__anchor, _, __block) {
 	var div_3 = root_3();
 
 	{
-		var expression_2 = _$_.child(div_3, true);
+		var expression_2 = _$_.child(div_3);
 
 		_$_.expression(expression_2, sum);
 		_$_.pop(div_3);
@@ -88,7 +88,7 @@ export function MultipleTracked(__anchor, _, __block) {
 	var div_4 = _$_.first_child_frag(fragment_1);
 
 	{
-		var expression_3 = _$_.child(div_4, true);
+		var expression_3 = _$_.child(div_4);
 
 		_$_.expression(expression_3, () => _$_.get(lazy_4));
 		_$_.pop(div_4);
@@ -97,7 +97,7 @@ export function MultipleTracked(__anchor, _, __block) {
 	var div_5 = _$_.sibling(div_4);
 
 	{
-		var expression_4 = _$_.child(div_5, true);
+		var expression_4 = _$_.child(div_5);
 
 		_$_.expression(expression_4, () => _$_.get(lazy_5));
 		_$_.pop(div_5);
@@ -106,7 +106,7 @@ export function MultipleTracked(__anchor, _, __block) {
 	var div_6 = _$_.sibling(div_5);
 
 	{
-		var expression_5 = _$_.child(div_6, true);
+		var expression_5 = _$_.child(div_6);
 
 		_$_.expression(expression_5, () => _$_.get(lazy_6));
 		_$_.pop(div_6);
@@ -126,7 +126,7 @@ export function DerivedState(__anchor, _, __block) {
 	var div_7 = root_5();
 
 	{
-		var expression_6 = _$_.child(div_7, true);
+		var expression_6 = _$_.child(div_7);
 
 		_$_.expression(expression_6, fullName);
 		_$_.pop(div_7);

--- a/packages/ripple/tests/hydration/compiled/client/return.js
+++ b/packages/ripple/tests/hydration/compiled/client/return.js
@@ -1709,7 +1709,7 @@ export function ReactiveOuterInnerReturns(__anchor, _, __block) {
 		var div_39 = root_113();
 
 		{
-			var expression = _$_.child(div_39, true);
+			var expression = _$_.child(div_39);
 
 			_$_.expression(expression, () => _$_.get(lazy_4) ? 'a-on rest' : 'a-off rest');
 			_$_.pop(div_39);

--- a/packages/ripple/tests/hydration/compiled/client/track-async-serialization.js
+++ b/packages/ripple/tests/hydration/compiled/client/track-async-serialization.js
@@ -56,7 +56,7 @@ export function AsyncWithServerCall(__anchor, _, __block) {
 			var p_1 = root_1();
 
 			{
-				var expression = _$_.child(p_1, true);
+				var expression = _$_.child(p_1);
 
 				_$_.expression(expression, () => _$_.get(lazy_1));
 				_$_.pop(p_1);
@@ -89,7 +89,7 @@ export function AsyncSimpleValue(__anchor, _, __block) {
 			var p_3 = root_4();
 
 			{
-				var expression_1 = _$_.child(p_3, true);
+				var expression_1 = _$_.child(p_3);
 
 				_$_.expression(expression_1, () => _$_.get(lazy_2));
 				_$_.pop(p_3);
@@ -122,7 +122,7 @@ export function AsyncNumericValue(__anchor, _, __block) {
 			var span_1 = root_7();
 
 			{
-				var expression_2 = _$_.child(span_1, true);
+				var expression_2 = _$_.child(span_1);
 
 				_$_.expression(expression_2, () => _$_.get(lazy_3));
 				_$_.pop(span_1);
@@ -158,7 +158,7 @@ export function AsyncObjectValue(__anchor, _, __block) {
 				var span_3 = _$_.child(div_1);
 
 				{
-					var expression_3 = _$_.child(span_3, true);
+					var expression_3 = _$_.child(span_3);
 
 					_$_.expression(expression_3, () => _$_.get(lazy_4).name);
 					_$_.pop(span_3);
@@ -167,7 +167,7 @@ export function AsyncObjectValue(__anchor, _, __block) {
 				var span_4 = _$_.sibling(span_3);
 
 				{
-					var expression_4 = _$_.child(span_4, true);
+					var expression_4 = _$_.child(span_4);
 
 					_$_.expression(expression_4, () => _$_.get(lazy_4).age);
 					_$_.pop(span_4);
@@ -205,7 +205,7 @@ export function AsyncMultipleValues(__anchor, _, __block) {
 				var span_5 = _$_.child(div_3);
 
 				{
-					var expression_5 = _$_.child(span_5, true);
+					var expression_5 = _$_.child(span_5);
 
 					_$_.expression(expression_5, () => _$_.get(lazy_5));
 					_$_.pop(span_5);
@@ -214,7 +214,7 @@ export function AsyncMultipleValues(__anchor, _, __block) {
 				var span_6 = _$_.sibling(span_5);
 
 				{
-					var expression_6 = _$_.child(span_6, true);
+					var expression_6 = _$_.child(span_6);
 
 					_$_.expression(expression_6, () => _$_.get(lazy_6));
 					_$_.pop(span_6);
@@ -248,7 +248,7 @@ export function AsyncWithCatch(__anchor, _, __block) {
 			var p_5 = root_16();
 
 			{
-				var expression_7 = _$_.child(p_5, true);
+				var expression_7 = _$_.child(p_5);
 
 				_$_.expression(expression_7, () => _$_.get(lazy_7));
 				_$_.pop(p_5);
@@ -260,7 +260,7 @@ export function AsyncWithCatch(__anchor, _, __block) {
 			var p_6 = root_17();
 
 			{
-				var expression_8 = _$_.child(p_6, true);
+				var expression_8 = _$_.child(p_6);
 
 				_$_.expression(expression_8, () => e.message);
 				_$_.pop(p_6);
@@ -292,7 +292,7 @@ export function ChildWithError(__anchor, _, __block) {
 			var p_8 = root_20();
 
 			{
-				var expression_9 = _$_.child(p_8, true);
+				var expression_9 = _$_.child(p_8);
 
 				_$_.expression(expression_9, () => _$_.get(lazy_8));
 				_$_.pop(p_8);
@@ -331,7 +331,7 @@ export function ParentWithCatch(__anchor, _, __block) {
 			var p_10 = root_24();
 
 			{
-				var expression_10 = _$_.child(p_10, true);
+				var expression_10 = _$_.child(p_10);
 
 				_$_.expression(expression_10, () => e.message);
 				_$_.pop(p_10);
@@ -365,7 +365,7 @@ export function AsyncWithReactiveDependency(__anchor, _, __block) {
 			var p_11 = root_26();
 
 			{
-				var expression_11 = _$_.child(p_11, true);
+				var expression_11 = _$_.child(p_11);
 
 				_$_.expression(expression_11, () => _$_.get(lazy_10));
 				_$_.pop(p_11);

--- a/packages/ripple/tests/hydration/compiled/client/try.js
+++ b/packages/ripple/tests/hydration/compiled/client/try.js
@@ -54,7 +54,7 @@ function AsyncList(__anchor, _, __block) {
 				var li_1 = root_4();
 
 				{
-					var expression = _$_.child(li_1, true);
+					var expression = _$_.child(li_1);
 
 					_$_.expression(expression, () => item);
 					_$_.pop(li_1);
@@ -107,7 +107,7 @@ function AsyncContent(__anchor, _, __block) {
 	var div_3 = root_8();
 
 	{
-		var expression_1 = _$_.child(div_3, true);
+		var expression_1 = _$_.child(div_3);
 
 		_$_.expression(expression_1, () => _$_.get(lazy_1));
 		_$_.pop(div_3);

--- a/packages/ripple/tests/hydration/compiled/server/basic.js
+++ b/packages/ripple/tests/hydration/compiled/server/basic.js
@@ -345,6 +345,245 @@ export function NestedTsxTsrxExpressionValues() {
 	_$_.pop_component();
 }
 
+export function MixedTsrxCollectionText() {
+	_$_.push_component();
+
+	const content = _$_.tsrx_element(function render_children() {
+		_$_.regular_block(() => {
+			_$_.render_expression([
+				'alpha ',
+				_$_.tsrx_element(function render_children() {
+					_$_.output_push('<strong');
+					_$_.output_push(' class="middle"');
+					_$_.output_push('>');
+
+					{
+						_$_.output_push('beta');
+					}
+
+					_$_.output_push('</strong>');
+				}),
+				' gamma ',
+				[
+					'delta ',
+					_$_.tsrx_element(function render_children() {
+						_$_.output_push('<em');
+						_$_.output_push(' class="tail"');
+						_$_.output_push('>');
+
+						{
+							_$_.output_push('epsilon');
+						}
+
+						_$_.output_push('</em>');
+					}),
+					' zeta'
+				]
+			]);
+		});
+	});
+
+	_$_.regular_block(() => {
+		_$_.output_push('<div');
+		_$_.output_push(' class="mixed-collection"');
+		_$_.output_push('>');
+
+		{
+			_$_.render_expression(content);
+		}
+
+		_$_.output_push('</div>');
+	});
+
+	_$_.pop_component();
+}
+
+export function MixedTsrxCollectionSplitServerText() {
+	_$_.push_component();
+
+	const content = _$_.tsrx_element(function render_children() {
+		_$_.regular_block(() => {
+			_$_.render_expression([
+				'alpha ',
+				_$_.tsrx_element(function render_children() {
+					_$_.output_push('<strong');
+					_$_.output_push(' class="middle"');
+					_$_.output_push('>');
+
+					{
+						_$_.output_push('beta');
+					}
+
+					_$_.output_push('</strong>');
+				}),
+				' gamma ',
+				[
+					'delta ',
+					_$_.tsrx_element(function render_children() {
+						_$_.output_push('<em');
+						_$_.output_push(' class="tail"');
+						_$_.output_push('>');
+
+						{
+							_$_.output_push('epsilon');
+						}
+
+						_$_.output_push('</em>');
+					}),
+					' zeta'
+				]
+			]);
+		});
+	});
+
+	_$_.regular_block(() => {
+		_$_.output_push('<div');
+		_$_.output_push(' class="mixed-collection-split"');
+		_$_.output_push('>');
+
+		{
+			_$_.render_expression(content);
+		}
+
+		_$_.output_push('</div>');
+	});
+
+	_$_.pop_component();
+}
+
+export function MixedTsrxCollectionSplitClientText() {
+	_$_.push_component();
+
+	const content = _$_.tsrx_element(function render_children() {
+		_$_.regular_block(() => {
+			_$_.render_expression([
+				'alpha ',
+				_$_.tsrx_element(function render_children() {
+					_$_.output_push('<strong');
+					_$_.output_push(' class="middle"');
+					_$_.output_push('>');
+
+					{
+						_$_.output_push('beta');
+					}
+
+					_$_.output_push('</strong>');
+				}),
+				' gamma ',
+				[
+					'changed ',
+					_$_.tsrx_element(function render_children() {
+						_$_.output_push('<em');
+						_$_.output_push(' class="tail"');
+						_$_.output_push('>');
+
+						{
+							_$_.output_push('epsilon');
+						}
+
+						_$_.output_push('</em>');
+					}),
+					' zeta'
+				]
+			]);
+		});
+	});
+
+	_$_.regular_block(() => {
+		_$_.output_push('<div');
+		_$_.output_push(' class="mixed-collection-split"');
+		_$_.output_push('>');
+
+		{
+			_$_.render_expression(content);
+		}
+
+		_$_.output_push('</div>');
+	});
+
+	_$_.pop_component();
+}
+
+export function MixedTsrxCollectionPrimitiveServerText() {
+	_$_.push_component();
+
+	const content = _$_.tsrx_element(function render_children() {
+		_$_.regular_block(() => {
+			_$_.render_expression([
+				'count: ',
+				1,
+				' / ',
+				true,
+				_$_.tsrx_element(function render_children() {
+					_$_.output_push('<span');
+					_$_.output_push(' class="primitive-tail"');
+					_$_.output_push('>');
+
+					{
+						_$_.output_push(' ok');
+					}
+
+					_$_.output_push('</span>');
+				})
+			]);
+		});
+	});
+
+	_$_.regular_block(() => {
+		_$_.output_push('<div');
+		_$_.output_push(' class="mixed-collection-primitive"');
+		_$_.output_push('>');
+
+		{
+			_$_.render_expression(content);
+		}
+
+		_$_.output_push('</div>');
+	});
+
+	_$_.pop_component();
+}
+
+export function MixedTsrxCollectionPrimitiveClientText() {
+	_$_.push_component();
+
+	const content = _$_.tsrx_element(function render_children() {
+		_$_.regular_block(() => {
+			_$_.render_expression([
+				'count: ',
+				2,
+				' / ',
+				false,
+				_$_.tsrx_element(function render_children() {
+					_$_.output_push('<span');
+					_$_.output_push(' class="primitive-tail"');
+					_$_.output_push('>');
+
+					{
+						_$_.output_push(' ok');
+					}
+
+					_$_.output_push('</span>');
+				})
+			]);
+		});
+	});
+
+	_$_.regular_block(() => {
+		_$_.output_push('<div');
+		_$_.output_push(' class="mixed-collection-primitive"');
+		_$_.output_push('>');
+
+		{
+			_$_.render_expression(content);
+		}
+
+		_$_.output_push('</div>');
+	});
+
+	_$_.pop_component();
+}
+
 export function NestedTsrxInsideTopLevelTsxExpression() {
 	_$_.push_component();
 

--- a/packages/ripple/tests/hydration/compiled/server/basic.js
+++ b/packages/ripple/tests/hydration/compiled/server/basic.js
@@ -628,6 +628,51 @@ export function DynamicArrayFromTrack() {
 	_$_.pop_component();
 }
 
+export function DynamicArrayFromConditional() {
+	_$_.push_component();
+
+	const condition = true;
+
+	const items = condition
+		? ['start:', ['one', 2], true, null, false, ':end']
+		: ['fallback'];
+
+	_$_.regular_block(() => {
+		_$_.output_push('<div');
+		_$_.output_push(' class="dynamic-array-conditional"');
+		_$_.output_push('>');
+
+		{
+			_$_.render_expression(items);
+		}
+
+		_$_.output_push('</div>');
+	});
+
+	_$_.pop_component();
+}
+
+export function DynamicArrayFromLogical() {
+	_$_.push_component();
+
+	const condition = true;
+	const items = condition && ['start:', ['one', 2], true, null, false, ':end'];
+
+	_$_.regular_block(() => {
+		_$_.output_push('<div');
+		_$_.output_push(' class="dynamic-array-logical"');
+		_$_.output_push('>');
+
+		{
+			_$_.render_expression(items);
+		}
+
+		_$_.output_push('</div>');
+	});
+
+	_$_.pop_component();
+}
+
 export function NestedTsrxInsideTopLevelTsxExpression() {
 	_$_.push_component();
 

--- a/packages/ripple/tests/hydration/compiled/server/basic.js
+++ b/packages/ripple/tests/hydration/compiled/server/basic.js
@@ -283,6 +283,186 @@ export function ExpressionContent() {
 	_$_.pop_component();
 }
 
+function makeNestedTsxTsrxFragment(label) {
+	return _$_.tsrx_element(function render_children() {
+		_$_.output_push('<span');
+		_$_.output_push(' class="label"');
+		_$_.output_push('>');
+
+		{
+			_$_.output_push(_$_.escape(label));
+		}
+
+		_$_.output_push('</span>');
+
+		const test = _$_.tsrx_element(function render_children() {
+			_$_.render_expression([1, 2, 3, 4].map((item) => _$_.tsrx_element(function render_children() {
+				{
+					_$_.render_expression(_$_.tsrx_element(function render_children() {
+						{
+							_$_.output_push('<div');
+							_$_.output_push(' class="helper-item"');
+							_$_.output_push('>');
+
+							{
+								_$_.output_push(_$_.escape(item));
+							}
+
+							_$_.output_push('</div>');
+						}
+					}));
+				}
+			})));
+		});
+
+		_$_.render_expression(test);
+	});
+}
+
+export function NestedTsxTsrxExpressionValues() {
+	_$_.push_component();
+
+	_$_.regular_block(() => {
+		_$_.render_expression(_$_.tsrx_element(function render_children() {
+			_$_.render_expression([1, 2, 3].map((item) => _$_.tsrx_element(function render_children() {
+				_$_.output_push('<div');
+				_$_.output_push(' class="app-item"');
+				_$_.output_push('>');
+
+				{
+					_$_.output_push(_$_.escape(item));
+				}
+
+				_$_.output_push('</div>');
+			})));
+		}));
+	});
+
+	_$_.regular_block(() => {
+		_$_.render_expression(makeNestedTsxTsrxFragment('from helper'));
+	});
+
+	_$_.pop_component();
+}
+
+export function NestedTsrxInsideTopLevelTsxExpression() {
+	_$_.push_component();
+
+	const content = _$_.tsrx_element(function render_children() {
+		_$_.regular_block(() => {
+			_$_.output_push('<section');
+			_$_.output_push(' class="outer"');
+			_$_.output_push('>');
+
+			{
+				_$_.render_expression(_$_.tsrx_element(function render_children() {
+					{
+						_$_.output_push('<div');
+						_$_.output_push(' class="inner"');
+						_$_.output_push('>');
+
+						{
+							_$_.output_push('from tsrx');
+						}
+
+						_$_.output_push('</div>');
+					}
+				}));
+			}
+
+			_$_.output_push('</section>');
+		});
+	});
+
+	_$_.regular_block(() => {
+		_$_.render_expression(content);
+	});
+
+	_$_.pop_component();
+}
+
+export function NestedTsrxElementsInsideTopLevelTsxValue() {
+	_$_.push_component();
+
+	const content = _$_.tsrx_element(function render_children() {
+		_$_.regular_block(() => {
+			_$_.output_push('<div');
+			_$_.output_push(' class="wrapper"');
+			_$_.output_push('>');
+
+			{
+				_$_.render_expression(_$_.tsrx_element(function render_children() {
+					{
+						_$_.output_push('<section');
+						_$_.output_push(' class="native"');
+						_$_.output_push('>');
+
+						{
+							_$_.output_push('<span');
+							_$_.output_push(' class="nested-tsrx"');
+							_$_.output_push('>');
+
+							{
+								_$_.output_push('inside nested tsrx');
+							}
+
+							_$_.output_push('</span>');
+						}
+
+						_$_.output_push('</section>');
+					}
+				}));
+			}
+
+			_$_.output_push('</div>');
+		});
+	});
+
+	_$_.regular_block(() => {
+		_$_.render_expression(content);
+	});
+
+	_$_.pop_component();
+}
+
+export function TsxDeclaredInsideNestedTsrxFromTopLevelTsx() {
+	_$_.push_component();
+
+	const content = _$_.tsrx_element(function render_children() {
+		_$_.regular_block(() => {
+			_$_.render_expression(_$_.tsrx_element(function render_children() {
+				const nested = _$_.tsrx_element(function render_children() {
+					_$_.output_push('<span');
+					_$_.output_push(' class="nested-tsx"');
+					_$_.output_push('>');
+
+					{
+						_$_.output_push('inside nested tsx');
+					}
+
+					_$_.output_push('</span>');
+				});
+
+				_$_.output_push('<div');
+				_$_.output_push(' class="native"');
+				_$_.output_push('>');
+
+				{
+					_$_.render_expression(nested);
+				}
+
+				_$_.output_push('</div>');
+			}));
+		});
+	});
+
+	_$_.regular_block(() => {
+		_$_.render_expression(content);
+	});
+
+	_$_.pop_component();
+}
+
 function TextProp(__props) {
 	_$_.push_component();
 

--- a/packages/ripple/tests/hydration/compiled/server/basic.js
+++ b/packages/ripple/tests/hydration/compiled/server/basic.js
@@ -584,6 +584,50 @@ export function MixedTsrxCollectionPrimitiveClientText() {
 	_$_.pop_component();
 }
 
+function createPrimitiveItems() {
+	return ['start:', ['one', 2], true, null, false, ':end'];
+}
+
+export function DynamicArrayFromCall() {
+	_$_.push_component();
+
+	const items = createPrimitiveItems();
+
+	_$_.regular_block(() => {
+		_$_.output_push('<div');
+		_$_.output_push(' class="dynamic-array-call"');
+		_$_.output_push('>');
+
+		{
+			_$_.render_expression(items);
+		}
+
+		_$_.output_push('</div>');
+	});
+
+	_$_.pop_component();
+}
+
+export function DynamicArrayFromTrack() {
+	_$_.push_component();
+
+	let lazy = _$_.track(['start:', ['one', 2], true, null, false, ':end'], 'b5de6402');
+
+	_$_.regular_block(() => {
+		_$_.output_push('<div');
+		_$_.output_push(' class="dynamic-array-track"');
+		_$_.output_push('>');
+
+		{
+			_$_.render_expression(_$_.get(lazy));
+		}
+
+		_$_.output_push('</div>');
+	});
+
+	_$_.pop_component();
+}
+
 export function NestedTsrxInsideTopLevelTsxExpression() {
 	_$_.push_component();
 
@@ -723,7 +767,7 @@ function TextProp(__props) {
 export function TextPropWithToggle() {
 	_$_.push_component();
 
-	let lazy = _$_.track(false, 'b5de6402');
+	let lazy_1 = _$_.track(false, '1ba81c3b');
 
 	_$_.regular_block(() => {
 		{
@@ -731,7 +775,7 @@ export function TextPropWithToggle() {
 
 			const args = [
 				{
-					children: _$_.normalize_children(_$_.get(lazy) ? 'hello' : '')
+					children: _$_.normalize_children(_$_.get(lazy_1) ? 'hello' : '')
 				}
 			];
 

--- a/packages/ripple/tests/hydration/components/basic.tsrx
+++ b/packages/ripple/tests/hydration/components/basic.tsrx
@@ -198,6 +198,20 @@ export component DynamicArrayFromTrack() {
 	<div class="dynamic-array-track">{items}</div>
 }
 
+export component DynamicArrayFromConditional() {
+	const condition = true;
+	const items = condition ? ['start:', ['one', 2], true, null, false, ':end'] : ['fallback'];
+
+	<div class="dynamic-array-conditional">{items}</div>
+}
+
+export component DynamicArrayFromLogical() {
+	const condition = true;
+	const items = condition && ['start:', ['one', 2], true, null, false, ':end'];
+
+	<div class="dynamic-array-logical">{items}</div>
+}
+
 export component NestedTsrxInsideTopLevelTsxExpression() {
 	const content = <tsx>
 		<section class="outer">

--- a/packages/ripple/tests/hydration/components/basic.tsrx
+++ b/packages/ripple/tests/hydration/components/basic.tsrx
@@ -87,6 +87,101 @@ export component NestedTsxTsrxExpressionValues() {
 	{makeNestedTsxTsrxFragment('from helper')}
 }
 
+export component MixedTsrxCollectionText() {
+	const content = <tsx>
+		{[
+			'alpha ',
+			<strong class="middle">
+				{'beta'}
+			</strong>,
+			' gamma ',
+			[
+				'delta ',
+				<em class="tail">
+					{'epsilon'}
+				</em>,
+				' zeta',
+			],
+		]}
+	</tsx>;
+
+	<div class="mixed-collection">{content}</div>
+}
+
+export component MixedTsrxCollectionSplitServerText() {
+	const content = <tsx>
+		{[
+			'alpha ',
+			<strong class="middle">
+				{'beta'}
+			</strong>,
+			' gamma ',
+			[
+				'delta ',
+				<em class="tail">
+					{'epsilon'}
+				</em>,
+				' zeta',
+			],
+		]}
+	</tsx>;
+
+	<div class="mixed-collection-split">{content}</div>
+}
+
+export component MixedTsrxCollectionSplitClientText() {
+	const content = <tsx>
+		{[
+			'alpha ',
+			<strong class="middle">
+				{'beta'}
+			</strong>,
+			' gamma ',
+			[
+				'changed ',
+				<em class="tail">
+					{'epsilon'}
+				</em>,
+				' zeta',
+			],
+		]}
+	</tsx>;
+
+	<div class="mixed-collection-split">{content}</div>
+}
+
+export component MixedTsrxCollectionPrimitiveServerText() {
+	const content = <tsx>
+		{[
+			'count: ',
+			1,
+			' / ',
+			true,
+			<span class="primitive-tail">
+				{' ok'}
+			</span>,
+		]}
+	</tsx>;
+
+	<div class="mixed-collection-primitive">{content}</div>
+}
+
+export component MixedTsrxCollectionPrimitiveClientText() {
+	const content = <tsx>
+		{[
+			'count: ',
+			2,
+			' / ',
+			false,
+			<span class="primitive-tail">
+				{' ok'}
+			</span>,
+		]}
+	</tsx>;
+
+	<div class="mixed-collection-primitive">{content}</div>
+}
+
 export component NestedTsrxInsideTopLevelTsxExpression() {
 	const content = <tsx>
 		<section class="outer">

--- a/packages/ripple/tests/hydration/components/basic.tsrx
+++ b/packages/ripple/tests/hydration/components/basic.tsrx
@@ -182,6 +182,22 @@ export component MixedTsrxCollectionPrimitiveClientText() {
 	<div class="mixed-collection-primitive">{content}</div>
 }
 
+function createPrimitiveItems() {
+	return ['start:', ['one', 2], true, null, false, ':end'];
+}
+
+export component DynamicArrayFromCall() {
+	const items = createPrimitiveItems();
+
+	<div class="dynamic-array-call">{items}</div>
+}
+
+export component DynamicArrayFromTrack() {
+	let &[items] = track(['start:', ['one', 2], true, null, false, ':end']);
+
+	<div class="dynamic-array-track">{items}</div>
+}
+
 export component NestedTsrxInsideTopLevelTsxExpression() {
 	const content = <tsx>
 		<section class="outer">

--- a/packages/ripple/tests/hydration/components/basic.tsrx
+++ b/packages/ripple/tests/hydration/components/basic.tsrx
@@ -66,6 +66,72 @@ export component ExpressionContent() {
 	<span>{label.toUpperCase()}</span>
 }
 
+function makeNestedTsxTsrxFragment(label: string) {
+	return <tsrx>
+		<span class="label">{label}</span>
+		const test = <tsx>
+			{[1, 2, 3, 4].map(
+				(item) => <tsx>
+					{<tsrx>
+						<div class="helper-item">{item}</div>
+					</tsrx>}
+				</tsx>,
+			)}
+		</tsx>;
+		{test}
+	</tsrx>;
+}
+
+export component NestedTsxTsrxExpressionValues() {
+	{<tsx>{[1, 2, 3].map((item) => <div class="app-item">{item}</div>)}</tsx>}
+	{makeNestedTsxTsrxFragment('from helper')}
+}
+
+export component NestedTsrxInsideTopLevelTsxExpression() {
+	const content = <tsx>
+		<section class="outer">
+			{<tsrx>
+				<div class="inner">
+					{'from tsrx'}
+				</div>
+			</tsrx>}
+		</section>
+	</tsx>;
+
+	{content}
+}
+
+export component NestedTsrxElementsInsideTopLevelTsxValue() {
+	const content = <tsx>
+		<div class="wrapper">
+			{<tsrx>
+				<section class="native">
+					<span class="nested-tsrx">
+						{'inside nested tsrx'}
+					</span>
+				</section>
+			</tsrx>}
+		</div>
+	</tsx>;
+
+	{content}
+}
+
+export component TsxDeclaredInsideNestedTsrxFromTopLevelTsx() {
+	const content = <tsx>
+		{<tsrx>
+			const nested = <tsx>
+				<span class="nested-tsx">
+					{'inside nested tsx'}
+				</span>
+			</tsx>;
+			<div class="native">{nested}</div>
+		</tsrx>}
+	</tsx>;
+
+	{content}
+}
+
 component TextProp(&{ children }: { children: string }) {
 	<div class="text-prop">{children}</div>
 }

--- a/packages/ripple/tests/server/basic.test.tsrx
+++ b/packages/ripple/tests/server/basic.test.tsrx
@@ -55,15 +55,15 @@ second"</pre>
 		expect(body).toBeHtml('<div><span>Server</span></div>');
 	});
 
-	it('renders nested tsx and tsrx expression values', async () => {
+	it('renders deeply nested tsx and tsrx expression values', async () => {
 		function makeFragment(label: string) {
 			return <tsrx>
-				<span>{label}</span>
+				<span class="label">{label}</span>
 				const test = <tsx>
-					{[1, 2, 3].map(
+					{[1, 2, 3, 4].map(
 						(item) => <tsx>
 							{<tsrx>
-								<div>{item}</div>
+								<div class="helper-item">{item}</div>
 							</tsrx>}
 						</tsx>,
 					)}
@@ -73,23 +73,23 @@ second"</pre>
 		}
 
 		component Basic() {
-			{<tsx>{[1, 2].map((item) => <div>{item}</div>)}</tsx>}
-			{makeFragment('Server')}
+			{<tsx>{[1, 2, 3].map((item) => <div class="app-item">{item}</div>)}</tsx>}
+			{makeFragment('from helper')}
 		}
 
 		const { body } = await render(Basic);
 
 		expect(body).toBeHtml(
-			'<div>1</div><div>2</div><span>Server</span><div>1</div><div>2</div><div>3</div>',
+			'<div class="app-item">1</div><div class="app-item">2</div><div class="app-item">3</div><span class="label">from helper</span><div class="helper-item">1</div><div class="helper-item">2</div><div class="helper-item">3</div><div class="helper-item">4</div>',
 		);
 	});
 
 	it('renders tsrx nested directly inside a top-level tsx expression value', async () => {
 		component Basic() {
 			const content = <tsx>
-				<section>
+				<section class="outer">
 					{<tsrx>
-						<div>
+						<div class="inner">
 							{'from tsrx'}
 						</div>
 					</tsrx>}
@@ -101,16 +101,16 @@ second"</pre>
 
 		const { body } = await render(Basic);
 
-		expect(body).toBeHtml('<section><div>from tsrx</div></section>');
+		expect(body).toBeHtml('<section class="outer"><div class="inner">from tsrx</div></section>');
 	});
 
 	it('renders nested elements from tsrx inside a top-level tsx value', async () => {
 		component Basic() {
 			const content = <tsx>
-				<div>
+				<div class="wrapper">
 					{<tsrx>
-						<section>
-							<span>
+						<section class="native">
+							<span class="nested-tsrx">
 								{'inside nested tsrx'}
 							</span>
 						</section>
@@ -123,7 +123,9 @@ second"</pre>
 
 		const { body } = await render(Basic);
 
-		expect(body).toBeHtml('<div><section><span>inside nested tsrx</span></section></div>');
+		expect(body).toBeHtml(
+			'<div class="wrapper"><section class="native"><span class="nested-tsrx">inside nested tsrx</span></section></div>',
+		);
 	});
 
 	it('renders tsx declared inside tsrx nested from a top-level tsx value', async () => {
@@ -131,11 +133,11 @@ second"</pre>
 			const content = <tsx>
 				{<tsrx>
 					const nested = <tsx>
-						<span>
+						<span class="nested-tsx">
 							{'inside nested tsx'}
 						</span>
 					</tsx>;
-					<div>{nested}</div>
+					<div class="native">{nested}</div>
 				</tsrx>}
 			</tsx>;
 
@@ -144,7 +146,9 @@ second"</pre>
 
 		const { body } = await render(Basic);
 
-		expect(body).toBeHtml('<div><span>inside nested tsx</span></div>');
+		expect(body).toBeHtml(
+			'<div class="native"><span class="nested-tsx">inside nested tsx</span></div>',
+		);
 	});
 
 	it('renders tracked state updates', async () => {

--- a/packages/ripple/tests/server/basic.test.tsrx
+++ b/packages/ripple/tests/server/basic.test.tsrx
@@ -185,6 +185,23 @@ second"</pre>
 		expect(body).toBeHtml('<div>start:one2truefalse:end</div><div>start:one2truefalse:end</div>');
 	});
 
+	it('flattens conditional primitive array expressions', async () => {
+		component Basic() {
+			const condition = true;
+			const ternary_items = condition
+				? ['start:', ['one', 2], null, true, false, ':end']
+				: ['fallback'];
+			const logical_items = condition && ['start:', ['one', 2], null, true, false, ':end'];
+
+			<div>{ternary_items}</div>
+			<div>{logical_items}</div>
+		}
+
+		const { body } = await render(Basic);
+
+		expect(body).toBeHtml('<div>start:one2truefalse:end</div><div>start:one2truefalse:end</div>');
+	});
+
 	it('renders tracked state updates', async () => {
 		component Counter() {
 			let &[count] = track(0);

--- a/packages/ripple/tests/server/basic.test.tsrx
+++ b/packages/ripple/tests/server/basic.test.tsrx
@@ -151,6 +151,40 @@ second"</pre>
 		);
 	});
 
+	it('flattens nested primitive arrays inside mixed tsrx collections', async () => {
+		component Basic() {
+			<div>
+				{<tsx>
+					{[
+						'start:',
+						['one', 2, true, null, false],
+						<strong>
+							{'!'}
+						</strong>,
+						':end',
+					]}
+				</tsx>}
+			</div>
+		}
+
+		const { body } = await render(Basic);
+
+		expect(body).toBeHtml('<div>start:one2truefalse<strong>!</strong>:end</div>');
+	});
+
+	it('flattens direct primitive array expressions', async () => {
+		component Basic() {
+			const items = ['start:', ['one', 2], null, true, false, ':end'];
+
+			<div>{['start:', ['one', 2], null, true, false, ':end']}</div>
+			<div>{items}</div>
+		}
+
+		const { body } = await render(Basic);
+
+		expect(body).toBeHtml('<div>start:one2truefalse:end</div><div>start:one2truefalse:end</div>');
+	});
+
 	it('renders tracked state updates', async () => {
 		component Counter() {
 			let &[count] = track(0);

--- a/packages/ripple/tests/server/basic.test.tsrx
+++ b/packages/ripple/tests/server/basic.test.tsrx
@@ -130,13 +130,11 @@ second"</pre>
 		component Basic() {
 			const content = <tsx>
 				{<tsrx>
-					const nested =
-					<tsx>
+					const nested = <tsx>
 						<span>
 							{'inside nested tsx'}
 						</span>
-					</tsx>
-					;
+					</tsx>;
 					<div>{nested}</div>
 				</tsrx>}
 			</tsx>;

--- a/packages/ripple/tests/server/basic.test.tsrx
+++ b/packages/ripple/tests/server/basic.test.tsrx
@@ -55,6 +55,100 @@ second"</pre>
 		expect(body).toBeHtml('<div><span>Server</span></div>');
 	});
 
+	it('renders nested tsx and tsrx expression values', async () => {
+		function makeFragment(label: string) {
+			return <tsrx>
+				<span>{label}</span>
+				const test = <tsx>
+					{[1, 2, 3].map(
+						(item) => <tsx>
+							{<tsrx>
+								<div>{item}</div>
+							</tsrx>}
+						</tsx>,
+					)}
+				</tsx>;
+				{test}
+			</tsrx>;
+		}
+
+		component Basic() {
+			{<tsx>{[1, 2].map((item) => <div>{item}</div>)}</tsx>}
+			{makeFragment('Server')}
+		}
+
+		const { body } = await render(Basic);
+
+		expect(body).toBeHtml(
+			'<div>1</div><div>2</div><span>Server</span><div>1</div><div>2</div><div>3</div>',
+		);
+	});
+
+	it('renders tsrx nested directly inside a top-level tsx expression value', async () => {
+		component Basic() {
+			const content = <tsx>
+				<section>
+					{<tsrx>
+						<div>
+							{'from tsrx'}
+						</div>
+					</tsrx>}
+				</section>
+			</tsx>;
+
+			{content}
+		}
+
+		const { body } = await render(Basic);
+
+		expect(body).toBeHtml('<section><div>from tsrx</div></section>');
+	});
+
+	it('renders nested elements from tsrx inside a top-level tsx value', async () => {
+		component Basic() {
+			const content = <tsx>
+				<div>
+					{<tsrx>
+						<section>
+							<span>
+								{'inside nested tsrx'}
+							</span>
+						</section>
+					</tsrx>}
+				</div>
+			</tsx>;
+
+			{content}
+		}
+
+		const { body } = await render(Basic);
+
+		expect(body).toBeHtml('<div><section><span>inside nested tsrx</span></section></div>');
+	});
+
+	it('renders tsx declared inside tsrx nested from a top-level tsx value', async () => {
+		component Basic() {
+			const content = <tsx>
+				{<tsrx>
+					const nested =
+					<tsx>
+						<span>
+							{'inside nested tsx'}
+						</span>
+					</tsx>
+					;
+					<div>{nested}</div>
+				</tsrx>}
+			</tsx>;
+
+			{content}
+		}
+
+		const { body } = await render(Basic);
+
+		expect(body).toBeHtml('<div><span>inside nested tsx</span></div>');
+	});
+
 	it('renders tracked state updates', async () => {
 		component Counter() {
 			let &[count] = track(0);

--- a/packages/ripple/tests/server/compiler.test.tsrx
+++ b/packages/ripple/tests/server/compiler.test.tsrx
@@ -168,6 +168,48 @@ export component App() {
 		expect((result.match(/children:/g) || []).length).toBe(1);
 		expect(result).toContain('children: _$_.tsrx_element(');
 	});
+
+	it('routes calls to functions with nested template returns through render_expression', () => {
+		const source = `
+component App() {
+	function make(flag) {
+		if (flag) {
+			return <tsx><span>{'nested'}</span></tsx>;
+		}
+
+		return null;
+	}
+
+	<div>{make(true)}</div>
+}
+`;
+
+		const result = compile(source, 'test.tsrx', { mode: 'server' }).code;
+
+		expect(result).toContain('_$_.render_expression(make(true))');
+		expect(result).not.toContain('_$_.escape(make(true))');
+	});
+
+	it('does not treat nested function template returns as outer function returns', () => {
+		const source = `
+component App() {
+	function make() {
+		function nested() {
+			return <tsx><span>{'nested'}</span></tsx>;
+		}
+
+		return nested;
+	}
+
+	<div>{make()}</div>
+}
+`;
+
+		const result = compile(source, 'test.tsrx', { mode: 'server' }).code;
+
+		expect(result).toContain('_$_.output_push(_$_.escape(make()))');
+		expect(result).not.toContain('_$_.render_expression(make())');
+	});
 });
 
 describe('compiler server module tests', () => {

--- a/packages/tsrx-ripple/src/transform/client/index.js
+++ b/packages/tsrx-ripple/src/transform/client/index.js
@@ -4152,7 +4152,9 @@ function transform_children(children, context) {
 			let is_create_text_only = false;
 			if (node.type === 'TSRXExpression' || node.type === 'Text' || node.type === 'Html') {
 				metadata = { tracking: false };
-				expression = /** @type {AST.Expression} */ (visit(node.expression, { ...state, metadata }));
+				expression = /** @type {AST.Expression} */ (
+					visit(node.expression, { ...state, flush_node: null, metadata })
+				);
 				is_create_text_only =
 					node.type !== 'Html' && normalized.length === 1 && expression.type === 'Literal';
 			}

--- a/packages/tsrx-ripple/src/transform/client/index.js
+++ b/packages/tsrx-ripple/src/transform/client/index.js
@@ -644,6 +644,36 @@ function SetStateForOutsideComponent(state, more_state = {}) {
 	});
 }
 
+/**
+ * @param {ESTreeJSX.JSXElement | ESTreeJSX.JSXFragment} node
+ * @param {TransformClientContext} context
+ * @returns {AST.CallExpression}
+ */
+function build_jsx_to_tsrx_element(node, context) {
+	const { state, visit, path } = context;
+	const result = jsx_to_ripple_node(/** @type {AST.Node} */ (node), path, state.source);
+	const converted = Array.isArray(result) ? result : [result];
+	/** @type {AST.Node[]} */
+	const children = converted.filter((child) => child != null && child.type !== 'EmptyStatement');
+
+	apply_tsrx_css_scoping(children, state);
+
+	const children_component = b.component(b.id('render_children'), [], children);
+
+	return b.call(
+		'_$_.tsrx_element',
+		/** @type {AST.Expression} */ (
+			visit(children_component, {
+				...state,
+				flush_node: null,
+				namespace: state.namespace,
+				is_tsrx_element: true,
+				jsx_to_tsrx_element: true,
+			})
+		),
+	);
+}
+
 /** @type {Visitors<AST.Node, TransformClientState>} */
 const visitors = {
 	_(node, { next, state, path }) {
@@ -1223,6 +1253,9 @@ const visitors = {
 		if (context.state.to_ts) {
 			return context.next();
 		}
+		if (context.state.jsx_to_tsrx_element) {
+			return build_jsx_to_tsrx_element(node, context);
+		}
 		const attributes = node.openingFragment.attributes;
 		const normalized_children = node.children.filter((child) => {
 			return child.type !== 'JSXText' || child.value.trim() !== '';
@@ -1274,6 +1307,9 @@ const visitors = {
 	JSXElement(node, context) {
 		if (context.state.to_ts) {
 			return context.next();
+		}
+		if (context.state.jsx_to_tsrx_element) {
+			return build_jsx_to_tsrx_element(node, context);
 		}
 		const name = node.openingElement.name;
 		const attributes = node.openingElement.attributes;
@@ -1392,7 +1428,7 @@ const visitors = {
 		/** @type {AST.Node[]} */
 		const children_filtered = [];
 		for (const raw_child of node.children) {
-			const result = jsx_to_ripple_node(/** @type {AST.Node} */ (raw_child), path);
+			const result = jsx_to_ripple_node(/** @type {AST.Node} */ (raw_child), path, state.source);
 			const items = Array.isArray(result) ? result : [result];
 			for (const child of items) {
 				if (child == null || child.type === 'EmptyStatement') continue;
@@ -1414,6 +1450,7 @@ const visitors = {
 					...state,
 					namespace: state.namespace,
 					is_tsrx_element: true,
+					jsx_to_tsrx_element: true,
 				})
 			),
 		);
@@ -1459,6 +1496,7 @@ const visitors = {
 					...state,
 					namespace: state.namespace,
 					is_tsrx_element: true,
+					jsx_to_tsrx_element: true,
 				})
 			),
 		);
@@ -5568,6 +5606,7 @@ export function transform_client(filename, source, analysis, to_ts, minify_css, 
 		stylesheets: [],
 		to_ts,
 		filename,
+		source,
 		namespace: 'html',
 		metadata: {},
 		errors: analysis.errors,

--- a/packages/tsrx-ripple/src/transform/client/index.js
+++ b/packages/tsrx-ripple/src/transform/client/index.js
@@ -4329,7 +4329,7 @@ function transform_children(children, context) {
 				) {
 					skipped++;
 					state.template?.push(' ');
-					const id = flush_node(true);
+					const id = flush_node(false);
 					const call = b.call('_$_.expression', id, b.thunk(expr));
 					state.init?.push(
 						state.namespace !== DEFAULT_NAMESPACE

--- a/packages/tsrx-ripple/src/transform/client/index.js
+++ b/packages/tsrx-ripple/src/transform/client/index.js
@@ -122,6 +122,31 @@ function apply_tsrx_css_scoping(nodes, state) {
 }
 
 /**
+ * JSX parsed inside `<tsx>` treats `<tsx>`/`<tsrx>` as ordinary JSX tags. For
+ * TypeScript output, convert those reserved tags back into TSRX nodes before
+ * visiting so nested islands use the same lowering path as top-level islands.
+ *
+ * @param {ESTreeJSX.JSXElement} node
+ * @param {VisitorClientContext} context
+ * @returns {AST.Node | null}
+ */
+function jsx_template_to_ts_node(node, context) {
+	const name = node.openingElement.name;
+	if (name.type !== 'JSXIdentifier' || (name.name !== 'tsx' && name.name !== 'tsrx')) {
+		return null;
+	}
+
+	const converted = jsx_to_ripple_node(
+		/** @type {AST.Node} */ (/** @type {unknown} */ (node)),
+		context.path,
+	);
+	if (converted === null || Array.isArray(converted)) {
+		return null;
+	}
+	return /** @type {AST.Node} */ (converted);
+}
+
+/**
  * @param {AST.ImportDeclaration} node
  * @returns {string | null}
  */
@@ -651,7 +676,7 @@ function SetStateForOutsideComponent(state, more_state = {}) {
  */
 function build_jsx_to_tsrx_element(node, context) {
 	const { state, visit, path } = context;
-	const result = jsx_to_ripple_node(/** @type {AST.Node} */ (node), path, state.source);
+	const result = jsx_to_ripple_node(/** @type {AST.Node} */ (node), path);
 	const converted = Array.isArray(result) ? result : [result];
 	/** @type {AST.Node[]} */
 	const children = converted.filter((child) => child != null && child.type !== 'EmptyStatement');
@@ -1229,6 +1254,17 @@ const visitors = {
 					metadata: { path: [] },
 				});
 			}
+			if (node.expression?.type === 'JSXElement') {
+				const tsx_template_node = jsx_template_to_ts_node(node.expression, context);
+				if (tsx_template_node !== null) {
+					return b.jsx_expression_container(
+						/** @type {AST.Expression | ESTreeJSX.JSXEmptyExpression} */ (
+							context.visit(tsx_template_node, context.state)
+						),
+						/** @type {AST.NodeWithLocation} */ (node),
+					);
+				}
+			}
 			return context.next();
 		}
 		return context.visit(node.expression);
@@ -1306,6 +1342,10 @@ const visitors = {
 
 	JSXElement(node, context) {
 		if (context.state.to_ts) {
+			const tsx_template_node = jsx_template_to_ts_node(node, context);
+			if (tsx_template_node !== null) {
+				return context.visit(tsx_template_node, context.state);
+			}
 			return context.next();
 		}
 		if (context.state.jsx_to_tsrx_element) {
@@ -1428,7 +1468,7 @@ const visitors = {
 		/** @type {AST.Node[]} */
 		const children_filtered = [];
 		for (const raw_child of node.children) {
-			const result = jsx_to_ripple_node(/** @type {AST.Node} */ (raw_child), path, state.source);
+			const result = jsx_to_ripple_node(/** @type {AST.Node} */ (raw_child), path);
 			const items = Array.isArray(result) ? result : [result];
 			for (const child of items) {
 				if (child == null || child.type === 'EmptyStatement') continue;
@@ -5606,7 +5646,6 @@ export function transform_client(filename, source, analysis, to_ts, minify_css, 
 		stylesheets: [],
 		to_ts,
 		filename,
-		source,
 		namespace: 'html',
 		metadata: {},
 		errors: analysis.errors,

--- a/packages/tsrx-ripple/src/transform/server/index.js
+++ b/packages/tsrx-ripple/src/transform/server/index.js
@@ -101,7 +101,7 @@ function apply_tsrx_css_scoping(nodes, state) {
  */
 function build_jsx_to_tsrx_element(node, context) {
 	const { visit, state, path } = context;
-	const result = jsx_to_ripple_node(/** @type {AST.Node} */ (node), path, state.source);
+	const result = jsx_to_ripple_node(/** @type {AST.Node} */ (node), path);
 	const converted = Array.isArray(result) ? result : [result];
 	/** @type {AST.Node[]} */
 	const children = converted.filter((child) => child != null && child.type !== 'EmptyStatement');
@@ -135,7 +135,7 @@ function build_template_node_to_tsrx_element(node, context) {
 	const children =
 		node.type === 'Tsx'
 			? node.children
-					.map((child) => jsx_to_ripple_node(/** @type {AST.Node} */ (child), path, state.source))
+					.map((child) => jsx_to_ripple_node(/** @type {AST.Node} */ (child), path))
 					.flat()
 					.filter((child) => child != null)
 			: node.children.filter((child) => child != null && child.type !== 'EmptyStatement');
@@ -232,6 +232,25 @@ function is_template_value_call(expression, scope) {
 	}
 
 	return function_returns_template_value(scope.get(expression.callee.name)?.initial);
+}
+
+/**
+ * @param {AST.Node} expression
+ * @param {ScopeInterface} scope
+ * @returns {boolean}
+ */
+function is_template_value_binding(expression, scope) {
+	if (expression.type !== 'Identifier') {
+		return false;
+	}
+
+	const binding = scope.get(expression.name);
+	const initial = binding?.initial;
+	return (
+		binding?.metadata?.is_template_value === true ||
+		initial?.type === 'Tsx' ||
+		initial?.type === 'Tsrx'
+	);
 }
 
 /**
@@ -437,23 +456,16 @@ function transform_variable_declaration(node, context) {
 			}
 		}
 
+		const declarator_init = /** @type {AST.Node | null | undefined} */ (declarator.init);
 		const init =
-			declarator.init?.type === 'Tsx' || declarator.init?.type === 'Tsrx'
-				? build_template_node_to_tsrx_element(declarator.init, context)
-				: declarator.init
+			declarator_init?.type === 'Tsx' || declarator_init?.type === 'Tsrx'
+				? build_template_node_to_tsrx_element(declarator_init, context)
+				: declarator_init
 					? /** @type {AST.Expression} */ (
-							context.visit(declarator.init, { ...context.state, template_child: false })
+							context.visit(declarator_init, { ...context.state, template_child: false })
 						)
 					: null;
 		transformed_inits.set(declarator, init);
-
-		if (
-			declarator.id.type === 'Identifier' &&
-			(declarator.init?.type === 'Tsx' || declarator.init?.type === 'Tsrx')
-		) {
-			context.state.template_value_locals ??= new Set();
-			context.state.template_value_locals.add(declarator.id.name);
-		}
 	}
 
 	return {
@@ -1883,8 +1895,7 @@ const visitors = {
 			is_children_template_expression(node.expression, state.scope) ||
 			contains_template_value_node(/** @type {AST.Node} */ (node.expression)) ||
 			is_template_value_call(/** @type {AST.Expression} */ (node.expression), state.scope) ||
-			(node.expression.type === 'Identifier' &&
-				state.template_value_locals?.has(node.expression.name));
+			is_template_value_binding(node.expression, state.scope);
 		let expression = /** @type {AST.Expression} */ (
 			visit(node.expression, {
 				...state,
@@ -1917,7 +1928,7 @@ const visitors = {
 
 	Tsx(node, { visit, state, path }) {
 		const converted_children = node.children
-			.map((child) => jsx_to_ripple_node(/** @type {AST.Node} */ (child), path, state.source))
+			.map((child) => jsx_to_ripple_node(/** @type {AST.Node} */ (child), path))
 			.flat()
 			.filter((child) => child != null);
 		apply_tsrx_css_scoping(converted_children, state);
@@ -2163,7 +2174,6 @@ export function transform_server(filename, source, analysis, minify_css, dev = f
 		server_block_locals: [],
 		server_exported_names: [],
 		filename,
-		source,
 		namespace: 'html',
 		// TODO: should we remove all `to_ts` usages we use the client rendering for that?
 		to_ts: false,

--- a/packages/tsrx-ripple/src/transform/server/index.js
+++ b/packages/tsrx-ripple/src/transform/server/index.js
@@ -23,6 +23,7 @@ import {
 	obfuscateIdentifier,
 	BLOCK_CLOSE,
 	BLOCK_OPEN,
+	isFunctionNode,
 } from '@tsrx/core';
 const b = builders;
 import { walk } from 'zimmerframe';
@@ -190,16 +191,66 @@ function contains_template_value_node(node) {
 }
 
 /**
+ * @param {AST.Statement} statement
+ * @returns {boolean}
+ */
+function statement_returns_template_value(statement) {
+	switch (statement.type) {
+		case 'ReturnStatement':
+			return (
+				statement.argument != null &&
+				contains_template_value_node(/** @type {AST.Node} */ (statement.argument))
+			);
+
+		case 'BlockStatement':
+			return statements_return_template_value(statement.body);
+
+		case 'IfStatement':
+			return (
+				statement_returns_template_value(statement.consequent) ||
+				(statement.alternate != null && statement_returns_template_value(statement.alternate))
+			);
+
+		case 'SwitchStatement':
+			return statement.cases.some((switch_case) =>
+				statements_return_template_value(switch_case.consequent),
+			);
+
+		case 'TryStatement':
+			return (
+				statement_returns_template_value(statement.block) ||
+				(statement.handler != null && statement_returns_template_value(statement.handler.body)) ||
+				(statement.finalizer != null && statement_returns_template_value(statement.finalizer))
+			);
+
+		case 'ForStatement':
+		case 'ForInStatement':
+		case 'ForOfStatement':
+		case 'WhileStatement':
+		case 'DoWhileStatement':
+		case 'LabeledStatement':
+		case 'WithStatement':
+			return statement_returns_template_value(statement.body);
+
+		default:
+			return false;
+	}
+}
+
+/**
+ * @param {AST.Statement[]} statements
+ * @returns {boolean}
+ */
+function statements_return_template_value(statements) {
+	return statements.some(statement_returns_template_value);
+}
+
+/**
  * @param {AST.Node | null | undefined} node
  * @returns {boolean}
  */
 function function_returns_template_value(node) {
-	if (
-		node == null ||
-		(node.type !== 'FunctionDeclaration' &&
-			node.type !== 'FunctionExpression' &&
-			node.type !== 'ArrowFunctionExpression')
-	) {
+	if (node == null || !isFunctionNode(node)) {
 		return false;
 	}
 
@@ -207,18 +258,11 @@ function function_returns_template_value(node) {
 		return contains_template_value_node(/** @type {AST.Node} */ (node.body));
 	}
 
-	const body = node.body?.type === 'BlockStatement' ? node.body.body : [];
-	for (const statement of body) {
-		if (
-			statement.type === 'ReturnStatement' &&
-			statement.argument &&
-			contains_template_value_node(/** @type {AST.Node} */ (statement.argument))
-		) {
-			return true;
-		}
+	if (node.body?.type !== 'BlockStatement') {
+		return false;
 	}
 
-	return false;
+	return statements_return_template_value(node.body.body);
 }
 
 /**

--- a/packages/tsrx-ripple/src/transform/server/index.js
+++ b/packages/tsrx-ripple/src/transform/server/index.js
@@ -258,11 +258,12 @@ function function_returns_template_value(node) {
 		return contains_template_value_node(/** @type {AST.Node} */ (node.body));
 	}
 
-	if (node.body?.type !== 'BlockStatement') {
+	const body = /** @type {AST.Function} */ (node).body;
+	if (body.type !== 'BlockStatement') {
 		return false;
 	}
 
-	return statements_return_template_value(node.body.body);
+	return statements_return_template_value(body.body);
 }
 
 /**

--- a/packages/tsrx-ripple/src/transform/server/index.js
+++ b/packages/tsrx-ripple/src/transform/server/index.js
@@ -1,4 +1,5 @@
 /** @import * as AST from 'estree'; */
+/** @import * as ESTreeJSX from 'estree-jsx'; */
 /** @import { RawSourceMap } from 'source-map'; */
 /**
 @import {
@@ -91,6 +92,146 @@ function apply_tsrx_css_scoping(nodes, state) {
 	for (const node of nodes) {
 		visit_node(node);
 	}
+}
+
+/**
+ * @param {ESTreeJSX.JSXElement | ESTreeJSX.JSXFragment} node
+ * @param {TransformServerContext} context
+ * @returns {AST.CallExpression}
+ */
+function build_jsx_to_tsrx_element(node, context) {
+	const { visit, state, path } = context;
+	const result = jsx_to_ripple_node(/** @type {AST.Node} */ (node), path, state.source);
+	const converted = Array.isArray(result) ? result : [result];
+	/** @type {AST.Node[]} */
+	const children = converted.filter((child) => child != null && child.type !== 'EmptyStatement');
+
+	apply_tsrx_css_scoping(children, state);
+
+	/** @type {AST.Statement[]} */
+	const init = [];
+	transform_children(
+		children,
+		/** @type {TransformServerContext} */ ({
+			visit,
+			state: {
+				...state,
+				init,
+				jsx_to_tsrx_element: true,
+			},
+		}),
+	);
+
+	return b.call('_$_.tsrx_element', b.function(b.id('render_children'), [], b.block(init)));
+}
+
+/**
+ * @param {AST.Tsx | AST.Tsrx} node
+ * @param {TransformServerContext} context
+ * @returns {AST.CallExpression}
+ */
+function build_template_node_to_tsrx_element(node, context) {
+	const { visit, state, path } = context;
+	const children =
+		node.type === 'Tsx'
+			? node.children
+					.map((child) => jsx_to_ripple_node(/** @type {AST.Node} */ (child), path, state.source))
+					.flat()
+					.filter((child) => child != null)
+			: node.children.filter((child) => child != null && child.type !== 'EmptyStatement');
+
+	apply_tsrx_css_scoping(children, state);
+
+	/** @type {AST.Statement[]} */
+	const init = [];
+	transform_children(
+		children,
+		/** @type {TransformServerContext} */ ({
+			visit,
+			state: {
+				...state,
+				init,
+				template_child: false,
+				jsx_to_tsrx_element: true,
+			},
+		}),
+	);
+
+	return b.call('_$_.tsrx_element', b.function(b.id('render_children'), [], b.block(init)));
+}
+
+/**
+ * @param {AST.Node} node
+ * @returns {boolean}
+ */
+function contains_template_value_node(node) {
+	let found = false;
+
+	walk(node, null, {
+		_(node, { next }) {
+			if (found) {
+				return;
+			}
+			if (
+				node.type === 'JSXElement' ||
+				node.type === 'JSXFragment' ||
+				node.type === 'Tsx' ||
+				node.type === 'Tsrx' ||
+				node.type === 'TsxCompat'
+			) {
+				found = true;
+				return;
+			}
+			next();
+		},
+	});
+
+	return found;
+}
+
+/**
+ * @param {AST.Node | null | undefined} node
+ * @returns {boolean}
+ */
+function function_returns_template_value(node) {
+	if (
+		node == null ||
+		(node.type !== 'FunctionDeclaration' &&
+			node.type !== 'FunctionExpression' &&
+			node.type !== 'ArrowFunctionExpression')
+	) {
+		return false;
+	}
+
+	if (node.type === 'ArrowFunctionExpression' && node.body.type !== 'BlockStatement') {
+		return contains_template_value_node(/** @type {AST.Node} */ (node.body));
+	}
+
+	const body = node.body?.type === 'BlockStatement' ? node.body.body : [];
+	for (const statement of body) {
+		if (
+			statement.type === 'ReturnStatement' &&
+			statement.argument &&
+			contains_template_value_node(/** @type {AST.Node} */ (statement.argument))
+		) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/**
+ * @param {AST.Expression} expression
+ * @param {ScopeInterface} scope
+ * @returns {boolean}
+ */
+function is_template_value_call(expression, scope) {
+	if (expression.type !== 'CallExpression' || expression.callee.type !== 'Identifier') {
+		return false;
+	}
+
+	return function_returns_template_value(scope.get(expression.callee.name)?.initial);
 }
 
 /**
@@ -275,6 +416,57 @@ function collect_returns_from_children(children) {
 }
 
 /**
+ * @param {AST.VariableDeclaration} node
+ * @param {TransformServerContext} context
+ * @returns {AST.VariableDeclaration}
+ */
+function transform_variable_declaration(node, context) {
+	/** @type {Map<AST.VariableDeclarator, AST.Expression | null>} */
+	const transformed_inits = new Map();
+
+	for (const declarator of node.declarations) {
+		if (!context.state.to_ts) {
+			delete declarator.id.typeAnnotation;
+
+			if (
+				(declarator.id.type === 'ObjectPattern' || declarator.id.type === 'ArrayPattern') &&
+				declarator.id.lazy &&
+				declarator.id.metadata?.lazy_id
+			) {
+				declarator.id = b.id(declarator.id.metadata.lazy_id);
+			}
+		}
+
+		const init =
+			declarator.init?.type === 'Tsx' || declarator.init?.type === 'Tsrx'
+				? build_template_node_to_tsrx_element(declarator.init, context)
+				: declarator.init
+					? /** @type {AST.Expression} */ (
+							context.visit(declarator.init, { ...context.state, template_child: false })
+						)
+					: null;
+		transformed_inits.set(declarator, init);
+
+		if (
+			declarator.id.type === 'Identifier' &&
+			(declarator.init?.type === 'Tsx' || declarator.init?.type === 'Tsrx')
+		) {
+			context.state.template_value_locals ??= new Set();
+			context.state.template_value_locals.add(declarator.id.name);
+		}
+	}
+
+	return {
+		...node,
+		declarations: node.declarations.map((declarator) => ({
+			...declarator,
+			id: /** @type {AST.Pattern} */ (context.visit(declarator.id)),
+			init: transformed_inits.get(declarator) ?? null,
+		})),
+	};
+}
+
+/**
  * @param {AST.Node[]} children
  * @param {TransformServerContext} context
  */
@@ -353,7 +545,12 @@ function transform_children(children, context) {
 			node.type === 'Component'
 		) {
 			state.init?.push(
-				/** @type {AST.Statement} */ (visit(node, { ...local_state, return_flags })),
+				node.type === 'VariableDeclaration'
+					? transform_variable_declaration(node, {
+							...context,
+							state: local_state,
+						})
+					: /** @type {AST.Statement} */ (visit(node, { ...local_state, return_flags })),
 			);
 			if (node.type === 'ReturnStatement') {
 				const info = return_flags.get(node);
@@ -673,6 +870,20 @@ const visitors = {
 		return context.next();
 	},
 
+	JSXElement(node, context) {
+		if (context.state.jsx_to_tsrx_element) {
+			return build_jsx_to_tsrx_element(node, context);
+		}
+		return context.next();
+	},
+
+	JSXFragment(node, context) {
+		if (context.state.jsx_to_tsrx_element) {
+			return build_jsx_to_tsrx_element(node, context);
+		}
+		return context.next();
+	},
+
 	NewExpression(node, context) {
 		const callee = node.callee;
 
@@ -781,8 +992,7 @@ const visitors = {
 	ArrowFunctionExpression(node, context) {
 		delete node.returnType;
 		delete node.typeParameters;
-		for (let i = 0; i < node.params.length; i++) {
-			const param = node.params[i];
+		const params = node.params.map((param) => {
 			delete param.typeAnnotation;
 			// Handle AssignmentPattern (parameters with default values)
 			if (param.type === 'AssignmentPattern' && param.left) {
@@ -792,14 +1002,21 @@ const visitors = {
 			const pattern = param.type === 'AssignmentPattern' ? param.left : param;
 			if (pattern.type === 'ObjectPattern' || pattern.type === 'ArrayPattern') {
 				const transformed_pattern = replace_lazy_param_pattern(pattern);
-				node.params[i] =
-					param.type === 'AssignmentPattern'
-						? /** @type {AST.AssignmentPattern} */ ({ ...param, left: transformed_pattern })
-						: transformed_pattern;
+				return param.type === 'AssignmentPattern'
+					? /** @type {AST.AssignmentPattern} */ ({ ...param, left: transformed_pattern })
+					: transformed_pattern;
 			}
-		}
+			return param;
+		});
 
-		return context.next();
+		return {
+			...node,
+			params: params.map((param) => /** @type {AST.Pattern} */ (context.visit(param))),
+			body:
+				node.body.type === 'BlockStatement'
+					? /** @type {AST.BlockStatement} */ (context.visit(node.body))
+					: /** @type {AST.Expression} */ (context.visit(node.body)),
+		};
 	},
 
 	TSAsExpression(node, context) {
@@ -950,22 +1167,7 @@ const visitors = {
 	},
 
 	VariableDeclaration(node, context) {
-		for (const declarator of node.declarations) {
-			if (!context.state.to_ts) {
-				delete declarator.id.typeAnnotation;
-
-				// Replace lazy destructuring patterns with the generated identifier
-				if (
-					(declarator.id.type === 'ObjectPattern' || declarator.id.type === 'ArrayPattern') &&
-					declarator.id.lazy &&
-					declarator.id.metadata?.lazy_id
-				) {
-					declarator.id = b.id(declarator.id.metadata.lazy_id);
-				}
-			}
-		}
-
-		return context.next();
+		return transform_variable_declaration(node, context);
 	},
 
 	Element(node, context) {
@@ -1677,8 +1879,18 @@ const visitors = {
 	},
 
 	TSRXExpression(node, { visit, state }) {
-		let expression = /** @type {AST.Expression} */ (visit(node.expression, state));
-		const is_children_expression = is_children_template_expression(node.expression, state.scope);
+		const is_children_expression =
+			is_children_template_expression(node.expression, state.scope) ||
+			contains_template_value_node(/** @type {AST.Node} */ (node.expression)) ||
+			is_template_value_call(/** @type {AST.Expression} */ (node.expression), state.scope) ||
+			(node.expression.type === 'Identifier' &&
+				state.template_value_locals?.has(node.expression.name));
+		let expression = /** @type {AST.Expression} */ (
+			visit(node.expression, {
+				...state,
+				template_child: is_children_expression ? false : state.template_child,
+			})
+		);
 
 		if (expression.type === 'Literal') {
 			state.init?.push(
@@ -1705,7 +1917,7 @@ const visitors = {
 
 	Tsx(node, { visit, state, path }) {
 		const converted_children = node.children
-			.map((child) => jsx_to_ripple_node(/** @type {AST.Node} */ (child), path))
+			.map((child) => jsx_to_ripple_node(/** @type {AST.Node} */ (child), path, state.source))
 			.flat()
 			.filter((child) => child != null);
 		apply_tsrx_css_scoping(converted_children, state);
@@ -1719,6 +1931,7 @@ const visitors = {
 				state: {
 					...state,
 					init,
+					jsx_to_tsrx_element: true,
 				},
 			}),
 		);
@@ -1750,6 +1963,7 @@ const visitors = {
 				state: {
 					...state,
 					init,
+					jsx_to_tsrx_element: true,
 				},
 			}),
 		);
@@ -1949,6 +2163,7 @@ export function transform_server(filename, source, analysis, minify_css, dev = f
 		server_block_locals: [],
 		server_exported_names: [],
 		filename,
+		source,
 		namespace: 'html',
 		// TODO: should we remove all `to_ts` usages we use the client rendering for that?
 		to_ts: false,

--- a/packages/tsrx-ripple/src/transform/server/index.js
+++ b/packages/tsrx-ripple/src/transform/server/index.js
@@ -192,35 +192,37 @@ function contains_template_value_node(node) {
 
 /**
  * @param {AST.Statement} statement
+ * @param {(expression: AST.Expression) => boolean} returns_value
  * @returns {boolean}
  */
-function statement_returns_template_value(statement) {
+function statement_returns_value(statement, returns_value) {
 	switch (statement.type) {
 		case 'ReturnStatement':
 			return (
 				statement.argument != null &&
-				contains_template_value_node(/** @type {AST.Node} */ (statement.argument))
+				returns_value(/** @type {AST.Expression} */ (statement.argument))
 			);
 
 		case 'BlockStatement':
-			return statements_return_template_value(statement.body);
+			return statements_return_value(statement.body, returns_value);
 
 		case 'IfStatement':
 			return (
-				statement_returns_template_value(statement.consequent) ||
-				(statement.alternate != null && statement_returns_template_value(statement.alternate))
+				statement_returns_value(statement.consequent, returns_value) ||
+				(statement.alternate != null && statement_returns_value(statement.alternate, returns_value))
 			);
 
 		case 'SwitchStatement':
 			return statement.cases.some((switch_case) =>
-				statements_return_template_value(switch_case.consequent),
+				statements_return_value(switch_case.consequent, returns_value),
 			);
 
 		case 'TryStatement':
 			return (
-				statement_returns_template_value(statement.block) ||
-				(statement.handler != null && statement_returns_template_value(statement.handler.body)) ||
-				(statement.finalizer != null && statement_returns_template_value(statement.finalizer))
+				statement_returns_value(statement.block, returns_value) ||
+				(statement.handler != null &&
+					statement_returns_value(statement.handler.body, returns_value)) ||
+				(statement.finalizer != null && statement_returns_value(statement.finalizer, returns_value))
 			);
 
 		case 'ForStatement':
@@ -230,7 +232,7 @@ function statement_returns_template_value(statement) {
 		case 'DoWhileStatement':
 		case 'LabeledStatement':
 		case 'WithStatement':
-			return statement_returns_template_value(statement.body);
+			return statement_returns_value(statement.body, returns_value);
 
 		default:
 			return false;
@@ -239,23 +241,25 @@ function statement_returns_template_value(statement) {
 
 /**
  * @param {AST.Statement[]} statements
+ * @param {(expression: AST.Expression) => boolean} returns_value
  * @returns {boolean}
  */
-function statements_return_template_value(statements) {
-	return statements.some(statement_returns_template_value);
+function statements_return_value(statements, returns_value) {
+	return statements.some((statement) => statement_returns_value(statement, returns_value));
 }
 
 /**
  * @param {AST.Node | null | undefined} node
+ * @param {(expression: AST.Expression) => boolean} returns_value
  * @returns {boolean}
  */
-function function_returns_template_value(node) {
+function function_returns_value(node, returns_value) {
 	if (node == null || !isFunctionNode(node)) {
 		return false;
 	}
 
 	if (node.type === 'ArrowFunctionExpression' && node.body.type !== 'BlockStatement') {
-		return contains_template_value_node(/** @type {AST.Node} */ (node.body));
+		return returns_value(/** @type {AST.Expression} */ (node.body));
 	}
 
 	const body = /** @type {AST.Function} */ (node).body;
@@ -263,7 +267,17 @@ function function_returns_template_value(node) {
 		return false;
 	}
 
-	return statements_return_template_value(body.body);
+	return statements_return_value(body.body, returns_value);
+}
+
+/**
+ * @param {AST.Node | null | undefined} node
+ * @returns {boolean}
+ */
+function function_returns_template_value(node) {
+	return function_returns_value(node, (expression) =>
+		contains_template_value_node(/** @type {AST.Node} */ (expression)),
+	);
 }
 
 /**
@@ -299,20 +313,53 @@ function is_template_value_binding(expression, scope) {
 }
 
 /**
- * @param {AST.Node} expression
+ * @param {AST.Expression | AST.SpreadElement} expression
  * @param {ScopeInterface} scope
+ * @param {TransformServerContext} context
  * @returns {boolean}
  */
-function is_collection_value_expression(expression, scope) {
+function is_collection_value_expression(expression, scope, context) {
 	if (expression.type === 'ArrayExpression') {
 		return true;
+	}
+
+	if (
+		expression.type === 'TSAsExpression' ||
+		expression.type === 'TSSatisfiesExpression' ||
+		expression.type === 'TSNonNullExpression'
+	) {
+		return is_collection_value_expression(expression.expression, scope, context);
+	}
+
+	if (expression.type === 'CallExpression') {
+		if (is_ripple_track_call(expression.callee, context)) {
+			const first_arg = expression.arguments[0];
+			return (
+				first_arg != null &&
+				is_collection_value_expression(
+					/** @type {AST.Expression | AST.SpreadElement} */ (first_arg),
+					scope,
+					context,
+				)
+			);
+		}
+
+		if (expression.callee.type === 'Identifier') {
+			return function_returns_value(scope.get(expression.callee.name)?.initial, (expression) =>
+				is_collection_value_expression(expression, scope, context),
+			);
+		}
 	}
 
 	if (expression.type !== 'Identifier') {
 		return false;
 	}
 
-	return scope.get(expression.name)?.initial?.type === 'ArrayExpression';
+	const initial = scope.get(expression.name)?.initial;
+	return (
+		initial != null &&
+		is_collection_value_expression(/** @type {AST.Expression} */ (initial), scope, context)
+	);
 }
 
 /**
@@ -1952,13 +1999,18 @@ const visitors = {
 		context.state.init?.push(b.stmt(b.call('_$_.try_block', try_fn, catch_fn, pending_fn)));
 	},
 
-	TSRXExpression(node, { visit, state }) {
+	TSRXExpression(node, context) {
+		const { visit, state } = context;
 		const is_children_expression =
 			is_children_template_expression(node.expression, state.scope) ||
 			contains_template_value_node(/** @type {AST.Node} */ (node.expression)) ||
 			is_template_value_call(/** @type {AST.Expression} */ (node.expression), state.scope) ||
-			is_template_value_binding(node.expression, state.scope) ||
-			is_collection_value_expression(node.expression, state.scope);
+			is_template_value_binding(node.expression, state.scope);
+		const is_collection_expression = is_collection_value_expression(
+			/** @type {AST.Expression} */ (node.expression),
+			state.scope,
+			context,
+		);
 		let expression = /** @type {AST.Expression} */ (
 			visit(node.expression, {
 				...state,
@@ -1970,7 +2022,7 @@ const visitors = {
 			state.init?.push(
 				b.stmt(b.call(b.id('_$_.output_push'), b.literal(escape(expression.value)))),
 			);
-		} else if (is_children_expression) {
+		} else if (is_children_expression || is_collection_expression) {
 			state.init?.push(b.stmt(b.call('_$_.render_expression', expression)));
 		} else {
 			state.init?.push(b.stmt(b.call(b.id('_$_.output_push'), b.call('_$_.escape', expression))));

--- a/packages/tsrx-ripple/src/transform/server/index.js
+++ b/packages/tsrx-ripple/src/transform/server/index.js
@@ -299,6 +299,23 @@ function is_template_value_binding(expression, scope) {
 }
 
 /**
+ * @param {AST.Node} expression
+ * @param {ScopeInterface} scope
+ * @returns {boolean}
+ */
+function is_collection_value_expression(expression, scope) {
+	if (expression.type === 'ArrayExpression') {
+		return true;
+	}
+
+	if (expression.type !== 'Identifier') {
+		return false;
+	}
+
+	return scope.get(expression.name)?.initial?.type === 'ArrayExpression';
+}
+
+/**
  * @param {AST.ImportDeclaration} node
  * @returns {string | null}
  */
@@ -1940,7 +1957,8 @@ const visitors = {
 			is_children_template_expression(node.expression, state.scope) ||
 			contains_template_value_node(/** @type {AST.Node} */ (node.expression)) ||
 			is_template_value_call(/** @type {AST.Expression} */ (node.expression), state.scope) ||
-			is_template_value_binding(node.expression, state.scope);
+			is_template_value_binding(node.expression, state.scope) ||
+			is_collection_value_expression(node.expression, state.scope);
 		let expression = /** @type {AST.Expression} */ (
 			visit(node.expression, {
 				...state,

--- a/packages/tsrx-ripple/src/transform/server/index.js
+++ b/packages/tsrx-ripple/src/transform/server/index.js
@@ -331,6 +331,20 @@ function is_collection_value_expression(expression, scope, context) {
 		return is_collection_value_expression(expression.expression, scope, context);
 	}
 
+	if (expression.type === 'ConditionalExpression') {
+		return (
+			is_collection_value_expression(expression.consequent, scope, context) ||
+			is_collection_value_expression(expression.alternate, scope, context)
+		);
+	}
+
+	if (expression.type === 'LogicalExpression') {
+		return (
+			is_collection_value_expression(expression.left, scope, context) ||
+			is_collection_value_expression(expression.right, scope, context)
+		);
+	}
+
 	if (expression.type === 'CallExpression') {
 		if (is_ripple_track_call(expression.callee, context)) {
 			const first_arg = expression.arguments[0];

--- a/packages/tsrx-ripple/src/utils.js
+++ b/packages/tsrx-ripple/src/utils.js
@@ -1137,6 +1137,8 @@ export function jsx_to_ripple_node(node, inherited_path = []) {
 				id,
 				attributes,
 				children: [],
+				openingElement: opening,
+				closingElement: node.closingElement,
 				selfClosing: opening.selfClosing,
 				metadata: { scoped: false, path: inherited_path },
 				start: node.start,

--- a/packages/tsrx-ripple/src/utils.js
+++ b/packages/tsrx-ripple/src/utils.js
@@ -13,7 +13,6 @@ import {
 	isNonDelegated,
 	isVoidElement,
 	normalizeEventName,
-	parseModule,
 	simpleHash,
 	strongHash,
 } from '@tsrx/core';
@@ -1034,27 +1033,19 @@ function jsx_member_expression_to_member_expression(jsx_member) {
  * (Element, Text, TSRXExpression) for processing inside `<tsx>` blocks.
  * @param {AST.Node} node
  * @param {AST.Node[]} [inherited_path=[]]
- * @param {string} [source]
  * @returns {AST.Node | AST.Node[] | null}
  */
-export function jsx_to_ripple_node(node, inherited_path = [], source) {
+export function jsx_to_ripple_node(node, inherited_path = []) {
 	if (node.type === 'JSXElement') {
 		const opening = node.openingElement;
 		const name = opening.name;
 
 		if (name.type === 'JSXIdentifier' && (name.name === 'tsx' || name.name === 'tsrx')) {
-			if (name.name === 'tsrx' && source !== undefined) {
-				const parsed = parse_jsx_tsrx_node(node, source);
-				if (parsed !== null) {
-					return parsed;
-				}
-			}
-
 			const children =
 				name.name === 'tsrx'
 					? /** @type {AST.Node[]} */ (
 							/** @type {AST.Node[]} */ (node.children)
-								.map((child) => jsx_to_ripple_node(child, inherited_path, source))
+								.map((child) => jsx_to_ripple_node(child, inherited_path))
 								.flat()
 								.filter(Boolean)
 						)
@@ -1155,7 +1146,7 @@ export function jsx_to_ripple_node(node, inherited_path = [], source) {
 
 		element.children = /** @type {AST.Node[]} */ (
 			/** @type {AST.Node[]} */ (node.children)
-				.map((child) => jsx_to_ripple_node(child, [...inherited_path, element], source))
+				.map((child) => jsx_to_ripple_node(child, [...inherited_path, element]))
 				.flat()
 				.filter(Boolean)
 		);
@@ -1194,78 +1185,11 @@ export function jsx_to_ripple_node(node, inherited_path = [], source) {
 	if (node.type === 'JSXFragment') {
 		return /** @type {AST.Node[]} */ (
 			/** @type {AST.Node[]} */ (node.children)
-				.map((child) => jsx_to_ripple_node(child, inherited_path, source))
+				.map((child) => jsx_to_ripple_node(child, inherited_path))
 				.flat()
 				.filter(Boolean)
 		);
 	}
 
 	return node;
-}
-
-/**
- * Re-parse nested `<tsrx>` inside JSX-style `<tsx>` so native TSRX setup
- * statements stay in statement position instead of becoming JSX text.
- * @param {AST.Node} node
- * @param {string} source
- * @returns {AST.Node | null}
- */
-function parse_jsx_tsrx_node(node, source) {
-	if (typeof node.start !== 'number' || typeof node.end !== 'number') {
-		return null;
-	}
-
-	const prefix = 'const __tsrx = ';
-	const wrapped = `${prefix}${source.slice(node.start, node.end)};`;
-
-	try {
-		const ast = parseModule(wrapped, 'nested.tsrx', { loose: true });
-		const declaration = ast.body[0];
-		if (declaration?.type !== 'VariableDeclaration') {
-			return null;
-		}
-		const parsed = declaration.declarations[0]?.init;
-		if (!parsed) {
-			return null;
-		}
-		offset_node_positions(/** @type {AST.Node} */ (parsed), node.start - prefix.length);
-		return /** @type {AST.Node} */ (parsed);
-	} catch {
-		return null;
-	}
-}
-
-/**
- * @param {AST.Node} node
- * @param {number} offset
- * @param {Set<object>} [seen]
- * @returns {void}
- */
-function offset_node_positions(node, offset, seen = new Set()) {
-	if (node === null || typeof node !== 'object' || seen.has(node)) {
-		return;
-	}
-	seen.add(node);
-
-	if (typeof node.start === 'number') {
-		node.start += offset;
-	}
-	if (typeof node.end === 'number') {
-		node.end += offset;
-	}
-
-	for (const value of Object.values(node)) {
-		if (value === null || typeof value !== 'object') {
-			continue;
-		}
-		if (Array.isArray(value)) {
-			for (const item of value) {
-				if (item !== null && typeof item === 'object') {
-					offset_node_positions(/** @type {AST.Node} */ (item), offset, seen);
-				}
-			}
-		} else if ('type' in value) {
-			offset_node_positions(/** @type {AST.Node} */ (value), offset, seen);
-		}
-	}
 }

--- a/packages/tsrx-ripple/src/utils.js
+++ b/packages/tsrx-ripple/src/utils.js
@@ -13,6 +13,7 @@ import {
 	isNonDelegated,
 	isVoidElement,
 	normalizeEventName,
+	parseModule,
 	simpleHash,
 	strongHash,
 } from '@tsrx/core';
@@ -1033,12 +1034,42 @@ function jsx_member_expression_to_member_expression(jsx_member) {
  * (Element, Text, TSRXExpression) for processing inside `<tsx>` blocks.
  * @param {AST.Node} node
  * @param {AST.Node[]} [inherited_path=[]]
+ * @param {string} [source]
  * @returns {AST.Node | AST.Node[] | null}
  */
-export function jsx_to_ripple_node(node, inherited_path = []) {
+export function jsx_to_ripple_node(node, inherited_path = [], source) {
 	if (node.type === 'JSXElement') {
 		const opening = node.openingElement;
 		const name = opening.name;
+
+		if (name.type === 'JSXIdentifier' && (name.name === 'tsx' || name.name === 'tsrx')) {
+			if (name.name === 'tsrx' && source !== undefined) {
+				const parsed = parse_jsx_tsrx_node(node, source);
+				if (parsed !== null) {
+					return parsed;
+				}
+			}
+
+			const children =
+				name.name === 'tsrx'
+					? /** @type {AST.Node[]} */ (
+							/** @type {AST.Node[]} */ (node.children)
+								.map((child) => jsx_to_ripple_node(child, inherited_path, source))
+								.flat()
+								.filter(Boolean)
+						)
+					: node.children;
+
+			return /** @type {AST.Node} */ (
+				/** @type {unknown} */ ({
+					...node,
+					type: name.name === 'tsx' ? 'Tsx' : 'Tsrx',
+					children,
+					attributes: opening.attributes,
+					selfClosing: opening.selfClosing,
+				})
+			);
+		}
 
 		/** @type {AST.Identifier | AST.MemberExpression} */
 		let id;
@@ -1124,7 +1155,7 @@ export function jsx_to_ripple_node(node, inherited_path = []) {
 
 		element.children = /** @type {AST.Node[]} */ (
 			/** @type {AST.Node[]} */ (node.children)
-				.map((child) => jsx_to_ripple_node(child, [...inherited_path, element]))
+				.map((child) => jsx_to_ripple_node(child, [...inherited_path, element], source))
 				.flat()
 				.filter(Boolean)
 		);
@@ -1163,11 +1194,78 @@ export function jsx_to_ripple_node(node, inherited_path = []) {
 	if (node.type === 'JSXFragment') {
 		return /** @type {AST.Node[]} */ (
 			/** @type {AST.Node[]} */ (node.children)
-				.map((child) => jsx_to_ripple_node(child, inherited_path))
+				.map((child) => jsx_to_ripple_node(child, inherited_path, source))
 				.flat()
 				.filter(Boolean)
 		);
 	}
 
 	return node;
+}
+
+/**
+ * Re-parse nested `<tsrx>` inside JSX-style `<tsx>` so native TSRX setup
+ * statements stay in statement position instead of becoming JSX text.
+ * @param {AST.Node} node
+ * @param {string} source
+ * @returns {AST.Node | null}
+ */
+function parse_jsx_tsrx_node(node, source) {
+	if (typeof node.start !== 'number' || typeof node.end !== 'number') {
+		return null;
+	}
+
+	const prefix = 'const __tsrx = ';
+	const wrapped = `${prefix}${source.slice(node.start, node.end)};`;
+
+	try {
+		const ast = parseModule(wrapped, 'nested.tsrx', { loose: true });
+		const declaration = ast.body[0];
+		if (declaration?.type !== 'VariableDeclaration') {
+			return null;
+		}
+		const parsed = declaration.declarations[0]?.init;
+		if (!parsed) {
+			return null;
+		}
+		offset_node_positions(/** @type {AST.Node} */ (parsed), node.start - prefix.length);
+		return /** @type {AST.Node} */ (parsed);
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * @param {AST.Node} node
+ * @param {number} offset
+ * @param {Set<object>} [seen]
+ * @returns {void}
+ */
+function offset_node_positions(node, offset, seen = new Set()) {
+	if (node === null || typeof node !== 'object' || seen.has(node)) {
+		return;
+	}
+	seen.add(node);
+
+	if (typeof node.start === 'number') {
+		node.start += offset;
+	}
+	if (typeof node.end === 'number') {
+		node.end += offset;
+	}
+
+	for (const value of Object.values(node)) {
+		if (value === null || typeof value !== 'object') {
+			continue;
+		}
+		if (Array.isArray(value)) {
+			for (const item of value) {
+				if (item !== null && typeof item === 'object') {
+					offset_node_positions(/** @type {AST.Node} */ (item), offset, seen);
+				}
+			}
+		} else if ('type' in value) {
+			offset_node_positions(/** @type {AST.Node} */ (value), offset, seen);
+		}
+	}
 }

--- a/packages/tsrx-ripple/tests/basic.test.js
+++ b/packages/tsrx-ripple/tests/basic.test.js
@@ -263,6 +263,28 @@ describe('@tsrx/ripple <tsrx> Volar output', () => {
 	});
 });
 
+describe('@tsrx/ripple <tsx> expression values', () => {
+	it('lowers tsx values nested in template expressions', () => {
+		const { code } = compile(
+			`component App() {
+				const primary = true;
+				<div>
+					{<tsx>
+						{primary
+							? ['first:', <strong>{'one'}</strong>, ':tail']
+							: ['second:', <strong>{'two'}</strong>, ':done']}
+					</tsx>}
+				</div>
+			}`,
+			'App.tsrx',
+		);
+
+		expect(code).toContain('_$_.tsrx_element');
+		expect(code).toContain('? [');
+		expect(code).not.toContain('<tsx>');
+	});
+});
+
 describe('@tsrx/ripple nested function fragment returns', () => {
 	it('keeps special fragment returns inside component-local functions', () => {
 		const { code } = compile(

--- a/packages/tsrx-ripple/tests/basic.test.js
+++ b/packages/tsrx-ripple/tests/basic.test.js
@@ -227,6 +227,20 @@ component App() {
 });
 
 describe('@tsrx/ripple <tsrx> Volar output', () => {
+	it('prints JSX converted from nested tsrx inside tsx expression containers', () => {
+		const source = `component App() {
+	const content = <tsx>
+		<section>{<tsrx><div>{'inside'}</div></tsrx>}</section>
+	</tsx>;
+	{content}
+}`;
+		const result = compile_to_volar_mappings(source, 'App.tsrx', { loose: true });
+
+		expect(result.code).toContain('<section>{<div>');
+		expect(result.code).not.toContain('<tsrx>');
+		expect(result.code).not.toContain('<tsx>');
+	});
+
 	it('returns children before and after setup statements', () => {
 		const source = `class Foo { bar() { return <tsrx><div>"before"</div> const x = 1; <div>{x}</div></tsrx>; } }`;
 		const result = compile_to_volar_mappings(source, 'App.tsrx', { loose: true });

--- a/packages/tsrx-ripple/tests/basic.test.js
+++ b/packages/tsrx-ripple/tests/basic.test.js
@@ -283,6 +283,43 @@ describe('@tsrx/ripple <tsx> expression values', () => {
 		expect(code).toContain('? [');
 		expect(code).not.toContain('<tsx>');
 	});
+
+	it('uses server render_expression for conditional array expression values', () => {
+		const { code } = compile(
+			`component App() {
+				const condition = true;
+				const ternary_items = condition ? ['start:', ['one', 2], ':end'] : ['fallback'];
+				const logical_items = condition && ['start:', ['one', 2], ':end'];
+
+				<div>{ternary_items}</div>
+				<div>{logical_items}</div>
+			}`,
+			'App.tsrx',
+			{ mode: 'server' },
+		);
+
+		expect(code).toContain('_$_.render_expression(ternary_items)');
+		expect(code).toContain('_$_.render_expression(logical_items)');
+		expect(code).not.toContain('_$_.escape(ternary_items)');
+		expect(code).not.toContain('_$_.escape(logical_items)');
+	});
+
+	it('uses client expression anchors that can hydrate conditional array markers', () => {
+		const { code } = compile(
+			`component App() {
+				const condition = true;
+				const items = condition ? ['start:', ['one', 2], ':end'] : ['fallback'];
+
+				<div>{items}</div>
+			}`,
+			'App.tsrx',
+		);
+
+		expect(code).toContain('template(`<div> </div>`');
+		expect(code).toContain('_$_.child(');
+		expect(code).not.toContain('_$_.child(div, true)');
+		expect(code).toContain('_$_.expression(');
+	});
 });
 
 describe('@tsrx/ripple nested function fragment returns', () => {

--- a/packages/tsrx-ripple/tests/jsx-runtime-types.test.js
+++ b/packages/tsrx-ripple/tests/jsx-runtime-types.test.js
@@ -1,0 +1,79 @@
+import ts from 'typescript';
+import { compile_to_volar_mappings } from '../src/index.js';
+
+/**
+ * @param {string} code
+ */
+function get_variable_types(code) {
+	const root = process.cwd();
+	const file = `${root}/__virtual_tsrx_type_test.tsx`;
+	const options = {
+		jsx: ts.JsxEmit.Preserve,
+		module: ts.ModuleKind.ESNext,
+		moduleResolution: ts.ModuleResolutionKind.Bundler,
+		target: ts.ScriptTarget.ESNext,
+		noEmit: true,
+		types: [],
+		baseUrl: root,
+		paths: {
+			'ripple/jsx-runtime': ['packages/ripple/src/jsx-runtime.d.ts'],
+			ripple: ['packages/ripple/types/index.d.ts'],
+			'#public': ['packages/ripple/types/index.d.ts'],
+			'#helpers': ['packages/ripple/src/helpers.d.ts'],
+		},
+	};
+	const host = ts.createCompilerHost(options);
+	const get_source_file = host.getSourceFile.bind(host);
+	host.getSourceFile = (name, language_version, on_error, should_create_new_source_file) =>
+		name === file
+			? ts.createSourceFile(name, code, language_version, true, ts.ScriptKind.TSX)
+			: get_source_file(name, language_version, on_error, should_create_new_source_file);
+	host.fileExists = (name) => name === file || ts.sys.fileExists(name);
+	host.readFile = (name) => (name === file ? code : ts.sys.readFile(name));
+
+	const program = ts.createProgram([file], options, host);
+	const diagnostics = ts
+		.getPreEmitDiagnostics(program)
+		.map((diagnostic) => ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n'));
+	expect(diagnostics).toEqual([]);
+
+	const checker = program.getTypeChecker();
+	const source_file = /** @type {ts.SourceFile} */ (program.getSourceFile(file));
+	/** @type {Map<string, string>} */
+	const types = new Map();
+
+	/**
+	 * @param {ts.Node} node
+	 */
+	function visit(node) {
+		if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name)) {
+			types.set(node.name.text, checker.typeToString(checker.getTypeAtLocation(node.name)));
+		}
+		ts.forEachChild(node, visit);
+	}
+	visit(source_file);
+
+	return types;
+}
+
+describe('@tsrx/ripple Volar JSX expression types', () => {
+	it('types tsx and nested tsrx expression values as TSRXElement', () => {
+		const source = `
+component App() {
+	const content = <tsx>
+		{<tsrx>
+			const nested = <tsx><span /></tsx>;
+			<div>{nested}</div>
+		</tsrx>}
+	</tsx>;
+
+	{content}
+}
+`;
+		const { code } = compile_to_volar_mappings(source, 'App.tsrx', { loose: true });
+		const types = get_variable_types(`import 'ripple/jsx-runtime';\n${code}`);
+
+		expect(types.get('content')).toBe('TSRXElement');
+		expect(types.get('nested')).toBe('TSRXElement');
+	});
+});

--- a/packages/tsrx/src/plugin.js
+++ b/packages/tsrx/src/plugin.js
@@ -478,7 +478,7 @@ export function TSRXPlugin(config) {
 					}
 
 					if (this.type === tt.braceL) {
-						body.push(this.jsx_parseExpressionContainer());
+						body.push(this.#parseTsxIslandExpressionContainer());
 					} else if (this.type === tstt.jsxTagStart) {
 						body.push(super.jsx_parseElement());
 					} else {
@@ -490,6 +490,79 @@ export function TSRXPlugin(config) {
 						this.next();
 					}
 				}
+			}
+
+			#parseTsxIslandExpressionContainer() {
+				if (!this.#isAtReservedTemplateExpressionContainer()) {
+					return this.jsx_parseExpressionContainer();
+				}
+
+				const node = /** @type {ESTreeJSX.JSXExpressionContainer} */ (this.startNode());
+				this.next();
+				this.next();
+				const expression = /** @type {AST.Expression | ESTreeJSX.JSXEmptyExpression} */ (
+					/** @type {unknown} */ (this.parseElement())
+				);
+				node.expression = expression;
+				this.#popTokenContextsAfterTemplateExpressionElement(
+					/** @type {AST.Tsx | AST.Tsrx | AST.TsxCompat} */ (/** @type {unknown} */ (expression)),
+				);
+				this.expect(tt.braceR);
+				return this.finishNode(node, 'JSXExpressionContainer');
+			}
+
+			#isAtReservedTemplateExpressionContainer() {
+				if (this.type !== tt.braceL) {
+					return false;
+				}
+
+				let index = this.start + 1;
+				while (index < this.input.length) {
+					const ch = this.input.charCodeAt(index);
+					if (
+						ch === CharCode.space ||
+						ch === CharCode.tab ||
+						ch === CharCode.lineFeed ||
+						ch === CharCode.carriageReturn
+					) {
+						index++;
+					} else {
+						break;
+					}
+				}
+
+				if (this.input.charCodeAt(index) !== CharCode.lessThan) {
+					return false;
+				}
+
+				return this.#isReservedTemplateTagNameStart(index + 1);
+			}
+
+			/**
+			 * @param {number} index
+			 */
+			#isReservedTemplateTagNameStart(index) {
+				const char_after_tsx = this.input.charCodeAt(index + 3);
+				const char_after_tsrx = this.input.charCodeAt(index + 4);
+				return (
+					(this.input.startsWith('tsx', index) &&
+						(index + 3 >= this.input.length ||
+							char_after_tsx === CharCode.greaterThan ||
+							char_after_tsx === CharCode.slash ||
+							char_after_tsx === CharCode.space ||
+							char_after_tsx === CharCode.tab ||
+							char_after_tsx === CharCode.lineFeed ||
+							char_after_tsx === CharCode.carriageReturn ||
+							char_after_tsx === CharCode.colon)) ||
+					(this.input.startsWith('tsrx', index) &&
+						(index + 4 >= this.input.length ||
+							char_after_tsrx === CharCode.greaterThan ||
+							char_after_tsrx === CharCode.slash ||
+							char_after_tsrx === CharCode.space ||
+							char_after_tsrx === CharCode.tab ||
+							char_after_tsrx === CharCode.lineFeed ||
+							char_after_tsrx === CharCode.carriageReturn))
+				);
 			}
 
 			/**
@@ -2202,10 +2275,11 @@ export function TSRXPlugin(config) {
 
 			/** @type {Parse.Parser['jsx_readToken']} */
 			jsx_readToken() {
-				const inside_tsx_compat = this.#path.findLast(
-					(n) => n.type === 'TsxCompat' || n.type === 'Tsx',
+				const current_template_node = this.#path.findLast(
+					(n) =>
+						n.type === 'Element' || n.type === 'Tsx' || n.type === 'Tsrx' || n.type === 'TsxCompat',
 				);
-				if (inside_tsx_compat) {
+				if (current_template_node?.type === 'TsxCompat' || current_template_node?.type === 'Tsx') {
 					return super.jsx_readToken();
 				}
 				let out = '',
@@ -2385,8 +2459,11 @@ export function TSRXPlugin(config) {
 			 * @type {Parse.Parser['jsx_parseElement']}
 			 */
 			jsx_parseElement() {
-				const inside_tsx = this.#path.findLast((n) => n.type === 'TsxCompat' || n.type === 'Tsx');
-				if (inside_tsx) {
+				const current_template_node = this.#path.findLast(
+					(n) =>
+						n.type === 'Element' || n.type === 'Tsx' || n.type === 'Tsrx' || n.type === 'TsxCompat',
+				);
+				if (current_template_node?.type === 'TsxCompat' || current_template_node?.type === 'Tsx') {
 					// Inside tsx/tsx:*, let acorn-jsx handle it normally
 					return super.jsx_parseElement();
 				}
@@ -2887,9 +2964,24 @@ export function TSRXPlugin(config) {
 			parseTemplateBody(body) {
 				const inside_func =
 					this.context.some((n) => n.token === 'function') || this.scopeStack.length > 1;
-				const inside_tsx_island = this.#path.findLast(
-					(n) => n.type === 'Tsx' || n.type === 'TsxCompat',
+				const current_template_node = this.#path.findLast(
+					(n) =>
+						n.type === 'Element' || n.type === 'Tsx' || n.type === 'Tsrx' || n.type === 'TsxCompat',
 				);
+				const inside_tsx_island =
+					current_template_node?.type === 'Tsx' || current_template_node?.type === 'TsxCompat'
+						? current_template_node
+						: null;
+
+				if (current_template_node?.type === 'Tsrx' && this.type === tstt.jsxText) {
+					while (this.curContext() === tstc.tc_expr) {
+						this.context.pop();
+					}
+					this.pos = this.start;
+					this.next();
+					this.parseTemplateBody(body);
+					return;
+				}
 
 				if (!inside_func) {
 					if (this.type.label === 'continue') {

--- a/packages/tsrx/src/scope.js
+++ b/packages/tsrx/src/scope.js
@@ -205,11 +205,18 @@ export function create_scopes(ast, root, parent, error_options) {
 			for (const declarator of node.declarations) {
 				/** @type {Binding[]} */
 				const bindings = [];
+				const initial = /** @type {AST.Expression | AST.Tsx | AST.Tsrx | null} */ (declarator.init);
 
 				state.scope.declarators.set(declarator, bindings);
 
 				for (const id of extract_identifiers(declarator.id)) {
-					const binding = state.scope.declare(id, 'normal', node.kind, declarator.init);
+					const binding = state.scope.declare(id, 'normal', node.kind, initial);
+					if (initial?.type === 'Tsx' || initial?.type === 'Tsrx') {
+						binding.metadata = {
+							...(binding.metadata ?? {}),
+							is_template_value: true,
+						};
+					}
 					bindings.push(binding);
 				}
 			}

--- a/packages/tsrx/types/index.d.ts
+++ b/packages/tsrx/types/index.d.ts
@@ -1247,7 +1247,9 @@ export interface Binding {
 		| AST.FunctionDeclaration
 		| AST.ClassDeclaration
 		| AST.ImportDeclaration
-		| AST.TSModuleDeclaration;
+		| AST.TSModuleDeclaration
+		| AST.Tsx
+		| AST.Tsrx;
 	/** Whether this binding has been reassigned */
 	reassigned: boolean;
 	/** Whether this binding has been mutated (property access) */
@@ -1261,6 +1263,7 @@ export interface Binding {
 		is_dynamic_component?: boolean;
 		pattern?: AST.Identifier;
 		is_ripple_object?: boolean;
+		is_template_value?: boolean;
 	} | null;
 	/** Kind of binding */
 	kind: BindingKind;
@@ -1340,7 +1343,9 @@ export interface ScopeInterface {
 			| AST.FunctionDeclaration
 			| AST.ClassDeclaration
 			| AST.ImportDeclaration
-			| AST.TSModuleDeclaration,
+			| AST.TSModuleDeclaration
+			| AST.Tsx
+			| AST.Tsrx,
 	): Binding;
 	/** Get binding by name */
 	get(name: string): Binding | null;
@@ -1416,6 +1421,7 @@ export interface TransformServerState extends BaseState {
 	template_child?: boolean;
 	skip_regular_blocks?: boolean;
 	in_regular_block?: boolean;
+	jsx_to_tsrx_element?: boolean;
 }
 
 export type UpdateList = Array<
@@ -1450,6 +1456,7 @@ export interface TransformClientState extends BaseState {
 	skip_children_traversal: boolean;
 	return_flags?: Map<AST.ReturnStatement, { name: string; tracked: boolean }>;
 	is_tsrx_element?: boolean;
+	jsx_to_tsrx_element?: boolean;
 }
 
 /** Override zimmerframe types and provide our own */

--- a/packages/zed-plugin/languages/tsrx/injections.scm
+++ b/packages/zed-plugin/languages/tsrx/injections.scm
@@ -24,6 +24,13 @@
   (#eq? @_tsx_name "tsx")
   (#set! injection.language "tsx"))
 
+; TSRX islands keep Ripple syntax, including when nested inside a TSX island.
+((jsx_element
+  open_tag: (jsx_opening_element
+    name: (jsx_element_name (identifier) @_tsrx_name))) @injection.content
+  (#eq? @_tsrx_name "tsrx")
+  (#set! injection.language "ripple"))
+
 ((jsx_element
   open_tag: (jsx_opening_element
     name: (jsx_element_name

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -699,6 +699,12 @@ importers:
         specifier: catalog:default
         version: 1.2.2
     devDependencies:
+      '@types/estree':
+        specifier: catalog:default
+        version: 1.0.8
+      '@types/estree-jsx':
+        specifier: catalog:default
+        version: 1.0.5
       '@types/node':
         specifier: catalog:default
         version: 24.11.0


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches compiler lowering plus client/server rendering & hydration paths for expressions and arrays, which can cause subtle DOM/hydration mismatches if edge cases are missed. Added tests reduce risk but changes span multiple layers (parser, runtime, editor/prettier integrations).
> 
> **Overview**
> **Nested `<tsx>`/`<tsrx>` islands are now treated as first-class expression values** across the stack: the parser recognizes reserved `<tsx>`/`<tsrx>` inside `<tsx>{...}</tsx>` expression containers, the compiler lowers them back into TSRX nodes for `to_ts`/Volar mappings, and TextMate/Tree-sitter injections highlight/inject Ripple syntax for nested `<tsrx>`.
> 
> **Runtime rendering/hydration is expanded to support nested template values and array collections**: client `expression()` can render and hydrate arrays (including nested arrays) without duplicating/coalesced server text, and server `render_expression()` now renders arrays by recursively emitting mixed text/TSRX elements. SSR transform logic routes calls/bindings that may yield template values (and collection expressions) through `render_expression` instead of `escape`, and variable initializers of `Tsx`/`Tsrx` are converted to `_$_.tsrx_element` during server transform.
> 
> **DX fixes**: `ripple/jsx-runtime` types now return `TSRXElement` (including `JSX.Element` and `Fragment`) so assigned TSX/TSRX fragments type as renderable values, and the Prettier plugin preserves comments/semicolons around nested islands. Extensive new client/server/hydration/compiler tests cover deep nesting, helper returns, and mixed collection hydration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 625fec6ed35af5e40582776dfb8747a733a443ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->