### PR TITLE
chore(zed-plugin): .gitignore extension.wasm, compiled during extension install

### DIFF
--- a/packages/zed-plugin/.gitignore
+++ b/packages/zed-plugin/.gitignore
@@ -3,3 +3,4 @@ target/
 
 # Zed build artifacts (grammar checkout + compiled wasm)
 grammars/
+extension.wasm


### PR DESCRIPTION
when i installed the extension in zed `extension.wasm` was generated. I assume this should be ignored.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only updates `.gitignore` and does not affect runtime behavior or build logic.
> 
> **Overview**
> Prevents the Zed extension install/build from polluting git status by adding `extension.wasm` to `packages/zed-plugin/.gitignore`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3e387dd8e0fde5b63aa10af6344f53e64e42725. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->