### PR TITLE
fix(prettier-plugin): print TypeScript satisfies expressions

### DIFF
--- a/.changeset/silver-satisfies-print.md
+++ b/.changeset/silver-satisfies-print.md
@@ -1,0 +1,5 @@
+---
+"@tsrx/prettier-plugin": patch
+---
+
+Print TypeScript `satisfies` expressions instead of replacing them with unknown-node comments.

--- a/packages/prettier-plugin/src/index.js
+++ b/packages/prettier-plugin/src/index.js
@@ -1506,6 +1506,15 @@ function printRippleNode(node, path, options, print, args) {
 			break;
 		}
 
+		case 'TSSatisfiesExpression': {
+			nodeContent = [
+				path.call(print, 'expression'),
+				' satisfies ',
+				path.call(print, 'typeAnnotation'),
+			];
+			break;
+		}
+
 		case 'TSNonNullExpression': {
 			nodeContent = [path.call(print, 'expression'), '!'];
 			break;

--- a/packages/prettier-plugin/src/index.test.js
+++ b/packages/prettier-plugin/src/index.test.js
@@ -2638,6 +2638,35 @@ component Child({ something }) {
 			expect(result).toBeWithNewline(expected);
 		});
 
+		it('prints satisfies expressions in switch default cases', async () => {
+			const input = `export component Test(props: { status: "ok" | "error" }) {
+  switch (props.status) {
+    case "ok":
+      <div>"ok"</div>
+      return
+    case "error":
+      <div>"error"</div>
+      return
+    default:
+      props.status satisfies never
+  }
+}`;
+			const expected = `export component Test(props: { status: "ok" | "error" }) {
+  switch (props.status) {
+    case "ok":
+      <div>"ok"</div>
+      return;
+    case "error":
+      <div>"error"</div>
+      return;
+    default:
+      props.status satisfies never;
+  }
+}`;
+			const result = await format(input);
+			expect(result).toBeWithNewline(expected);
+		});
+
 		it('prints function with a rest parameter correctly', async () => {
 			const expected = `function TestRest(...args: string[]) {
   console.log(args);


### PR DESCRIPTION
Fixes the Prettier plugin’s handling of `TSSatisfiesExpression` nodes. Previously, expressions like `props.status satisfies never` fell through to the unknown-node fallback and formatted as `/* Unknown: TSSatisfiesExpression */`.

Changes:
- Adds printer support for `TSSatisfiesExpression`.
- Adds a regression test for a switch exhaustiveness default case.