### PR TITLE
fix: parse, recognize tsrx inside tsx

### DIFF
--- a/.changeset/fair-tsrx-shorthand.md
+++ b/.changeset/fair-tsrx-shorthand.md
@@ -1,0 +1,5 @@
+---
+'@tsrx/core': patch
+---
+
+Allow native TSRX shorthand attributes inside `<tsrx>` blocks nested under TSX.

--- a/packages/tsrx/src/plugin.js
+++ b/packages/tsrx/src/plugin.js
@@ -826,7 +826,11 @@ export function TSRXPlugin(config) {
 			}
 
 			#isDoubleQuotedTextChildStart() {
-				if (this.#path.findLast((n) => n.type === 'TsxCompat' || n.type === 'Tsx')) {
+				const current_template_node = this.#path.findLast(
+					(n) =>
+						n.type === 'Element' || n.type === 'Tsx' || n.type === 'Tsrx' || n.type === 'TsxCompat',
+				);
+				if (current_template_node?.type === 'TsxCompat' || current_template_node?.type === 'Tsx') {
 					return false;
 				}
 
@@ -2028,8 +2032,17 @@ export function TSRXPlugin(config) {
 					);
 
 				if (this.eat(tt.braceL)) {
-					const inside_tsx = this.#path.findLast((n) => n.type === 'TsxCompat' || n.type === 'Tsx');
-					if (inside_tsx) {
+					const current_template_node = this.#path.findLast(
+						(n) =>
+							n.type === 'Element' ||
+							n.type === 'Tsx' ||
+							n.type === 'Tsrx' ||
+							n.type === 'TsxCompat',
+					);
+					if (
+						current_template_node?.type === 'Tsx' ||
+						current_template_node?.type === 'TsxCompat'
+					) {
 						if (this.type === tt.ellipsis) {
 							this.expect(tt.ellipsis);
 							/** @type {ESTreeJSX.JSXSpreadAttribute} */ (node).argument = this.parseMaybeAssign();

--- a/packages/tsrx/tests/shared/compile.js
+++ b/packages/tsrx/tests/shared/compile.js
@@ -198,6 +198,31 @@ export function runSharedTsxExpressionTsrxTests({ compile, name, classAttrName }
 			expect(code).toContain(` ${classAttrName}={classes.contentEditable}`);
 			expect(code).toContain(`placeholder={<div ${classAttrName}={classes.placeholder}>`);
 		});
+
+		it('allows native shorthand attributes in tsrx blocks nested under TSX', () => {
+			const { code } = compile(
+				`export function Test(props) {
+					return <>
+						<List
+							items={props.items}
+							renderItem={(item) =>
+								<tsrx>
+									<ItemView {item} onSelect={props.onSelect}>
+										"Selected"
+									</ItemView>
+								</tsrx>
+							}
+						/>
+					</>;
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).not.toContain('<tsrx>');
+			expect(code).toContain('item={item}');
+			expect(code).toContain('onSelect={props.onSelect}');
+			expect(code).toContain('{"Selected"}');
+		});
 	});
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches TSRX/TSX parsing heuristics in `plugin.js`, which can subtly affect tokenization/attribute parsing across mixed-template code. Scope is small and covered by a new regression test, but parser changes can have edge-case fallout.
> 
> **Overview**
> Allows native TSRX shorthand attributes (e.g. `<ItemView {item} />`) to parse correctly inside `<tsrx>` blocks that are *nested within TSX/JSX*.
> 
> This adjusts template-context detection in the parser (`#isDoubleQuotedTextChildStart` and `jsx_parseAttribute`) so TSX-only attribute rules apply only when the *current* template node is TSX/compat, not merely when any TSX exists in the ancestor path, and adds a shared compile regression test plus a patch changeset for `@tsrx/core`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a02c3578088a078cb9032b6eb2e9d2f68d903179. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->