### PR TITLE
fix: parsing tsrx expressions in functions

### DIFF
--- a/.changeset/clean-tsrx-expression-props.md
+++ b/.changeset/clean-tsrx-expression-props.md
@@ -1,0 +1,5 @@
+---
+"@tsrx/core": patch
+---
+
+Transform nested `<tsrx>` templates inside TSX expressions instead of preserving invalid `<tsrx>` JSX tags in framework output.

--- a/packages/ripple/tests/client/tsx.test.tsrx
+++ b/packages/ripple/tests/client/tsx.test.tsrx
@@ -545,9 +545,7 @@ describe('tsx expression', () => {
 			const content = <tsx>
 				<section class="outer">
 					{<tsrx>
-						<div class="inner">
-							{'from tsrx'}
-						</div>
+						<div class="inner">{'from tsrx'}</div>
 					</tsrx>}
 				</section>
 			</tsx>;
@@ -568,9 +566,7 @@ describe('tsx expression', () => {
 				<div class="wrapper">
 					{<tsrx>
 						<section class="native">
-							<span class="nested-tsrx">
-								{'inside nested tsrx'}
-							</span>
+							<span class="nested-tsrx">{'inside nested tsrx'}</span>
 						</section>
 					</tsrx>}
 				</div>

--- a/packages/ripple/tests/hydration/compiled/client/basic.js
+++ b/packages/ripple/tests/hydration/compiled/client/basic.js
@@ -13,64 +13,61 @@ var root_8 = _$_.template(`<!><!>`, 1, 2);
 var root_9 = _$_.template(`<div> </div>`, 0);
 var root_10 = _$_.template(`<!>`, 1, 1);
 var root_11 = _$_.template(`<div> </div><span> </span>`, 1, 2);
-var root_15 = _$_.template(`<div class="helper-item"> </div>`, 0);
-var root_14 = _$_.template(`<!>`, 1, 1);
-var root_16 = _$_.template(` `, 1, 1);
+var root_14 = _$_.template(`<div class="helper-item"> </div>`, 0);
+var root_15 = _$_.template(`<!>`, 1, 1);
 var root_13 = _$_.template(`<!>`, 1, 1);
-var root_17 = _$_.template(` `, 1, 1);
+var root_16 = _$_.template(` `, 1, 1);
 var root_12 = _$_.template(`<span class="label"> </span><!>`, 1, 2);
-var root_18 = _$_.template(`<div class="app-item"> </div>`, 0);
-var root_19 = _$_.template(` `, 1, 1);
-var root_20 = _$_.template(`<!><!>`, 1, 2);
-var root_21 = _$_.template(`<strong class="middle">beta</strong>`, 0);
-var root_22 = _$_.template(`<em class="tail">epsilon</em>`, 0);
-var root_23 = _$_.template(` `, 1, 1);
-var root_24 = _$_.template(`<div class="mixed-collection"><!></div>`, 0);
-var root_25 = _$_.template(`<strong class="middle">beta</strong>`, 0);
-var root_26 = _$_.template(`<em class="tail">epsilon</em>`, 0);
-var root_27 = _$_.template(` `, 1, 1);
-var root_28 = _$_.template(`<div class="mixed-collection-split"><!></div>`, 0);
-var root_29 = _$_.template(`<strong class="middle">beta</strong>`, 0);
-var root_30 = _$_.template(`<em class="tail">epsilon</em>`, 0);
-var root_31 = _$_.template(` `, 1, 1);
-var root_32 = _$_.template(`<div class="mixed-collection-split"><!></div>`, 0);
-var root_33 = _$_.template(`<span class="primitive-tail"> ok</span>`, 0);
-var root_34 = _$_.template(` `, 1, 1);
-var root_35 = _$_.template(`<div class="mixed-collection-primitive"><!></div>`, 0);
-var root_36 = _$_.template(`<span class="primitive-tail"> ok</span>`, 0);
-var root_37 = _$_.template(` `, 1, 1);
-var root_38 = _$_.template(`<div class="mixed-collection-primitive"><!></div>`, 0);
-var root_39 = _$_.template(`<div class="dynamic-array-call"> </div>`, 0);
-var root_40 = _$_.template(`<div class="dynamic-array-track"> </div>`, 0);
-var root_41 = _$_.template(`<div class="dynamic-array-conditional"> </div>`, 0);
-var root_42 = _$_.template(`<div class="dynamic-array-logical"> </div>`, 0);
-var root_45 = _$_.template(`<div class="inner">from tsrx</div>`, 0);
+var root_17 = _$_.template(`<div class="app-item"> </div>`, 0);
+var root_18 = _$_.template(` `, 1, 1);
+var root_19 = _$_.template(`<!><!>`, 1, 2);
+var root_20 = _$_.template(`<strong class="middle">beta</strong>`, 0);
+var root_21 = _$_.template(`<em class="tail">epsilon</em>`, 0);
+var root_22 = _$_.template(` `, 1, 1);
+var root_23 = _$_.template(`<div class="mixed-collection"><!></div>`, 0);
+var root_24 = _$_.template(`<strong class="middle">beta</strong>`, 0);
+var root_25 = _$_.template(`<em class="tail">epsilon</em>`, 0);
+var root_26 = _$_.template(` `, 1, 1);
+var root_27 = _$_.template(`<div class="mixed-collection-split"><!></div>`, 0);
+var root_28 = _$_.template(`<strong class="middle">beta</strong>`, 0);
+var root_29 = _$_.template(`<em class="tail">epsilon</em>`, 0);
+var root_30 = _$_.template(` `, 1, 1);
+var root_31 = _$_.template(`<div class="mixed-collection-split"><!></div>`, 0);
+var root_32 = _$_.template(`<span class="primitive-tail"> ok</span>`, 0);
+var root_33 = _$_.template(` `, 1, 1);
+var root_34 = _$_.template(`<div class="mixed-collection-primitive"><!></div>`, 0);
+var root_35 = _$_.template(`<span class="primitive-tail"> ok</span>`, 0);
+var root_36 = _$_.template(` `, 1, 1);
+var root_37 = _$_.template(`<div class="mixed-collection-primitive"><!></div>`, 0);
+var root_38 = _$_.template(`<div class="dynamic-array-call"> </div>`, 0);
+var root_39 = _$_.template(`<div class="dynamic-array-track"> </div>`, 0);
+var root_40 = _$_.template(`<div class="dynamic-array-conditional"> </div>`, 0);
+var root_41 = _$_.template(`<div class="dynamic-array-logical"> </div>`, 0);
+var root_43 = _$_.template(`<div class="inner">from tsrx</div>`, 0);
+var root_42 = _$_.template(`<section class="outer"><!></section>`, 0);
 var root_44 = _$_.template(`<!>`, 1, 1);
-var root_43 = _$_.template(`<section class="outer"> </section>`, 0);
-var root_46 = _$_.template(`<!>`, 1, 1);
-var root_49 = _$_.template(`<section class="native"><span class="nested-tsrx">inside nested tsrx</span></section>`, 0);
-var root_48 = _$_.template(`<!>`, 1, 1);
-var root_47 = _$_.template(`<div class="wrapper"> </div>`, 0);
+var root_46 = _$_.template(`<section class="native"><span class="nested-tsrx">inside nested tsrx</span></section>`, 0);
+var root_45 = _$_.template(`<div class="wrapper"><!></div>`, 0);
+var root_47 = _$_.template(`<!>`, 1, 1);
+var root_48 = _$_.template(`<span class="nested-tsx">inside nested tsx</span>`, 0);
+var root_49 = _$_.template(`<div class="native"><!></div>`, 0);
 var root_50 = _$_.template(`<!>`, 1, 1);
-var root_51 = _$_.template(`<span class="nested-tsx">inside nested tsx</span>`, 0);
-var root_52 = _$_.template(`<div class="native"><!></div>`, 0);
-var root_53 = _$_.template(`<!>`, 1, 1);
-var root_54 = _$_.template(`<!>`, 1, 1);
-var root_55 = _$_.template(`<div class="text-prop"><!></div>`, 0);
-var root_56 = _$_.template(`<!><button class="show-text">Show</button>`, 1, 2);
-var root_57 = _$_.template(`<h1 class="sr-only">heading</h1><p class="subtitle">first paragraph</p><p class="subtitle">second paragraph</p>`, 1, 3);
-var root_58 = _$_.template(`<!><span class="sibling1"> </span><span class="sibling2"> </span>`, 1, 3);
-var root_59 = _$_.template(`<h1 class="sr-only">Ripple</h1><img src="/images/logo.png" alt="Logo" class="logo"><p class="subtitle">the elegant TypeScript UI framework</p>`, 1, 3);
-var root_61 = _$_.template(`<a href="/playground" class="playground-link">Playground</a>`, 0);
-var root_60 = _$_.template(`<div class="social-links"><a href="https://github.com" class="github-link">GitHub</a><a href="https://discord.com" class="discord-link">Discord</a><!></div>`, 0);
-var root_62 = _$_.template(`<main><div class="container"><!></div></main>`, 0);
-var root_63 = _$_.template(`<div class="content"><p>Some content here</p></div>`, 0);
-var root_65 = _$_.template(`<!><!><!><!>`, 1, 4);
-var root_64 = _$_.template(`<!>`, 1, 1);
-var root_66 = _$_.template(`<footer class="last-child">I am the last child</footer>`, 0);
-var root_67 = _$_.template(`<div class="wrapper"><h1>Header</h1><p>Some content</p><!></div>`, 0);
-var root_68 = _$_.template(`<div class="inner"><span>Inner text</span><!></div>`, 0);
-var root_69 = _$_.template(`<section class="outer"><h2>Section title</h2><!></section>`, 0);
+var root_51 = _$_.template(`<!>`, 1, 1);
+var root_52 = _$_.template(`<div class="text-prop"><!></div>`, 0);
+var root_53 = _$_.template(`<!><button class="show-text">Show</button>`, 1, 2);
+var root_54 = _$_.template(`<h1 class="sr-only">heading</h1><p class="subtitle">first paragraph</p><p class="subtitle">second paragraph</p>`, 1, 3);
+var root_55 = _$_.template(`<!><span class="sibling1"> </span><span class="sibling2"> </span>`, 1, 3);
+var root_56 = _$_.template(`<h1 class="sr-only">Ripple</h1><img src="/images/logo.png" alt="Logo" class="logo"><p class="subtitle">the elegant TypeScript UI framework</p>`, 1, 3);
+var root_58 = _$_.template(`<a href="/playground" class="playground-link">Playground</a>`, 0);
+var root_57 = _$_.template(`<div class="social-links"><a href="https://github.com" class="github-link">GitHub</a><a href="https://discord.com" class="discord-link">Discord</a><!></div>`, 0);
+var root_59 = _$_.template(`<main><div class="container"><!></div></main>`, 0);
+var root_60 = _$_.template(`<div class="content"><p>Some content here</p></div>`, 0);
+var root_62 = _$_.template(`<!><!><!><!>`, 1, 4);
+var root_61 = _$_.template(`<!>`, 1, 1);
+var root_63 = _$_.template(`<footer class="last-child">I am the last child</footer>`, 0);
+var root_64 = _$_.template(`<div class="wrapper"><h1>Header</h1><p>Some content</p><!></div>`, 0);
+var root_65 = _$_.template(`<div class="inner"><span>Inner text</span><!></div>`, 0);
+var root_66 = _$_.template(`<section class="outer"><h2>Section title</h2><!></section>`, 0);
 
 import { track } from 'ripple';
 
@@ -241,44 +238,37 @@ function makeNestedTsxTsrxFragment(label) {
 		}
 
 		const test = _$_.tsrx_element(function render_children(__anchor, __block) {
-			var fragment_9 = root_17();
-			var expression_6 = _$_.first_child_frag(fragment_9);
+			var fragment_8 = root_16();
+			var expression_6 = _$_.first_child_frag(fragment_8);
 
 			_$_.expression(expression_6, () => _$_.with_scope(__block, () => [1, 2, 3, 4].map((item) => _$_.tsrx_element(function render_children(__anchor, __block) {
 				var fragment_6 = root_13();
-				var node_5 = _$_.first_child_frag(fragment_6);
+				var node_4 = _$_.first_child_frag(fragment_6);
 
-				_$_.expression(node_5, () => _$_.tsrx_element(function render_children(__anchor, __block) {
-					var fragment_8 = root_16();
-					var expression_5 = _$_.first_child_frag(fragment_8);
+				_$_.expression(node_4, () => _$_.tsrx_element(function render_children(__anchor, __block) {
+					var fragment_7 = root_15();
+					var expression_5 = _$_.first_child_frag(fragment_7);
 
 					_$_.expression(expression_5, () => _$_.tsrx_element(function render_children(__anchor, __block) {
-						var fragment_7 = root_14();
-						var node_4 = _$_.first_child_frag(fragment_7);
+						var div_8 = root_14();
 
-						_$_.expression(node_4, () => _$_.tsrx_element(function render_children(__anchor, __block) {
-							var div_8 = root_15();
+						{
+							var expression_4 = _$_.child(div_8);
 
-							{
-								var expression_4 = _$_.child(div_8);
+							_$_.expression(expression_4, () => item);
+							_$_.pop(div_8);
+						}
 
-								_$_.expression(expression_4, () => item);
-								_$_.pop(div_8);
-							}
-
-							_$_.append(__anchor, div_8);
-						}));
-
-						_$_.append(__anchor, fragment_7);
+						_$_.append(__anchor, div_8);
 					}));
 
-					_$_.append(__anchor, fragment_8);
+					_$_.append(__anchor, fragment_7);
 				}));
 
 				_$_.append(__anchor, fragment_6);
 			}))));
 
-			_$_.append(__anchor, fragment_9);
+			_$_.append(__anchor, fragment_8);
 		});
 
 		var expression_7 = _$_.sibling(span_3);
@@ -291,15 +281,15 @@ function makeNestedTsxTsrxFragment(label) {
 export function NestedTsxTsrxExpressionValues(__anchor, _, __block) {
 	_$_.push_component();
 
-	var fragment_11 = root_20();
-	var expression_10 = _$_.first_child_frag(fragment_11);
+	var fragment_10 = root_19();
+	var expression_10 = _$_.first_child_frag(fragment_10);
 
 	_$_.expression(expression_10, () => _$_.tsrx_element(function render_children(__anchor, __block) {
-		var fragment_10 = root_19();
-		var expression_9 = _$_.first_child_frag(fragment_10);
+		var fragment_9 = root_18();
+		var expression_9 = _$_.first_child_frag(fragment_9);
 
 		_$_.expression(expression_9, () => _$_.with_scope(__block, () => [1, 2, 3].map((item) => _$_.tsrx_element(function render_children(__anchor, __block) {
-			var div_9 = root_18();
+			var div_9 = root_17();
 
 			{
 				var expression_8 = _$_.child(div_9);
@@ -311,13 +301,13 @@ export function NestedTsxTsrxExpressionValues(__anchor, _, __block) {
 			_$_.append(__anchor, div_9);
 		}))));
 
-		_$_.append(__anchor, fragment_10);
+		_$_.append(__anchor, fragment_9);
 	}));
 
 	var expression_11 = _$_.sibling(expression_10);
 
 	_$_.expression(expression_11, () => _$_.with_scope(__block, () => makeNestedTsxTsrxFragment('from helper')));
-	_$_.append(__anchor, fragment_11);
+	_$_.append(__anchor, fragment_10);
 	_$_.pop_component();
 }
 
@@ -325,13 +315,13 @@ export function MixedTsrxCollectionText(__anchor, _, __block) {
 	_$_.push_component();
 
 	const content = _$_.tsrx_element(function render_children(__anchor, __block) {
-		var fragment_12 = root_23();
-		var expression_12 = _$_.first_child_frag(fragment_12);
+		var fragment_11 = root_22();
+		var expression_12 = _$_.first_child_frag(fragment_11);
 
 		_$_.expression(expression_12, () => [
 			'alpha ',
 			_$_.tsrx_element(function render_children(__anchor, __block) {
-				var strong = root_21();
+				var strong = root_20();
 
 				_$_.append(__anchor, strong);
 			}),
@@ -339,7 +329,7 @@ export function MixedTsrxCollectionText(__anchor, _, __block) {
 			[
 				'delta ',
 				_$_.tsrx_element(function render_children(__anchor, __block) {
-					var em = root_22();
+					var em = root_21();
 
 					_$_.append(__anchor, em);
 				}),
@@ -347,10 +337,10 @@ export function MixedTsrxCollectionText(__anchor, _, __block) {
 			]
 		]);
 
-		_$_.append(__anchor, fragment_12);
+		_$_.append(__anchor, fragment_11);
 	});
 
-	var div_10 = root_24();
+	var div_10 = root_23();
 
 	{
 		var expression_13 = _$_.child(div_10);
@@ -367,13 +357,13 @@ export function MixedTsrxCollectionSplitServerText(__anchor, _, __block) {
 	_$_.push_component();
 
 	const content = _$_.tsrx_element(function render_children(__anchor, __block) {
-		var fragment_13 = root_27();
-		var expression_14 = _$_.first_child_frag(fragment_13);
+		var fragment_12 = root_26();
+		var expression_14 = _$_.first_child_frag(fragment_12);
 
 		_$_.expression(expression_14, () => [
 			'alpha ',
 			_$_.tsrx_element(function render_children(__anchor, __block) {
-				var strong_1 = root_25();
+				var strong_1 = root_24();
 
 				_$_.append(__anchor, strong_1);
 			}),
@@ -381,7 +371,7 @@ export function MixedTsrxCollectionSplitServerText(__anchor, _, __block) {
 			[
 				'delta ',
 				_$_.tsrx_element(function render_children(__anchor, __block) {
-					var em_1 = root_26();
+					var em_1 = root_25();
 
 					_$_.append(__anchor, em_1);
 				}),
@@ -389,10 +379,10 @@ export function MixedTsrxCollectionSplitServerText(__anchor, _, __block) {
 			]
 		]);
 
-		_$_.append(__anchor, fragment_13);
+		_$_.append(__anchor, fragment_12);
 	});
 
-	var div_11 = root_28();
+	var div_11 = root_27();
 
 	{
 		var expression_15 = _$_.child(div_11);
@@ -409,13 +399,13 @@ export function MixedTsrxCollectionSplitClientText(__anchor, _, __block) {
 	_$_.push_component();
 
 	const content = _$_.tsrx_element(function render_children(__anchor, __block) {
-		var fragment_14 = root_31();
-		var expression_16 = _$_.first_child_frag(fragment_14);
+		var fragment_13 = root_30();
+		var expression_16 = _$_.first_child_frag(fragment_13);
 
 		_$_.expression(expression_16, () => [
 			'alpha ',
 			_$_.tsrx_element(function render_children(__anchor, __block) {
-				var strong_2 = root_29();
+				var strong_2 = root_28();
 
 				_$_.append(__anchor, strong_2);
 			}),
@@ -423,7 +413,7 @@ export function MixedTsrxCollectionSplitClientText(__anchor, _, __block) {
 			[
 				'changed ',
 				_$_.tsrx_element(function render_children(__anchor, __block) {
-					var em_2 = root_30();
+					var em_2 = root_29();
 
 					_$_.append(__anchor, em_2);
 				}),
@@ -431,10 +421,10 @@ export function MixedTsrxCollectionSplitClientText(__anchor, _, __block) {
 			]
 		]);
 
-		_$_.append(__anchor, fragment_14);
+		_$_.append(__anchor, fragment_13);
 	});
 
-	var div_12 = root_32();
+	var div_12 = root_31();
 
 	{
 		var expression_17 = _$_.child(div_12);
@@ -451,8 +441,8 @@ export function MixedTsrxCollectionPrimitiveServerText(__anchor, _, __block) {
 	_$_.push_component();
 
 	const content = _$_.tsrx_element(function render_children(__anchor, __block) {
-		var fragment_15 = root_34();
-		var expression_18 = _$_.first_child_frag(fragment_15);
+		var fragment_14 = root_33();
+		var expression_18 = _$_.first_child_frag(fragment_14);
 
 		_$_.expression(expression_18, () => [
 			'count: ',
@@ -460,16 +450,16 @@ export function MixedTsrxCollectionPrimitiveServerText(__anchor, _, __block) {
 			' / ',
 			true,
 			_$_.tsrx_element(function render_children(__anchor, __block) {
-				var span_4 = root_33();
+				var span_4 = root_32();
 
 				_$_.append(__anchor, span_4);
 			})
 		]);
 
-		_$_.append(__anchor, fragment_15);
+		_$_.append(__anchor, fragment_14);
 	});
 
-	var div_13 = root_35();
+	var div_13 = root_34();
 
 	{
 		var expression_19 = _$_.child(div_13);
@@ -486,8 +476,8 @@ export function MixedTsrxCollectionPrimitiveClientText(__anchor, _, __block) {
 	_$_.push_component();
 
 	const content = _$_.tsrx_element(function render_children(__anchor, __block) {
-		var fragment_16 = root_37();
-		var expression_20 = _$_.first_child_frag(fragment_16);
+		var fragment_15 = root_36();
+		var expression_20 = _$_.first_child_frag(fragment_15);
 
 		_$_.expression(expression_20, () => [
 			'count: ',
@@ -495,16 +485,16 @@ export function MixedTsrxCollectionPrimitiveClientText(__anchor, _, __block) {
 			' / ',
 			false,
 			_$_.tsrx_element(function render_children(__anchor, __block) {
-				var span_5 = root_36();
+				var span_5 = root_35();
 
 				_$_.append(__anchor, span_5);
 			})
 		]);
 
-		_$_.append(__anchor, fragment_16);
+		_$_.append(__anchor, fragment_15);
 	});
 
-	var div_14 = root_38();
+	var div_14 = root_37();
 
 	{
 		var expression_21 = _$_.child(div_14);
@@ -525,7 +515,7 @@ export function DynamicArrayFromCall(__anchor, _, __block) {
 	_$_.push_component();
 
 	const items = _$_.with_scope(__block, createPrimitiveItems);
-	var div_15 = root_39();
+	var div_15 = root_38();
 
 	{
 		var expression_22 = _$_.child(div_15);
@@ -542,7 +532,7 @@ export function DynamicArrayFromTrack(__anchor, _, __block) {
 	_$_.push_component();
 
 	let lazy = _$_.track(['start:', ['one', 2], true, null, false, ':end'], __block, 'b5de6402');
-	var div_16 = root_40();
+	var div_16 = root_39();
 
 	{
 		var expression_23 = _$_.child(div_16);
@@ -564,7 +554,7 @@ export function DynamicArrayFromConditional(__anchor, _, __block) {
 		? ['start:', ['one', 2], true, null, false, ':end']
 		: ['fallback'];
 
-	var div_17 = root_41();
+	var div_17 = root_40();
 
 	{
 		var expression_24 = _$_.child(div_17);
@@ -582,7 +572,7 @@ export function DynamicArrayFromLogical(__anchor, _, __block) {
 
 	const condition = true;
 	const items = condition && ['start:', ['one', 2], true, null, false, ':end'];
-	var div_18 = root_42();
+	var div_18 = root_41();
 
 	{
 		var expression_25 = _$_.child(div_18);
@@ -599,22 +589,15 @@ export function NestedTsrxInsideTopLevelTsxExpression(__anchor, _, __block) {
 	_$_.push_component();
 
 	const content = _$_.tsrx_element(function render_children(__anchor, __block) {
-		var section_1 = root_43();
+		var section_1 = root_42();
 
 		{
 			var expression_26 = _$_.child(section_1);
 
 			_$_.expression(expression_26, () => _$_.tsrx_element(function render_children(__anchor, __block) {
-				var fragment_17 = root_44();
-				var node_6 = _$_.first_child_frag(fragment_17);
+				var div_19 = root_43();
 
-				_$_.expression(node_6, () => _$_.tsrx_element(function render_children(__anchor, __block) {
-					var div_19 = root_45();
-
-					_$_.append(__anchor, div_19);
-				}));
-
-				_$_.append(__anchor, fragment_17);
+				_$_.append(__anchor, div_19);
 			}));
 
 			_$_.pop(section_1);
@@ -623,11 +606,11 @@ export function NestedTsrxInsideTopLevelTsxExpression(__anchor, _, __block) {
 		_$_.append(__anchor, section_1);
 	});
 
-	var fragment_18 = root_46();
-	var expression_27 = _$_.first_child_frag(fragment_18);
+	var fragment_16 = root_44();
+	var expression_27 = _$_.first_child_frag(fragment_16);
 
 	_$_.expression(expression_27, () => content);
-	_$_.append(__anchor, fragment_18);
+	_$_.append(__anchor, fragment_16);
 	_$_.pop_component();
 }
 
@@ -635,22 +618,15 @@ export function NestedTsrxElementsInsideTopLevelTsxValue(__anchor, _, __block) {
 	_$_.push_component();
 
 	const content = _$_.tsrx_element(function render_children(__anchor, __block) {
-		var div_20 = root_47();
+		var div_20 = root_45();
 
 		{
 			var expression_28 = _$_.child(div_20);
 
 			_$_.expression(expression_28, () => _$_.tsrx_element(function render_children(__anchor, __block) {
-				var fragment_19 = root_48();
-				var node_7 = _$_.first_child_frag(fragment_19);
+				var section_2 = root_46();
 
-				_$_.expression(node_7, () => _$_.tsrx_element(function render_children(__anchor, __block) {
-					var section_2 = root_49();
-
-					_$_.append(__anchor, section_2);
-				}));
-
-				_$_.append(__anchor, fragment_19);
+				_$_.append(__anchor, section_2);
 			}));
 
 			_$_.pop(div_20);
@@ -659,11 +635,11 @@ export function NestedTsrxElementsInsideTopLevelTsxValue(__anchor, _, __block) {
 		_$_.append(__anchor, div_20);
 	});
 
-	var fragment_20 = root_50();
-	var expression_29 = _$_.first_child_frag(fragment_20);
+	var fragment_17 = root_47();
+	var expression_29 = _$_.first_child_frag(fragment_17);
 
 	_$_.expression(expression_29, () => content);
-	_$_.append(__anchor, fragment_20);
+	_$_.append(__anchor, fragment_17);
 	_$_.pop_component();
 }
 
@@ -671,17 +647,17 @@ export function TsxDeclaredInsideNestedTsrxFromTopLevelTsx(__anchor, _, __block)
 	_$_.push_component();
 
 	const content = _$_.tsrx_element(function render_children(__anchor, __block) {
-		var fragment_21 = root_53();
-		var expression_31 = _$_.first_child_frag(fragment_21);
+		var fragment_18 = root_50();
+		var expression_31 = _$_.first_child_frag(fragment_18);
 
 		_$_.expression(expression_31, () => _$_.tsrx_element(function render_children(__anchor, __block) {
 			const nested = _$_.tsrx_element(function render_children(__anchor, __block) {
-				var span_6 = root_51();
+				var span_6 = root_48();
 
 				_$_.append(__anchor, span_6);
 			});
 
-			var div_21 = root_52();
+			var div_21 = root_49();
 
 			{
 				var expression_30 = _$_.child(div_21);
@@ -693,21 +669,21 @@ export function TsxDeclaredInsideNestedTsrxFromTopLevelTsx(__anchor, _, __block)
 			_$_.append(__anchor, div_21);
 		}));
 
-		_$_.append(__anchor, fragment_21);
+		_$_.append(__anchor, fragment_18);
 	});
 
-	var fragment_22 = root_54();
-	var expression_32 = _$_.first_child_frag(fragment_22);
+	var fragment_19 = root_51();
+	var expression_32 = _$_.first_child_frag(fragment_19);
 
 	_$_.expression(expression_32, () => content);
-	_$_.append(__anchor, fragment_22);
+	_$_.append(__anchor, fragment_19);
 	_$_.pop_component();
 }
 
 function TextProp(__anchor, __props, __block) {
 	_$_.push_component();
 
-	var div_22 = root_55();
+	var div_22 = root_52();
 
 	{
 		var expression_33 = _$_.child(div_22);
@@ -724,11 +700,11 @@ export function TextPropWithToggle(__anchor, _, __block) {
 	_$_.push_component();
 
 	let lazy_1 = _$_.track(false, __block, '1ba81c3b');
-	var fragment_23 = root_56();
-	var node_8 = _$_.first_child_frag(fragment_23);
+	var fragment_20 = root_53();
+	var node_5 = _$_.first_child_frag(fragment_20);
 
 	TextProp(
-		node_8,
+		node_5,
 		{
 			get children() {
 				return _$_.normalize_children(_$_.get(lazy_1) ? 'hello' : '');
@@ -737,20 +713,20 @@ export function TextPropWithToggle(__anchor, _, __block) {
 		_$_.active_block
 	);
 
-	var button_1 = _$_.sibling(node_8);
+	var button_1 = _$_.sibling(node_5);
 
 	button_1.__click = () => _$_.set(lazy_1, true);
-	_$_.append(__anchor, fragment_23);
+	_$_.append(__anchor, fragment_20);
 	_$_.pop_component();
 }
 
 function StaticHeader(__anchor, _, __block) {
 	_$_.push_component();
 
-	var fragment_24 = root_57();
+	var fragment_21 = root_54();
 
 	_$_.next(2);
-	_$_.append(__anchor, fragment_24, true);
+	_$_.append(__anchor, fragment_21, true);
 	_$_.pop_component();
 }
 
@@ -758,12 +734,12 @@ export function StaticChildWithSiblings(__anchor, _, __block) {
 	_$_.push_component();
 
 	const foo = 'bar';
-	var fragment_25 = root_58();
-	var node_9 = _$_.first_child_frag(fragment_25);
+	var fragment_22 = root_55();
+	var node_6 = _$_.first_child_frag(fragment_22);
 
-	StaticHeader(node_9, {}, _$_.active_block);
+	StaticHeader(node_6, {}, _$_.active_block);
 
-	var span_7 = _$_.sibling(node_9);
+	var span_7 = _$_.sibling(node_6);
 
 	{
 		var expression_34 = _$_.child(span_7);
@@ -782,38 +758,38 @@ export function StaticChildWithSiblings(__anchor, _, __block) {
 	}
 
 	_$_.next();
-	_$_.append(__anchor, fragment_25, true);
+	_$_.append(__anchor, fragment_22, true);
 	_$_.pop_component();
 }
 
 function Header(__anchor, _, __block) {
 	_$_.push_component();
 
-	var fragment_26 = root_59();
+	var fragment_23 = root_56();
 
 	_$_.next(2);
-	_$_.append(__anchor, fragment_26, true);
+	_$_.append(__anchor, fragment_23, true);
 	_$_.pop_component();
 }
 
 function Actions(__anchor, { playgroundVisible = false }, __block) {
 	_$_.push_component();
 
-	var div_23 = root_60();
+	var div_23 = root_57();
 
 	{
 		var a_2 = _$_.child(div_23);
 		var a_1 = _$_.sibling(a_2);
-		var node_10 = _$_.sibling(a_1);
+		var node_7 = _$_.sibling(a_1);
 
 		{
 			var consequent = (__anchor) => {
-				var a_3 = root_61();
+				var a_3 = root_58();
 
 				_$_.append(__anchor, a_3);
 			};
 
-			_$_.if(node_10, (__render) => {
+			_$_.if(node_7, (__render) => {
 				if (playgroundVisible) __render(consequent);
 			});
 		}
@@ -828,7 +804,7 @@ function Actions(__anchor, { playgroundVisible = false }, __block) {
 function Layout(__anchor, { children }, __block) {
 	_$_.push_component();
 
-	var main_1 = root_62();
+	var main_1 = root_59();
 
 	{
 		var div_24 = _$_.child(main_1);
@@ -848,7 +824,7 @@ function Layout(__anchor, { children }, __block) {
 function Content(__anchor, _, __block) {
 	_$_.push_component();
 
-	var div_25 = root_63();
+	var div_25 = root_60();
 
 	_$_.append(__anchor, div_25);
 	_$_.pop_component();
@@ -857,43 +833,43 @@ function Content(__anchor, _, __block) {
 export function WebsiteIndex(__anchor, _, __block) {
 	_$_.push_component();
 
-	var fragment_27 = root_64();
-	var node_11 = _$_.first_child_frag(fragment_27);
+	var fragment_24 = root_61();
+	var node_8 = _$_.first_child_frag(fragment_24);
 
 	Layout(
-		node_11,
+		node_8,
 		{
 			children: _$_.tsrx_element(function render_children(__anchor, __block) {
-				var fragment_28 = root_65();
-				var node_12 = _$_.first_child_frag(fragment_28);
+				var fragment_25 = root_62();
+				var node_9 = _$_.first_child_frag(fragment_25);
 
-				Header(node_12, {}, _$_.active_block);
+				Header(node_9, {}, _$_.active_block);
 
-				var node_13 = _$_.sibling(node_12);
+				var node_10 = _$_.sibling(node_9);
 
-				Actions(node_13, { playgroundVisible: true }, _$_.active_block);
+				Actions(node_10, { playgroundVisible: true }, _$_.active_block);
 
-				var node_14 = _$_.sibling(node_13);
+				var node_11 = _$_.sibling(node_10);
 
-				Content(node_14, {}, _$_.active_block);
+				Content(node_11, {}, _$_.active_block);
 
-				var node_15 = _$_.sibling(node_14);
+				var node_12 = _$_.sibling(node_11);
 
-				Actions(node_15, { playgroundVisible: false }, _$_.active_block);
-				_$_.append(__anchor, fragment_28);
+				Actions(node_12, { playgroundVisible: false }, _$_.active_block);
+				_$_.append(__anchor, fragment_25);
 			})
 		},
 		_$_.active_block
 	);
 
-	_$_.append(__anchor, fragment_27);
+	_$_.append(__anchor, fragment_24);
 	_$_.pop_component();
 }
 
 function LastChild(__anchor, _, __block) {
 	_$_.push_component();
 
-	var footer_1 = root_66();
+	var footer_1 = root_63();
 
 	_$_.append(__anchor, footer_1);
 	_$_.pop_component();
@@ -902,14 +878,14 @@ function LastChild(__anchor, _, __block) {
 export function ComponentAsLastSibling(__anchor, _, __block) {
 	_$_.push_component();
 
-	var div_26 = root_67();
+	var div_26 = root_64();
 
 	{
 		var h1_1 = _$_.child(div_26);
 		var p_1 = _$_.sibling(h1_1);
-		var node_16 = _$_.sibling(p_1);
+		var node_13 = _$_.sibling(p_1);
 
-		LastChild(node_16, {}, _$_.active_block);
+		LastChild(node_13, {}, _$_.active_block);
 		_$_.pop(div_26);
 	}
 
@@ -920,13 +896,13 @@ export function ComponentAsLastSibling(__anchor, _, __block) {
 function InnerContent(__anchor, _, __block) {
 	_$_.push_component();
 
-	var div_27 = root_68();
+	var div_27 = root_65();
 
 	{
 		var span_9 = _$_.child(div_27);
-		var node_17 = _$_.sibling(span_9);
+		var node_14 = _$_.sibling(span_9);
 
-		LastChild(node_17, {}, _$_.active_block);
+		LastChild(node_14, {}, _$_.active_block);
 		_$_.pop(div_27);
 	}
 
@@ -937,13 +913,13 @@ function InnerContent(__anchor, _, __block) {
 export function NestedComponentAsLastSibling(__anchor, _, __block) {
 	_$_.push_component();
 
-	var section_3 = root_69();
+	var section_3 = root_66();
 
 	{
 		var h2_1 = _$_.child(section_3);
-		var node_18 = _$_.sibling(h2_1);
+		var node_15 = _$_.sibling(h2_1);
 
-		InnerContent(node_18, {}, _$_.active_block);
+		InnerContent(node_15, {}, _$_.active_block);
 		_$_.pop(section_3);
 	}
 

--- a/packages/ripple/tests/hydration/compiled/server/basic.js
+++ b/packages/ripple/tests/hydration/compiled/server/basic.js
@@ -299,17 +299,15 @@ function makeNestedTsxTsrxFragment(label) {
 			_$_.render_expression([1, 2, 3, 4].map((item) => _$_.tsrx_element(function render_children() {
 				{
 					_$_.render_expression(_$_.tsrx_element(function render_children() {
+						_$_.output_push('<div');
+						_$_.output_push(' class="helper-item"');
+						_$_.output_push('>');
+
 						{
-							_$_.output_push('<div');
-							_$_.output_push(' class="helper-item"');
-							_$_.output_push('>');
-
-							{
-								_$_.output_push(_$_.escape(item));
-							}
-
-							_$_.output_push('</div>');
+							_$_.output_push(_$_.escape(item));
 						}
+
+						_$_.output_push('</div>');
 					}));
 				}
 			})));
@@ -684,17 +682,15 @@ export function NestedTsrxInsideTopLevelTsxExpression() {
 
 			{
 				_$_.render_expression(_$_.tsrx_element(function render_children() {
+					_$_.output_push('<div');
+					_$_.output_push(' class="inner"');
+					_$_.output_push('>');
+
 					{
-						_$_.output_push('<div');
-						_$_.output_push(' class="inner"');
-						_$_.output_push('>');
-
-						{
-							_$_.output_push('from tsrx');
-						}
-
-						_$_.output_push('</div>');
+						_$_.output_push('from tsrx');
 					}
+
+					_$_.output_push('</div>');
 				}));
 			}
 
@@ -720,25 +716,23 @@ export function NestedTsrxElementsInsideTopLevelTsxValue() {
 
 			{
 				_$_.render_expression(_$_.tsrx_element(function render_children() {
+					_$_.output_push('<section');
+					_$_.output_push(' class="native"');
+					_$_.output_push('>');
+
 					{
-						_$_.output_push('<section');
-						_$_.output_push(' class="native"');
+						_$_.output_push('<span');
+						_$_.output_push(' class="nested-tsrx"');
 						_$_.output_push('>');
 
 						{
-							_$_.output_push('<span');
-							_$_.output_push(' class="nested-tsrx"');
-							_$_.output_push('>');
-
-							{
-								_$_.output_push('inside nested tsrx');
-							}
-
-							_$_.output_push('</span>');
+							_$_.output_push('inside nested tsrx');
 						}
 
-						_$_.output_push('</section>');
+						_$_.output_push('</span>');
 					}
+
+					_$_.output_push('</section>');
 				}));
 			}
 

--- a/packages/ripple/tests/hydration/components/basic.tsrx
+++ b/packages/ripple/tests/hydration/components/basic.tsrx
@@ -216,9 +216,7 @@ export component NestedTsrxInsideTopLevelTsxExpression() {
 	const content = <tsx>
 		<section class="outer">
 			{<tsrx>
-				<div class="inner">
-					{'from tsrx'}
-				</div>
+				<div class="inner">{'from tsrx'}</div>
 			</tsrx>}
 		</section>
 	</tsx>;
@@ -231,9 +229,7 @@ export component NestedTsrxElementsInsideTopLevelTsxValue() {
 		<div class="wrapper">
 			{<tsrx>
 				<section class="native">
-					<span class="nested-tsrx">
-						{'inside nested tsrx'}
-					</span>
+					<span class="nested-tsrx">{'inside nested tsrx'}</span>
 				</section>
 			</tsrx>}
 		</div>

--- a/packages/ripple/tests/server/basic.test.tsrx
+++ b/packages/ripple/tests/server/basic.test.tsrx
@@ -89,9 +89,7 @@ second"</pre>
 			const content = <tsx>
 				<section class="outer">
 					{<tsrx>
-						<div class="inner">
-							{'from tsrx'}
-						</div>
+						<div class="inner">{'from tsrx'}</div>
 					</tsrx>}
 				</section>
 			</tsx>;
@@ -110,9 +108,7 @@ second"</pre>
 				<div class="wrapper">
 					{<tsrx>
 						<section class="native">
-							<span class="nested-tsrx">
-								{'inside nested tsrx'}
-							</span>
+							<span class="nested-tsrx">{'inside nested tsrx'}</span>
 						</section>
 					</tsrx>}
 				</div>

--- a/packages/tsrx-preact/tests/basic.test.js
+++ b/packages/tsrx-preact/tests/basic.test.js
@@ -6,6 +6,7 @@ import {
 	runSharedCompileTests,
 	runSharedComponentParamsTests,
 	runSharedSwitchHelperHoistingTests,
+	runSharedTsxExpressionTsrxTests,
 } from '@tsrx/core/test-harness/compile';
 import { runSharedSourceMappingTests } from '@tsrx/core/test-harness/source-mappings';
 import { compile, compile_to_volar_mappings } from '../src/index.js';
@@ -18,6 +19,7 @@ runSharedSourceMappingTests({
 });
 
 runSharedAnonymousComponentTests({ compile, name: 'preact' });
+runSharedTsxExpressionTsrxTests({ compile, name: 'preact', classAttrName: 'class' });
 runSharedCompileTests({ compile, name: 'preact', classAttrName: 'class' });
 runSharedCompileDiagnosticsTests({ compile_to_volar_mappings, name: 'preact' });
 runSharedClassComponentDeclarationTests({ compile, compile_to_volar_mappings, name: 'preact' });

--- a/packages/tsrx-react/tests/basic.test.js
+++ b/packages/tsrx-react/tests/basic.test.js
@@ -6,6 +6,7 @@ import {
 	runSharedCompileTests,
 	runSharedComponentParamsTests,
 	runSharedSwitchHelperHoistingTests,
+	runSharedTsxExpressionTsrxTests,
 } from '@tsrx/core/test-harness/compile';
 import { runSharedSourceMappingTests } from '@tsrx/core/test-harness/source-mappings';
 import { compile, compile_to_volar_mappings } from '../src/index.js';
@@ -18,6 +19,7 @@ runSharedSourceMappingTests({
 });
 
 runSharedAnonymousComponentTests({ compile, name: 'react' });
+runSharedTsxExpressionTsrxTests({ compile, name: 'react', classAttrName: 'className' });
 runSharedCompileTests({ compile, name: 'react', classAttrName: 'className' });
 runSharedCompileDiagnosticsTests({ compile_to_volar_mappings, name: 'react' });
 runSharedClassComponentDeclarationTests({ compile, compile_to_volar_mappings, name: 'react' });

--- a/packages/tsrx-solid/tests/basic.test.js
+++ b/packages/tsrx-solid/tests/basic.test.js
@@ -6,6 +6,7 @@ import {
 	runSharedCompileTests,
 	runSharedComponentParamsTests,
 	runSharedSwitchHelperHoistingTests,
+	runSharedTsxExpressionTsrxTests,
 } from '@tsrx/core/test-harness/compile';
 import { runSharedSourceMappingTests } from '@tsrx/core/test-harness/source-mappings';
 import { compile, compile_to_volar_mappings } from '../src/index.js';
@@ -18,6 +19,7 @@ runSharedSourceMappingTests({
 });
 
 runSharedAnonymousComponentTests({ compile, name: 'solid' });
+runSharedTsxExpressionTsrxTests({ compile, name: 'solid', classAttrName: 'class' });
 runSharedCompileTests({ compile, name: 'solid', classAttrName: 'class' });
 runSharedCompileDiagnosticsTests({ compile_to_volar_mappings, name: 'solid' });
 runSharedClassComponentDeclarationTests({ compile, compile_to_volar_mappings, name: 'solid' });

--- a/packages/tsrx-vue/tests/basic.test.js
+++ b/packages/tsrx-vue/tests/basic.test.js
@@ -7,6 +7,7 @@ import {
 	runSharedComponentParamsTests,
 	runSharedNestedLazyDestructuringTests,
 	runSharedSwitchHelperHoistingTests,
+	runSharedTsxExpressionTsrxTests,
 } from '@tsrx/core/test-harness/compile';
 import { runSharedSourceMappingTests } from '@tsrx/core/test-harness/source-mappings';
 import { compile, compile_to_volar_mappings } from '../src/index.js';
@@ -18,6 +19,7 @@ runSharedSourceMappingTests({
 	rejectsComponentAwait: true,
 });
 runSharedAnonymousComponentTests({ compile, name: 'vue' });
+runSharedTsxExpressionTsrxTests({ compile, name: 'vue', classAttrName: 'class' });
 runSharedComponentLoopControlFlowTests({ compile, name: 'vue' });
 runSharedCompileDiagnosticsTests({ compile_to_volar_mappings, name: 'vue' });
 runSharedClassComponentDeclarationTests({ compile, compile_to_volar_mappings, name: 'vue' });

--- a/packages/tsrx/src/plugin.js
+++ b/packages/tsrx/src/plugin.js
@@ -275,6 +275,7 @@ export function TSRXPlugin(config) {
 			#componentDepth = 0;
 			#functionBodyDepth = 0;
 			#allowExpressionContainerTrailingSemicolon = false;
+			#tsxIslandExpressionDepth = 0;
 
 			/**
 			 * @type {Parse.Parser['finishNode']}
@@ -493,22 +494,27 @@ export function TSRXPlugin(config) {
 			}
 
 			#parseTsxIslandExpressionContainer() {
-				if (!this.#isAtReservedTemplateExpressionContainer()) {
-					return this.jsx_parseExpressionContainer();
-				}
+				this.#tsxIslandExpressionDepth++;
+				try {
+					if (!this.#isAtReservedTemplateExpressionContainer()) {
+						return this.jsx_parseExpressionContainer();
+					}
 
-				const node = /** @type {ESTreeJSX.JSXExpressionContainer} */ (this.startNode());
-				this.next();
-				this.next();
-				const expression = /** @type {AST.Expression | ESTreeJSX.JSXEmptyExpression} */ (
-					/** @type {unknown} */ (this.parseElement())
-				);
-				node.expression = expression;
-				this.#popTokenContextsAfterTemplateExpressionElement(
-					/** @type {AST.Tsx | AST.Tsrx | AST.TsxCompat} */ (/** @type {unknown} */ (expression)),
-				);
-				this.expect(tt.braceR);
-				return this.finishNode(node, 'JSXExpressionContainer');
+					const node = /** @type {ESTreeJSX.JSXExpressionContainer} */ (this.startNode());
+					this.next();
+					this.next();
+					const expression = /** @type {AST.Expression | ESTreeJSX.JSXEmptyExpression} */ (
+						/** @type {unknown} */ (this.parseElement())
+					);
+					node.expression = expression;
+					this.#popTokenContextsAfterTemplateExpressionElement(
+						/** @type {AST.Tsx | AST.Tsrx | AST.TsxCompat} */ (/** @type {unknown} */ (expression)),
+					);
+					this.expect(tt.braceR);
+					return this.finishNode(node, 'JSXExpressionContainer');
+				} finally {
+					this.#tsxIslandExpressionDepth--;
+				}
 			}
 
 			#isAtReservedTemplateExpressionContainer() {
@@ -2459,15 +2465,6 @@ export function TSRXPlugin(config) {
 			 * @type {Parse.Parser['jsx_parseElement']}
 			 */
 			jsx_parseElement() {
-				const current_template_node = this.#path.findLast(
-					(n) =>
-						n.type === 'Element' || n.type === 'Tsx' || n.type === 'Tsrx' || n.type === 'TsxCompat',
-				);
-				if (current_template_node?.type === 'TsxCompat' || current_template_node?.type === 'Tsx') {
-					// Inside tsx/tsx:*, let acorn-jsx handle it normally
-					return super.jsx_parseElement();
-				}
-
 				// Check if the element being parsed IS a <tsx>, <tsrx>, or <tsx:*> tag
 				// Current token is jsxTagStart, this.end is position after '<'
 				const tag_name_start = this.end;
@@ -2494,6 +2491,20 @@ export function TSRXPlugin(config) {
 						char_after_tsrx === CharCode.lineFeed ||
 						char_after_tsrx === CharCode.carriageReturn);
 
+				const current_template_node = this.#path.findLast(
+					(n) =>
+						n.type === 'Element' || n.type === 'Tsx' || n.type === 'Tsrx' || n.type === 'TsxCompat',
+				);
+				if (
+					(current_template_node?.type === 'TsxCompat' || current_template_node?.type === 'Tsx') &&
+					!is_tsrx_tag
+				) {
+					// Inside tsx/tsx:*, let acorn-jsx handle regular TSX tags normally.
+					// Nested <tsrx> still needs Ripple's native template parser so it
+					// can lower through the same path as <tsrx> in component bodies.
+					return super.jsx_parseElement();
+				}
+
 				if (is_fragment_tag || is_tsx_tag || is_tsrx_tag) {
 					// Use Ripple's parseElement to create a Tsx/Tsrx/TsxCompat node.
 					// Bare fragments (<></>) are shorthand for <tsx>...</tsx>.
@@ -2501,9 +2512,21 @@ export function TSRXPlugin(config) {
 					const parsed = /** @type {import('estree-jsx').JSXElement} */ (
 						/** @type {unknown} */ (this.parseElement())
 					);
-					this.#popTokenContextsAfterTemplateExpressionElement(
-						/** @type {AST.Tsx | AST.Tsrx | AST.TsxCompat} */ (/** @type {unknown} */ (parsed)),
-					);
+					if (
+						current_template_node?.type !== 'Tsx' &&
+						current_template_node?.type !== 'TsxCompat'
+					) {
+						this.#popTokenContextsAfterTemplateExpressionElement(
+							/** @type {AST.Tsx | AST.Tsrx | AST.TsxCompat} */ (/** @type {unknown} */ (parsed)),
+						);
+					} else if (this.type === tt.braceR && this.curContext() === tstc.tc_expr) {
+						if (this.#tsxIslandExpressionDepth === 0) {
+							// Acorn still owns the surrounding JSX expression container.
+							// Keep a block-expression context for its closing `}` so the
+							// parent TSX tag continues tokenizing as JSX afterward.
+							this.context.push(b_expr);
+						}
+					}
 					return parsed;
 				}
 

--- a/packages/tsrx/tests/shared/compile.js
+++ b/packages/tsrx/tests/shared/compile.js
@@ -164,6 +164,44 @@ export function runSharedCompileDiagnosticsTests({ compile_to_volar_mappings, na
 }
 
 /**
+ * @param {CompileHarness} harness
+ */
+export function runSharedTsxExpressionTsrxTests({ compile, name, classAttrName }) {
+	describe(`[${name}] <tsrx> inside TSX expressions`, () => {
+		it('lowers nested native TSRX templates inside regular function TSX props', () => {
+			const { code } = compile(
+				`function App3() {
+					return <>
+						<PlainTextPlugin
+							ErrorBoundary={LexicalErrorBoundary}
+							contentEditable={<tsrx>
+								<ContentEditable
+									aria-placeholder={placeholder}
+									class={classes.contentEditable}
+									placeholder={<tsrx>
+										<div class={classes.placeholder}>{placeholder}</div>
+									</tsrx>}
+								/>
+							</tsrx>}
+							placeholder={<tsrx>
+								<div class={classes.placeholder}>{placeholder}</div>
+							</tsrx>}
+						/>
+					</>;
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).not.toContain('<tsrx>');
+			expect(code).not.toContain('</tsrx>');
+			expect(code).toContain('contentEditable={<ContentEditable');
+			expect(code).toContain(` ${classAttrName}={classes.contentEditable}`);
+			expect(code).toContain(`placeholder={<div ${classAttrName}={classes.placeholder}>`);
+		});
+	});
+}
+
+/**
  * Nested `&{...}` / `&[...]` patterns must chain accessors through every lazy
  * level: a reference to the inner binding becomes the full member path through
  * the synthesized parent identifier, and assignments to it write back through

--- a/packages/tsrx/tests/shared/runtime/tsx-expression-tsrx-components.tsrx
+++ b/packages/tsrx/tests/shared/runtime/tsx-expression-tsrx-components.tsrx
@@ -1,0 +1,49 @@
+component PlainTextPlugin(props: { contentEditable: any; placeholder: any }) {
+	<section class="tsrx-expression-prop-root">
+		<div class="tsrx-expression-content">{props.contentEditable}</div>
+		<div class="tsrx-expression-plugin-placeholder">{props.placeholder}</div>
+	</section>
+}
+
+component ContentEditable(props: {
+	'aria-placeholder'?: string;
+	class?: string;
+	className?: string;
+	placeholder: any;
+}) {
+	const className = props.className ?? props.class ?? '';
+
+	<article class="tsrx-expression-editable">
+		<span class="tsrx-expression-editable-class">{className}</span>
+		<div class="tsrx-expression-inner-placeholder">{props.placeholder}</div>
+	</article>
+}
+
+export component TsrxInTsxExpressionApp() {
+	const placeholder = 'shared placeholder';
+	const classes = {
+		contentEditable: 'editable-class',
+		placeholder: 'placeholder-class',
+	};
+
+	function renderPlugin() {
+		return <>
+			<PlainTextPlugin
+				contentEditable={<tsrx>
+					<ContentEditable
+						aria-placeholder={placeholder}
+						class={classes.contentEditable}
+						placeholder={<tsrx>
+							<div class={classes.placeholder}>{placeholder}</div>
+						</tsrx>}
+					/>
+				</tsrx>}
+				placeholder={<tsrx>
+					<div class={classes.placeholder}>{placeholder}</div>
+				</tsrx>}
+			/>
+		</>;
+	}
+
+	{renderPlugin()}
+}

--- a/packages/tsrx/tests/shared/runtime/tsx-expression-tsrx.js
+++ b/packages/tsrx/tests/shared/runtime/tsx-expression-tsrx.js
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { TsrxInTsxExpressionApp } from './tsx-expression-tsrx-components.tsrx';
+
+export function runTsxExpressionTsrxRuntimeTests() {
+	async function settle() {
+		const flush = /** @type {(() => Promise<void>) | undefined} */ (
+			/** @type {any} */ (globalThis).flush
+		);
+		if (flush) {
+			await flush();
+		}
+	}
+
+	async function mount(Component) {
+		await globalThis
+			/** @type {any} */ .render(Component);
+		await settle();
+	}
+
+	function text(selector) {
+		const container = /** @type {HTMLElement} */ (/** @type {any} */ (globalThis).container);
+		return container.querySelector(selector)?.textContent ?? null;
+	}
+
+	describe('<tsrx> inside TSX expressions at runtime', () => {
+		it('renders native TSRX passed through regular function JSX props', async () => {
+			await mount(TsrxInTsxExpressionApp);
+
+			expect(text('.tsrx-expression-editable-class')).toBe('editable-class');
+			expect(text('.tsrx-expression-inner-placeholder .placeholder-class')).toBe(
+				'shared placeholder',
+			);
+			expect(text('.tsrx-expression-plugin-placeholder .placeholder-class')).toBe(
+				'shared placeholder',
+			);
+		});
+	});
+}

--- a/packages/vite-plugin-preact/tests/runtime.test.tsrx
+++ b/packages/vite-plugin-preact/tests/runtime.test.tsrx
@@ -4,6 +4,9 @@ import { useState } from 'preact/hooks';
 import {
 	runSwitchFallthroughRuntimeTests,
 } from '@tsrx/core/test-harness/runtime/switch-fallthrough';
+import {
+	runTsxExpressionTsrxRuntimeTests,
+} from '@tsrx/core/test-harness/runtime/tsx-expression-tsrx';
 
 function text(selector: string): string | null {
 	return container.querySelector(selector)?.textContent ?? null;
@@ -417,3 +420,4 @@ describe('@tsrx/vite-plugin-preact runtime', () => {
 });
 
 runSwitchFallthroughRuntimeTests();
+runTsxExpressionTsrxRuntimeTests();

--- a/packages/vite-plugin-react/tests/runtime.test.tsrx
+++ b/packages/vite-plugin-react/tests/runtime.test.tsrx
@@ -3,6 +3,9 @@ import { useState, use } from 'react';
 import {
 	runSwitchFallthroughRuntimeTests,
 } from '@tsrx/core/test-harness/runtime/switch-fallthrough';
+import {
+	runTsxExpressionTsrxRuntimeTests,
+} from '@tsrx/core/test-harness/runtime/tsx-expression-tsrx';
 
 const EXPECTED_ERROR_LOG_SNIPPETS = [
 	'sync boom',
@@ -1824,3 +1827,4 @@ describe('tsrx-react runtime', () => {
 });
 
 runSwitchFallthroughRuntimeTests();
+runTsxExpressionTsrxRuntimeTests();

--- a/packages/vite-plugin-solid/tests/runtime.test.tsrx
+++ b/packages/vite-plugin-solid/tests/runtime.test.tsrx
@@ -3,6 +3,9 @@ import { createSignal, lazy } from 'solid-js';
 import {
 	runSwitchFallthroughRuntimeTests,
 } from '@tsrx/core/test-harness/runtime/switch-fallthrough';
+import {
+	runTsxExpressionTsrxRuntimeTests,
+} from '@tsrx/core/test-harness/runtime/tsx-expression-tsrx';
 
 const EXPECTED_ERROR_LOG_SNIPPETS = [
 	'sync boom',
@@ -1528,3 +1531,4 @@ describe('tsrx-solid runtime', () => {
 });
 
 runSwitchFallthroughRuntimeTests();
+runTsxExpressionTsrxRuntimeTests();

--- a/packages/vite-plugin-vue/tests/runtime.test.tsrx
+++ b/packages/vite-plugin-vue/tests/runtime.test.tsrx
@@ -3,6 +3,9 @@ import { defineVaporAsyncComponent, inject, provide, reactive, ref, watch, watch
 import {
 	runSwitchFallthroughRuntimeTests,
 } from '@tsrx/core/test-harness/runtime/switch-fallthrough';
+import {
+	runTsxExpressionTsrxRuntimeTests,
+} from '@tsrx/core/test-harness/runtime/tsx-expression-tsrx';
 
 const EXPECTED_ERROR_LOG_SNIPPETS = [
 	'sync boom',
@@ -1522,3 +1525,4 @@ describe('tsrx-vue runtime', () => {
 });
 
 runSwitchFallthroughRuntimeTests();
+runTsxExpressionTsrxRuntimeTests();


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes JSX/TSX parsing logic in `@tsrx/core` to treat nested `<tsrx>` differently inside TSX expression containers, which can affect compilation of mixed TSX/TSRX templates across targets. Risk is mitigated by new shared compile/runtime tests added for React/Preact/Solid/Vue and Ripple hydration fixtures.
> 
> **Overview**
> Fixes compilation of native `<tsrx>` templates nested inside TSX expression values (e.g. JSX props) so they are **lowered as TSRX** rather than emitted as invalid `<tsrx>` JSX tags.
> 
> Updates the parser (`packages/tsrx/src/plugin.js`) to special-case nested `<tsrx>` within `<tsx>`/`<tsx:*>` and to track TSX-island expression depth to keep Acorn token contexts balanced.
> 
> Adds new shared compile + runtime test coverage for this scenario across framework adapters, and updates Ripple client/server/hydration fixtures accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 492b2b954117c5d269e3a3e06c16d1043f94b90c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->