### PR TITLE
fix(prettier): do not force parens on fragment returns

### DIFF
--- a/.changeset/quiet-template-arrows.md
+++ b/.changeset/quiet-template-arrows.md
@@ -1,0 +1,5 @@
+---
+"@tsrx/prettier-plugin": patch
+---
+
+Avoid forcing parentheses around template arrow returns in JSX attributes and format explicit `<tsx>` blocks across lines.

--- a/packages/prettier-plugin/src/index.js
+++ b/packages/prettier-plugin/src/index.js
@@ -2839,20 +2839,15 @@ function printArrowFunction(node, path, options, print, args) {
 		// to avoid ambiguity with block statements or to clarify intent
 		const bodyDoc = path.call(print, 'body');
 		const groupId = Symbol('arrow');
-		const shouldBreakBody = shouldBreakArrowExpressionBody(node.body, options);
+		const shouldBreakBody = shouldBreakArrowExpressionBody(node.body, options, args);
 		/** @type {Doc | Doc[]} */
 		let bodyContent;
 		if (
 			node.body.type === 'ObjectExpression' ||
 			node.body.type === 'AssignmentExpression' ||
-			node.body.type === 'SequenceExpression' ||
-			(args?.isInAttribute && isTemplateExpression(node.body))
+			node.body.type === 'SequenceExpression'
 		) {
-			if (isTemplateExpression(node.body)) {
-				bodyContent = ['(', indent([hardline, bodyDoc]), hardline, ')'];
-			} else {
-				bodyContent = ['(', bodyDoc, ')'];
-			}
+			bodyContent = ['(', bodyDoc, ')'];
 		} else {
 			bodyContent = bodyDoc;
 		}
@@ -2883,6 +2878,15 @@ function isTemplateExpression(node) {
 		node.type === 'JSXElement' ||
 		node.type === 'JSXFragment'
 	);
+}
+
+/**
+ * Check whether a braced attribute expression should close on its own line.
+ * @param {AST.Node} node - The expression inside the attribute braces
+ * @returns {boolean}
+ */
+function shouldBreakAttributeExpressionClosingBrace(node) {
+	return node.type === 'ArrowFunctionExpression' && node.body && isTemplateExpression(node.body);
 }
 
 /**
@@ -3095,9 +3099,13 @@ function sourceSpanExceedsPrintWidth(node, options) {
  * Check if an arrow expression body should break immediately after `=>`.
  * @param {AST.Expression} node - The arrow body expression
  * @param {RippleFormatOptions} options - Prettier options
+ * @param {PrintArgs} [args] - Additional context arguments
  * @returns {boolean}
  */
-function shouldBreakArrowExpressionBody(node, options) {
+function shouldBreakArrowExpressionBody(node, options, args) {
+	if (args?.isInAttribute && isTemplateExpression(node)) {
+		return true;
+	}
 	return (
 		(node.type === 'BinaryExpression' || node.type === 'LogicalExpression') &&
 		sourceSpanExceedsPrintWidth(/** @type {AST.NodeWithLocation} */ (node), options)
@@ -5778,7 +5786,7 @@ function printTsx(node, path, options, print) {
 		return [tagName, closingTagName];
 	}
 
-	if (printedChildren.length > 1) {
+	if (!is_fragment || printedChildren.length > 1) {
 		return group([
 			tagName,
 			indent([hardline, join(hardline, printedChildren)]),
@@ -6192,11 +6200,15 @@ function printJSXAttribute(attr, path, options, print) {
 	}
 
 	if (attr.value.type === 'JSXExpressionContainer') {
+		const expression = attr.value.expression;
 		const exprDoc = path.call(
 			(valuePath) => print(valuePath, { isInAttribute: true }),
 			'value',
 			'expression',
 		);
+		if (shouldBreakAttributeExpressionClosingBrace(expression)) {
+			return [name, '={', exprDoc, hardline, '}'];
+		}
 		return [name, '={', exprDoc, '}'];
 	}
 
@@ -6774,6 +6786,9 @@ function printAttribute(node, path, options, print) {
 			parts.push('={');
 			// Pass inline context for attribute values (keep objects compact)
 			parts.push(path.call((attrPath) => print(attrPath, { isInAttribute: true }), 'value'));
+			if (shouldBreakAttributeExpressionClosingBrace(node.value)) {
+				parts.push(hardline);
+			}
 			parts.push('}');
 		}
 	}

--- a/packages/prettier-plugin/src/index.test.js
+++ b/packages/prettier-plugin/src/index.test.js
@@ -200,6 +200,58 @@ describe('prettier-plugin', () => {
 			expect(result).toBeWithNewline(expected);
 		});
 
+		it('should format explicit tsx arrow returns like tsrx blocks', async () => {
+			const input = `component Test(props) {
+	const func = (item) => <tsx><ItemView item={item} onSelect={props.onSelect} /></tsx>;
+
+	<List
+		items={props.items}
+		renderItem={(item) => <tsx><ItemView item={item} onSelect={props.onSelect} /></tsx>}
+	/>
+}`;
+			const expected = `component Test(props) {
+  const func = (item) => <tsx>
+    <ItemView item={item} onSelect={props.onSelect} />
+  </tsx>;
+
+  <List
+    items={props.items}
+    renderItem={(item) =>
+      <tsx>
+        <ItemView item={item} onSelect={props.onSelect} />
+      </tsx>
+    }
+  />
+}`;
+			const result = await format(input);
+			expect(result).toBeWithNewline(expected);
+		});
+
+		it('should format template arrow returns in tsx attributes like ripple attributes', async () => {
+			const input = `component Test(props) {
+	const view = <tsx>
+		<List
+			items={props.items}
+			renderItem={(item) => <tsx><ItemView item={item} onSelect={props.onSelect} /></tsx>}
+		/>
+	</tsx>;
+}`;
+			const expected = `component Test(props) {
+  const view = <tsx>
+    <List
+      items={props.items}
+      renderItem={(item) =>
+        <tsx>
+          <ItemView item={item} onSelect={props.onSelect} />
+        </tsx>
+      }
+    />
+  </tsx>;
+}`;
+			const result = await format(input);
+			expect(result).toBeWithNewline(expected);
+		});
+
 		it('should preserve comments before expressions after nested tsx and tsrx blocks', async () => {
 			const input = `component App() {
 	const content = <tsx>
@@ -255,7 +307,7 @@ describe('prettier-plugin', () => {
 }`,
 					expected: `component Test() {
   <A
-    fallback={(error) => (
+    fallback={(error) =>
       <>
         <B
           id="xyz"
@@ -265,7 +317,7 @@ describe('prettier-plugin', () => {
           otherProp={2}
         />
       </>
-    )}
+    }
   />
 }`,
 				},
@@ -279,7 +331,7 @@ describe('prettier-plugin', () => {
 }`,
 					expected: `component Test() {
   <A
-    fallback={(error) => (
+    fallback={(error) =>
       <tsx>
         <B
           id="xyz"
@@ -289,7 +341,7 @@ describe('prettier-plugin', () => {
           otherProp={2}
         />
       </tsx>
-    )}
+    }
   />
 }`,
 				},
@@ -303,7 +355,7 @@ describe('prettier-plugin', () => {
 }`,
 					expected: `component Test() {
   <A
-    fallback={(error) => (
+    fallback={(error) =>
       <tsrx>
         <B
           id="xyz"
@@ -313,7 +365,7 @@ describe('prettier-plugin', () => {
           otherProp={2}
         />
       </tsrx>
-    )}
+    }
   />
 }`,
 				},
@@ -327,7 +379,7 @@ describe('prettier-plugin', () => {
 }`,
 					expected: `component Test() {
   <A
-    fallback={(error) => (
+    fallback={(error) =>
       <tsx:react>
         <B
           id="xyz"
@@ -337,7 +389,7 @@ describe('prettier-plugin', () => {
           otherProp={2}
         />
       </tsx:react>
-    )}
+    }
   />
 }`,
 				},
@@ -1015,7 +1067,9 @@ import { Something, type Props, track } from 'ripple';`;
 const foo = <tsx><Bar {...props} /></tsx>;`;
 
 			const expected = `const props = {};
-const foo = <tsx><Bar {...props} /></tsx>;`;
+const foo = <tsx>
+  <Bar {...props} />
+</tsx>;`;
 
 			const result = await format(input, { singleQuote: true });
 			expect(result).toBeWithNewline(expected);
@@ -2279,7 +2333,9 @@ files = [...(files ?? []), ...dt.files];`;
 
 			const expected = `class Foo {
   bar() {
-    return <tsx>{'Hello'}</tsx>;
+    return <tsx>
+      {'Hello'}
+    </tsx>;
   }
 }`;
 

--- a/packages/ripple/tests/client/tsx.test.tsrx
+++ b/packages/ripple/tests/client/tsx.test.tsrx
@@ -37,7 +37,9 @@ describe('tsx expression', () => {
 
 	it('renders a basic fragment shorthand element', () => {
 		component App() {
-			const el = <tsx><div>hello world</div></tsx>;
+			const el = <tsx>
+				<div>hello world</div>
+			</tsx>;
 			{el}
 		}
 		render(App);
@@ -97,7 +99,9 @@ describe('tsx expression', () => {
 
 	it('renders a tsx element assigned to a variable', () => {
 		component App() {
-			const el = <tsx><span class="test">content</span></tsx>;
+			const el = <tsx>
+				<span class="test">content</span>
+			</tsx>;
 			{el}
 		}
 		render(App);
@@ -140,7 +144,9 @@ describe('tsx expression', () => {
 
 	it('renders a tsx element inline in a parent element', () => {
 		component App() {
-			const el = <tsx><span>inline</span></tsx>;
+			const el = <tsx>
+				<span>inline</span>
+			</tsx>;
 			<div class="parent">{el}</div>
 		}
 		render(App);
@@ -172,7 +178,9 @@ describe('tsx expression', () => {
 	it('conditionally renders tsx elements', () => {
 		component App() {
 			let &[show] = track(true);
-			const el = <tsx><div class="tsx-content">visible</div></tsx>;
+			const el = <tsx>
+				<div class="tsx-content">visible</div>
+			</tsx>;
 
 			if (show) {
 				{el}
@@ -197,7 +205,9 @@ describe('tsx expression', () => {
 		}
 
 		component App() {
-			const el = <tsx><span>from tsx</span></tsx>;
+			const el = <tsx>
+				<span>from tsx</span>
+			</tsx>;
 			<Child children={el} />
 		}
 		render(App);
@@ -209,7 +219,9 @@ describe('tsx expression', () => {
 
 	it('renders tsx element with text content only', () => {
 		component App() {
-			const el = <tsx>just text</tsx>;
+			const el = <tsx>
+				just text
+			</tsx>;
 			{el}
 		}
 
@@ -237,7 +249,9 @@ describe('tsx expression', () => {
 		component App() {
 			let &[name] = track('initial');
 
-			const el = <tsx><div id={name} class={'cls-' + name}>content</div></tsx>;
+			const el = <tsx>
+				<div id={name} class={'cls-' + name}>content</div>
+			</tsx>;
 			{el}
 			<button onClick={() => (name = 'updated')}>{'update'}</button>
 		}
@@ -299,7 +313,9 @@ describe('tsx expression', () => {
 		component App() {
 			let &[color] = track('red');
 
-			const el = <tsx><div style={'color: ' + color}>styled</div></tsx>;
+			const el = <tsx>
+				<div style={'color: ' + color}>styled</div>
+			</tsx>;
 			{el}
 			<button onClick={() => (color = 'blue')}>{'change color'}</button>
 		}
@@ -351,7 +367,11 @@ describe('tsx expression', () => {
 		}
 
 		component App() {
-			<Wrapper content={<tsx><span class="inner">direct prop</span></tsx>} />
+			<Wrapper
+				content={<tsx>
+					<span class="inner">direct prop</span>
+				</tsx>}
+			/>
 		}
 
 		render(App);
@@ -371,8 +391,12 @@ describe('tsx expression', () => {
 
 		component App() {
 			<Card
-				title={<tsx><span class="bold">Title</span></tsx>}
-				children={<tsx><p>Card content here</p></tsx>}
+				title={<tsx>
+					<span class="bold">Title</span>
+				</tsx>}
+				children={<tsx>
+					<p>Card content here</p>
+				</tsx>}
 			/>
 		}
 
@@ -384,7 +408,9 @@ describe('tsx expression', () => {
 
 	it('renders tsx from function defined outside component', () => {
 		function createBadge(label: string) {
-			return <tsx><span class="badge">{label}</span></tsx>;
+			return <tsx>
+				<span class="badge">{label}</span>
+			</tsx>;
 		}
 
 		component App() {
@@ -399,7 +425,9 @@ describe('tsx expression', () => {
 
 	it('renders tsx from function with multiple elements', () => {
 		function createListItem(item: string) {
-			return <tsx><li class="list-item">{item}</li></tsx>;
+			return <tsx>
+				<li class="list-item">{item}</li>
+			</tsx>;
 		}
 
 		component App() {
@@ -479,7 +507,9 @@ describe('tsx expression', () => {
 
 	it('renders nested tsx from multiple functions', () => {
 		function createIcon(name: string) {
-			return <tsx><i class={'icon icon-' + name}></i></tsx>;
+			return <tsx>
+				<i class={'icon icon-' + name}></i>
+			</tsx>;
 		}
 
 		function createButton(icon: string, label: string) {
@@ -521,7 +551,9 @@ describe('tsx expression', () => {
 		}
 
 		component App() {
-			{<tsx>{[1, 2, 3].map((item) => <div class="app-item">{item}</div>)}</tsx>}
+			{<tsx>
+				{[1, 2, 3].map((item) => <div class="app-item">{item}</div>)}
+			</tsx>}
 			{makeFragment('from helper')}
 		}
 
@@ -615,7 +647,12 @@ describe('tsx expression', () => {
 
 		component App() {
 			<Alert message="No icon" />
-			<Alert icon={<tsx><span class="custom-icon">✓</span></tsx>} message="Custom icon" />
+			<Alert
+				icon={<tsx>
+					<span class="custom-icon">✓</span>
+				</tsx>}
+				message="Custom icon"
+			/>
 		}
 
 		render(App);
@@ -627,7 +664,9 @@ describe('tsx expression', () => {
 
 	it('renders tsx stored in array via function', () => {
 		function createItem(className: string, content: string) {
-			return <tsx><div class={className}>{content}</div></tsx>;
+			return <tsx>
+				<div class={className}>{content}</div>
+			</tsx>;
 		}
 
 		component App() {
@@ -654,11 +693,17 @@ describe('tsx expression', () => {
 	it('renders tsx conditionally from function', () => {
 		function createContent(type: string) {
 			if (type === 'success') {
-				return <tsx><div class="success">Success!</div></tsx>;
+				return <tsx>
+					<div class="success">Success!</div>
+				</tsx>;
 			} else if (type === 'error') {
-				return <tsx><div class="error">Error!</div></tsx>;
+				return <tsx>
+					<div class="error">Error!</div>
+				</tsx>;
 			}
-			return <tsx><div class="default">Default</div></tsx>;
+			return <tsx>
+				<div class="default">Default</div>
+			</tsx>;
 		}
 
 		component App() {

--- a/packages/ripple/tests/hydration/components/basic.tsrx
+++ b/packages/ripple/tests/hydration/components/basic.tsrx
@@ -83,7 +83,9 @@ function makeNestedTsxTsrxFragment(label: string) {
 }
 
 export component NestedTsxTsrxExpressionValues() {
-	{<tsx>{[1, 2, 3].map((item) => <div class="app-item">{item}</div>)}</tsx>}
+	{<tsx>
+		{[1, 2, 3].map((item) => <div class="app-item">{item}</div>)}
+	</tsx>}
 	{makeNestedTsxTsrxFragment('from helper')}
 }
 

--- a/packages/ripple/tests/server/basic.test.tsrx
+++ b/packages/ripple/tests/server/basic.test.tsrx
@@ -73,7 +73,9 @@ second"</pre>
 		}
 
 		component Basic() {
-			{<tsx>{[1, 2, 3].map((item) => <div class="app-item">{item}</div>)}</tsx>}
+			{<tsx>
+				{[1, 2, 3].map((item) => <div class="app-item">{item}</div>)}
+			</tsx>}
 			{makeFragment('from helper')}
 		}
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core formatting heuristics for arrow functions and `<tsx>` printing, which can affect many code paths and introduce output churn or edge-case misformatting. Risk is limited to developer tooling (Prettier plugin) with test coverage added/updated.
> 
> **Overview**
> Adjusts the Prettier plugin to **stop forcing parentheses** around arrow-function returns when the body is a template expression (`<tsx>`, `<tsrx>`, JSX elements/fragments) in JSX/Ripple attributes, and instead breaks after `=>` and places the closing `}` on its own line for these cases.
> 
> Also updates `<tsx>` printing so explicit `<tsx>...</tsx>` blocks with a single child (non-fragment) are formatted across multiple lines (consistent with `<tsrx>`), and refreshes/adds formatter and Ripple runtime tests to match the new output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5e69c82b4c710c268e2fb225c39d76a1c0e55dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->