### PR TITLE
prop getter generation for JSX apply same as TSRX

### DIFF
--- a/.changeset/curly-maps-joke.md
+++ b/.changeset/curly-maps-joke.md
@@ -1,0 +1,5 @@
+---
+"@tsrx/ripple": patch
+---
+
+Align prop getter generation for JSX-style TSRX expression fragments with native TSRX component templates.

--- a/.changeset/curly-maps-joke.md
+++ b/.changeset/curly-maps-joke.md
@@ -1,5 +1,7 @@
 ---
 "@tsrx/ripple": patch
+"@tsrx/core": patch
 ---
 
 Align prop getter generation for JSX-style TSRX expression fragments with native TSRX component templates.
+Reject native dynamic marker syntax on TSX attribute names and inside TSX fragments.

--- a/packages/tsrx-ripple/src/utils.js
+++ b/packages/tsrx-ripple/src/utils.js
@@ -1398,7 +1398,6 @@ export function jsx_to_ripple_node(node, inherited_path = []) {
 		const attributes = opening.attributes
 			.map((attr) => {
 				if (attr.type === 'JSXAttribute') {
-					const is_dynamic = attr.value && attr.value.type === 'JSXExpressionContainer';
 					return /** @type {AST.Node} */ ({
 						type: 'Attribute',
 						name: {
@@ -1407,7 +1406,7 @@ export function jsx_to_ripple_node(node, inherited_path = []) {
 								attr.name.type === 'JSXIdentifier'
 									? attr.name.name
 									: attr.name.namespace.name + ':' + attr.name.name.name,
-							tracked: is_dynamic,
+							tracked: false,
 							start: attr.name.start,
 							end: attr.name.end,
 						},

--- a/packages/tsrx-ripple/tests/basic.test.js
+++ b/packages/tsrx-ripple/tests/basic.test.js
@@ -308,6 +308,218 @@ describe('@tsrx/ripple <tsrx> Volar output', () => {
 });
 
 describe('@tsrx/ripple <tsx> expression values', () => {
+	it('passes plain identifier props directly in fragment shorthand values', () => {
+		const { code } = compile(
+			`component Some(props) {}
+			function Test() {
+				const placeholder = 'value';
+				return <><Some prop={placeholder} /></>;
+			}`,
+			'App.tsrx',
+		);
+
+		expect(code).toContain('Some(node, { prop: placeholder }, _$_.active_block);');
+		expect(code).not.toContain('get prop()');
+	});
+
+	it('passes plain identifier props directly in tsx expression values', () => {
+		const { code } = compile(
+			`component Some(props) {}
+			function Test() {
+				const placeholder = 'value';
+				return <tsx><Some prop={placeholder} /></tsx>;
+			}`,
+			'App.tsrx',
+		);
+
+		expect(code).toContain('Some(node, { prop: placeholder }, _$_.active_block);');
+		expect(code).not.toContain('get prop()');
+	});
+
+	it('passes plain identifier props directly in tsrx expression values', () => {
+		const { code } = compile(
+			`component Some(props) {}
+			function Test() {
+				const placeholder = 'value';
+				return <tsrx><Some prop={placeholder} /></tsrx>;
+			}`,
+			'App.tsrx',
+		);
+
+		expect(code).toContain('Some(node, { prop: placeholder }, _$_.active_block);');
+		expect(code).not.toContain('get prop()');
+	});
+
+	it('passes plain identifier props directly in component bodies', () => {
+		const { code } = compile(
+			`component Some(props) {}
+			component Test() {
+				const placeholder = 'value';
+				<Some prop={placeholder} />
+			}`,
+			'App.tsrx',
+		);
+
+		expect(code).toContain('Some(node, { prop: placeholder }, _$_.active_block);');
+		expect(code).not.toContain('get prop()');
+	});
+
+	it('passes plain non-tracked expression props directly', () => {
+		const { code } = compile(
+			`component Some(props) {}
+			function Test() {
+				const first = 'hello';
+				const second = 'world';
+				return <><Some prop={first + second} /></>;
+			}`,
+			'App.tsrx',
+		);
+
+		expect(code).toContain('Some(node, { prop: first + second }, _$_.active_block);');
+		expect(code).not.toContain('get prop()');
+	});
+
+	it('wraps member expression props in getters', () => {
+		const { code } = compile(
+			`component Some(props) {}
+			function Test() {
+				const obj = { value: 'value' };
+				return <><Some prop={obj.value} /></>;
+			}`,
+			'App.tsrx',
+		);
+
+		expect(code).toContain('get prop()');
+		expect(code).toContain('return obj.value;');
+	});
+
+	it('wraps computed member expression props in getters', () => {
+		const { code } = compile(
+			`component Some(props) {}
+			function Test() {
+				const obj = { value: 'value' };
+				const key = 'value';
+				return <tsx><Some prop={obj[key]} /></tsx>;
+			}`,
+			'App.tsrx',
+		);
+
+		expect(code).toContain('get prop()');
+		expect(code).toContain('return obj[key];');
+	});
+
+	it('wraps call expression props in getters', () => {
+		const { code } = compile(
+			`component Some(props) {}
+			function getValue() {
+				return 'value';
+			}
+			function Test() {
+				return <tsrx><Some prop={getValue()} /></tsrx>;
+			}`,
+			'App.tsrx',
+		);
+
+		expect(code).toContain('get prop()');
+		expect(code).toContain('getValue');
+	});
+
+	it('wraps call expression props in fragment shorthand values in getters', () => {
+		const { code } = compile(
+			`component Some(props) {}
+			function getValue() {
+				return 'value';
+			}
+			function Test() {
+				return <><Some prop={getValue()} /></>;
+			}`,
+			'App.tsrx',
+		);
+
+		expect(code).toContain('get prop()');
+		expect(code).toContain('getValue');
+	});
+
+	it('wraps call expression props in component bodies in getters', () => {
+		const { code } = compile(
+			`component Some(props) {}
+			function getValue() {
+				return 'value';
+			}
+			component Test() {
+				<Some prop={getValue()} />
+			}`,
+			'App.tsrx',
+		);
+
+		expect(code).toContain('get prop()');
+		expect(code).toContain('getValue');
+	});
+
+	it('wraps lazy tracked identifier props in fragment shorthand values in getters', () => {
+		const { code } = compile(
+			`import { track } from 'ripple';
+			component Some(props) {}
+			component Test() {
+				let &[count] = track(0);
+				const content = <><Some prop={count} /></>;
+				{content}
+			}`,
+			'App.tsrx',
+		);
+
+		expect(code).toContain('get prop()');
+		expect(code).toContain('return lazy.value;');
+	});
+
+	it('wraps lazy tracked identifier props in function fragment returns in getters', () => {
+		const { code } = compile(
+			`import { track } from 'ripple';
+			component Some(props) {}
+			function Test() {
+				let &[count] = track(0);
+				return <><Some prop={count} /></>;
+			}`,
+			'App.tsrx',
+		);
+
+		expect(code).toContain('return _$_.tsrx_element');
+		expect(code).toContain('get prop()');
+		expect(code).toContain('return lazy.value;');
+	});
+
+	it('wraps lazy tracked identifier props in getters', () => {
+		const { code } = compile(
+			`import { track } from 'ripple';
+			component Some(props) {}
+			component Test() {
+				let &[count] = track(0);
+				const content = <tsx><Some prop={count} /></tsx>;
+				{content}
+			}`,
+			'App.tsrx',
+		);
+
+		expect(code).toContain('get prop()');
+		expect(code).toContain('return lazy.value;');
+	});
+
+	it('wraps lazy tracked expression props in getters', () => {
+		const { code } = compile(
+			`import { track } from 'ripple';
+			component Some(props) {}
+			component Test() {
+				let &[count] = track(0);
+				const content = <tsrx><Some prop={count % 2 ? 'odd' : 'even'} /></tsrx>;
+				{content}
+			}`,
+			'App.tsrx',
+		);
+
+		expect(code).toContain('get prop()');
+		expect(code).toContain(`return lazy.value % 2 ? 'odd' : 'even';`);
+	});
+
 	it('lowers tsx values nested in template expressions', () => {
 		const { code } = compile(
 			`component App() {

--- a/packages/tsrx/src/plugin.js
+++ b/packages/tsrx/src/plugin.js
@@ -422,6 +422,9 @@ export function TSRXPlugin(config) {
 					}
 					if (child?.type === 'JSXElement') {
 						const name = child.openingElement?.name;
+						if (name?.type === 'JSXIdentifier' && name.name === 'tsrx') {
+							continue;
+						}
 						const is_dynamic_name =
 							(name?.type === 'JSXIdentifier' && name.tracked) ||
 							(name?.type === 'JSXMemberExpression' &&

--- a/packages/tsrx/src/plugin.js
+++ b/packages/tsrx/src/plugin.js
@@ -21,6 +21,10 @@ const JSX_EXPRESSION_VALUE_ERROR =
 	'JSX elements cannot be used as expressions. Wrap JSX with `<>...</>` or `<tsx>...</tsx>`, wrap TSRX templates with `<tsrx>...</tsrx>`, or use elements as statements within a component.';
 const HTML_ATTRIBUTE_VALUE_ERROR =
 	'`{html ...}` is not supported as an attribute value. Use a string literal or expression without `html`.';
+const DYNAMIC_ELEMENT_IN_TSX_ERROR =
+	'Dynamic element syntax (`<@...>`) is only supported in native TSRX templates.';
+const DYNAMIC_ATTRIBUTE_NAME_ERROR =
+	'Dynamic component / element syntax (`@`) is only supported on native TSRX element names, not attribute names.';
 
 const CharCode = Object.freeze({
 	tab: 9,
@@ -406,6 +410,35 @@ export function TSRXPlugin(config) {
 					node?.type === 'Tsrx' ||
 					node?.type === 'TsxCompat'
 				);
+			}
+
+			/**
+			 * @param {AST.Node[]} children
+			 */
+			#reportDynamicJsxElementsInTsx(children) {
+				for (const child of children) {
+					if (child?.type === 'Tsrx') {
+						continue;
+					}
+					if (child?.type === 'JSXElement') {
+						const name = child.openingElement?.name;
+						const is_dynamic_name =
+							(name?.type === 'JSXIdentifier' && name.tracked) ||
+							(name?.type === 'JSXMemberExpression' &&
+								name.object.type === 'JSXIdentifier' &&
+								name.object.tracked);
+						if (is_dynamic_name) {
+							this.#report_recoverable_error_range(
+								/** @type {AST.NodeWithLocation} */ (name).start ?? child.start,
+								/** @type {AST.NodeWithLocation} */ (name).end ?? child.end,
+								DYNAMIC_ELEMENT_IN_TSX_ERROR,
+							);
+						}
+						this.#reportDynamicJsxElementsInTsx(/** @type {AST.Node[]} */ (child.children));
+					} else if (child?.type === 'Tsx' || child?.type === 'TsxCompat') {
+						this.#reportDynamicJsxElementsInTsx(/** @type {AST.Node[]} */ (child.children));
+					}
+				}
 			}
 
 			#parseNativeTemplateExpressionContainer() {
@@ -2107,6 +2140,20 @@ export function TSRXPlugin(config) {
 					}
 				}
 				/** @type {ESTreeJSX.JSXAttribute} */ (node).name = this.jsx_parseNamespacedName();
+				if (
+					/** @type {ESTreeJSX.JSXAttribute} */ (node).name.type === 'JSXIdentifier' &&
+					/** @type {ESTreeJSX.JSXIdentifier} */ (/** @type {ESTreeJSX.JSXAttribute} */ (node).name)
+						.tracked
+				) {
+					this.#report_recoverable_error_range(
+						/** @type {AST.NodeWithLocation} */ (node).start,
+						/** @type {AST.NodeWithLocation} */ (/** @type {ESTreeJSX.JSXAttribute} */ (node).name)
+							.end ??
+							node.end ??
+							node.start,
+						DYNAMIC_ATTRIBUTE_NAME_ERROR,
+					);
+				}
 				const value = /** @type {ESTreeJSX.JSXAttribute['value'] | null} */ (
 					this.eat(tt.eq) ? this.jsx_parseAttributeValue() : null
 				);
@@ -2512,6 +2559,13 @@ export function TSRXPlugin(config) {
 					(current_template_node?.type === 'TsxCompat' || current_template_node?.type === 'Tsx') &&
 					!is_tsrx_tag
 				) {
+					if (this.input.charCodeAt(tag_name_start) === CharCode.at) {
+						this.#report_recoverable_error_range(
+							this.start,
+							tag_name_start + 1,
+							DYNAMIC_ELEMENT_IN_TSX_ERROR,
+						);
+					}
 					// Inside tsx/tsx:*, let acorn-jsx handle regular TSX tags normally.
 					// Nested <tsrx> still needs Ripple's native template parser so it
 					// can lower through the same path as <tsrx> in component bodies.
@@ -2603,6 +2657,12 @@ export function TSRXPlugin(config) {
 					!is_tsx_compat &&
 					open.name.type === 'JSXIdentifier' &&
 					open.name.name === 'tsrx';
+				const is_dynamic_name =
+					!is_fragment &&
+					((open.name.type === 'JSXIdentifier' && open.name.tracked) ||
+						(open.name.type === 'JSXMemberExpression' &&
+							open.name.object.type === 'JSXIdentifier' &&
+							open.name.object.tracked));
 
 				if (is_tsx_compat) {
 					const namespace_node = /** @type {ESTreeJSX.JSXNamespacedName} */ (open.name);
@@ -2638,6 +2698,14 @@ export function TSRXPlugin(config) {
 					/** @type {AST.Tsx} */ (element).type = 'Tsx';
 				} else {
 					element.type = 'Element';
+				}
+
+				if ((is_tsx || is_fragment) && is_dynamic_name) {
+					this.#report_recoverable_error_range(
+						open.name.start ?? open.start,
+						open.name.end ?? open.end,
+						DYNAMIC_ELEMENT_IN_TSX_ERROR,
+					);
 				}
 
 				for (const attr of open.attributes) {
@@ -2698,6 +2766,7 @@ export function TSRXPlugin(config) {
 					this.#parseNativeTemplateBody(element, /** @type {AST.Element} */ (element).children, {
 						enterScope: true,
 					});
+					this.#reportDynamicJsxElementsInTsx(/** @type {AST.Element} */ (element).children);
 
 					if (/** @type {AST.Tsx} */ (element).type === 'Tsx') {
 						this.#path.pop();
@@ -2875,6 +2944,9 @@ export function TSRXPlugin(config) {
 						this.#parseNativeTemplateBody(element, /** @type {AST.Element} */ (element).children, {
 							enterScope: true,
 						});
+						if (/** @type {AST.Tsx} */ (element).type === 'Tsx') {
+							this.#reportDynamicJsxElementsInTsx(/** @type {AST.Element} */ (element).children);
+						}
 
 						if (/** @type {AST.Tsx} */ (element).type === 'Tsx') {
 							this.#path.pop();

--- a/packages/tsrx/tests/shared/compile.js
+++ b/packages/tsrx/tests/shared/compile.js
@@ -2098,20 +2098,6 @@ export function optionalFn(bar: string, baz?: string) {
 			).not.toThrow();
 		});
 
-		it('supports dynamic element syntax in direct tsrx children of fragment shorthand values', () => {
-			expect(() =>
-				compile(
-					`class Foo {
-						bar() {
-							const tag = 'section';
-							return <><tsrx><@tag id="x" /></tsrx></>;
-						}
-					}`,
-					'App.tsrx',
-				),
-			).not.toThrow();
-		});
-
 		it('declares normalized host spread refs inside tsx expression blocks', () => {
 			const { code } = compile(
 				`class Foo {

--- a/packages/tsrx/tests/shared/compile.js
+++ b/packages/tsrx/tests/shared/compile.js
@@ -2015,6 +2015,75 @@ export function optionalFn(bar: string, baz?: string) {
 			expect(code).not.toContain('<tsx>');
 		});
 
+		it('rejects dynamic attribute names inside tsx blocks', () => {
+			expect(() =>
+				compile(
+					`component Some(props) {}
+					class Foo {
+						bar() {
+							const placeholder = 'value';
+							return <tsx><Some @prop={placeholder} /></tsx>;
+						}
+					}`,
+					'App.tsrx',
+				),
+			).toThrow(/not attribute names/);
+		});
+
+		it('rejects dynamic element syntax inside tsx blocks', () => {
+			expect(() =>
+				compile(
+					`class Foo {
+						bar() {
+							const tag = 'section';
+							return <tsx><@tag id="x" /></tsx>;
+						}
+					}`,
+					'App.tsrx',
+				),
+			).toThrow(/only supported in native TSRX templates/);
+		});
+
+		it('rejects dynamic element syntax inside fragment shorthand values', () => {
+			expect(() =>
+				compile(
+					`class Foo {
+						bar() {
+							const tag = 'section';
+							return <><@tag id="x" /></>;
+						}
+					}`,
+					'App.tsrx',
+				),
+			).toThrow(/only supported in native TSRX templates/);
+		});
+
+		it('supports dynamic element syntax in native tsrx templates', () => {
+			expect(() =>
+				compile(
+					`export component App() {
+						const tag = 'section';
+						<@tag id="x" />
+					}`,
+					'App.tsrx',
+				),
+			).not.toThrow();
+		});
+
+		it('supports dynamic element syntax in explicit tsrx templates', () => {
+			expect(() =>
+				compile(
+					`class Foo {
+						bar() {
+							const tag = 'section';
+							return <tsrx><@tag id="x" /></tsrx>;
+						}
+					}`,
+					'App.tsrx',
+				),
+			).not.toThrow();
+		});
+
 		it('declares normalized host spread refs inside tsx expression blocks', () => {
 			const { code } = compile(
 				`class Foo {

--- a/packages/tsrx/tests/shared/compile.js
+++ b/packages/tsrx/tests/shared/compile.js
@@ -2084,6 +2084,34 @@ export function optionalFn(bar: string, baz?: string) {
 			).not.toThrow();
 		});
 
+		it('supports dynamic element syntax in direct tsrx children of tsx blocks', () => {
+			expect(() =>
+				compile(
+					`class Foo {
+						bar() {
+							const tag = 'section';
+							return <tsx><tsrx><@tag id="x" /></tsrx></tsx>;
+						}
+					}`,
+					'App.tsrx',
+				),
+			).not.toThrow();
+		});
+
+		it('supports dynamic element syntax in direct tsrx children of fragment shorthand values', () => {
+			expect(() =>
+				compile(
+					`class Foo {
+						bar() {
+							const tag = 'section';
+							return <><tsrx><@tag id="x" /></tsrx></>;
+						}
+					}`,
+					'App.tsrx',
+				),
+			).not.toThrow();
+		});
+
 		it('declares normalized host spread refs inside tsx expression blocks', () => {
 			const { code } = compile(
 				`class Foo {


### PR DESCRIPTION
based on this discord conversation: https://discord.com/channels/1411020393170473002/1411355263071420567/1507457125008408758


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes reactive prop lowering for JSX-style templates, which can affect runtime update behavior; parser errors are additive for invalid `@` in TSX.
> 
> **Overview**
> Aligns **component prop codegen** for JSX-style fragments (`<>...</>`, `<tsx>`, `<tsrx>`) with native TSRX templates: plain identifiers and simple non-reactive expressions are passed through directly, while member/call expressions and **lazy tracked** values still get `get prop()` wrappers.
> 
> In `@tsrx/ripple`, JSX-to-AST conversion no longer marks every `{expr}` attribute name as `tracked`, so getter generation follows the same rules as native templates instead of treating all JSX expression props as dynamic.
> 
> The **TSRX parser** now rejects native dynamic `@` syntax inside TSX/fragment islands (`<@tag>`, `@prop` on attributes) with clear errors, while keeping `<@tag>` valid in native and nested `<tsrx>` templates. Broad compile tests document the prop and diagnostic behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc0986f8867f1ceeb3e0cb957057873f9a02a160. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->