### PR TITLE
feat: type support for refs: anonymous, named and ref attr, fix returnType

### DIFF
--- a/.changeset/refkey-jsx-types.md
+++ b/.changeset/refkey-jsx-types.md
@@ -1,9 +1,14 @@
 ---
 'ripple': patch
+'@tsrx/ripple': patch
+'@tsrx/react': patch
+'@tsrx/preact': patch
+'@tsrx/solid': patch
+'@tsrx/vue': patch
 '@tsrx/core': patch
 '@tsrx/prettier-plugin': patch
 ---
 
-Type host `ref={...}` attributes and generated ref keys so inline callbacks `{ref ...}` receive element-specific JSX types.
+Type host `ref={...}` attributes, named ref props, and generated ref keys so inline callbacks `{ref ...}` receive element-specific JSX types.
 
 Exclude `returnType` from the compiler types that use typeAnnotation instead due to the way `@sveltejs/acorn-typescript` parses them.

--- a/.changeset/refkey-jsx-types.md
+++ b/.changeset/refkey-jsx-types.md
@@ -1,0 +1,9 @@
+---
+'ripple': patch
+'@tsrx/core': patch
+'@tsrx/prettier-plugin': patch
+---
+
+Type host `ref={...}` attributes and generated ref keys so inline callbacks `{ref ...}` receive element-specific JSX types.
+
+Exclude `returnType` from the compiler types that use typeAnnotation instead due to the way `@sveltejs/acorn-typescript` parses them.

--- a/packages/prettier-plugin/src/index.js
+++ b/packages/prettier-plugin/src/index.js
@@ -2182,9 +2182,7 @@ function printRippleNode(node, path, options, print, args) {
 
 			// Handle return type
 			parts.push(' => ');
-			if (node.returnType) {
-				parts.push(path.call(print, 'returnType'));
-			} else if (node.typeAnnotation) {
+			if (node.typeAnnotation) {
 				parts.push(path.call(print, 'typeAnnotation'));
 			}
 
@@ -5495,9 +5493,7 @@ function printTSConstructorType(node, path, options, print) {
 	}
 	parts.push(')');
 	parts.push(' => ');
-	if (node.returnType) {
-		parts.push(path.call(print, 'returnType'));
-	} else if (node.typeAnnotation) {
+	if (node.typeAnnotation) {
 		parts.push(path.call(print, 'typeAnnotation'));
 	}
 	return parts;

--- a/packages/ripple/src/jsx-runtime.d.ts
+++ b/packages/ripple/src/jsx-runtime.d.ts
@@ -1,4 +1,4 @@
-import type { AddEventObject, TSRXElement } from '#public';
+import type { AddEventObject, RefKey, TSRXElement } from '#public';
 import type { Nullable } from '#helpers';
 
 /**
@@ -66,6 +66,17 @@ type EventHandlerObject<
 type EventHandlerValue<Target extends globalThis.EventTarget, EventType extends globalThis.Event> =
 	| EventHandler<Target, EventType>
 	| EventHandlerObject<Target, EventType>;
+
+type RefValue<Target extends globalThis.Element> =
+	| ((node: Target) => void | (() => void))
+	| { value: Target | null }
+	| Target
+	| null
+	| undefined;
+
+type RefAttribute<Target extends globalThis.Element> = {
+	[Key in RefKey]?: RefValue<Target>;
+};
 
 type ElementEventHandler<
 	Target extends globalThis.EventTarget,
@@ -459,7 +470,10 @@ type SlotHTMLAttributes<Target extends HTMLSlotElement = HTMLSlotElement> =
 	};
 
 // Base HTML attributes
-interface HTMLAttributes<Target extends globalThis.Element = globalThis.HTMLElement> {
+interface HTMLAttributes<
+	Target extends globalThis.Element = globalThis.HTMLElement,
+> extends RefAttribute<Target> {
+	ref?: RefValue<Target>;
 	class?: ClassValue | undefined | null;
 	className?: Nullable<string>;
 	id?: Nullable<string>;
@@ -1255,7 +1269,7 @@ declare global {
 			template: HTMLAttributes<HTMLTemplateElement>;
 
 			// Catch-all for any other elements
-			[elemName: string]: HTMLAttributes<never>;
+			[elemName: string]: HTMLAttributes<any>;
 		}
 
 		interface ElementChildrenAttribute {

--- a/packages/ripple/types/index.d.ts
+++ b/packages/ripple/types/index.d.ts
@@ -4,6 +4,8 @@ export type { AddEventOptions, AddEventObject, ExtendedEventOptions } from '@tsr
 export type Component<T = Record<string, any>> = (props: T) => void;
 
 declare const TSRX_ELEMENT: unique symbol;
+declare const REF_KEY: unique symbol;
+export type RefKey = typeof REF_KEY;
 
 export type TSRXElement = {
 	readonly render: Function;
@@ -149,7 +151,7 @@ declare global {
 	};
 }
 
-export function createRefKey(): symbol;
+export function createRefKey(): RefKey;
 
 export function isRefProp(value: unknown): boolean;
 

--- a/packages/tsrx-ripple/src/transform/client/index.js
+++ b/packages/tsrx-ripple/src/transform/client/index.js
@@ -42,10 +42,12 @@ import {
 	getOriginalEventName,
 	isEventAttribute,
 	isInsideComponent as is_inside_component,
+	isRefExpressionAttributeValue as is_ref_expression_attribute_value,
 	normalizeEventName,
 	shouldPreserveComment,
 	formatComment,
 	setLocation,
+	createElementRefTargetTypeForName as create_element_ref_target_type_for_name,
 } from '@tsrx/core';
 const b = builders;
 import {
@@ -582,10 +584,29 @@ function create_ref_value_call(source_argument, context) {
 	const args = [b.thunk(argument)];
 	add_ref_setter_arg(args, source, argument);
 
-	return b.call(
+	const call = b.call(
 		state.to_ts ? set_hidden_import_from_ripple('createRefProp', context) : '_$_.create_ref_prop',
 		...args,
 	);
+	if (state.to_ts && state.ref_target_type) {
+		call.typeArguments = b.ts_type_parameter_instantiation([state.ref_target_type]);
+	}
+	return call;
+}
+
+/**
+ * @param {AST.Element} node
+ * @param {TransformClientState} state
+ * @returns {AST.TypeNode | null}
+ */
+function create_element_ref_target_type(node, state) {
+	if (!is_element_dom_element(node)) {
+		return null;
+	}
+	const element_name = /** @type {AST.Identifier} */ (node.id).name;
+	const namespace =
+		element_name === 'svg' ? 'svg' : element_name === 'math' ? 'mathml' : state.namespace;
+	return create_element_ref_target_type_for_name(element_name, namespace);
 }
 
 /**
@@ -3311,6 +3332,15 @@ function transform_ts_child(node, context) {
 		/** @type {ESTreeJSX.JSXElement['children']} */
 		const children = [];
 		let has_children_props = false;
+		const is_dom_element = is_element_dom_element(node);
+		const element_name =
+			/** @type {AST.Node} */ (node.id).type === 'Identifier'
+				? /** @type {AST.Identifier} */ (node.id).name
+				: null;
+		const child_namespace =
+			is_dom_element && element_name !== null
+				? determine_namespace_for_children(element_name, state.namespace)
+				: state.namespace;
 
 		const attributes = node.attributes.map((attr) => {
 			if (attr.type === 'Attribute') {
@@ -3318,13 +3348,22 @@ function transform_ts_child(node, context) {
 				const attr_value = /** @type { AST.Expression & AST.NodeWithLocation | null} */ (
 					attr.value
 				);
+				const ref_target_type = is_ref_expression_attribute_value(attr_value)
+					? create_element_ref_target_type(node, state)
+					: null;
 				const value =
 					attr_value === null
 						? // <div attr>, not adding `name` for loc because `jsx_name` below
 							// will take care of the mapping JSXAttribute's JSXIdentifier
 							b.literal(true)
 						: // reset init, update, final to avoid adding attr value to the component body
-							visit(attr_value, SetStateForOutsideComponent(state));
+							visit(
+								attr_value,
+								SetStateForOutsideComponent(
+									state,
+									ref_target_type ? { ref_target_type } : undefined,
+								),
+							);
 
 				// Handle both regular identifiers and tracked identifiers
 				/** @type {string} */
@@ -3403,10 +3442,9 @@ function transform_ts_child(node, context) {
 		});
 
 		if (!node.selfClosing && !node.unclosed && !has_children_props && node.children.length > 0) {
-			const is_dom_element = is_element_dom_element(node);
 			const component_scope = /** @type {ScopeInterface} */ (context.state.scopes.get(node));
 			const thunk =
-				/** @type {AST.Identifier} */ (node.id).name === 'style'
+				element_name === 'style'
 					? null
 					: b.thunk(
 							b.block(
@@ -3415,10 +3453,8 @@ function transform_ts_child(node, context) {
 									state: {
 										...state,
 										scope: component_scope,
-										inside_head:
-											/** @type {AST.Identifier} */ (node.id).name === 'head'
-												? true
-												: state.inside_head,
+										inside_head: element_name === 'head' ? true : state.inside_head,
+										namespace: child_namespace,
 										skip_children_traversal: is_dom_element,
 									},
 								}),

--- a/packages/tsrx-ripple/tests/basic.test.js
+++ b/packages/tsrx-ripple/tests/basic.test.js
@@ -150,9 +150,32 @@ describe('@tsrx/ripple named ref props', () => {
 
 		expect(code).toContain("import { _$_RefProp__create } from 'ripple/compiler/internal/import';");
 		expect(code).toContain(
-			'<input input_ref={_$_RefProp__create(() => input, (v) => input = v)} />',
+			"<input input_ref={_$_RefProp__create<HTMLElementTagNameMap['input']>(() => input, (v) => input = v)} />",
 		);
 		expect(code).not.toContain('input_ref={ref input}');
+	});
+
+	it('preserves child namespaces for nested host ref props in Volar TypeScript output', () => {
+		const { code } = compile_to_volar_mappings(
+			`component App() {
+				let circle;
+				let div;
+				<svg>
+					<circle circle_ref={ref circle} />
+					<foreignObject>
+						<div div_ref={ref div} />
+					</foreignObject>
+				</svg>
+			}`,
+			'App.tsrx',
+		);
+
+		expect(code).toContain(
+			"<circle circle_ref={_$_RefProp__create<SVGElementTagNameMap['circle']>(() => circle, (v) => circle = v)} />",
+		);
+		expect(code).toContain(
+			"<div div_ref={_$_RefProp__create<HTMLElementTagNameMap['div']>(() => div, (v) => div = v)} />",
+		);
 	});
 
 	it('does not map the generated named ref setter back to the source ref target', () => {

--- a/packages/tsrx-solid/src/transform.js
+++ b/packages/tsrx-solid/src/transform.js
@@ -4,7 +4,9 @@
 
 import {
 	createJsxTransform,
+	createElementRefTargetType,
 	error,
+	addRefTargetTypeToRefPropAttributes as add_ref_target_type_to_ref_prop_attributes,
 	mergeDuplicateRefs,
 	toJsxAttribute,
 	validateAtMostOneRefAttribute,
@@ -1490,6 +1492,7 @@ function to_jsx_element(node, transform_context, pre_walk_children) {
 		node.attributes || [],
 		is_composite,
 		transform_context,
+		node,
 	);
 
 	const html_child_transform = rewrite_host_html_children(
@@ -1656,9 +1659,10 @@ function has_text_content_attribute(attributes) {
  * @param {any[]} raw_attrs
  * @param {boolean} is_composite
  * @param {TransformContext} transform_context
+ * @param {any} element
  * @returns {any[]}
  */
-function transform_element_attributes(raw_attrs, is_composite, transform_context) {
+function transform_element_attributes(raw_attrs, is_composite, transform_context, element) {
 	validateAtMostOneRefAttribute(raw_attrs, /** @type {any} */ (transform_context));
 	/** @type {any[]} */
 	const result = [];
@@ -1670,6 +1674,12 @@ function transform_element_attributes(raw_attrs, is_composite, transform_context
 	)) {
 		if (!attr) continue;
 		result.push(toJsxAttribute(attr, /** @type {any} */ (transform_context)));
+	}
+	if (transform_context.typeOnly) {
+		add_ref_target_type_to_ref_prop_attributes(
+			result,
+			!is_composite ? createElementRefTargetType(element) : null,
+		);
 	}
 	return mergeDuplicateRefs(
 		normalize_solid_host_ref_spreads(result, !is_composite, transform_context),
@@ -1837,6 +1847,7 @@ function create_dynamic_jsx_element(dynamic_id, node, transform_context) {
 		node.attributes || [],
 		is_composite,
 		transform_context,
+		null,
 	);
 	const selfClosing = !!node.selfClosing;
 	const children = create_element_children(node.children || [], transform_context);

--- a/packages/tsrx/src/index.js
+++ b/packages/tsrx/src/index.js
@@ -142,6 +142,7 @@ export { escape, escape_script as escapeScript } from './utils/escaping.js';
 
 // Transform
 export {
+	add_ref_target_type_to_ref_prop_attributes as addRefTargetTypeToRefPropAttributes,
 	add_jsx_setup_declaration as addJsxSetupDeclaration,
 	clone_switch_helper_invocation as cloneSwitchHelperInvocation,
 	collect_param_bindings as collectParamBindings,
@@ -149,12 +150,15 @@ export {
 	create_hook_safe_helper as createHookSafeHelper,
 	create_host_html_attribute as createHostHtmlAttribute,
 	create_host_html_conflict_error as createHostHtmlConflictError,
+	create_element_ref_target_type as createElementRefTargetType,
+	create_element_ref_target_type_for_name as createElementRefTargetTypeForName,
 	createJsxTransform,
 	CREATE_REF_PROP_INTERNAL_NAME,
 	extract_jsx_setup_declarations as extractJsxSetupDeclarations,
 	get_host_html_conflicting_attribute as getHostHtmlConflictingAttribute,
 	get_invalid_html_child_error_message as getInvalidHtmlChildErrorMessage,
 	is_component_like_element,
+	is_ref_expression_attribute_value as isRefExpressionAttributeValue,
 	is_ref_prop_expression as isRefPropExpression,
 	MERGE_REFS_INTERNAL_NAME,
 	merge_duplicate_refs as mergeDuplicateRefs,

--- a/packages/tsrx/src/transform/jsx/index.js
+++ b/packages/tsrx/src/transform/jsx/index.js
@@ -570,6 +570,12 @@ export function createJsxTransform(platform) {
 					!is_component,
 					transform_context,
 				);
+				if (transform_context.typeOnly) {
+					add_ref_target_type_to_ref_prop_attributes(
+						attrs,
+						!is_component ? create_element_ref_target_type(visited) : null,
+					);
+				}
 				return {
 					...visited,
 					attributes: merge_duplicate_refs(
@@ -5174,10 +5180,41 @@ function transform_element_attributes_dispatch(attrs, transform_context, element
 	const result = hook
 		? hook(attrs, transform_context, element)
 		: attrs.map((/** @type {any} */ a) => to_jsx_attribute(a, transform_context));
+	if (transform_context.typeOnly) {
+		add_ref_target_type_to_ref_prop_attributes(
+			result,
+			!is_component ? create_element_ref_target_type(element) : null,
+		);
+	}
 	return merge_duplicate_refs(
 		normalize_host_ref_spreads(result, !is_component, transform_context),
 		transform_context,
 	);
+}
+
+/**
+ * @param {any[]} attrs
+ * @param {AST.TypeNode | null} ref_target_type
+ * @returns {void}
+ */
+export function add_ref_target_type_to_ref_prop_attributes(attrs, ref_target_type) {
+	if (!ref_target_type) return;
+	for (const attr of attrs) {
+		const expression =
+			attr?.type === 'JSXAttribute' &&
+			attr.value?.type === 'JSXExpressionContainer' &&
+			attr.value.expression?.type !== 'JSXEmptyExpression'
+				? attr.value.expression
+				: null;
+		if (
+			expression?.type === 'CallExpression' &&
+			expression.callee?.type === 'Identifier' &&
+			expression.callee.name === CREATE_REF_PROP_INTERNAL_NAME &&
+			!expression.typeArguments
+		) {
+			expression.typeArguments = b.ts_type_parameter_instantiation([ref_target_type]);
+		}
+	}
 }
 
 /**
@@ -5596,6 +5633,115 @@ export const CREATE_REF_PROP_INTERNAL_NAME = '__create_ref_prop';
 export const NORMALIZE_SPREAD_PROPS_INTERNAL_NAME = '__normalize_spread_props';
 export const MAP_ITERABLE_INTERNAL_NAME = '__map_iterable';
 export const ITERATION_VALUE_INTERNAL_NAME = '__IterationValue';
+
+const HTML_REF_TAG_NAMES = new Set(
+	'a abbr address area article aside audio b base bdi bdo blockquote body br button canvas caption cite code col colgroup data datalist dd del details dfn dialog div dl dt em embed fieldset figcaption figure footer form h1 h2 h3 h4 h5 h6 head header hgroup hr html i iframe img input ins kbd label legend li link main map mark menu meta meter nav noscript object ol optgroup option output p picture pre progress q rp rt ruby s samp script search section select slot small source span strong style sub summary sup table tbody td template textarea tfoot th thead time title tr track u ul var video wbr'.split(
+		' ',
+	),
+);
+
+const SVG_REF_TAG_NAMES = new Set(
+	'a animate animateMotion animateTransform circle clipPath defs desc ellipse feBlend feColorMatrix feComponentTransfer feComposite feConvolveMatrix feDiffuseLighting feDisplacementMap feDistantLight feDropShadow feFlood feFuncA feFuncB feFuncG feFuncR feGaussianBlur feImage feMerge feMergeNode feMorphology feOffset fePointLight feSpecularLighting feSpotLight feTile feTurbulence filter foreignObject g image line linearGradient marker mask metadata mpath path pattern polygon polyline radialGradient rect script set stop style svg switch symbol text textPath title tspan use view'.split(
+		' ',
+	),
+);
+
+const MATHML_REF_TAG_NAMES = new Set(
+	'annotation annotation-xml maction math merror mfrac mi mmultiscripts mn mo mover mpadded mphantom mprescripts mroot mrow ms mspace msqrt mstyle msub msubsup msup mtable mtd mtext mtr munder munderover semantics'.split(
+		' ',
+	),
+);
+
+/**
+ * @param {any} value
+ * @returns {boolean}
+ */
+export function is_ref_expression_attribute_value(value) {
+	return (
+		value?.type === 'RefExpression' ||
+		(value?.type === 'JSXExpressionContainer' && value.expression?.type === 'RefExpression')
+	);
+}
+
+/**
+ * @param {any} element
+ * @param {'html' | 'svg' | 'mathml'} [namespace]
+ * @returns {AST.TypeNode | null}
+ */
+export function create_element_ref_target_type(element, namespace) {
+	const tag_name = get_element_ref_tag_name(element);
+	return tag_name === null ? null : create_element_ref_target_type_for_name(tag_name, namespace);
+}
+
+/**
+ * @param {string} tag_name
+ * @param {'html' | 'svg' | 'mathml'} [namespace]
+ * @returns {AST.TypeNode}
+ */
+export function create_element_ref_target_type_for_name(tag_name, namespace = 'html') {
+	const resolved_namespace =
+		tag_name === 'svg'
+			? 'svg'
+			: tag_name === 'math'
+				? 'mathml'
+				: namespace === 'html'
+					? infer_ref_namespace(tag_name)
+					: namespace;
+
+	if (resolved_namespace === 'svg') {
+		return SVG_REF_TAG_NAMES.has(tag_name)
+			? create_tag_name_map_ref_type('SVGElementTagNameMap', tag_name)
+			: b.ts_type_reference(b.id('SVGElement'));
+	}
+	if (resolved_namespace === 'mathml') {
+		return MATHML_REF_TAG_NAMES.has(tag_name)
+			? create_tag_name_map_ref_type('MathMLElementTagNameMap', tag_name)
+			: b.ts_type_reference(b.id('MathMLElement'));
+	}
+	return HTML_REF_TAG_NAMES.has(tag_name)
+		? create_tag_name_map_ref_type('HTMLElementTagNameMap', tag_name)
+		: b.ts_type_reference(b.id('HTMLElement'));
+}
+
+/**
+ * @param {string} tag_name
+ * @returns {'html' | 'svg' | 'mathml'}
+ */
+function infer_ref_namespace(tag_name) {
+	if (HTML_REF_TAG_NAMES.has(tag_name)) return 'html';
+	if (SVG_REF_TAG_NAMES.has(tag_name)) return 'svg';
+	if (MATHML_REF_TAG_NAMES.has(tag_name)) return 'mathml';
+	return 'html';
+}
+
+/**
+ * @param {any} element
+ * @returns {string | null}
+ */
+function get_element_ref_tag_name(element) {
+	const id = element?.id;
+	if (id?.type === 'Identifier') return id.name;
+	const name = element?.name;
+	if (name?.type === 'JSXIdentifier') return name.name;
+	if (element?.openingElement?.name?.type === 'JSXIdentifier') {
+		return element.openingElement.name.name;
+	}
+	return null;
+}
+
+/**
+ * @param {string} map_name
+ * @param {string} tag_name
+ * @returns {AST.TypeNode}
+ */
+function create_tag_name_map_ref_type(map_name, tag_name) {
+	return /** @type {AST.TypeNode} */ ({
+		type: 'TSIndexedAccessType',
+		objectType: b.ts_type_reference(b.id(map_name)),
+		indexType: b.ts_literal_type(b.literal(tag_name)),
+		metadata: { path: [] },
+	});
+}
 
 /**
  * @param {any} attr

--- a/packages/tsrx/tests/shared/source-mappings.js
+++ b/packages/tsrx/tests/shared/source-mappings.js
@@ -936,33 +936,34 @@ export component App() {
 }
 
 component App() {
-	let input: HTMLInputElement | undefined;
+	let host_input: HTMLInputElement | undefined;
+	let child_input: HTMLInputElement | undefined;
 	const state = { input: undefined as HTMLInputElement | undefined };
-	<input type="text" inputRef={ref input} />
-	<Child inputRef={ref input} otherRef={ref state.input} />
+	<input type="text" hostRef={ref host_input} />
+	<Child inputRef={ref child_input} otherRef={ref state.input} />
 }`;
 			const result = compile_to_volar_mappings(source, 'App.tsrx', { loose: true });
 
 			const host_element_offset = source.indexOf('<input type="text"');
-			const host_ref_name_offset = source.indexOf('inputRef', host_element_offset);
-			const host_ref_container_offset = source.indexOf('{ref input}', host_element_offset);
+			const host_ref_name_offset = source.indexOf('hostRef', host_element_offset);
+			const host_ref_container_offset = source.indexOf('{ref host_input}', host_element_offset);
 			const generated_host_element_offset = result.code.indexOf('<input type="text"');
 			const generated_host_ref_name_offset = result.code.indexOf(
-				'inputRef',
+				'hostRef',
 				generated_host_element_offset,
 			);
 			const generated_host_ref_offset = result.code.indexOf(
 				'create_ref_prop',
 				generated_host_element_offset,
 			);
-			const ref_container_offset = source.indexOf('{ref input}');
-			const ref_input_offset = source.indexOf('ref input') + 'ref '.length;
+			const ref_container_offset = source.indexOf('{ref host_input}');
+			const ref_input_offset = source.indexOf('ref host_input') + 'ref '.length;
 			const ref_state_container_offset = source.indexOf('{ref state.input}');
 			const ref_state_offset = source.indexOf('ref state.input') + 'ref '.length;
 			const ref_state_input_offset = ref_state_offset + 'state.'.length;
 			const generated_input_getter = result.code.indexOf(
-				'input',
-				result.code.indexOf('() => input'),
+				'host_input',
+				result.code.indexOf('() => host_input'),
 			);
 			const generated_state_getter = result.code.indexOf(
 				'state.input',
@@ -974,10 +975,10 @@ component App() {
 					(mapping) => mapping.sourceOffsets[0] === source_offset && mapping.lengths[0] === length,
 				);
 
-			const input_mappings = find_mappings(ref_input_offset, 'input'.length);
+			const input_mappings = find_mappings(ref_input_offset, 'host_input'.length);
 			const state_mappings = find_mappings(ref_state_offset, 'state'.length);
 			const state_input_mappings = find_mappings(ref_state_input_offset, 'input'.length);
-			const host_ref_name_mappings = find_mappings(host_ref_name_offset, 'inputRef'.length);
+			const host_ref_name_mappings = find_mappings(host_ref_name_offset, 'hostRef'.length);
 			const container_mappings = result.mappings.filter(
 				(mapping) =>
 					mapping.sourceOffsets[0] === ref_container_offset ||
@@ -995,9 +996,18 @@ component App() {
 			});
 
 			expect(result.errors).toEqual([]);
-			expect(result.code).toContain('() => input, (v) => input = v');
+			expect(result.code).toContain(
+				"hostRef={__create_ref_prop<HTMLElementTagNameMap['input']>(() => host_input, (v) => host_input = v)}",
+			);
+			expect(result.code).toContain(
+				'inputRef={__create_ref_prop(() => child_input, (v) => child_input = v)}',
+			);
+			expect(result.code).toContain(
+				'otherRef={__create_ref_prop(() => state.input, (v) => state.input = v)}',
+			);
+			expect(result.code).toContain('() => host_input, (v) => host_input = v');
 			expect(result.code).toContain('() => state.input, (v) => state.input = v');
-			expect(result.code).toContain('inputRef={');
+			expect(result.code).toContain('hostRef={');
 			expect(container_mappings).toEqual([]);
 			expect(host_wrapper_mappings).toEqual([]);
 			expect(host_ref_name_mappings).toHaveLength(1);

--- a/packages/tsrx/types/index.d.ts
+++ b/packages/tsrx/types/index.d.ts
@@ -1461,6 +1461,7 @@ export interface TransformClientState extends BaseState {
 	return_flags?: Map<AST.ReturnStatement, { name: string; tracked: boolean }>;
 	is_tsrx_element?: boolean;
 	jsx_to_tsrx_element?: boolean;
+	ref_target_type?: AST.TypeNode;
 }
 
 /** Override zimmerframe types and provide our own */

--- a/packages/tsrx/types/index.d.ts
+++ b/packages/tsrx/types/index.d.ts
@@ -827,7 +827,7 @@ declare module 'estree' {
 	interface TSBooleanKeyword extends AcornTSNode<TSESTree.TSBooleanKeyword> {}
 	interface TSCallSignatureDeclaration extends Omit<
 		AcornTSNode<TSESTree.TSCallSignatureDeclaration>,
-		'typeParameters' | 'typeAnnotation'
+		'typeParameters' | 'params' | 'returnType'
 	> {
 		parameters: Parameter[];
 		typeParameters: TSTypeParameterDeclaration | undefined;
@@ -844,7 +844,7 @@ declare module 'estree' {
 	}
 	interface TSConstructorType extends Omit<
 		AcornTSNode<TSESTree.TSConstructorType>,
-		'typeParameters' | 'params'
+		'typeParameters' | 'params' | 'returnType'
 	> {
 		typeAnnotation: TSTypeAnnotation | undefined;
 		typeParameters: TSTypeParameterDeclaration | undefined;
@@ -852,7 +852,7 @@ declare module 'estree' {
 	}
 	interface TSConstructSignatureDeclaration extends Omit<
 		AcornTSNode<TSESTree.TSConstructSignatureDeclaration>,
-		'typeParameters' | 'typeAnnotation'
+		'typeParameters' | 'params' | 'returnType'
 	> {
 		parameters: Parameter[];
 		typeParameters: TSTypeParameterDeclaration | undefined;
@@ -892,7 +892,7 @@ declare module 'estree' {
 	}
 	interface TSFunctionType extends Omit<
 		AcornTSNode<TSESTree.TSFunctionType>,
-		'typeParameters' | 'params'
+		'typeParameters' | 'params' | 'returnType'
 	> {
 		typeAnnotation: TSTypeAnnotation | undefined;
 		typeParameters: TSTypeParameterDeclaration | undefined;
@@ -961,7 +961,7 @@ declare module 'estree' {
 	}
 	interface TSMethodSignature extends Omit<
 		AcornTSNode<TSESTree.TSMethodSignature>,
-		'key' | 'typeParameters' | 'params' | 'typeAnnotation'
+		'key' | 'typeParameters' | 'params' | 'returnType'
 	> {
 		key: PropertyNameComputed | PropertyNameNonComputed;
 		typeParameters: TSTypeParameterDeclaration | undefined;

--- a/packages/tsrx/types/runtime/ref.d.ts
+++ b/packages/tsrx/types/runtime/ref.d.ts
@@ -4,6 +4,13 @@ export type MergeableRefCallback<T> = {
 export type MergeableRefObject<T> = { current: T | null };
 export type MergeableVueRef<T> = { value: T | null };
 export type RefProp<T = unknown> = (node: T | null) => void | (() => void);
+export type RefValue<T = Element> =
+	| ((node: T) => void | (() => void))
+	| { current: T | null }
+	| { value: T | null }
+	| T
+	| null
+	| undefined;
 
 export type MergeableRef<T> =
 	| MergeableRefCallback<T>
@@ -14,9 +21,9 @@ export type MergeableRef<T> =
 
 export function mergeRefs<T = any>(...refs: Array<MergeableRef<T>>): (node: T | null) => () => void;
 export function isRefProp(value: unknown): boolean;
-export function create_ref_prop<T>(
-	get_ref_value: () => T,
-	set_ref_value?: (value: T) => void,
+export function create_ref_prop<T = Element>(
+	get_ref_value: () => RefValue<T>,
+	set_ref_value?: (value: any) => void,
 ): RefProp<T>;
 export function apply_ref_value<T>(
 	ref_value: unknown,


### PR DESCRIPTION
fixes #1165 

## Summary

- Adds element-specific typing for host `ref={...}` attributes, named ref props, and generated ref keys in TypeScript output.
- Threads inferred ref target types through TSRX JSX transforms, including Ripple and Solid output.
- Preserves SVG/MathML/HTML namespace context so nested host refs get the correct element type, e.g. `SVGElementTagNameMap['circle']` vs `HTMLElementTagNameMap['div']`.
- Updates Ripple JSX runtime types so `RefKey` and arbitrary generated ref-key attributes can carry typed ref values.
- Aligns compiler/prettier TypeScript AST handling around `typeAnnotation` instead of `returnType` for affected function/constructor signature nodes.
- Adds/updates tests for named ref prop typing and source mappings.
