### PR TITLE
fix(prettier-plugin): preserve required assignment parens

### DIFF
--- a/.changeset/polite-nullish-assignments.md
+++ b/.changeset/polite-nullish-assignments.md
@@ -1,0 +1,5 @@
+---
+'@tsrx/prettier-plugin': patch
+---
+
+Preserve required parentheses around assignment expressions in precedence-sensitive expression contexts.

--- a/packages/prettier-plugin/src/index.js
+++ b/packages/prettier-plugin/src/index.js
@@ -361,6 +361,49 @@ function binaryExpressionNeedsParens(node, parent) {
 }
 
 /**
+ * Check if a parenthesized AssignmentExpression needs its parentheses preserved.
+ * @param {AST.AssignmentExpression} node - The expression node
+ * @param {AST.Node | null} parent - The parent node
+ * @returns {boolean} - True if parentheses are needed
+ */
+function assignmentExpressionNeedsParens(node, parent) {
+	if (!node.metadata?.parenthesized || !parent) {
+		return false;
+	}
+
+	if (parent.type === 'BinaryExpression' || parent.type === 'LogicalExpression') {
+		return true;
+	}
+
+	if (parent.type === 'ConditionalExpression') {
+		return parent.test === node;
+	}
+
+	if (parent.type === 'AwaitExpression' || parent.type === 'YieldExpression') {
+		return parent.argument === node;
+	}
+
+	if (parent.type === 'CallExpression' || parent.type === 'NewExpression') {
+		return parent.callee === node;
+	}
+
+	if (parent.type === 'TaggedTemplateExpression') {
+		return parent.tag === node;
+	}
+
+	if (
+		parent.type === 'TSAsExpression' ||
+		parent.type === 'TSSatisfiesExpression' ||
+		parent.type === 'TSNonNullExpression' ||
+		parent.type === 'TSInstantiationExpression'
+	) {
+		return parent.expression === node;
+	}
+
+	return false;
+}
+
+/**
  * Create a function that skips specified characters in text
  * @param {string | RegExp} characters - Characters to skip
  * @returns {(text: string, startIndex: number | false, options?: { backwards?: boolean }) => number | false}
@@ -1337,6 +1380,10 @@ function printRippleNode(node, path, options, print, args) {
 				group(indent(line), { id: groupId }),
 				indentIfBreak(rightSide, { groupId }),
 			]);
+			const parent = path.getParentNode();
+			if (assignmentExpressionNeedsParens(node, parent)) {
+				nodeContent = ['(', nodeContent, ')'];
+			}
 			break;
 		}
 

--- a/packages/prettier-plugin/src/index.test.js
+++ b/packages/prettier-plugin/src/index.test.js
@@ -805,6 +805,28 @@ function test() {
 			expect(result).toBeWithNewline(expected);
 		});
 
+		it('should preserve required parentheses around assignment expressions', async () => {
+			const input = `const openSignal = useRef<Signal<boolean> | null>(null)
+const open = props.open ?? (openSignal.current ??= signal(false))
+const sum = a + (b = c)
+const condition = (a = b) ? c : d
+const called = (factory = getFactory())()
+async function load() {
+  await (promise = getPromise())
+}`;
+			const expected = `const openSignal = useRef<Signal<boolean> | null>(null);
+const open = props.open ?? (openSignal.current ??= signal(false));
+const sum = a + (b = c);
+const condition = (a = b) ? c : d;
+const called = (factory = getFactory())();
+async function load() {
+  await (promise = getPromise());
+}`;
+
+			const result = await format(input, { singleQuote: true });
+			expect(result).toBeWithNewline(expected);
+		});
+
 		it('should not change formatting for function object properties and properties in square brackets', async () => {
 			const expected = `export component App() {
   const SYMBOL_PROP = Symbol();


### PR DESCRIPTION
Preserves parenthesized assignment expressions when dropping the parens would change parsing or produce invalid output.

This fixes cases like:

```ts
const open = props.open ?? (openSignal.current ??= signal(false));
```

which previously formatted to invalid output by removing the assignment parentheses.

Supported contexts:

- Binary expressions, tested
- Logical expressions, tested
- Conditional expression tests, tested
- Call expression callees, tested
- New expression callees
- Tagged template tags
- Await operands, tested
- Yield operands
- TypeScript `as`, `satisfies`, non-null, and instantiation expression operands

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core printing of `AssignmentExpression`, so formatting output changes broadly and could introduce new precedence/parentheses regressions, but the logic is narrowly scoped and covered by a focused test.
> 
> **Overview**
> Fixes the printer to **preserve required parentheses around parenthesized `AssignmentExpression`s** when they appear in precedence-sensitive contexts (e.g. binary/logical ops, conditional tests, call/new/tagged-template callee/tag, `await`/`yield`, and several TS expression wrappers), preventing Prettier output from becoming invalid or changing meaning.
> 
> Adds a new `assignmentExpressionNeedsParens` check in `index.js`, applies it when printing assignments, and includes a regression test plus a patch changeset for `@tsrx/prettier-plugin`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c09716ae58286aeff871c5a00b5a4a460e484b03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->