### PR TITLE
fix(prettier-plugin): start restoring deleted prettier tests

### DIFF
--- a/.changeset/neat-template-arrow-returns.md
+++ b/.changeset/neat-template-arrow-returns.md
@@ -1,0 +1,5 @@
+---
+"@tsrx/prettier-plugin": patch
+---
+
+Format TSRX arrow returns and fragments consistently across declarations and attributes.

--- a/packages/prettier-plugin/src/index.js
+++ b/packages/prettier-plugin/src/index.js
@@ -2682,6 +2682,12 @@ function printArrowFunction(node, path, options, print, args) {
 		if (shouldBreakBody) {
 			parts.push(' =>', indent([hardline, bodyContent]));
 		} else {
+			if (isTemplateExpression(node.body)) {
+				return conditionalGroup([
+					group([...parts, ' => ', bodyContent]),
+					group([...parts, ' =>', indent([hardline, bodyContent])]),
+				]);
+			}
 			parts.push(
 				' =>',
 				group(indent(line), { id: groupId }),
@@ -2710,10 +2716,17 @@ function isTemplateExpression(node) {
 /**
  * Check whether a braced attribute expression should close on its own line.
  * @param {AST.Node} node - The expression inside the attribute braces
+ * @param {RippleFormatOptions} options - Prettier options
+ * @param {AST.NodeWithLocation} [attributeNode] - The full attribute node
  * @returns {boolean}
  */
-function shouldBreakAttributeExpressionClosingBrace(node) {
-	return node.type === 'ArrowFunctionExpression' && node.body && isTemplateExpression(node.body);
+function shouldBreakAttributeExpressionClosingBrace(node, options, attributeNode) {
+	return (
+		node.type === 'ArrowFunctionExpression' &&
+		node.body &&
+		isTemplateExpression(node.body) &&
+		sourceSpanExceedsPrintWidth(attributeNode ?? /** @type {AST.NodeWithLocation} */ (node), options)
+	);
 }
 
 /**
@@ -2930,9 +2943,6 @@ function sourceSpanExceedsPrintWidth(node, options) {
  * @returns {boolean}
  */
 function shouldBreakArrowExpressionBody(node, options, args) {
-	if (args?.isInAttribute && isTemplateExpression(node)) {
-		return true;
-	}
 	return (
 		(node.type === 'BinaryExpression' || node.type === 'LogicalExpression') &&
 		sourceSpanExceedsPrintWidth(/** @type {AST.NodeWithLocation} */ (node), options)
@@ -5032,6 +5042,16 @@ function printVariableDeclarator(node, path, options, print) {
 			}
 		}
 
+		if (isTemplateExpression(node.init)) {
+			const groupId = Symbol('declaration');
+			return group([
+				group(id),
+				' =',
+				group(indent(line), { id: groupId }),
+				indentIfBreak(init, { groupId }),
+			]);
+		}
+
 		// Default: simple inline format with space
 		// Use group to allow breaking if needed - but keep inline when it fits
 		return group([id, ' = ', init]);
@@ -6067,7 +6087,7 @@ function printJSXAttribute(attr, path, options, print) {
 			'value',
 			'expression',
 		);
-		if (shouldBreakAttributeExpressionClosingBrace(expression)) {
+		if (shouldBreakAttributeExpressionClosingBrace(expression, options, attr)) {
 			return [name, '={', exprDoc, hardline, '}'];
 		}
 		return [name, '={', exprDoc, '}'];
@@ -6275,9 +6295,12 @@ function printElement(element, path, options, print) {
 				const attrDoc = print(attrPath);
 				parts.push(attrDoc);
 				const attr_node = /** @type {AST.Attribute | AST.SpreadAttribute} */ (attrPath.node);
+				const attr_value = attr_node.type === 'Attribute' ? attr_node.value : null;
+				const is_template_arrow_attribute =
+					attr_value?.type === 'ArrowFunctionExpression' && isTemplateExpression(attr_value.body);
 				if (
 					!hasBreakingAttribute &&
-					(willBreak(attrDoc) ||
+					((willBreak(attrDoc) && !is_template_arrow_attribute) ||
 						(attr_node.type === 'Attribute' && is_attribute_value_breakable(attr_node.value)))
 				) {
 					hasBreakingAttribute = true;
@@ -6650,8 +6673,8 @@ function printAttribute(node, path, options, print) {
 			parts.push('={');
 			// Pass inline context for attribute values (keep objects compact)
 			parts.push(path.call((attrPath) => print(attrPath, { isInAttribute: true }), 'value'));
-			if (shouldBreakAttributeExpressionClosingBrace(node.value)) {
-				parts.push(hardline);
+			if (shouldBreakAttributeExpressionClosingBrace(node.value, options, node)) {
+				parts.push(ifBreak(hardline, ''));
 			}
 			parts.push('}');
 		}

--- a/packages/prettier-plugin/src/index.test.js
+++ b/packages/prettier-plugin/src/index.test.js
@@ -14,12 +14,256 @@ expect.extend({
 
 		return {
 			pass,
-			message: () => `Expected:\n${expectedWithNewline}\nReceived:\n${received}`,
+			message: () => {
+				const { matcherHint, EXPECTED_COLOR, RECEIVED_COLOR } = this.utils;
+
+				/**
+				 * @param {string} str
+				 * @param {(str: string) => string} colorFn
+				 */
+				const formatWithColor = (str, colorFn) => {
+					return colorFn(str);
+				};
+
+				// Just apply color without modifying the string
+				return (
+					matcherHint('toBeWithNewline') +
+					'\n\nExpected:\n' +
+					formatWithColor(expectedWithNewline, EXPECTED_COLOR) +
+					'\nReceived:\n' +
+					formatWithColor(received, RECEIVED_COLOR)
+				);
+			},
 		};
 	},
 });
 
 describe('prettier-plugin', () => {
+	it('should format a simple function', async () => {
+		const input = `export function Test(){let count=0;<div>{"Hello"}</div>}`;
+		const expected = `export function Test() {
+  let count = 0;
+  <div>{'Hello'}</div>
+}`;
+		const result = await format(input, { singleQuote: true });
+		expect(result).toBeWithNewline(expected);
+	});
+
+	it('should format tsrx expression fragments', async () => {
+		const input = `function App(){const content=<>const label="Hi";<div>"Hello" {label}</div>{content}</>;}`;
+		const expected = `function App() {
+  const content = <>
+    const label = 'Hi';
+    <div>"Hello"{label}</div>
+    {content}
+  </>;
+}`;
+		const result = await format(input, { singleQuote: true });
+		expect(result).toBeWithNewline(expected);
+	});
+
+	it('keeps ordinary single-expression blocks expanded', async () => {
+		const input = `function Test(){ {value} }`;
+		const expected = `function Test() {
+  {
+    value;
+  }
+}`;
+
+		const result = await format(input);
+		expect(result).toBeWithNewline(expected);
+	});
+
+	it('should keep sibling children in tsrx expression fragments on separate lines', async () => {
+		const input = `function Test(p1,p2){return <><div>"Hello"</div><div>{p1}</div><div>{p2}</div></>}`;
+		const expected = `function Test(p1, p2) {
+  return <>
+    <div>"Hello"</div>
+    <div>{p1}</div>
+    <div>{p2}</div>
+  </>;
+}`;
+		const result = await format(input);
+		expect(result).toBeWithNewline(expected);
+	});
+
+	it('keeps fitting tsrx arrow returns inline in declarations and attributes', async () => {
+		const input = `function Test(props){const func=(item)=><><Item {item}/></>;<List renderItem={(item)=><><Item {item}/></>} />}`;
+		const expected = `function Test(props) {
+  const func = (item) => <><Item {item} /></>;
+  <List renderItem={(item) => <><Item {item} /></>} />
+}`;
+
+		const result = await format(input, { printWidth: 60 });
+		expect(result).toBeWithNewline(expected);
+	});
+
+	it('breaks non-fitting tsrx arrow returns after the arrow in declarations and attributes - printWidth: 60', async () => {
+		const input = `function Test(props) {
+  const func = (item) => <><ItemView {item} onSelect={props.onSelect} /></>;
+  <List
+    items={props.items}
+    renderItem={(item) => <><ItemView {item} onSelect={props.onSelect} /></>}
+  />
+}`;
+		const expected = `function Test(props) {
+  const func = (item) =>
+    <><ItemView {item} onSelect={props.onSelect} /></>;
+  <List
+    items={props.items}
+    renderItem={(item) =>
+      <><ItemView {item} onSelect={props.onSelect} /></>
+    }
+  />
+}`;
+		const result = await format(input, { singleQuote: true, printWidth: 60 });
+		expect(result).toBeWithNewline(expected);
+	});
+
+	it('breaks non-fitting tsrx arrow returns after the arrow in declarations and attributes - printWidth: 80', async () => {
+		const input = `function Test(props) {
+  const func = (item) => <><ItemView {item} onSelect={props.onSelect} /></>;
+  <List
+    items={props.items}
+    renderItem={(item) => <><ItemView {item} onSelect={props.onSelect} /></>}
+  />
+}`;
+		const expected = `function Test(props) {
+  const func = (item) => <><ItemView {item} onSelect={props.onSelect} /></>;
+  <List
+    items={props.items}
+    renderItem={(item) => <><ItemView {item} onSelect={props.onSelect} /></>}
+  />
+}`;
+		const result = await format(input, { singleQuote: true, printWidth: 80 });
+		expect(result).toBeWithNewline(expected);
+	});
+
+	it('keeps fitting single-child fragments inline and expands non-fitting single-child fragments', async () => {
+		const input = `function Test(){const short=<><span>"Ready"</span></>;const long=<><ReallyLongComponentName first={alpha} second={beta} third={gamma}/></>;}`;
+		const expected = `function Test() {
+  const short = <><span>"Ready"</span></>;
+  const long = <>
+    <ReallyLongComponentName
+      first={alpha}
+      second={beta}
+      third={gamma}
+    />
+  </>;
+}`;
+
+		const result = await format(input, { printWidth: 60 });
+		expect(result).toBeWithNewline(expected);
+	});
+
+	it('expands multi-child fragments while keeping fitting openers on the first line', async () => {
+		const input = `function Test(){const short=<><div>"A"</div><div>"B"</div></>;const thisNameIsRidiculouslyLongEnoughToMissThePrintWidth=<><div>"A"</div><div>"B"</div></>;}`;
+		const expected = `function Test() {
+  const short = <>
+    <div>"A"</div>
+    <div>"B"</div>
+  </>;
+  const thisNameIsRidiculouslyLongEnoughToMissThePrintWidth =
+    <>
+      <div>"A"</div>
+      <div>"B"</div>
+    </>;
+}`;
+
+		const result = await format(input, { printWidth: 60 });
+		expect(result).toBeWithNewline(expected);
+	});
+
+	it('should preserve comments before expressions after nested tsx and tsrx blocks', async () => {
+		const expected = `function App() {
+  const content = <>
+    <span class="nested-tsx">{'inside nested tsx'}</span>
+    <div class="native">{nested}</div>
+    // const content =
+    //   <div>{hey()}</div>
+    // ;
+    {content}
+  </>;
+  return content;
+}`;
+		const result = await format(expected, { singleQuote: true });
+		expect(result).toBeWithNewline(expected);
+	});
+
+	it('should format whitespace correctly', async () => {
+		const input = `export function Test(){
+  return <>
+        let count=0
+        // comment
+        <div>{"Hello"}</div>
+        <div>
+          let two=2
+          {"Hello"}
+        </div>
+  </>;
+    }`;
+		const expected = `export function Test() {
+  return <>
+    let count = 0;
+    // comment
+    <div>{'Hello'}</div>
+    <div>
+      let two = 2;
+      {'Hello'}
+    </div>
+  </>;
+}`;
+		const result = await format(input, { singleQuote: true });
+		expect(result).toBeWithNewline(expected);
+	});
+
+	it('should format whitespace correctly #2', async () => {
+		const input = `export function Test(){
+    return <>
+        let count=0
+          const x = () => {
+            console.log("test");
+            if (x) {
+              console.log('test');
+              return null;
+            }
+            if (y) {
+              return null;
+            }
+            return x;
+          }
+        <div>{"Hello"}</div>
+        <div>
+          let two=2
+          {"Hello"}
+        </div>
+    </>;
+    }`;
+		const expected = `export function Test() {
+  return <>
+    let count = 0;
+    const x = () => {
+      console.log('test');
+      if (x) {
+        console.log('test');
+        return null;
+      }
+      if (y) {
+        return null;
+      }
+      return x;
+    };
+    <div>{'Hello'}</div>
+    <div>
+      let two = 2;
+      {'Hello'}
+    </div>
+  </>;
+}`;
+		const result = await format(input, { singleQuote: true });
+		expect(result).toBeWithNewline(expected);
+	});
+
 	it('registers .tsrx as a supported file extension', () => {
 		const ripple_language = languages?.[0];
 


### PR DESCRIPTION
Start the process of restoring deleted tests for prettier.  Will be in draft until the new tsrx syntax if finalized and all deleted tests that still apply are added back.