### PR TITLE
fix(parser, prettier): block comments parsing and printing

### DIFF
--- a/.changeset/template-block-comments.md
+++ b/.changeset/template-block-comments.md
@@ -1,0 +1,13 @@
+---
+'@tsrx/core': patch
+'@tsrx/prettier-plugin': patch
+---
+
+Strip `/* … */` block comments from template text on all targets. The
+template raw-text scanner only recognized line comments, so block comments
+in text position leaked into compiled output (production templates, server
+output, and to_ts virtual code) and, in one position, were both recorded as
+a comment and kept as text. Block comments are now removed from `JSXText`
+and recorded as comments everywhere, and the Prettier plugin prints them
+back (including before closing tags/fragments and in comment-only bodies)
+instead of relying on the leaked text.

--- a/packages/prettier-plugin/src/index.js
+++ b/packages/prettier-plugin/src/index.js
@@ -5960,26 +5960,13 @@ function printJSXElement(node, path, options, print) {
 		{ shouldBreak: shouldForceBreak },
 	);
 
-	// Trailing comments after the last child are attached by the parser either to
-	// the closing tag (`closingElement.leadingComments`) or, when the last child is
-	// an `{expr}` container, to `metadata.elementLeadingComments` positioned inside
-	// the body (start >= opening tag end). Emit both before `</tag>`.
-	const openingTagEnd = /** @type {AST.NodeWithLocation} */ (openingElement).end;
-	const bodyMetaComments = (node.metadata?.elementLeadingComments ?? []).filter(
-		(/** @type {AST.Comment} */ comment) =>
-			typeof comment.start === 'number' && comment.start >= openingTagEnd,
+	// Comments before `</tag>` and the comments of a comment-only element.
+	const { closingCommentDocs, innerCommentDocs } = collectElementBodyCommentDocs(
+		node,
+		openingElement,
+		node.closingElement,
 	);
-	const trailingComments = [
-		...(node.closingElement?.leadingComments ?? []),
-		...bodyMetaComments,
-	].sort((a, b) => /** @type {number} */ (a.start) - /** @type {number} */ (b.start));
-	const lastMeaningfulChild = [...(node.children ?? [])]
-		.reverse()
-		.find((child) => child.type !== 'JSXText' || child.value.trim());
-	const closingCommentDocs = printElementBodyLineComments(trailingComments, lastMeaningfulChild);
 	const hasClosingComments = closingCommentDocs.length > 0;
-	// A comment-only element has no children; its comments live in `innerComments`.
-	const innerCommentDocs = printElementBodyLineComments(node.innerComments);
 
 	if (!hasChildren) {
 		const bodyComments = [...innerCommentDocs, ...closingCommentDocs];
@@ -6171,7 +6158,19 @@ function printJSXElement(node, path, options, print) {
 function printJSXFragment(node, path, options, print) {
 	const hasChildren = node.children && node.children.length > 0;
 
+	// Comments before `</>` and the comments of a comment-only fragment.
+	const fragment = /** @type {any} */ (node);
+	const { closingCommentDocs, innerCommentDocs } = collectElementBodyCommentDocs(
+		node,
+		fragment.openingFragment,
+		fragment.closingFragment,
+	);
+
 	if (!hasChildren) {
+		const bodyComments = [...innerCommentDocs, ...closingCommentDocs];
+		if (bodyComments.length > 0) {
+			return group(['<>', indent(bodyComments), hardline, '</>']);
+		}
 		return '<></>';
 	}
 
@@ -6219,7 +6218,11 @@ function printJSXFragment(node, path, options, print) {
 	}
 
 	// Check if content can be inlined (single text node or single expression)
-	if (childrenDocs.length === 1 && typeof childrenDocs[0] === 'string') {
+	if (
+		childrenDocs.length === 1 &&
+		typeof childrenDocs[0] === 'string' &&
+		closingCommentDocs.length === 0
+	) {
 		return ['<>', childrenDocs[0], '</>'];
 	}
 	const meaningfulChildren = node.children.filter(
@@ -6230,6 +6233,7 @@ function printJSXFragment(node, path, options, print) {
 		meaningfulChildren.length === 1 &&
 		meaningfulChildren[0].type === 'JSXElement' &&
 		wasOriginallySingleLine(node) &&
+		closingCommentDocs.length === 0 &&
 		!willBreak(childrenDocs[0])
 	) {
 		// Keep the fragment inline when it fits; otherwise expand `<>` onto its own
@@ -6253,7 +6257,12 @@ function printJSXFragment(node, path, options, print) {
 	}
 
 	// Build the final fragment
-	return group(['<>', indent([hardline, ...formattedChildren]), hardline, '</>']);
+	return group([
+		'<>',
+		indent([hardline, ...formattedChildren, ...closingCommentDocs]),
+		hardline,
+		'</>',
+	]);
 }
 
 /**
@@ -6338,18 +6347,48 @@ function printTemplateChildLeadingComments(child) {
 }
 
 /**
- * Build doc parts for `//` line comments attached to an element body — trailing
+ * Collect and print the comments that belong to an element/fragment body:
+ * trailing comments after the last child (attached by the parser to the closing
+ * tag's `leadingComments` or, when the last child is an `{expr}` container, to
+ * `metadata.elementLeadingComments` positioned inside the body) and the comments
+ * of a comment-only body (`innerComments`).
+ * @param {any} node
+ * @param {any} openingNode
+ * @param {any} closingNode
+ * @returns {{ closingCommentDocs: Doc[], innerCommentDocs: Doc[] }}
+ */
+function collectElementBodyCommentDocs(node, openingNode, closingNode) {
+	const openingEnd = openingNode?.end;
+	const bodyMetaComments = (node.metadata?.elementLeadingComments ?? []).filter(
+		(/** @type {AST.Comment} */ comment) =>
+			typeof comment.start === 'number' &&
+			typeof openingEnd === 'number' &&
+			comment.start >= openingEnd,
+	);
+	const trailingComments = [...(closingNode?.leadingComments ?? []), ...bodyMetaComments].sort(
+		(/** @type {AST.Comment} */ a, /** @type {AST.Comment} */ b) =>
+			/** @type {number} */ (a.start) - /** @type {number} */ (b.start),
+	);
+	const lastMeaningfulChild = [...(node.children ?? [])]
+		.reverse()
+		.find((/** @type {any} */ child) => child.type !== 'JSXText' || child.value.trim());
+	return {
+		closingCommentDocs: printElementBodyComments(trailingComments, lastMeaningfulChild),
+		innerCommentDocs: printElementBodyComments(node.innerComments),
+	};
+}
+
+/**
+ * Build doc parts for comments attached to an element body — trailing
  * comments before `</tag>` (`closingElement.leadingComments`) or the comments of a
- * comment-only element (`innerComments`). Block comments are intentionally skipped:
- * they survive in the adjacent JSXText value and are already rendered as text, so
- * emitting them here would duplicate them. Each comment is emitted on its own line
+ * comment-only element (`innerComments`). Each comment is emitted on its own line
  * at the children indent.
  * @param {AST.Comment[] | null | undefined} commentList
  * @param {any} [previousNode]
  * @returns {Doc[]}
  */
-function printElementBodyLineComments(commentList, previousNode = null) {
-	const comments = (commentList ?? []).filter((comment) => comment.type === 'Line');
+function printElementBodyComments(commentList, previousNode = null) {
+	const comments = commentList ?? [];
 	if (comments.length === 0) {
 		return [];
 	}
@@ -6363,7 +6402,9 @@ function printElementBodyLineComments(commentList, previousNode = null) {
 		if (prev && getBlankLinesBetweenNodes(prev, comments[i]) > 0) {
 			parts.push(hardline);
 		}
-		parts.push('//' + comments[i].value);
+		parts.push(
+			comments[i].type === 'Line' ? '//' + comments[i].value : '/*' + comments[i].value + '*/',
+		);
 		prev = comments[i];
 	}
 	return parts;
@@ -6404,10 +6445,10 @@ function printJSXCodeBlock(node, path, options, print) {
 		parts.push(path.call(print, 'render'));
 	}
 	// Trailing comments after the last statement/render inside the block.
-	const innerCommentDocs = printElementBodyLineComments(node.innerComments);
+	const innerCommentDocs = printElementBodyComments(node.innerComments);
 	if (innerCommentDocs.length > 0) {
 		const lastNode = node.render ?? node.body[node.body.length - 1];
-		const firstComment = (node.innerComments ?? []).find((c) => c.type === 'Line');
+		const firstComment = (node.innerComments ?? [])[0];
 		if (lastNode && firstComment && getBlankLinesBetweenNodes(lastNode, firstComment) > 0) {
 			parts.push(hardline);
 		}

--- a/packages/prettier-plugin/src/index.js
+++ b/packages/prettier-plugin/src/index.js
@@ -2292,20 +2292,20 @@ function printRippleNode(node, path, options, print, args) {
 			break;
 
 		case 'JSXStyleElement':
-			nodeContent = printJSXElement(
-				/** @type {ESTreeJSX.JSXElement} */ (/** @type {unknown} */ (node)),
+			nodeContent = printJSXElement(node, path, options, print);
+			break;
+
+		case 'JSXElement':
+			nodeContent = printJSXElement(/** @type {AST.TSRXJSXElement} */ (node), path, options, print);
+			break;
+
+		case 'JSXFragment':
+			nodeContent = printJSXFragment(
+				/** @type {AST.TSRXJSXFragment} */ (node),
 				path,
 				options,
 				print,
 			);
-			break;
-
-		case 'JSXElement':
-			nodeContent = printJSXElement(node, path, options, print);
-			break;
-
-		case 'JSXFragment':
-			nodeContent = printJSXFragment(node, path, options, print);
 			break;
 
 		case 'JSXText':
@@ -5695,86 +5695,6 @@ function normalizeInlineJSXText(raw) {
 }
 
 /**
- * @param {AST.Node} parentNode
- * @param {AST.Node} firstChild
- * @param {Doc} childDoc
- * @returns {boolean}
- */
-function shouldInlineSingleChild(parentNode, firstChild, childDoc) {
-	if (!firstChild || childDoc == null) {
-		return false;
-	}
-
-	if (firstChild.type === 'JSXText') {
-		return true;
-	}
-
-	if (typeof childDoc === 'string') {
-		return childDoc.length <= 20 && !childDoc.includes('\n');
-	}
-
-	// Inline JSX expressions if they fit, but respect original multi-line formatting
-	// for non-literal expressions (e.g. {children} should stay multi-line if written that way)
-	if (firstChild.type === 'JSXExpressionContainer') {
-		if (wasOriginallySingleLine(parentNode)) {
-			return true;
-		}
-		// For multi-line parents, only inline if the expression is a simple literal
-		const expr = firstChild.expression;
-		if (expr && (expr.type === 'Literal' || expr.type === 'TemplateLiteral')) {
-			return true;
-		}
-		return false;
-	}
-
-	// Respect original formatting for elements: if parent was originally multi-line, keep it multi-line
-	// This follows Prettier's philosophy for decorators and objects
-	if (!wasOriginallySingleLine(parentNode)) {
-		return false;
-	}
-
-	if (firstChild.type === 'JSXElement' && firstChild.openingElement?.selfClosing) {
-		const parent = /** @type {any} */ (parentNode);
-		return !parent.openingElement?.attributes?.length;
-	}
-
-	return false;
-}
-
-/**
- * Check whether a child can participate in compact inline TSRX content.
- * @param {any} child
- * @returns {boolean}
- */
-function isInlineableTextOrExpressionChild(child) {
-	if (!child || (child.type !== 'JSXText' && child.type !== 'JSXExpressionContainer')) {
-		return false;
-	}
-
-	if (hasComment(/** @type {AST.Node & AST.NodeWithMaybeComments} */ (child))) {
-		return false;
-	}
-
-	const expression = /** @type {{ expression?: AST.Node & AST.NodeWithMaybeComments }} */ (child)
-		.expression;
-	return !expression || !hasComment(expression);
-}
-
-/**
- * @param {any} node
- * @returns {boolean}
- */
-function shouldTryInlineMultipleTextChildren(node) {
-	return (
-		wasOriginallySingleLine(node) &&
-		Array.isArray(node.children) &&
-		node.children.length > 1 &&
-		node.children.some((/** @type {any} */ child) => child.type === 'JSXText') &&
-		node.children.every(isInlineableTextOrExpressionChild)
-	);
-}
-
-/**
  * @param {AST.Node} child
  * @returns {boolean}
  */
@@ -5796,71 +5716,9 @@ function isSimpleJSXExpressionChild(child) {
 }
 
 /**
- * Get leading comments from element metadata
- * @param {ESTreeJSX.JSXElement} node - The element node
- * @returns {AST.Comment[]}
- */
-function getElementLeadingComments(node) {
-	const fromMetadata = node?.metadata?.elementLeadingComments;
-	if (Array.isArray(fromMetadata)) {
-		return fromMetadata;
-	}
-	return [];
-}
-
-/**
- * Create doc parts for element-level comments
- * @param {AST.Comment[]} comments - Array of comments
- * @returns {Doc[]}
- */
-function createElementLevelCommentParts(comments) {
-	if (!comments || comments.length === 0) {
-		return [];
-	}
-
-	/** @type {Doc[]} */
-	const parts = [];
-
-	for (let i = 0; i < comments.length; i++) {
-		const comment = comments[i];
-		const nextComment = comments[i + 1];
-
-		if (comment.type === 'Line') {
-			parts.push('//' + comment.value);
-			parts.push(hardline);
-		} else if (comment.type === 'Block') {
-			parts.push('/*' + comment.value + '*/');
-			parts.push(hardline);
-		}
-
-		if (nextComment) {
-			const blankLinesBetween = getBlankLinesBetweenNodes(comment, nextComment);
-			if (blankLinesBetween > 0) {
-				parts.push(hardline);
-			}
-		}
-	}
-
-	return parts;
-}
-
-/**
- * Create element-level comment parts with trailing hardline trimmed
- * @param {AST.Comment[]} comments - Array of comments
- * @returns {Doc[]}
- */
-function createElementLevelCommentPartsTrimmed(comments) {
-	const parts = createElementLevelCommentParts(comments);
-	if (parts.length > 0 && parts[parts.length - 1] === hardline) {
-		parts.pop();
-	}
-	return parts;
-}
-
-/**
  * Print a JSX element
- * @param {AST.TSRXJSXElement} node - The JSX element node
- * @param {AstPath<any>} path - The AST path
+ * @param {AST.TSRXJSXElement | AST.JSXStyleElement} node - The JSX element node
+ * @param {AstPath<AST.TSRXJSXElement>} path - The AST path
  * @param {RippleFormatOptions} options - Prettier options
  * @param {PrintFn} print - Print callback
  * @returns {Doc | Doc[]}
@@ -5873,7 +5731,7 @@ function printJSXElement(node, path, options, print) {
 	// Dynamic tags (`<{expr}>`) print the opening expression for both tags so
 	// they stay textually identical; static names print as plain strings.
 	const tagName =
-		/** @type {any} */ (openingElement.name).type === 'JSXExpressionContainer'
+		openingElement.name.type === 'JSXExpressionContainer'
 			? ['{', path.call(print, 'openingElement', 'name', 'expression'), '}']
 			: printJSXElementName(openingElement.name);
 
@@ -5962,7 +5820,7 @@ function printJSXElement(node, path, options, print) {
 
 	// Comments before `</tag>` and the comments of a comment-only element.
 	const { closingCommentDocs, innerCommentDocs } = collectElementBodyCommentDocs(
-		node,
+		/** @type {AST.TSRXJSXElement} */ (node),
 		openingElement,
 		node.closingElement,
 	);
@@ -6099,7 +5957,7 @@ function printJSXElement(node, path, options, print) {
 		];
 	}
 	const meaningfulChildren = node.children.filter(
-		(/** @type {any} */ child) => child.type !== 'JSXText' || child.value.trim(),
+		(child) => child.type !== 'JSXText' || child.value.trim(),
 	);
 	const singleMeaningfulChild = meaningfulChildren.length === 1 ? meaningfulChildren[0] : null;
 	if (
@@ -6114,9 +5972,9 @@ function printJSXElement(node, path, options, print) {
 		!forceMultiline &&
 		childrenDocs.length > 1 &&
 		wasOriginallySingleLine(node) &&
-		node.children.some((/** @type {any} */ child) => child.type === 'JSXText') &&
+		node.children.some((child) => child.type === 'JSXText') &&
 		node.children.every(
-			(/** @type {any} */ child) =>
+			(child) =>
 				child.type === 'JSXText' || isSimpleJSXExpressionChild(/** @type {AST.Node} */ (child)),
 		)
 	) {
@@ -6149,8 +6007,8 @@ function printJSXElement(node, path, options, print) {
 
 /**
  * Print a JSX fragment (<>...</>)
- * @param {ESTreeJSX.JSXFragment} node - The JSX fragment node
- * @param {AstPath<ESTreeJSX.JSXFragment>} path - The AST path
+ * @param {AST.TSRXJSXFragment} node - The JSX fragment node
+ * @param {AstPath<AST.TSRXJSXFragment>} path - The AST path
  * @param {RippleFormatOptions} options - Prettier options
  * @param {PrintFn} print - Print callback
  * @returns {Doc}
@@ -6159,11 +6017,10 @@ function printJSXFragment(node, path, options, print) {
 	const hasChildren = node.children && node.children.length > 0;
 
 	// Comments before `</>` and the comments of a comment-only fragment.
-	const fragment = /** @type {any} */ (node);
 	const { closingCommentDocs, innerCommentDocs } = collectElementBodyCommentDocs(
 		node,
-		fragment.openingFragment,
-		fragment.closingFragment,
+		node.openingFragment,
+		node.closingFragment,
 	);
 
 	if (!hasChildren) {
@@ -6175,7 +6032,7 @@ function printJSXFragment(node, path, options, print) {
 	}
 
 	// A `@{ … }` code block is the whole body and hugs the tags: `<>@{ … }</>`.
-	if (node.children.length === 1 && /** @type {any} */ (node.children[0]).type === 'JSXCodeBlock') {
+	if (node.children.length === 1 && node.children[0].type === 'JSXCodeBlock') {
 		return group(['<>', path.call(print, 'children', 0), '</>']);
 	}
 
@@ -6271,14 +6128,14 @@ function printJSXFragment(node, path, options, print) {
  * opening tag's end, but the child is visited first). Pull those out of the
  * children and return a map from attribute index to the comments that precede it,
  * so the element printer can render them in the opening tag instead of the body.
- * @param {AST.TSRXJSXElement} node
+ * @param {AST.TSRXJSXElement | AST.JSXStyleElement} node
  * @returns {Map<number, AST.Comment[]>}
  */
 function collectOpeningTagComments(node) {
 	/** @type {Map<number, AST.Comment[]>} */
 	const byAttr = new Map();
 	const openingElement = /** @type {AST.NodeWithLocation} */ (node.openingElement);
-	const attributes = /** @type {any[]} */ (node.openingElement?.attributes) ?? [];
+	const attributes = node.openingElement?.attributes ?? [];
 	if (!openingElement || attributes.length === 0 || !Array.isArray(node.children)) {
 		return byAttr;
 	}
@@ -6297,7 +6154,7 @@ function collectOpeningTagComments(node) {
 			}
 		}
 		if (keep.length !== lead.length) {
-			/** @type {any} */ (child).leadingComments = keep;
+			child.leadingComments = keep;
 		}
 	}
 	if (collected.length === 0) return byAttr;
@@ -6352,9 +6209,9 @@ function printTemplateChildLeadingComments(child) {
  * tag's `leadingComments` or, when the last child is an `{expr}` container, to
  * `metadata.elementLeadingComments` positioned inside the body) and the comments
  * of a comment-only body (`innerComments`).
- * @param {any} node
- * @param {any} openingNode
- * @param {any} closingNode
+ * @param {AST.TSRXJSXElement | AST.TSRXJSXFragment} node
+ * @param {AST.TSRXJSXElement['openingElement'] | AST.TSRXJSXFragment['openingFragment']} openingNode
+ * @param {AST.TSRXJSXElement['closingElement'] | AST.TSRXJSXFragment['closingFragment']} closingNode
  * @returns {{ closingCommentDocs: Doc[], innerCommentDocs: Doc[] }}
  */
 function collectElementBodyCommentDocs(node, openingNode, closingNode) {
@@ -6371,7 +6228,7 @@ function collectElementBodyCommentDocs(node, openingNode, closingNode) {
 	);
 	const lastMeaningfulChild = [...(node.children ?? [])]
 		.reverse()
-		.find((/** @type {any} */ child) => child.type !== 'JSXText' || child.value.trim());
+		.find((child) => child.type !== 'JSXText' || child.value.trim());
 	return {
 		closingCommentDocs: printElementBodyComments(trailingComments, lastMeaningfulChild),
 		innerCommentDocs: printElementBodyComments(node.innerComments),
@@ -6528,540 +6385,4 @@ function printJSXElementName(node) {
 		return namespace_name + ':' + local_name;
 	}
 	return 'Unknown';
-}
-
-/**
- * Print a member expression as simple string (for element tag names)
- * @param {AST.Node} node - The node to print
- * @param {RippleFormatOptions} options - Prettier options
- * @param {boolean} [computed=false] - Whether the property is computed
- * @returns {string}
- */
-function printMemberExpressionSimple(node, options, computed = false) {
-	if (node.type === 'JSXIdentifier') {
-		return node.name;
-	}
-
-	if (node.type === 'JSXMemberExpression') {
-		return (
-			printMemberExpressionSimple(node.object, options) +
-			'.' +
-			printMemberExpressionSimple(node.property, options, true)
-		);
-	}
-
-	if (node.type === 'JSXNamespacedName') {
-		return node.namespace.name + ':' + node.name.name;
-	}
-
-	if (node.type === 'Identifier') {
-		return node.name;
-	}
-
-	if (node.type === 'MemberExpression') {
-		const obj = printMemberExpressionSimple(node.object, options);
-		let prop;
-		if (node.computed) {
-			prop = '[' + printMemberExpressionSimple(node.property, options, true) + ']';
-		} else {
-			prop = '.' + printMemberExpressionSimple(node.property, options, true);
-		}
-		return obj + prop;
-	}
-
-	if (node.type === 'Literal') {
-		return computed ? formatStringLiteral(node.value, options) : JSON.stringify(node.value);
-	}
-	return '';
-}
-
-/**
- * Check whether an attribute value can expand into multiline content.
- * @param {AST.Expression | null | undefined} value - The attribute value node
- * @param {boolean} [is_nested_in_object=false] - Whether this value is nested within an object literal
- * @returns {boolean}
- */
-function is_attribute_value_breakable(value, is_nested_in_object = false) {
-	if (!value) return false;
-
-	switch (value.type) {
-		case 'ConditionalExpression':
-			// Keep simple top-level ternary attributes inline when they fit.
-			// We only force-break when a conditional is nested in an object literal value.
-			return is_nested_in_object;
-		case 'ObjectExpression':
-			return value.properties.some(
-				(property) =>
-					property.type === 'Property' &&
-					is_attribute_value_breakable(/** @type {AST.Expression} */ (property.value), true),
-			);
-		default:
-			return false;
-	}
-}
-
-/**
- * Print a JSX element node
- * @param {AST.Element} element - The element node
- * @param {AstPath<AST.Element>} path - The AST path
- * @param {RippleFormatOptions} options - Prettier options
- * @param {PrintFn} print - Print callback
- * @returns {Doc}
- */
-function printElement(element, path, options, print) {
-	const node = /** @type {any} */ (element);
-	const tagName = printMemberExpressionSimple(node.id, options);
-	const openingElement = /** @type {any} */ (node.openingElement);
-	/** @type {Doc} */
-	let typeArgsDoc = '';
-	if (openingElement?.typeArguments) {
-		typeArgsDoc = path.call(print, 'openingElement', 'typeArguments');
-	}
-	const elementLeadingComments = getElementLeadingComments(/** @type {any} */ (node));
-
-	// `metadata.elementLeadingComments` may include comments that actually appear *inside* the element
-	// body (after the opening tag). Those must not be hoisted before the element.
-	const outerElementLeadingComments = elementLeadingComments.filter(
-		(/** @type {AST.Comment} */ comment) =>
-			typeof comment.start !== 'number' || comment.start < node.start,
-	);
-	const innerElementBodyComments = elementLeadingComments.filter(
-		(/** @type {AST.Comment} */ comment) =>
-			typeof comment.start === 'number' &&
-			comment.start >= /** @type {AST.NodeWithLocation} */ (node.openingElement).end &&
-			comment.start < node.end,
-	);
-	const metadataCommentParts =
-		outerElementLeadingComments.length > 0
-			? createElementLevelCommentParts(outerElementLeadingComments)
-			: [];
-	const fallbackElementComments = [];
-	const shouldLiftTextLevelComments = outerElementLeadingComments.length === 0;
-
-	const hasChildren = Array.isArray(node.children) && node.children.length > 0;
-	const hasInnerComments = Array.isArray(node.innerComments) && node.innerComments.length > 0;
-	const isSelfClosing = !!node.selfClosing;
-	const hasAttributes = Array.isArray(node.attributes) && node.attributes.length > 0;
-
-	// Collect comments that the parser attached to children but actually belong inside
-	// the opening tag (positionally before openingElement.end). These should be printed
-	// as leading comments before the appropriate attribute, not lifted to element-level.
-	/** @type {Set<AST.Comment>} */
-	const openingTagCommentsSet = new Set();
-	if (hasChildren && node.openingElement) {
-		const openingEnd = /** @type {AST.NodeWithLocation} */ (node.openingElement).end;
-		for (const child of node.children) {
-			if (
-				(child.type === 'JSXExpressionContainer' || child.type === 'JSXText') &&
-				Array.isArray(child.leadingComments)
-			) {
-				for (const comment of child.leadingComments) {
-					if (
-						typeof comment.start === 'number' &&
-						comment.start >= node.start &&
-						comment.start < openingEnd
-					) {
-						openingTagCommentsSet.add(comment);
-					}
-				}
-			}
-		}
-	}
-
-	// Build a map from attribute index to comments that should precede that attribute
-	const openingTagCommentsByAttrIndex = new Map();
-	if (openingTagCommentsSet.size > 0 && hasAttributes) {
-		const sortedOTC = [...openingTagCommentsSet].sort(
-			(a, b) => /** @type {number} */ (a.start) - /** @type {number} */ (b.start),
-		);
-		let commentIdx = 0;
-		for (let attrIdx = 0; attrIdx < node.attributes.length; attrIdx++) {
-			const attr = node.attributes[attrIdx];
-			const commentsForAttr = [];
-			while (
-				commentIdx < sortedOTC.length &&
-				/** @type {number} */ (sortedOTC[commentIdx].start) <
-					/** @type {AST.NodeWithLocation} */ (attr).start
-			) {
-				commentsForAttr.push(sortedOTC[commentIdx]);
-				commentIdx++;
-			}
-			if (commentsForAttr.length > 0) {
-				openingTagCommentsByAttrIndex.set(attrIdx, commentsForAttr);
-			}
-		}
-	}
-
-	if (isSelfClosing && !hasInnerComments && !hasAttributes) {
-		const elementDoc = group(['<', tagName, typeArgsDoc, ' />']);
-		return metadataCommentParts.length > 0 ? [...metadataCommentParts, elementDoc] : elementDoc;
-	}
-
-	// Determine the line break type for attributes
-	// When singleAttributePerLine is true, force each attribute on its own line with hardline
-	// Otherwise, use line to allow collapsing when it fits
-	const attrLineBreak = options.singleAttributePerLine ? hardline : line;
-
-	const shouldUseSelfClosingSyntax = isSelfClosing || (!hasChildren && !hasInnerComments);
-
-	const hasOpeningTagComments = openingTagCommentsSet.size > 0;
-	let attrIndex = 0;
-	let hasBreakingAttribute = false;
-	const attrDocs = hasAttributes
-		? path.map((attrPath) => {
-				const idx = attrIndex++;
-				const commentsForAttr = openingTagCommentsByAttrIndex.get(idx);
-				/** @type {Doc[]} */
-				const parts = [];
-				if (commentsForAttr) {
-					for (const comment of commentsForAttr) {
-						// Line comments (//) consume the rest of the line, so they must
-						// use hardline to force a break. Block comments can use normal breaks.
-						if (comment.type === 'Line') {
-							parts.push(hardline);
-							parts.push('//' + comment.value);
-						} else if (comment.type === 'Block') {
-							parts.push(attrLineBreak);
-							parts.push('/*' + comment.value + '*/');
-						}
-					}
-				}
-				parts.push(attrLineBreak);
-				const attrDoc = print(attrPath);
-				parts.push(attrDoc);
-				const attr_node = /** @type {ESTreeJSX.JSXAttribute | ESTreeJSX.JSXSpreadAttribute} */ (
-					/** @type {unknown} */ (attrPath.node)
-				);
-				if (
-					!hasBreakingAttribute &&
-					(willBreak(attrDoc) ||
-						(attr_node.type === 'JSXAttribute' &&
-							is_attribute_value_breakable(/** @type {any} */ (attr_node.value))))
-				) {
-					hasBreakingAttribute = true;
-				}
-				return parts;
-			}, 'attributes')
-		: [];
-	const shouldForceBreak = hasOpeningTagComments || hasBreakingAttribute;
-	const openingTagAlwaysBreaks =
-		(hasAttributes && options.singleAttributePerLine) || shouldForceBreak;
-	const openingTag = group([
-		'<',
-		tagName,
-		typeArgsDoc,
-		hasAttributes
-			? indent([
-					...attrDocs,
-					// Force the group to break when there are line comments in the opening tag,
-					// or when any attribute value would break (e.g. multiline objects, ternaries).
-					// This ensures attributes are broken onto separate lines rather than breaking
-					// expression values inline on the same line as the tag name.
-					...(shouldForceBreak ? [breakParent] : []),
-				])
-			: '',
-		// Add line break opportunity before > or />
-		// Use line for self-closing (keeps space), softline for non-self-closing when attributes present
-		// When bracketSameLine is true, don't add line break for non-self-closing elements
-		shouldUseSelfClosingSyntax
-			? hasAttributes
-				? line
-				: ''
-			: hasAttributes && !options.bracketSameLine
-				? softline
-				: '',
-		shouldUseSelfClosingSyntax ? (hasAttributes ? '/>' : ' />') : '>',
-	]);
-
-	if (!hasChildren) {
-		if (!hasInnerComments) {
-			return metadataCommentParts.length > 0 ? [...metadataCommentParts, openingTag] : openingTag;
-		}
-
-		/** @type {Doc[]} */
-		const innerParts = [];
-		for (const comment of node.innerComments ?? []) {
-			if (comment.type === 'Line') {
-				innerParts.push('//' + comment.value);
-				innerParts.push(hardline);
-			} else if (comment.type === 'Block') {
-				innerParts.push('/*' + comment.value + '*/');
-				innerParts.push(hardline);
-			}
-		}
-
-		if (innerParts.length > 0 && innerParts[innerParts.length - 1] === hardline) {
-			innerParts.pop();
-		}
-
-		const closingTag = ['</', tagName, '>'];
-		const elementOutput = group([
-			openingTag,
-			indent([hardline, ...innerParts]),
-			hardline,
-			closingTag,
-		]);
-		return metadataCommentParts.length > 0
-			? [...metadataCommentParts, elementOutput]
-			: elementOutput;
-	}
-
-	// Has children - use unified children processing
-	// Build children with whitespace preservation
-	/** @type {Doc[]} */
-	const finalChildren = [];
-	const sortedInnerElementBodyComments =
-		innerElementBodyComments.length > 0
-			? innerElementBodyComments.slice().sort((a, b) => (a.start ?? 0) - (b.start ?? 0))
-			: [];
-	let innerElementBodyCommentIndex = 0;
-
-	for (let i = 0; i < node.children.length; i++) {
-		const currentChild = node.children[i];
-		const nextChild = node.children[i + 1];
-
-		// Insert any element-body comments that appear before this child.
-		if (innerElementBodyCommentIndex < sortedInnerElementBodyComments.length) {
-			const currentChildStart = typeof currentChild.start === 'number' ? currentChild.start : null;
-			if (currentChildStart != null) {
-				const commentsBefore = [];
-				while (innerElementBodyCommentIndex < sortedInnerElementBodyComments.length) {
-					/** @type {AST.Comment} */
-					const comment = sortedInnerElementBodyComments[innerElementBodyCommentIndex];
-					if (typeof comment.start !== 'number' || comment.start >= currentChildStart) {
-						break;
-					}
-					commentsBefore.push(comment);
-					innerElementBodyCommentIndex++;
-				}
-				if (commentsBefore.length > 0) {
-					if (finalChildren.length > 0) {
-						finalChildren.push(hardline);
-					}
-					finalChildren.push(...createElementLevelCommentPartsTrimmed(commentsBefore));
-					finalChildren.push(hardline);
-				}
-			}
-		}
-
-		const isTextLikeChild =
-			currentChild.type === 'JSXExpressionContainer' || currentChild.type === 'JSXText';
-		const hasTextLeadingComments =
-			shouldLiftTextLevelComments &&
-			isTextLikeChild &&
-			Array.isArray(currentChild.leadingComments) &&
-			currentChild.leadingComments.length > 0;
-		const currentChildAny = /** @type {any} */ (currentChild);
-		const rawExpressionLeadingComments =
-			isTextLikeChild && Array.isArray(currentChildAny.expression?.leadingComments)
-				? currentChildAny.expression.leadingComments
-				: null;
-		const elementBodyLeadingComments =
-			hasTextLeadingComments && node.openingElement
-				? /** @type {AST.Comment[]} */ (currentChild.leadingComments).filter(
-						(comment) =>
-							comment.context?.containerId === node.metadata?.commentContainerId &&
-							comment.context?.beforeMeaningfulChild &&
-							typeof comment.start === 'number' &&
-							comment.start >= /** @type {AST.NodeWithLocation} */ (node.openingElement).end &&
-							comment.start < /** @type {AST.NodeWithLocation} */ (currentChild).start,
-					)
-				: [];
-
-		if (hasTextLeadingComments) {
-			for (let j = 0; j < /** @type {AST.Comment[]} */ (currentChild.leadingComments).length; j++) {
-				const comment = /** @type {AST.Comment[]} */ (currentChild.leadingComments)[j];
-				// Don't lift comments that belong inside the opening tag (handled in attribute section)
-				if (!openingTagCommentsSet.has(comment) && !elementBodyLeadingComments.includes(comment)) {
-					fallbackElementComments.push(comment);
-				}
-			}
-		}
-
-		const childPrintArgs = /** @type {PrintArgs} */ ({});
-		if (hasTextLeadingComments) {
-			childPrintArgs.suppressLeadingComments = true;
-		}
-		if (rawExpressionLeadingComments && rawExpressionLeadingComments.length > 0) {
-			childPrintArgs.suppressExpressionLeadingComments = true;
-		}
-
-		const printedChild =
-			Object.keys(childPrintArgs).length > 0
-				? path.call((childPath) => print(childPath, childPrintArgs), 'children', i)
-				: path.call(print, 'children', i);
-
-		const childLeadingCommentParts =
-			elementBodyLeadingComments.length > 0
-				? createElementLevelCommentParts(elementBodyLeadingComments)
-				: rawExpressionLeadingComments && rawExpressionLeadingComments.length > 0
-					? createElementLevelCommentParts(rawExpressionLeadingComments)
-					: null;
-		const childDoc = childLeadingCommentParts
-			? [...childLeadingCommentParts, printedChild]
-			: printedChild;
-		finalChildren.push(childDoc);
-
-		// Insert element-body comments that fall between this child and the next child (or the closing tag).
-		let insertedBodyCommentsBetween = false;
-		if (innerElementBodyCommentIndex < sortedInnerElementBodyComments.length) {
-			const currentChildEnd = /** @type {AST.NodeWithLocation} */ (currentChild).end;
-			const nextChildStart =
-				nextChild && typeof nextChild.start === 'number' ? nextChild.start : null;
-			const commentsBetween = [];
-			while (innerElementBodyCommentIndex < sortedInnerElementBodyComments.length) {
-				/** @type {AST.Comment} */
-				const comment = sortedInnerElementBodyComments[innerElementBodyCommentIndex];
-				if (typeof comment.start !== 'number') {
-					innerElementBodyCommentIndex++;
-					continue;
-				}
-				if (comment.start < currentChildEnd) {
-					break;
-				}
-				if (nextChildStart != null && comment.start >= nextChildStart) {
-					break;
-				}
-				commentsBetween.push(comment);
-				innerElementBodyCommentIndex++;
-			}
-			if (commentsBetween.length > 0) {
-				const firstComment = commentsBetween[0];
-				const lastComment = commentsBetween[commentsBetween.length - 1];
-
-				// Preserve any blank line(s) that existed between the previous child and the comment block.
-				const blankLinesBefore = getBlankLinesBetweenNodes(currentChild, firstComment);
-				finalChildren.push(hardline);
-				if (blankLinesBefore > 0) {
-					finalChildren.push(hardline);
-				}
-
-				finalChildren.push(...createElementLevelCommentPartsTrimmed(commentsBetween));
-
-				if (nextChild) {
-					// Preserve any blank line(s) that existed between the comment block and the next child.
-					const blankLinesAfter = getBlankLinesBetweenNodes(lastComment, nextChild);
-					finalChildren.push(hardline);
-					if (blankLinesAfter > 0) {
-						finalChildren.push(hardline);
-					}
-				}
-				insertedBodyCommentsBetween = true;
-			}
-		}
-
-		if (nextChild) {
-			if (insertedBodyCommentsBetween) {
-				continue;
-			}
-			const whitespaceTarget =
-				nextChild.leadingComments && nextChild.leadingComments.length > 0
-					? nextChild.leadingComments[0]
-					: nextChild;
-			const whitespaceLinesCount = getBlankLinesBetweenNodes(currentChild, whitespaceTarget);
-			const isTextOrExpressionChild =
-				currentChild.type === 'JSXExpressionContainer' ||
-				currentChild.type === 'JSXText' ||
-				nextChild.type === 'JSXExpressionContainer' ||
-				nextChild.type === 'JSXText';
-
-			if (whitespaceLinesCount > 0) {
-				finalChildren.push(hardline);
-				finalChildren.push(hardline);
-			} else if (!isTextOrExpressionChild && shouldAddBlankLine(currentChild, nextChild)) {
-				finalChildren.push(hardline);
-				finalChildren.push(hardline);
-			} else {
-				finalChildren.push(hardline);
-			}
-		}
-	}
-
-	// Collect comments attached to the closing element (comments that appear after the last child
-	// but before the closing tag, e.g. `</div>`). The parser attaches these as leadingComments
-	// on either the closingElement node or the closingElement.name node depending on context.
-	const closingElementComments = [
-		...(node.closingElement && Array.isArray(node.closingElement.leadingComments)
-			? node.closingElement.leadingComments
-			: []),
-		...(node.closingElement &&
-		node.closingElement.name &&
-		Array.isArray(node.closingElement.name.leadingComments)
-			? node.closingElement.name.leadingComments
-			: []),
-	];
-
-	if (closingElementComments.length > 0) {
-		const lastChild = node.children[node.children.length - 1];
-		if (lastChild) {
-			const blankLinesBefore = getBlankLinesBetweenNodes(lastChild, closingElementComments[0]);
-			finalChildren.push(hardline);
-			if (blankLinesBefore > 0) {
-				finalChildren.push(hardline);
-			}
-		}
-		finalChildren.push(...createElementLevelCommentPartsTrimmed(closingElementComments));
-	}
-
-	const fallbackCommentParts =
-		fallbackElementComments.length > 0
-			? createElementLevelCommentParts(fallbackElementComments)
-			: [];
-	const leadingCommentParts =
-		metadataCommentParts.length > 0
-			? [...metadataCommentParts, ...fallbackCommentParts]
-			: fallbackCommentParts;
-
-	const closingTag = ['</', tagName, '>'];
-	let elementOutput;
-	const shouldTryInlineMultipleChildren =
-		!openingTagAlwaysBreaks &&
-		fallbackCommentParts.length === 0 &&
-		closingElementComments.length === 0 &&
-		shouldTryInlineMultipleTextChildren(node);
-
-	if (finalChildren.length === 1) {
-		const child = finalChildren[0];
-		const firstChild = /** @type {any} */ (node.children[0]);
-		const isNonSelfClosingElement =
-			firstChild && firstChild.type === 'Element' && !firstChild.selfClosing;
-		const isElementChild = firstChild && firstChild.type === 'Element';
-		const isRawTextChild =
-			firstChild && firstChild.type === 'Text' && typeof firstChild.raw === 'string';
-
-		if (
-			(typeof child === 'string' || isRawTextChild) &&
-			shouldInlineSingleChild(node, firstChild, child)
-		) {
-			elementOutput = openingTagAlwaysBreaks
-				? [openingTag, indent([hardline, child]), hardline, closingTag]
-				: conditionalGroup([
-						group([openingTag, child, closingTag]),
-						[openingTag, indent([hardline, child]), hardline, closingTag],
-					]);
-		} else if (
-			child &&
-			typeof child === 'object' &&
-			!isNonSelfClosingElement &&
-			shouldInlineSingleChild(node, firstChild, child)
-		) {
-			if (isElementChild && hasAttributes) {
-				elementOutput = [openingTag, indent([hardline, child]), hardline, closingTag];
-			} else {
-				elementOutput = group([openingTag, indent([softline, child]), softline, closingTag]);
-			}
-		} else {
-			elementOutput = [openingTag, indent([hardline, ...finalChildren]), hardline, closingTag];
-		}
-	} else if (shouldTryInlineMultipleChildren) {
-		const inlineChildren = path.map(print, 'children');
-		elementOutput = conditionalGroup([
-			group([openingTag, ...inlineChildren, closingTag]),
-			[openingTag, indent([hardline, ...finalChildren]), hardline, closingTag],
-		]);
-	} else {
-		elementOutput = group([openingTag, indent([hardline, ...finalChildren]), hardline, closingTag]);
-	}
-
-	return leadingCommentParts.length > 0 ? [...leadingCommentParts, elementOutput] : elementOutput;
 }

--- a/packages/prettier-plugin/src/index.test.js
+++ b/packages/prettier-plugin/src/index.test.js
@@ -2753,6 +2753,104 @@ function test() {
 			expect(result).toBeWithNewline(expected);
 		});
 
+		it('should preserve template comments and blank lines from unformatted input', async () => {
+			const input = `function TodoList() @{
+<>
+  /* world 0 */
+  // hello
+  /* world 1 */
+  <ul>
+  // hello
+  /* world 2 */
+
+  </ul>
+
+  <ul>
+  // hello
+  /* world 3 */
+  // hello
+  </ul>
+  /* world 4 */
+  </>
+}`;
+
+			const expected = `function TodoList() @{
+  <>
+    /* world 0 */
+    // hello
+    /* world 1 */
+    <ul>
+      // hello
+      /* world 2 */
+    </ul>
+
+    <ul>
+      // hello
+      /* world 3 */
+      // hello
+    </ul>
+    /* world 4 */
+  </>
+}`;
+
+			const result = await format(input, { singleQuote: true });
+			expect(result).toBeWithNewline(expected);
+			// Reformatting the output must be stable.
+			expect(await format(result, { singleQuote: true })).toBeWithNewline(expected);
+		});
+
+		it('should preserve block comments before a closing fragment', async () => {
+			const expected = `function App() @{
+  <>
+    <span>{'child'}</span>
+
+    /* block comment */
+  </>
+}`;
+
+			const result = await format(expected, { singleQuote: true });
+			expect(result).toBeWithNewline(expected);
+		});
+
+		it('should preserve a blank line before a trailing block comment in elements', async () => {
+			const expected = `function App() {
+  <div>
+    <span>{'child'}</span>
+
+    /* block comment */
+  </div>
+}`;
+
+			const result = await format(expected, { singleQuote: true });
+			expect(result).toBeWithNewline(expected);
+		});
+
+		it('should preserve a comment-only fragment body', async () => {
+			const expected = `function App() @{
+  <>
+    /* only */
+  </>
+}`;
+
+			const result = await format(expected, { singleQuote: true });
+			expect(result).toBeWithNewline(expected);
+		});
+
+		it('should keep blank lines around comments between template siblings', async () => {
+			const expected = `function App() @{
+  <>
+    <ul></ul>
+
+    /* between */
+
+    <ul></ul>
+  </>
+}`;
+
+			const result = await format(expected, { singleQuote: true });
+			expect(result).toBeWithNewline(expected);
+		});
+
 		it('should preserve trailing comments in function parameters', async () => {
 			const expected = `function test(
   // comment in params

--- a/packages/tsrx-ripple/src/transform/client/index.js
+++ b/packages/tsrx-ripple/src/transform/client/index.js
@@ -1428,7 +1428,7 @@ function SetStateForOutsideComponent(state, more_state = {}) {
 }
 
 /**
- * @param {AST.TSRXJSXElement | ESTreeJSX.JSXFragment} node
+ * @param {AST.TSRXJSXElement | AST.TSRXJSXFragment} node
  * @param {TransformClientContext} context
  * @returns {AST.CallExpression}
  */
@@ -1994,7 +1994,7 @@ const visitors = {
 			return context.next();
 		}
 		if (context.state.jsx_to_tsrx_element || is_native_tsrx_value_position(context.path)) {
-			return build_jsx_to_tsrx_element(node, context);
+			return build_jsx_to_tsrx_element(/** @type {AST.TSRXJSXFragment} */ (node), context);
 		}
 		return context.next();
 	},
@@ -2004,7 +2004,7 @@ const visitors = {
 			return context.next();
 		}
 		if (context.state.jsx_to_tsrx_element || is_native_tsrx_value_position(context.path)) {
-			return build_jsx_to_tsrx_element(node, context);
+			return build_jsx_to_tsrx_element(/** @type {AST.TSRXJSXElement} */ (node), context);
 		}
 		return context.next();
 	},

--- a/packages/tsrx-ripple/src/transform/server/index.js
+++ b/packages/tsrx-ripple/src/transform/server/index.js
@@ -318,7 +318,7 @@ function insert_style_ref_setup_statements(body, setup) {
 }
 
 /**
- * @param {AST.TSRXJSXElement | ESTreeJSX.JSXFragment} node
+ * @param {AST.TSRXJSXElement | AST.TSRXJSXFragment} node
  * @param {TransformServerContext} context
  * @returns {AST.CallExpression}
  */
@@ -1645,14 +1645,14 @@ const visitors = {
 
 	JSXElement(node, context) {
 		if (context.state.jsx_to_tsrx_element || is_native_tsrx_value_position(context.path)) {
-			return build_jsx_to_tsrx_element(node, context);
+			return build_jsx_to_tsrx_element(/** @type {AST.TSRXJSXElement} */ (node), context);
 		}
 		return context.next();
 	},
 
 	JSXFragment(node, context) {
 		if (context.state.jsx_to_tsrx_element || is_native_tsrx_value_position(context.path)) {
-			return build_jsx_to_tsrx_element(node, context);
+			return build_jsx_to_tsrx_element(/** @type {AST.TSRXJSXFragment} */ (node), context);
 		}
 		return context.next();
 	},

--- a/packages/tsrx-ripple/tests/basic.test.js
+++ b/packages/tsrx-ripple/tests/basic.test.js
@@ -1298,3 +1298,41 @@ describe('@tsrx/ripple unified function and component compilation', () => {
 		expect(server.code).not.toContain('Compat(__output');
 	});
 });
+
+describe('@tsrx/ripple template comments', () => {
+	const source = `function TodoList() @{
+<>
+  /* world 0 */
+  // hello
+  /* world 1 */
+  <ul>
+  // hello
+  /* world 2 */
+
+  </ul>
+
+  <ul>
+  // hello
+  /* world 3 */
+  // hello
+  </ul>
+  /* world 4 */
+  </>
+}`;
+
+	it('keeps line and block comments out of client templates', () => {
+		const { code } = compile(source, 'App.tsrx');
+		expect(code).not.toMatch(/world|hello/);
+		expect(code).toContain('<ul></ul><ul></ul>');
+	});
+
+	it('keeps line and block comments out of server output', () => {
+		const { code } = compile(source, 'App.tsrx', { mode: 'server' });
+		expect(code).not.toMatch(/world|hello/);
+	});
+
+	it('keeps template comments out of to_ts output', () => {
+		const { code } = compile_to_volar_mappings(source, 'App.tsrx', { loose: true });
+		expect(code).not.toMatch(/world|hello/);
+	});
+});

--- a/packages/tsrx/src/plugin.js
+++ b/packages/tsrx/src/plugin.js
@@ -2018,9 +2018,10 @@ export function TSRXPlugin(config) {
 					);
 					const closingEnd = closingStart + '</style>'.length;
 					const closingEndInfo = acorn.getLineInfo(this.input, closingEnd);
-					const closingElement = /** @type {ESTreeJSX.JSXClosingElement & AST.NodeWithLocation} */ (
-						this.startNodeAt(closingStart, closingStartLoc)
-					);
+					const closingElement =
+						/** @type {ESTreeJSX.TSRXJSXClosingElement & AST.NodeWithLocation} */ (
+							this.startNodeAt(closingStart, closingStartLoc)
+						);
 					closingElement.name = name;
 					this.finishNodeAt(
 						closingElement,
@@ -4221,8 +4222,10 @@ export function TSRXPlugin(config) {
 				} else {
 					if (is_style) {
 						/** @type {AST.JSXStyleElement} */ (node).type = 'JSXStyleElement';
-						/** @type {AST.JSXStyleElement} */ (node).openingElement = open;
-						/** @type {AST.JSXStyleElement} */ (node).closingElement = null;
+						/** @type {AST.JSXStyleElement} */ (node).openingElement =
+							/** @type {AST.JSXStyleElement['openingElement']} */ (open);
+						/** @type {AST.JSXStyleElement} */ (node).closingElement =
+							/** @type {AST.JSXStyleElement['closingElement']} */ (null);
 					} else {
 						/** @type {ESTreeJSX.JSXElement} */ (node).type = 'JSXElement';
 						/** @type {ESTreeJSX.JSXElement} */ (node).openingElement = open;

--- a/packages/tsrx/src/plugin.js
+++ b/packages/tsrx/src/plugin.js
@@ -55,27 +55,6 @@ const CharCode = Object.freeze({
 	closeBrace: 125,
 });
 
-/**
- * Keywords after which a `/` begins a regex literal rather than division, used
- * by the look-ahead scanners to track expression position in script content.
- */
-const REGEX_PRECEDING_KEYWORDS = new Set([
-	'return',
-	'typeof',
-	'instanceof',
-	'in',
-	'of',
-	'new',
-	'delete',
-	'void',
-	'do',
-	'else',
-	'yield',
-	'await',
-	'case',
-	'throw',
-]);
-
 // Transparent wrappers to look through when validating a dynamic tag
 // expression (`<{expr}>`), and syntax that disqualifies one outright.
 const DYNAMIC_TAG_WRAPPER_TYPES = new Set([
@@ -596,6 +575,26 @@ export function TSRXPlugin(config) {
 						}
 						continue;
 					}
+					if (this.#isTemplateBlockCommentStart(index)) {
+						const comment_start = index;
+						const comment_start_loc = acorn.getLineInfo(this.input, comment_start);
+						const close = this.input.indexOf('*/', index + 2);
+						const value_end = close === -1 ? this.input.length : close;
+						index = close === -1 ? this.input.length : close + 2;
+						if (this.options.onComment && comment_start >= token_end) {
+							const comment_end_loc = acorn.getLineInfo(this.input, index);
+							this.options.onComment(
+								true,
+								this.input.slice(comment_start + 2, value_end),
+								comment_start,
+								index,
+								new acorn.Position(comment_start_loc.line, comment_start_loc.column),
+								new acorn.Position(comment_end_loc.line, comment_end_loc.column),
+								/** @type {any} */ (null),
+							);
+						}
+						continue;
+					}
 					const ch = this.input.charCodeAt(index);
 					if (
 						ch === CharCode.lessThan ||
@@ -973,6 +972,19 @@ export function TSRXPlugin(config) {
 			}
 
 			/**
+			 * Unlike `//` (which is only a comment at line-start so inline text like
+			 * `https://…` stays text), `/*` starts a comment anywhere in template
+			 * text, matching `jsx_readToken`.
+			 * @param {number} index
+			 */
+			#isTemplateBlockCommentStart(index) {
+				return (
+					this.input.charCodeAt(index) === CharCode.slash &&
+					this.input.charCodeAt(index + 1) === CharCode.asterisk
+				);
+			}
+
+			/**
 			 * @param {number} start
 			 */
 			#templateRawTextEnd(start) {
@@ -984,7 +996,8 @@ export function TSRXPlugin(config) {
 						ch === CharCode.openBrace ||
 						ch === CharCode.closeBrace ||
 						this.#isJSXControlFlowDirectiveAt(index) ||
-						this.#isTemplateLineCommentStart(index)
+						this.#isTemplateLineCommentStart(index) ||
+						this.#isTemplateBlockCommentStart(index)
 					) {
 						break;
 					}

--- a/packages/tsrx/tests/utils/parser.test.js
+++ b/packages/tsrx/tests/utils/parser.test.js
@@ -562,6 +562,106 @@ abc
 		expect(value.children[0].value).toContain('const x = 1');
 	});
 
+	// Collect every JSXText value in the tree, and parse with `collect` so the
+	// recorded comments can be asserted alongside the text they were removed from.
+	function parseTemplateTextsAndComments(source) {
+		/** @type {import('estree').Comment[]} */
+		const comments = [];
+		const ast = parseModule(source, 'App.tsrx', { collect: true, comments });
+		const texts = [];
+		(function walk(node) {
+			if (!node || typeof node !== 'object') return;
+			if (Array.isArray(node)) return node.forEach(walk);
+			if (node.type === 'JSXText') texts.push(node.value);
+			for (const key in node) {
+				if (key === 'loc' || key === 'start' || key === 'end') continue;
+				walk(node[key]);
+			}
+		})(ast);
+		comments.sort((a, b) => a.start - b.start);
+		return { texts, comments };
+	}
+
+	it('strips block and line comments from template text and records them as comments', () => {
+		const { texts, comments } = parseTemplateTextsAndComments(`function TodoList() @{
+  <>
+    /* world 0 */
+    // hello
+    /* world 1 */
+    <ul>
+    // hello
+    /* world 2 */
+
+    </ul>
+
+    <ul>
+    // hello
+    /* world 3 */
+    // hello
+    </ul>
+    /* world 4 */
+  </>
+  }`);
+
+		for (const text of texts) {
+			expect(text).not.toMatch(/world|hello|\/\*|\/\//);
+		}
+		expect(comments.filter((comment) => comment.type === 'Block').map((c) => c.value)).toEqual([
+			' world 0 ',
+			' world 1 ',
+			' world 2 ',
+			' world 3 ',
+			' world 4 ',
+		]);
+		expect(comments.filter((comment) => comment.type === 'Line').map((c) => c.value)).toEqual([
+			' hello',
+			' hello',
+			' hello',
+			' hello',
+		]);
+	});
+
+	it('strips a block comment between words of template text', () => {
+		const { texts, comments } = parseTemplateTextsAndComments(`function App() @{
+	<div>hello /* note */ world</div>
+}`);
+
+		expect(texts).toEqual(['hello  world']);
+		expect(comments.map((comment) => comment.value)).toEqual([' note ']);
+	});
+
+	it('strips a block comment that is the only element content', () => {
+		const { texts, comments } = parseTemplateTextsAndComments(`function App() @{
+	<div>/* note */</div>
+}`);
+
+		expect(texts).toEqual([]);
+		expect(comments.map((comment) => comment.value)).toEqual([' note ']);
+	});
+
+	it('records a block comment before a closing fragment exactly once', () => {
+		const { texts, comments } = parseTemplateTextsAndComments(`function App() @{
+<>
+<ul></ul>
+/* z */
+</>
+}`);
+
+		for (const text of texts) {
+			expect(text).not.toContain('z');
+		}
+		expect(comments.map((comment) => comment.type + ':' + comment.value)).toEqual(['Block: z ']);
+	});
+
+	it('keeps // inside template text when it is not at line start', () => {
+		const { texts, comments } = parseTemplateTextsAndComments(`function App() @{
+	<div>visit https://x.com please</div>
+}`);
+
+		expect(texts).toEqual(['visit https://x.com please']);
+		expect(comments).toEqual([]);
+	});
+
 	it('keeps ordinary tag names as JSX identifiers', () => {
 		const ast = parseModule('const wrapper = <tsrx><div /></tsrx>;', 'App.tsrx');
 

--- a/packages/tsrx/types/index.d.ts
+++ b/packages/tsrx/types/index.d.ts
@@ -253,6 +253,9 @@ declare module 'estree' {
 		TsrxFragment: TsrxFragment;
 		Text: Text;
 		TSRXJSXElement: TSRXJSXElement;
+		TSRXJSXFragment: TSRXJSXFragment;
+		TSRXJSXOpeningElement: ESTreeJSX.TSRXJSXOpeningElement;
+		TSRXJSXClosingElement: ESTreeJSX.TSRXJSXClosingElement;
 		TSRXExpression: TSRXExpression;
 		Attribute: Attribute;
 		SpreadAttribute: SpreadAttribute;
@@ -346,7 +349,11 @@ declare module 'estree' {
 		| AST.JSXCodeBlock;
 
 	interface TSRXJSXElement
-		extends Omit<ESTreeJSX.JSXElement, 'children'>, AST.NodeWithMaybeComments {
+		extends
+			Omit<ESTreeJSX.JSXElement, 'children' | 'openingElement' | 'closingElement'>,
+			AST.NodeWithMaybeComments {
+		openingElement: ESTreeJSX.TSRXJSXOpeningElement;
+		closingElement: ESTreeJSX.TSRXJSXClosingElement | null;
 		children: TSRXJSXChild[];
 		metadata: BaseNodeMetaData & {
 			ts_name?: string;
@@ -366,13 +373,10 @@ declare module 'estree' {
 		innerComments?: AST.Comment[] | undefined;
 	}
 
-	interface JSXStyleElement extends AST.BaseExpression {
+	interface JSXStyleElement extends Omit<AST.TSRXJSXElement, 'type' | 'children'> {
 		type: 'JSXStyleElement';
-		openingElement: ESTreeJSX.JSXOpeningElement;
-		closingElement: ESTreeJSX.JSXClosingElement | null;
 		children: AST.CSS.StyleSheet[];
 		css?: string;
-		metadata: BaseNodeMetaData;
 		unclosed?: boolean;
 	}
 
@@ -520,7 +524,7 @@ declare module 'estree' {
 
 	type TSRXStatement = AST.Statement | TSESTree.Statement;
 
-	type NodeWithChildren = TSRXJSXElement | TSRXJSXFragment | JSXStyleElement;
+	type NodeWithChildren = TSRXJSXElement | TSRXJSXFragment | JSXStyleElement | ESTreeJSX.JSXElement;
 
 	export namespace CSS {
 		export interface BaseNode extends AST.NodeWithMaybeComments {
@@ -736,11 +740,11 @@ declare module 'estree-jsx' {
 	}
 
 	interface TSRXJSXOpeningElement extends Omit<JSXOpeningElement, 'name'> {
-		name: AST.MemberExpression | JSXIdentifier | JSXNamespacedName;
+		name: AST.MemberExpression | JSXIdentifier | JSXNamespacedName | JSXExpressionContainer;
 	}
 
 	interface TSRXJSXClosingElement extends Omit<JSXClosingElement, 'name'> {
-		name: AST.MemberExpression | JSXIdentifier | JSXNamespacedName;
+		name: AST.MemberExpression | JSXIdentifier | JSXNamespacedName | JSXExpressionContainer;
 	}
 
 	interface ExpressionMap {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches the core template lexer and Prettier JSX output paths used on every `.tsrx` file; behavior change is intentional but broad across compile and format pipelines.
> 
> **Overview**
> Fixes **`/* … */` block comments in TSRX template text** so they are parsed as comments (not literal `JSXText`) and round-trip through format/compile.
> 
> **`@tsrx/core` parser** (`plugin.js`): template raw-text scanning now treats `/*` as a block comment anywhere in text (like `jsx_readToken`), records it via `onComment`, and stops including it in `JSXText`. Line comments at line-start behavior is unchanged (`https://` stays text).
> 
> **Prettier plugin**: body comments are printed from AST comments for **both** `//` and `/* */` via `collectElementBodyCommentDocs` / `printElementBodyComments` on elements, fragments, and code blocks (including comment-only bodies and before `</>` / `</tag>`). Inline formatting no longer duplicates block comments that used to leak in text. A large legacy **`printElement`** path and related helpers are removed; printing goes through **`printJSXElement` / `printJSXFragment`** with tighter TSRX types.
> 
> **Types & transforms**: `TSRXJSXFragment`, opening/closing element types, and `JSXStyleElement` align with TSRX JSX; client/server `build_jsx_to_tsrx_element` casts updated. Tests cover parser stripping, compile output (client/server/to_ts), and Prettier stability for mixed line/block template comments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fb3a6ce14e845e9d5c67f949bf581add7ca0159. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->