### PR TITLE
fix(prettier): arrows that return long generic optional calls with nullish fallbacks

### DIFF
--- a/.changeset/curvy-jobs-format.md
+++ b/.changeset/curvy-jobs-format.md
@@ -1,0 +1,5 @@
+---
+"@tsrx/prettier-plugin": patch
+---
+
+Fix formatting for expression-bodied arrows that return long generic optional calls with nullish fallbacks.

--- a/packages/prettier-plugin/src/index.js
+++ b/packages/prettier-plugin/src/index.js
@@ -14,7 +14,7 @@
  * @typedef {((path: AstPath) => Doc) & ((path: AstPath, args: PrintArgs) => Doc)} PrintFn
  */
 
-/** @typedef {Partial<Pick<ParserOptions, 'singleQuote' | 'jsxSingleQuote' | 'semi' | 'trailingComma' | 'useTabs' | 'tabWidth' | 'singleAttributePerLine' | 'bracketSameLine' | 'bracketSpacing' | 'arrowParens' | 'originalText'>> & { locStart: (node: AST.NodeWithLocation) => number, locEnd: (node: AST.NodeWithLocation) => number }} RippleFormatOptions */
+/** @typedef {Partial<Pick<ParserOptions, 'singleQuote' | 'jsxSingleQuote' | 'semi' | 'trailingComma' | 'useTabs' | 'tabWidth' | 'singleAttributePerLine' | 'bracketSameLine' | 'bracketSpacing' | 'arrowParens' | 'originalText' | 'printWidth'>> & { locStart: (node: AST.NodeWithLocation) => number, locEnd: (node: AST.NodeWithLocation) => number }} RippleFormatOptions */
 
 /** @typedef {{ isInAttribute?: boolean, isInArray?: boolean, allowInlineObject?: boolean, isConditionalTest?: boolean, isNestedConditional?: boolean, suppressLeadingComments?: boolean, suppressExpressionLeadingComments?: boolean, isInlineContext?: boolean, isStatement?: boolean, isLogicalAndOr?: boolean, allowShorthandProperty?: boolean, isFirstChild?: boolean, skipComponentLabel?: boolean, noBreakInside?: boolean, expandLastArg?: boolean }} PrintArgs */
 
@@ -1923,6 +1923,13 @@ function printRippleNode(node, path, options, print, args) {
 		case 'LogicalExpression': {
 			const logicalParent = path.getParentNode();
 			let logicalResult;
+			const rightIsNullLiteral = node.right.type === 'Literal' && node.right.value === null;
+			const shouldKeepNullishFallbackInline =
+				node.operator === '??' &&
+				rightIsNullLiteral &&
+				(node.left.type === 'CallExpression' ||
+					node.left.type === 'ChainExpression' ||
+					node.left.type === 'NewExpression');
 			// Don't add indent if we're in a conditional test context
 			if (args?.isConditionalTest) {
 				logicalResult = group([
@@ -1930,6 +1937,14 @@ function printRippleNode(node, path, options, print, args) {
 					' ',
 					node.operator,
 					[line, path.call((childPath) => print(childPath, { isConditionalTest: true }), 'right')],
+				]);
+			} else if (shouldKeepNullishFallbackInline) {
+				logicalResult = group([
+					path.call(print, 'left'),
+					' ',
+					node.operator,
+					' ',
+					path.call(print, 'right'),
 				]);
 			} else {
 				logicalResult = group([
@@ -2814,36 +2829,45 @@ function printArrowFunction(node, path, options, print, args) {
 		parts.push(': ', path.call(print, 'returnType'));
 	}
 
-	parts.push(' => ');
-
 	// For block statements, print the body directly to get proper formatting
 	if (node.body.type === 'BlockStatement') {
+		parts.push(' => ');
 		parts.push(path.call(print, 'body'));
 	} else {
 		// For expression bodies, check if we need to wrap in parens
 		// Wrap ObjectExpression, AssignmentExpression, and SequenceExpression in parens
 		// to avoid ambiguity with block statements or to clarify intent
 		const bodyDoc = path.call(print, 'body');
+		const groupId = Symbol('arrow');
+		const shouldBreakBody = shouldBreakArrowExpressionBody(node.body, options);
+		/** @type {Doc | Doc[]} */
+		let bodyContent;
 		if (
 			node.body.type === 'ObjectExpression' ||
 			node.body.type === 'AssignmentExpression' ||
 			node.body.type === 'SequenceExpression' ||
 			(args?.isInAttribute && isTemplateExpression(node.body))
 		) {
-			parts.push('(');
 			if (isTemplateExpression(node.body)) {
-				parts.push(indent([hardline, bodyDoc]));
-				parts.push(hardline);
+				bodyContent = ['(', indent([hardline, bodyDoc]), hardline, ')'];
 			} else {
-				parts.push(bodyDoc);
+				bodyContent = ['(', bodyDoc, ')'];
 			}
-			parts.push(')');
 		} else {
-			parts.push(bodyDoc);
+			bodyContent = bodyDoc;
+		}
+		if (shouldBreakBody) {
+			parts.push(' =>', indent([hardline, bodyContent]));
+		} else {
+			parts.push(
+				' =>',
+				group(indent(line), { id: groupId }),
+				indentIfBreak(bodyContent, { groupId }),
+			);
 		}
 	}
 
-	return parts;
+	return group(parts);
 }
 
 /**
@@ -3051,6 +3075,33 @@ function shouldHugArrowFunctions(args) {
 	}
 
 	return firstBlockIndex === 0;
+}
+
+/**
+ * Check whether a node's original source span exceeds the configured print width.
+ * @param {AST.NodeWithLocation} node - The node to check
+ * @param {RippleFormatOptions} options - Prettier options
+ * @returns {boolean}
+ */
+function sourceSpanExceedsPrintWidth(node, options) {
+	const printWidth = options.printWidth ?? 80;
+	if (!options.originalText || node.start === undefined || node.end === undefined) {
+		return false;
+	}
+	return options.originalText.slice(node.start, node.end).length > printWidth;
+}
+
+/**
+ * Check if an arrow expression body should break immediately after `=>`.
+ * @param {AST.Expression} node - The arrow body expression
+ * @param {RippleFormatOptions} options - Prettier options
+ * @returns {boolean}
+ */
+function shouldBreakArrowExpressionBody(node, options) {
+	return (
+		(node.type === 'BinaryExpression' || node.type === 'LogicalExpression') &&
+		sourceSpanExceedsPrintWidth(/** @type {AST.NodeWithLocation} */ (node), options)
+	);
 }
 
 /**

--- a/packages/prettier-plugin/src/index.test.js
+++ b/packages/prettier-plugin/src/index.test.js
@@ -1380,6 +1380,19 @@ import { effect, track } from 'ripple';`;
 			expect(result).toBeWithNewline(expected);
 		});
 
+		it('should break arrow before a long generic optional call with nullish fallback', async () => {
+			const input = `const test = () => menuRef.current?.querySelector<HTMLElement>(
+        "[role=\\"menuitem\\"]:not([aria-disabled=\\"true\\"])",
+      ) ??
+        null`;
+			const expected = `const test = () =>
+  menuRef.current?.querySelector<HTMLElement>(
+    '[role="menuitem"]:not([aria-disabled="true"])',
+  ) ?? null;`;
+			const result = await format(input, { singleQuote: true });
+			expect(result).toBeWithNewline(expected);
+		});
+
 		it('does not add spaces around inlined array elements in destructured arguments', async () => {
 			const expected = `for (const [key, value] of Object.entries(attributes).filter(([_key, value]) => value !== '')) {
 }

--- a/packages/ripple/tests/client/compiler/compiler.basic.test.tsrx
+++ b/packages/ripple/tests/client/compiler/compiler.basic.test.tsrx
@@ -531,10 +531,11 @@ component App() {
 
 		function find_mapping(source_offset: number, generated_offset: number) {
 			return result.mappings.find(
-				(mapping) => mapping.sourceOffsets[0] === source_offset &&
-					mapping.generatedOffsets[0] === generated_offset &&
-					mapping.lengths[0] === 'nested'.length &&
-					mapping.generatedLengths[0] === 'nested'.length,
+				(mapping) =>
+					mapping.sourceOffsets[0] === source_offset &&
+						mapping.generatedOffsets[0] === generated_offset &&
+						mapping.lengths[0] === 'nested'.length &&
+						mapping.generatedLengths[0] === 'nested'.length,
 			);
 		}
 
@@ -668,10 +669,11 @@ export function optionalFn(declRequired: string, declMaybe?: string) {
 					generatedOffsets: number[];
 					lengths: number[];
 					generatedLengths: number[];
-				}) => mapping.sourceOffsets[0] === source_offset &&
-					mapping.generatedOffsets[0] === generated_offset &&
-					mapping.lengths[0] === identifier.length &&
-					mapping.generatedLengths[0] === identifier.length,
+				}) =>
+					mapping.sourceOffsets[0] === source_offset &&
+						mapping.generatedOffsets[0] === generated_offset &&
+						mapping.lengths[0] === identifier.length &&
+						mapping.generatedLengths[0] === identifier.length,
 			);
 
 			expect(source_offset).toBeGreaterThan(-1);
@@ -969,10 +971,11 @@ component App() {
 			generated_length = length,
 		) {
 			return result.mappings.find(
-				(mapping) => mapping.sourceOffsets[0] === source_offset &&
-					mapping.generatedOffsets[0] === generated_offset &&
-					mapping.lengths[0] === length &&
-					mapping.generatedLengths[0] === generated_length,
+				(mapping) =>
+					mapping.sourceOffsets[0] === source_offset &&
+						mapping.generatedOffsets[0] === generated_offset &&
+						mapping.lengths[0] === length &&
+						mapping.generatedLengths[0] === generated_length,
 			);
 		}
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core printing heuristics for `ArrowFunctionExpression` and `LogicalExpression`, which can alter formatting output across many files. Risk is limited to formatting (no runtime behavior), but snapshot/test churn is possible if edge cases differ from Prettier expectations.
> 
> **Overview**
> Fixes a Prettier printing edge case where expression-bodied arrows returning *long* binary/logical expressions (notably optional generic calls with `?? null`) were formatted awkwardly.
> 
> Arrow bodies now use a more fluid `group`/`indentIfBreak` layout and will break immediately after `=>` when the original source span exceeds `printWidth` for `BinaryExpression`/`LogicalExpression`; additionally, `LogicalExpression` special-cases `call/chain/new ?? null` to keep the `?? null` fallback inline. Includes a regression test and a patch changeset, plus minor test formatting tweaks in Ripple compiler mapping tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92eca5387b2afdcbdb8e0c030be877f8d6b46c79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->