### PR TITLE
fix: add diagnostic mapping for the whole arrow function

### DIFF
--- a/.changeset/smooth-arrows-verify.md
+++ b/.changeset/smooth-arrows-verify.md
@@ -1,0 +1,10 @@
+---
+'@tsrx/core': patch
+'@tsrx/react': patch
+'@tsrx/preact': patch
+'@tsrx/solid': patch
+'@tsrx/vue': patch
+'@tsrx/ripple': patch
+---
+
+Add verification-only Volar mappings for whole arrow functions.

--- a/packages/tsrx-ripple/src/transform/client/index.js
+++ b/packages/tsrx-ripple/src/transform/client/index.js
@@ -5570,6 +5570,8 @@ function create_tsx_with_typescript_support(comments) {
 		// prints as `() => ...` and segments.js can't resolve the return-type
 		// nodes' positions in the generated output.
 		ArrowFunctionExpression(node, context) {
+			if (node.loc) context.location(node.loc.start.line, node.loc.start.column);
+
 			if (node.async) context.write('async ');
 
 			if (node.typeParameters) {
@@ -5603,6 +5605,8 @@ function create_tsx_with_typescript_support(comments) {
 			} else {
 				context.visit(node.body);
 			}
+
+			if (node.loc) context.location(node.loc.end.line, node.loc.end.column);
 		},
 		ClassDeclaration(node, context) {
 			if (node.loc) {

--- a/packages/tsrx-ripple/tests/basic.test.js
+++ b/packages/tsrx-ripple/tests/basic.test.js
@@ -49,6 +49,27 @@ describe('@tsrx/ripple Volar mappings cover declaration keywords', () => {
 	});
 });
 
+describe('@tsrx/ripple Volar mappings cover arrow functions', () => {
+	it('adds a verification-only mapping for the whole arrow function', () => {
+		const source = `component C() { const f = (x: number): number => x + 1; }`;
+		const result = compile_to_volar_mappings(source, 'App.tsrx', { loose: true });
+		const source_arrow = '(x: number): number => x + 1';
+		const source_offset = source.indexOf(source_arrow);
+		const generated_offset = result.code.indexOf(source_arrow);
+		const mapping = find_exact_mapping(
+			result.mappings,
+			source_offset,
+			generated_offset,
+			source_arrow.length,
+		);
+
+		expect(mapping?.data.verification).toBe(true);
+		expect(mapping?.data.completion).toBeUndefined();
+		expect(mapping?.data.semantic).toBeUndefined();
+		expect(mapping?.data.navigation).toBeUndefined();
+	});
+});
+
 describe('@tsrx/ripple try pending fallbacks', () => {
 	it('allows empty pending blocks as null fallbacks', () => {
 		const { code } = compile(

--- a/packages/tsrx/src/transform/jsx/helpers.js
+++ b/packages/tsrx/src/transform/jsx/helpers.js
@@ -235,6 +235,7 @@ export function tsx_with_ts_locations() {
 		'AwaitExpression',
 		'SwitchStatement',
 		'TaggedTemplateExpression',
+		'ArrowFunctionExpression',
 		// JSX wrapper nodes: esrap writes `<`, `>`, `</`, `{`, `}` without
 		// locations, so the opening/closing element's and expression
 		// container's start and end don't resolve.

--- a/packages/tsrx/src/transform/segments.js
+++ b/packages/tsrx/src/transform/segments.js
@@ -903,6 +903,23 @@ export function convert_source_map_to_mappings(
 				node.type === 'ArrowFunctionExpression'
 			) {
 				const is_method = node.metadata?.is_method;
+
+				if (node.type === 'ArrowFunctionExpression' && node.loc) {
+					const start_key = `${node.loc.start.line}:${node.loc.start.column}`;
+					const end_key = `${node.loc.end.line}:${node.loc.end.column}`;
+
+					if (src_to_gen_map.has(start_key) && src_to_gen_map.has(end_key)) {
+						mappings.push(
+							get_mapping_from_node(
+								node,
+								src_to_gen_map,
+								gen_line_offsets,
+								mapping_data_verify_only,
+							),
+						);
+					}
+				}
+
 				// Add function/component keyword token
 				if (
 					(node.type === 'FunctionDeclaration' || node.type === 'FunctionExpression') &&

--- a/packages/tsrx/tests/shared/source-mappings.js
+++ b/packages/tsrx/tests/shared/source-mappings.js
@@ -5,6 +5,7 @@ import {
 	build_src_to_gen_map,
 	find_exact_mapping,
 	get_generated_position,
+	offset_to_line_col,
 } from '../../src/source-map-utils.js';
 
 /**
@@ -326,6 +327,48 @@ component C() {
 			);
 
 			expect(() => get_generated_position(2, 1, src_to_gen_map)).not.toThrow();
+		});
+	});
+
+	describe(`[${name}] raw source maps cover arrow functions`, () => {
+		it('maps the whole arrow function start and end', () => {
+			const source = `component C() { const f = (x: number): number => x + 1; }`;
+			const result = compile(source, 'App.tsrx');
+			const [src_to_gen_map] = build_src_to_gen_map(
+				result.map,
+				new Map(),
+				build_line_offsets(result.code),
+				result.code,
+			);
+			const source_line_offsets = build_line_offsets(source);
+			const arrow_start = source.indexOf('(x: number)');
+			const arrow_end = source.indexOf(';', arrow_start);
+			const start = offset_to_line_col(arrow_start, source_line_offsets);
+			const end = offset_to_line_col(arrow_end, source_line_offsets);
+
+			expect(() => get_generated_position(start.line, start.column, src_to_gen_map)).not.toThrow();
+			expect(() => get_generated_position(end.line, end.column, src_to_gen_map)).not.toThrow();
+		});
+	});
+
+	describe(`[${name}] Volar mappings cover arrow functions`, () => {
+		it('adds a verification-only mapping for the whole arrow function', () => {
+			const source = `component C() { const f = (x: number): number => x + 1; }`;
+			const result = compile_to_volar_mappings(source, 'App.tsrx', { loose: true });
+			const source_arrow = '(x: number): number => x + 1';
+			const source_offset = source.indexOf(source_arrow);
+			const generated_offset = result.code.indexOf(source_arrow);
+			const mapping = find_exact_mapping(
+				result.mappings,
+				source_offset,
+				generated_offset,
+				source_arrow.length,
+			);
+
+			expect(mapping?.data.verification).toBe(true);
+			expect(mapping?.data.completion).toBeUndefined();
+			expect(mapping?.data.semantic).toBeUndefined();
+			expect(mapping?.data.navigation).toBeUndefined();
 		});
 	});
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Source-map and IDE-mapping fixes with targeted tests; no auth, runtime behavior, or public API changes beyond patch releases.
> 
> **Overview**
> Fixes **TypeScript/Volar diagnostics** for annotated arrow functions inside compiled output by ensuring the **whole arrow** (including return types) maps correctly from source to generated code.
> 
> **Printing & source-map anchors:** Custom `ArrowFunctionExpression` printers now emit `typeParameters` and `returnType` (esrap previously dropped them), and record **start/end locations** on the arrow span. The shared JSX helper wraps arrows the same way, and `segments.js` adds a **verification-only** Volar mapping for the full `ArrowFunctionExpression` when both ends resolve in the source→generated map.
> 
> **Tests:** Ripple and shared harness tests assert verification-only mappings (no completion/semantic/navigation) and raw source-map coverage for arrow start/end. Changeset bumps `@tsrx/core`, react/preact/solid/vue, and ripple.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a66a1beea10026a3665db5e86b6862a5d61f0116. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->