### PR TITLE
chore(templates/basic): remove body margin & size `.app` as border-box

### DIFF
--- a/templates/basic/src/App.tsrx
+++ b/templates/basic/src/App.tsrx
@@ -38,7 +38,12 @@ export component App() {
 	</div>
 
 	<style>
+		:global(body) {
+			margin: 0;
+		}
+
 		.app {
+			box-sizing: border-box;
 			min-height: 100vh;
 			display: flex;
 			justify-content: center;


### PR DESCRIPTION
before:
<img width="1548" height="1156" alt="Screenshot From 2026-05-25 19-53-16" src="https://github.com/user-attachments/assets/e6491d19-08ac-4b9e-b684-a111e7b89c6e" />

after:
<img width="1548" height="1156" alt="Screenshot From 2026-05-25 19-54-11" src="https://github.com/user-attachments/assets/f115f824-568e-4b09-a0cd-c887203ba92f" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Template-only CSS tweaks with no runtime, auth, or data impact.
> 
> **Overview**
> The basic Ripple starter template now lays out edge-to-edge without the default browser body margin and keeps the full-viewport shell sized predictably with padding.
> 
> Scoped styles in `App.tsrx` add a **`:global(body)`** rule that sets **`margin: 0`**, and the **`.app`** root gets **`box-sizing: border-box`** so its **`1rem` padding** counts toward **`min-height: 100vh`** instead of overflowing past the viewport.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 624ac2fef13ee11ca5badd0dd0f8d27179008cc6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->