### PR TITLE
fix(prettier): union types, comments in destructured params

### DIFF
--- a/.changeset/chatty-comments-rest.md
+++ b/.changeset/chatty-comments-rest.md
@@ -1,0 +1,6 @@
+---
+'@tsrx/core': patch
+'@tsrx/prettier-plugin': patch
+---
+
+Preserve comments inside destructured typed parameters and type literals during formatting.

--- a/.changeset/neat-unions-format.md
+++ b/.changeset/neat-unions-format.md
@@ -1,0 +1,5 @@
+---
+'@tsrx/prettier-plugin': patch
+---
+
+Format multiline TypeScript union types with leading operators.

--- a/.changeset/neat-unions-format.md
+++ b/.changeset/neat-unions-format.md
@@ -2,4 +2,4 @@
 '@tsrx/prettier-plugin': patch
 ---
 
-Format multiline TypeScript union types with leading operators.
+Format multiline TypeScript union types with leading operators and normalize simple cast unions inline.

--- a/packages/prettier-plugin/src/index.js
+++ b/packages/prettier-plugin/src/index.js
@@ -35,6 +35,7 @@ const {
 	breakParent,
 	indentIfBreak,
 	lineSuffix,
+	align,
 } = builders;
 const { replaceEndOfLine, willBreak } = utils;
 
@@ -2137,8 +2138,7 @@ function printRippleNode(node, path, options, print, args) {
 			break;
 
 		case 'TSUnionType': {
-			const types = path.map(print, 'types');
-			nodeContent = join(' | ', types);
+			nodeContent = printTSUnionType(node, path, print);
 			break;
 		}
 
@@ -4416,6 +4416,30 @@ function printTSTypeAliasDeclaration(node, path, options, print) {
 	}
 
 	return group([head, ' =', indent([line, path.call(print, 'typeAnnotation')]), semi(options)]);
+}
+
+/**
+ * Print a TypeScript union type
+ * @param {AST.TSUnionType} node - The union node
+ * @param {AstPath<AST.TSUnionType>} path - The AST path
+ * @param {PrintFn} print - Print callback
+ * @returns {Doc}
+ */
+function printTSUnionType(node, path, print) {
+	const types = path.map(print, 'types');
+	const inlineDoc = join(' | ', types);
+	const multilineDoc = [
+		'| ',
+		join(
+			[hardline, '| '],
+			types.map((typeDoc) => align(2, typeDoc)),
+		),
+	];
+	const shouldBreak = node.types.some(
+		(typeNode, index) => !wasOriginallySingleLine(typeNode) || willBreak(types[index]),
+	);
+
+	return shouldBreak ? group(multilineDoc) : conditionalGroup([inlineDoc, multilineDoc]);
 }
 
 /**

--- a/packages/prettier-plugin/src/index.js
+++ b/packages/prettier-plugin/src/index.js
@@ -16,7 +16,7 @@
 
 /** @typedef {Partial<Pick<ParserOptions, 'singleQuote' | 'jsxSingleQuote' | 'semi' | 'trailingComma' | 'useTabs' | 'tabWidth' | 'singleAttributePerLine' | 'bracketSameLine' | 'bracketSpacing' | 'arrowParens' | 'originalText' | 'printWidth'>> & { locStart: (node: AST.NodeWithLocation) => number, locEnd: (node: AST.NodeWithLocation) => number }} RippleFormatOptions */
 
-/** @typedef {{ isInAttribute?: boolean, isInArray?: boolean, allowInlineObject?: boolean, isConditionalTest?: boolean, isNestedConditional?: boolean, suppressLeadingComments?: boolean, suppressExpressionLeadingComments?: boolean, isInlineContext?: boolean, isStatement?: boolean, isLogicalAndOr?: boolean, allowShorthandProperty?: boolean, isFirstChild?: boolean, skipComponentLabel?: boolean, noBreakInside?: boolean, expandLastArg?: boolean }} PrintArgs */
+/** @typedef {{ isInAttribute?: boolean, isInArray?: boolean, allowInlineObject?: boolean, isConditionalTest?: boolean, isNestedConditional?: boolean, suppressLeadingComments?: boolean, suppressExpressionLeadingComments?: boolean, isInlineContext?: boolean, isStatement?: boolean, isLogicalAndOr?: boolean, allowShorthandProperty?: boolean, isFirstChild?: boolean, skipComponentLabel?: boolean, noBreakInside?: boolean, expandLastArg?: boolean, preferInlineSimpleUnionType?: boolean }} PrintArgs */
 
 import { parseModule } from '@tsrx/core';
 import { doc } from 'prettier';
@@ -1503,16 +1503,24 @@ function printRippleNode(node, path, options, print, args) {
 			break;
 
 		case 'TSAsExpression': {
-			nodeContent = [path.call(print, 'expression'), ' as ', path.call(print, 'typeAnnotation')];
+			const typeAnnotation = path.call(
+				(typePath) => print(typePath, { preferInlineSimpleUnionType: true }),
+				'typeAnnotation',
+			);
+			nodeContent = willBreak(typeAnnotation)
+				? [path.call(print, 'expression'), ' as', indent([line, typeAnnotation])]
+				: [path.call(print, 'expression'), ' as ', typeAnnotation];
 			break;
 		}
 
 		case 'TSSatisfiesExpression': {
-			nodeContent = [
-				path.call(print, 'expression'),
-				' satisfies ',
-				path.call(print, 'typeAnnotation'),
-			];
+			const typeAnnotation = path.call(
+				(typePath) => print(typePath, { preferInlineSimpleUnionType: true }),
+				'typeAnnotation',
+			);
+			nodeContent = willBreak(typeAnnotation)
+				? [path.call(print, 'expression'), ' satisfies', indent([line, typeAnnotation])]
+				: [path.call(print, 'expression'), ' satisfies ', typeAnnotation];
 			break;
 		}
 
@@ -2138,7 +2146,7 @@ function printRippleNode(node, path, options, print, args) {
 			break;
 
 		case 'TSUnionType': {
-			nodeContent = printTSUnionType(node, path, print);
+			nodeContent = printTSUnionType(node, path, print, args);
 			break;
 		}
 
@@ -4423,9 +4431,10 @@ function printTSTypeAliasDeclaration(node, path, options, print) {
  * @param {AST.TSUnionType} node - The union node
  * @param {AstPath<AST.TSUnionType>} path - The AST path
  * @param {PrintFn} print - Print callback
+ * @param {PrintArgs} [args] - Additional context arguments
  * @returns {Doc}
  */
-function printTSUnionType(node, path, print) {
+function printTSUnionType(node, path, print, args) {
 	const types = path.map(print, 'types');
 	const inlineDoc = join(' | ', types);
 	const multilineDoc = [
@@ -4438,6 +4447,10 @@ function printTSUnionType(node, path, print) {
 	const shouldBreak = node.types.some(
 		(typeNode, index) => !wasOriginallySingleLine(typeNode) || willBreak(types[index]),
 	);
+
+	if (args?.preferInlineSimpleUnionType && !types.some((typeDoc) => willBreak(typeDoc))) {
+		return inlineDoc;
+	}
 
 	return shouldBreak ? group(multilineDoc) : conditionalGroup([inlineDoc, multilineDoc]);
 }

--- a/packages/prettier-plugin/src/index.test.js
+++ b/packages/prettier-plugin/src/index.test.js
@@ -3035,6 +3035,41 @@ function test() {
 		expect(result).toBeWithNewline(expected);
 	});
 
+	it('should preserve comments in destructured typed component parameters', async () => {
+		const expected = `component Child({
+  tr: &[count, tr],
+  // test,
+}: {
+  tr: [number, Tracked<number>];
+  // test: (node: HTMLDivElement) => void;
+}) {
+  <button
+    onClick={() => {
+      count++;
+      tr[0]++;
+    }}
+  >
+    {count}
+  </button>
+}`;
+
+		const result = await format(expected);
+		expect(result).toBeWithNewline(expected);
+	});
+
+	it('should preserve comments in destructured typed function parameters', async () => {
+		const expected = `function Child({
+  tr: &[count, tr],
+  // test,
+}: {
+  tr: [number, Tracked<number>];
+  // test: (node: HTMLDivElement) => void;
+}) {}`;
+
+		const result = await format(expected);
+		expect(result).toBeWithNewline(expected);
+	});
+
 	it('should preserve trailing comments in call arguments', async () => {
 		const expected = `fn(
   arg1,
@@ -3779,6 +3814,34 @@ second"</pre>
 }`;
 
 			const result = await format(input, { singleQuote: true });
+			expect(result).toBeWithNewline(expected);
+		});
+
+		it('should format multiline TypeScript union object types like Prettier TypeScript', async () => {
+			const input = `type SvgIconSource = { name: SvgIconName; data?: never } | {
+    data: SvgIconData;
+    name?: never;
+ }`;
+
+			const expected = `type SvgIconSource =
+  | { name: SvgIconName; data?: never }
+  | {
+      data: SvgIconData;
+      name?: never;
+    };`;
+
+			const result = await format(input);
+			expect(result).toBeWithNewline(expected);
+		});
+
+		it('should break long TypeScript union types with leading operators', async () => {
+			const input = `type Source = SomeVeryLongTypeNameThatWillDefinitelyNotFit | AnotherVeryLongTypeNameThatWillDefinitelyNotFit;`;
+
+			const expected = `type Source =
+  | SomeVeryLongTypeNameThatWillDefinitelyNotFit
+  | AnotherVeryLongTypeNameThatWillDefinitelyNotFit;`;
+
+			const result = await format(input, { printWidth: 50 });
 			expect(result).toBeWithNewline(expected);
 		});
 

--- a/packages/prettier-plugin/src/index.test.js
+++ b/packages/prettier-plugin/src/index.test.js
@@ -3817,6 +3817,42 @@ second"</pre>
 			expect(result).toBeWithNewline(expected);
 		});
 
+		it('should normalize simple cast union types at print width 100', async () => {
+			const input = `const alphaLink = container.querySelector('[data-route-id="alpha"]') as HTMLAnchorElement | null;
+const saveButton = container.querySelector('[data-action-id="save"]') as HTMLButtonElement | null;
+const deleteButton = container.querySelector('[data-action-id="delete"]') as | HTMLButtonElement
+| null;`;
+
+			const expected = `const alphaLink = container.querySelector('[data-route-id="alpha"]') as HTMLAnchorElement | null;
+const saveButton = container.querySelector('[data-action-id="save"]') as HTMLButtonElement | null;
+const deleteButton = container.querySelector(
+  '[data-action-id="delete"]',
+) as HTMLButtonElement | null;`;
+
+			const result = await format(input, { printWidth: 100, singleQuote: true });
+			expect(result).toBeWithNewline(expected);
+		});
+
+		it('should normalize simple cast union types at print width 80', async () => {
+			const input = `const alphaLink = container.querySelector('[data-route-id="alpha"]') as HTMLAnchorElement | null;
+const saveButton = container.querySelector('[data-action-id="save"]') as HTMLButtonElement | null;
+const deleteButton = container.querySelector('[data-action-id="delete"]') as | HTMLButtonElement
+| null;`;
+
+			const expected = `const alphaLink = container.querySelector(
+  '[data-route-id="alpha"]',
+) as HTMLAnchorElement | null;
+const saveButton = container.querySelector(
+  '[data-action-id="save"]',
+) as HTMLButtonElement | null;
+const deleteButton = container.querySelector(
+  '[data-action-id="delete"]',
+) as HTMLButtonElement | null;`;
+
+			const result = await format(input, { printWidth: 80, singleQuote: true });
+			expect(result).toBeWithNewline(expected);
+		});
+
 		it('should format multiline TypeScript union object types like Prettier TypeScript', async () => {
 			const input = `type SvgIconSource = { name: SvgIconName; data?: never } | {
     data: SvgIconData;

--- a/packages/tsrx/src/parse/index.js
+++ b/packages/tsrx/src/parse/index.js
@@ -605,6 +605,10 @@ export function get_comment_handlers(source, comments, index = 0) {
 									node_array = parent.elements;
 								} else if (parent.type === 'ObjectExpression') {
 									node_array = parent.properties;
+								} else if (parent.type === 'ObjectPattern') {
+									node_array = parent.properties;
+								} else if (parent.type === 'TSTypeLiteral') {
+									node_array = parent.members;
 								} else if (
 									parent.type === 'FunctionDeclaration' ||
 									parent.type === 'FunctionExpression' ||
@@ -622,11 +626,22 @@ export function get_comment_handlers(source, comments, index = 0) {
 								is_last_in_array = node_array.indexOf(node) === node_array.length - 1;
 							}
 
+							const trailingCommentBoundary =
+								parent &&
+								parent.type === 'ObjectPattern' &&
+								parent.typeAnnotation &&
+								parent.typeAnnotation.start !== undefined
+									? parent.typeAnnotation.start
+									: parent?.end;
+
 							if (is_last_in_array) {
 								if (isParam || isArgument) {
 									while (comments.length) {
 										const potentialComment = comments[0];
-										if (parent && potentialComment.start >= parent.end) {
+										if (
+											trailingCommentBoundary !== undefined &&
+											potentialComment.start >= trailingCommentBoundary
+										) {
 											break;
 										}
 
@@ -653,7 +668,12 @@ export function get_comment_handlers(source, comments, index = 0) {
 									// and they can be separated by newlines
 									while (comments.length) {
 										const comment = comments[0];
-										if (parent && comment.start >= parent.end) break;
+										if (
+											trailingCommentBoundary !== undefined &&
+											comment.start >= trailingCommentBoundary
+										) {
+											break;
+										}
 
 										const maybeInner = getEmptyElementInnerCommentTarget(comment);
 										if (maybeInner) {


### PR DESCRIPTION
fixes #1171 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formatter-only changes in union/cast printing with targeted tests; no runtime or security impact.
> 
> **Overview**
> Improves how the Ripple Prettier plugin prints **TypeScript unions** in `as` / `satisfies` casts and related type positions.
> 
> **Simple unions** (e.g. `HTMLButtonElement | null`) can stay on one line when used as a cast type, via a new `preferInlineSimpleUnionType` print flag on `printTSUnionType`. **Multiline unions** still use leading `|` operators; complex unions still break as before.
> 
> **`as` and `satisfies`** now lay out like other long type annotations: inline when the type fits, otherwise the keyword stays on the expression line and the type indents on the next line.
> 
> Regression tests cover `querySelector(...) as … | null` at print widths **80** and **100**. The changeset notes inline normalization for simple cast unions alongside existing multiline union behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d175faa1339a67a019cba40553e38766995beaec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->