### PR TITLE
fix(website-tsrx): fix sticky docs sidebar with overflow-x: clip

### DIFF
--- a/website-tsrx/src/components/layout.tsrx
+++ b/website-tsrx/src/components/layout.tsrx
@@ -1,6 +1,6 @@
 export function Layout({ children }: { children: any }) {
 	return <>
-		<main class="shell">{children}</main>
+		<div class="shell">{children}</div>
 		<style>
 			:global(*) {
 				box-sizing: border-box;
@@ -8,7 +8,8 @@ export function Layout({ children }: { children: any }) {
 
 			:global(html) {
 				scroll-behavior: smooth;
-				overflow-x: hidden;
+				overflow-x: clip;
+				scrollbar-gutter: stable;
 			}
 
 			:global(body) {
@@ -31,7 +32,6 @@ export function Layout({ children }: { children: any }) {
 					100% 100vh,
 					100% 100%;
 				min-height: 100vh;
-				overflow-x: hidden;
 			}
 
 			:global(a) {
@@ -41,7 +41,8 @@ export function Layout({ children }: { children: any }) {
 
 			:global(button),
 			:global(input),
-			:global(textarea) {
+			:global(textarea),
+			:global(select) {
 				font: inherit;
 			}
 

--- a/website-tsrx/src/pages/blog-simplifying-tsrx-after-feedback.tsrx
+++ b/website-tsrx/src/pages/blog-simplifying-tsrx-after-feedback.tsrx
@@ -1,3 +1,4 @@
+import { Layout } from '../components/layout.tsrx';
 import { highlight_tsrx } from '../lib/code-highlight.ts';
 
 const OLD_COMPONENT_SYNTAX_HTML = highlight_tsrx(
@@ -180,7 +181,7 @@ export function BlogSimplifyingTsrxAfterFeedbackPage() {
 				content="TSRX is removing early alpha syntax and moving closer to ordinary TypeScript and JSX patterns."
 			/>
 		</head>
-		<div class="app-shell">
+		<Layout>
 			<div class="page-shell">
 				<header class="masthead">
 					<a class="brand-lockup" href="/" aria-label="TSRX home">
@@ -415,57 +416,8 @@ export function BlogSimplifyingTsrxAfterFeedbackPage() {
 					<p>{'Copyright © 2025-present Dominic Gannaway'}</p>
 				</footer>
 			</div>
-		</div>
+		</Layout>
 		<style>
-			:global(*) {
-				box-sizing: border-box;
-			}
-
-			:global(html) {
-				scroll-behavior: smooth;
-				overflow-x: clip;
-				scrollbar-gutter: stable;
-			}
-
-			:global(body) {
-				margin: 0;
-				font-family:
-					system-ui,
-					-apple-system,
-					BlinkMacSystemFont,
-					'Segoe UI',
-					Roboto,
-					sans-serif;
-				color: #1a1640;
-				background:
-					radial-gradient(circle at top, rgba(146, 92, 255, 0.14), transparent 15%),
-					radial-gradient(circle at 80% 10%, rgba(111, 0, 255, 0.1), transparent 15%),
-					linear-gradient(180deg, #ffffff 0%, #f6f3ff 46%, #f2f4fb 100%);
-				background-repeat: no-repeat;
-				background-size:
-					100% 100vh,
-					100% 100vh,
-					100% 100%;
-				min-height: 100vh;
-				overflow-x: clip;
-			}
-
-			:global(a) {
-				color: inherit;
-				text-decoration: none;
-			}
-
-			:global(code),
-			:global(pre) {
-				font-family: 'Spline Sans Mono', 'SFMono-Regular', monospace;
-			}
-
-			.app-shell {
-				position: relative;
-				z-index: 1;
-				width: 100%;
-			}
-
 			.page-shell {
 				width: min(1040px, calc(100vw - 2rem));
 				margin: 0 auto;

--- a/website-tsrx/src/pages/blog.tsrx
+++ b/website-tsrx/src/pages/blog.tsrx
@@ -1,3 +1,5 @@
+import { Layout } from '../components/layout.tsrx';
+
 export function BlogPage() {
 	return <>
 		<head>
@@ -7,7 +9,7 @@ export function BlogPage() {
 				content="Updates from the TSRX project: language changes, design notes, and release context."
 			/>
 		</head>
-		<div class="app-shell">
+		<Layout>
 			<div class="page-shell">
 				<header class="masthead">
 					<a class="brand-lockup" href="/" aria-label="TSRX home">
@@ -59,52 +61,8 @@ export function BlogPage() {
 					<p>{'Copyright © 2025-present Dominic Gannaway'}</p>
 				</footer>
 			</div>
-		</div>
+		</Layout>
 		<style>
-			:global(*) {
-				box-sizing: border-box;
-			}
-
-			:global(html) {
-				scroll-behavior: smooth;
-				overflow-x: clip;
-				scrollbar-gutter: stable;
-			}
-
-			:global(body) {
-				margin: 0;
-				font-family:
-					system-ui,
-					-apple-system,
-					BlinkMacSystemFont,
-					'Segoe UI',
-					Roboto,
-					sans-serif;
-				color: #1a1640;
-				background:
-					radial-gradient(circle at top, rgba(146, 92, 255, 0.14), transparent 15%),
-					radial-gradient(circle at 80% 10%, rgba(111, 0, 255, 0.1), transparent 15%),
-					linear-gradient(180deg, #ffffff 0%, #f6f3ff 46%, #f2f4fb 100%);
-				background-repeat: no-repeat;
-				background-size:
-					100% 100vh,
-					100% 100vh,
-					100% 100%;
-				min-height: 100vh;
-				overflow-x: clip;
-			}
-
-			:global(a) {
-				color: inherit;
-				text-decoration: none;
-			}
-
-			.app-shell {
-				position: relative;
-				z-index: 1;
-				width: 100%;
-			}
-
 			.page-shell {
 				width: min(1040px, calc(100vw - 2rem));
 				margin: 0 auto;

--- a/website-tsrx/src/pages/features.tsrx
+++ b/website-tsrx/src/pages/features.tsrx
@@ -1,5 +1,6 @@
 // --- Code snippets ---
 
+import { Layout } from '../components/layout.tsrx';
 import { highlight_tsrx } from '../lib/code-highlight.ts';
 
 const COMPONENT_HTML = highlight_tsrx(
@@ -336,7 +337,7 @@ export function FeaturesPage() {
 				content="TSRX language features: function components, returned templates, control flow, error boundaries, and more."
 			/>
 		</head>
-		<div class="app-shell">
+		<Layout>
 			<div class="page-shell">
 				<header class="masthead">
 					<a class="brand-lockup" href="/" aria-label="TSRX home">
@@ -781,57 +782,8 @@ export function FeaturesPage() {
 					<p>{'Copyright © 2025-present Dominic Gannaway'}</p>
 				</footer>
 			</div>
-		</div>
+		</Layout>
 		<style>
-			:global(*) {
-				box-sizing: border-box;
-			}
-
-			:global(html) {
-				scroll-behavior: smooth;
-				overflow-x: clip;
-				scrollbar-gutter: stable;
-			}
-
-			:global(body) {
-				margin: 0;
-				font-family:
-					system-ui,
-					-apple-system,
-					BlinkMacSystemFont,
-					'Segoe UI',
-					Roboto,
-					sans-serif;
-				color: #1a1640;
-				background:
-					radial-gradient(circle at top, rgba(146, 92, 255, 0.14), transparent 15%),
-					radial-gradient(circle at 80% 10%, rgba(111, 0, 255, 0.1), transparent 15%),
-					linear-gradient(180deg, #ffffff 0%, #f6f3ff 46%, #f2f4fb 100%);
-				background-repeat: no-repeat;
-				background-size:
-					100% 100vh,
-					100% 100vh,
-					100% 100%;
-				min-height: 100vh;
-				overflow-x: clip;
-			}
-
-			:global(a) {
-				color: inherit;
-				text-decoration: none;
-			}
-
-			:global(code),
-			:global(pre) {
-				font-family: 'Spline Sans Mono', 'SFMono-Regular', monospace;
-			}
-
-			.app-shell {
-				position: relative;
-				z-index: 1;
-				width: 100%;
-			}
-
 			.page-shell {
 				width: min(1180px, calc(100vw - 2rem));
 				margin: 0 auto;

--- a/website-tsrx/src/pages/getting-started.tsrx
+++ b/website-tsrx/src/pages/getting-started.tsrx
@@ -1,5 +1,7 @@
 // --- Code snippets (hand-highlighted, matching homepage code-block style) ---
 
+import { Layout } from '../components/layout.tsrx';
+
 const INSTALL_HTML = [
 	'<span class="ln">1</span> <span class="fn">pnpm</span> <span class="prop">install</span> <span class="str">@tsrx/react</span> <span class="str">@tsrx/vite-plugin-react</span>',
 ].join('\n');
@@ -286,7 +288,7 @@ export function GettingStartedPage() {
 				content="Get started with TSRX: install with React, Preact, Solid, Vue, or Ripple for Vite, Rspack, Turbopack, or Bun, learn the function-return syntax, and explore inline template control flow."
 			/>
 		</head>
-		<div class="app-shell">
+		<Layout>
 			<div class="page-shell">
 				<header class="masthead">
 					<a class="brand-lockup" href="/" aria-label="TSRX home">
@@ -919,57 +921,8 @@ export function GettingStartedPage() {
 					<p>"Copyright © 2025-present Dominic Gannaway"</p>
 				</footer>
 			</div>
-		</div>
+		</Layout>
 		<style>
-			:global(*) {
-				box-sizing: border-box;
-			}
-
-			:global(html) {
-				scroll-behavior: smooth;
-				overflow-x: hidden;
-				scrollbar-gutter: stable;
-			}
-
-			:global(body) {
-				margin: 0;
-				font-family:
-					system-ui,
-					-apple-system,
-					BlinkMacSystemFont,
-					'Segoe UI',
-					Roboto,
-					sans-serif;
-				color: #1a1640;
-				background:
-					radial-gradient(circle at top, rgba(146, 92, 255, 0.14), transparent 15%),
-					radial-gradient(circle at 80% 10%, rgba(111, 0, 255, 0.1), transparent 15%),
-					linear-gradient(180deg, #ffffff 0%, #f6f3ff 46%, #f2f4fb 100%);
-				background-repeat: no-repeat;
-				background-size:
-					100% 100vh,
-					100% 100vh,
-					100% 100%;
-				min-height: 100vh;
-				overflow-x: hidden;
-			}
-
-			:global(a) {
-				color: inherit;
-				text-decoration: none;
-			}
-
-			:global(code),
-			:global(pre) {
-				font-family: 'Spline Sans Mono', 'SFMono-Regular', monospace;
-			}
-
-			.app-shell {
-				position: relative;
-				z-index: 1;
-				width: 100%;
-			}
-
 			.page-shell {
 				width: min(1180px, calc(100vw - 2rem));
 				margin: 0 auto;

--- a/website-tsrx/src/pages/index.tsrx
+++ b/website-tsrx/src/pages/index.tsrx
@@ -1,3 +1,4 @@
+import { Layout } from '../components/layout.tsrx';
 import { highlight_tsrx } from '../lib/code-highlight.ts';
 
 const SNIPPET_HTML = highlight_tsrx(
@@ -90,7 +91,7 @@ export function IndexPage() {
 				content="TSRX is a TypeScript language extension for building declarative UIs in an agentic era."
 			/>
 		</head>
-		<div class="app-shell">
+		<Layout>
 			<div class="page-shell">
 				<header class="masthead">
 					<a class="brand-lockup" href="#top" aria-label="TSRX home">
@@ -273,64 +274,8 @@ export function IndexPage() {
 					<p>{'Copyright © 2025-present Dominic Gannaway'}</p>
 				</footer>
 			</div>
-		</div>
+		</Layout>
 		<style>
-			:global(*) {
-				box-sizing: border-box;
-			}
-
-			:global(html) {
-				scroll-behavior: smooth;
-				overflow-x: hidden;
-				scrollbar-gutter: stable;
-			}
-
-			:global(body) {
-				margin: 0;
-				font-family:
-					system-ui,
-					-apple-system,
-					BlinkMacSystemFont,
-					'Segoe UI',
-					Roboto,
-					sans-serif;
-				color: #1a1640;
-				background:
-					radial-gradient(circle at top, rgba(146, 92, 255, 0.14), transparent 15%),
-					radial-gradient(circle at 80% 10%, rgba(111, 0, 255, 0.1), transparent 15%),
-					linear-gradient(180deg, #ffffff 0%, #f6f3ff 46%, #f2f4fb 100%);
-				background-repeat: no-repeat;
-				background-size:
-					100% 100vh,
-					100% 100vh,
-					100% 100%;
-				min-height: 100vh;
-				overflow-x: hidden;
-			}
-
-			:global(a) {
-				color: inherit;
-				text-decoration: none;
-			}
-
-			:global(button),
-			:global(input),
-			:global(textarea),
-			:global(select) {
-				font: inherit;
-			}
-
-			:global(code),
-			:global(pre) {
-				font-family: 'Spline Sans Mono', 'SFMono-Regular', monospace;
-			}
-
-			.app-shell {
-				position: relative;
-				z-index: 1;
-				width: 100%;
-			}
-
 			.page-shell {
 				width: min(1180px, calc(100vw - 2rem));
 				margin: 0 auto;

--- a/website-tsrx/src/pages/playground.tsrx
+++ b/website-tsrx/src/pages/playground.tsrx
@@ -1,4 +1,5 @@
 import { CompilerDemo } from '../components/compiler-demo.tsrx';
+import { Layout } from '../components/layout.tsrx';
 
 export function PlaygroundPage() {
 	return <>
@@ -9,86 +10,38 @@ export function PlaygroundPage() {
 				content="Try TSRX in the browser. Write component code and see the compiled code in real time."
 			/>
 		</head>
-		<div class="demo-page">
-			<header class="demo-nav">
-				<a class="brand-lockup" href="/" aria-label="TSRX home">
-					<img class="header-logo" src="/images/tsrx-mark.svg?v=4" alt="TSRX logo" />
-				</a>
-				<nav class="nav-links">
-					<a href="/getting-started">{'Getting Started'}</a>
-					<a href="/features">{'Features'}</a>
-					<a href="/specification">{'Specification'}</a>
-					<a href="/playground" aria-current="page">{'Playground'}</a>
-					<a href="/blog">{'Blog'}</a>
-					<a href="https://discord.gg/HCYpT5QHQR" target="_blank" rel="noopener noreferrer">
-						{'Discord'}
+		<Layout>
+			<div class="demo-page">
+				<header class="demo-nav">
+					<a class="brand-lockup" href="/" aria-label="TSRX home">
+						<img class="header-logo" src="/images/tsrx-mark.svg?v=4" alt="TSRX logo" />
 					</a>
-					<a
-						href="https://github.com/Ripple-TS/ripple/tree/main/packages/tsrx"
-						target="_blank"
-						rel="noopener noreferrer"
-					>
-						{'GitHub'}
-					</a>
-					<a href="/llms.txt" target="_blank" rel="noopener noreferrer">{'llms.txt'}</a>
-				</nav>
-			</header>
+					<nav class="nav-links">
+						<a href="/getting-started">{'Getting Started'}</a>
+						<a href="/features">{'Features'}</a>
+						<a href="/specification">{'Specification'}</a>
+						<a href="/playground" aria-current="page">{'Playground'}</a>
+						<a href="/blog">{'Blog'}</a>
+						<a href="https://discord.gg/HCYpT5QHQR" target="_blank" rel="noopener noreferrer">
+							{'Discord'}
+						</a>
+						<a
+							href="https://github.com/Ripple-TS/ripple/tree/main/packages/tsrx"
+							target="_blank"
+							rel="noopener noreferrer"
+						>
+							{'GitHub'}
+						</a>
+						<a href="/llms.txt" target="_blank" rel="noopener noreferrer">{'llms.txt'}</a>
+					</nav>
+				</header>
 
-			<main class="demo-main">
-				<CompilerDemo />
-			</main>
-		</div>
+				<main class="demo-main">
+					<CompilerDemo />
+				</main>
+			</div>
+		</Layout>
 		<style>
-			:global(*) {
-				box-sizing: border-box;
-			}
-
-			:global(html) {
-				scroll-behavior: smooth;
-				overflow-x: hidden;
-				scrollbar-gutter: stable;
-			}
-
-			:global(body) {
-				margin: 0;
-				font-family:
-					system-ui,
-					-apple-system,
-					BlinkMacSystemFont,
-					'Segoe UI',
-					Roboto,
-					sans-serif;
-				color: #1a1640;
-				background:
-					radial-gradient(circle at top, rgba(146, 92, 255, 0.14), transparent 15%),
-					radial-gradient(circle at 80% 10%, rgba(111, 0, 255, 0.1), transparent 15%),
-					linear-gradient(180deg, #ffffff 0%, #f6f3ff 46%, #f2f4fb 100%);
-				background-repeat: no-repeat;
-				background-size:
-					100% 100vh,
-					100% 100vh,
-					100% 100%;
-				min-height: 100vh;
-				overflow-x: hidden;
-			}
-
-			:global(a) {
-				color: inherit;
-				text-decoration: none;
-			}
-
-			:global(button),
-			:global(input),
-			:global(textarea),
-			:global(select) {
-				font: inherit;
-			}
-
-			:global(code),
-			:global(pre) {
-				font-family: 'Spline Sans Mono', 'SFMono-Regular', monospace;
-			}
-
 			.demo-page {
 				display: grid;
 				grid-template-rows: auto 1fr;

--- a/website-tsrx/src/pages/specification.tsrx
+++ b/website-tsrx/src/pages/specification.tsrx
@@ -1,3 +1,5 @@
+import { Layout } from '../components/layout.tsrx';
+
 const MODIFIED_PRODUCTIONS = [
 	'PrimaryExpression :',
 	'  TsrxExpression',
@@ -188,7 +190,7 @@ export function SpecificationPage() {
 				content="Draft TSRX language specification: TypeScript-compatible grammar extensions, TSRX return expressions, expression values, lazy destructuring, style identifiers, and host-defined server extensions."
 			/>
 		</head>
-		<div class="app-shell">
+		<Layout>
 			<div class="page-shell">
 				<header class="masthead">
 					<a class="brand-lockup" href="/" aria-label="TSRX home">
@@ -605,57 +607,8 @@ export function SpecificationPage() {
 					<p>{'Copyright © 2025-present Dominic Gannaway'}</p>
 				</footer>
 			</div>
-		</div>
+		</Layout>
 		<style>
-			:global(*) {
-				box-sizing: border-box;
-			}
-
-			:global(html) {
-				scroll-behavior: smooth;
-				overflow-x: hidden;
-				scrollbar-gutter: stable;
-			}
-
-			:global(body) {
-				margin: 0;
-				font-family:
-					system-ui,
-					-apple-system,
-					BlinkMacSystemFont,
-					'Segoe UI',
-					Roboto,
-					sans-serif;
-				color: #1a1640;
-				background:
-					radial-gradient(circle at top, rgba(146, 92, 255, 0.14), transparent 15%),
-					radial-gradient(circle at 80% 10%, rgba(111, 0, 255, 0.1), transparent 15%),
-					linear-gradient(180deg, #ffffff 0%, #f6f3ff 46%, #f2f4fb 100%);
-				background-repeat: no-repeat;
-				background-size:
-					100% 100vh,
-					100% 100vh,
-					100% 100%;
-				min-height: 100vh;
-				overflow-x: hidden;
-			}
-
-			:global(a) {
-				color: inherit;
-				text-decoration: none;
-			}
-
-			:global(code),
-			:global(pre) {
-				font-family: 'Spline Sans Mono', 'SFMono-Regular', monospace;
-			}
-
-			.app-shell {
-				position: relative;
-				z-index: 1;
-				width: 100%;
-			}
-
 			.page-shell {
 				width: min(1180px, calc(100vw - 2rem));
 				margin: 0 auto;


### PR DESCRIPTION
## Summary
- Switch global `overflow-x` from `hidden` to `clip` on `html` to fix sticky side nav on docs pages (`getting-started`, `features`, `specification`). `overflow-x: hidden` was creating a scroll container that broke `position: sticky`.
- Adopt the shared `Layout` component across all `website-tsrx` pages to centralize the global reset and remove duplicated `.app-shell` CSS.

## Test plan
- [x] Visually verified all 7 routes (`/`, `/getting-started`, `/features`, `/specification`, `/playground`, `/blog`, blog post)
- [x] Confirmed sticky side nav stays pinned while scrolling on docs pages
- [x] Before/after full-page screenshots compared (no visual regressions)
- [x] `pnpm format:check` on changed files


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS and markup refactor on the marketing/docs site only; no auth, data, or compiler/runtime logic changes.
> 
> **Overview**
> Fixes **sticky docs side navigation** on long pages by changing global horizontal overflow on `html` from `hidden` to **`clip`** (and adding **`scrollbar-gutter: stable`**), so `position: sticky` on `.side-nav` is no longer broken by an unintended scroll container. **`body`** no longer sets `overflow-x: hidden`.
> 
> **Centralizes site chrome** by wrapping all `website-tsrx` routes in the shared **`Layout`** component and deleting per-page copies of global resets, typography, and `.app-shell` styles. **`Layout`** now uses a **`div.shell`** wrapper (instead of `main`) and extends inherited form styling to **`select`**.
> 
> Scope is presentation-only across index, docs, blog, playground, and **`layout.tsrx`**; behavior change is mainly sticky nav + consistent globals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f2dcd02599341c72a953c36fbd875ad77943d7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->