### PR TITLE
Transform

### DIFF
--- a/.changeset/code-block-children-shared-transform.md
+++ b/.changeset/code-block-children-shared-transform.md
@@ -1,0 +1,16 @@
+---
+'@tsrx/core': patch
+---
+
+Fix `@{ … }` code blocks in template children position for the shared JSX
+transform (react, preact, solid, vue). Nesting deeper than two levels leaked a
+raw code block into the statement stream — triggering spurious
+`_tsrx_child_*` captures and an IIFE whose render output was discarded
+(dropped in react/preact, rendered out of position in solid) — and flattened
+blocks merged lexical scopes, so shadowed declarations produced invalid
+output. Each block is now its own scope and the lowering pays only for what
+the block uses: template-only blocks merge statically into the parent,
+code-only blocks become a plain `{ … }` statement block, blocks with both
+setup code and render output become a scoped IIFE child, and nested chains
+fold into a single closure with nested plain blocks. Empty chains compile to
+nothing at any depth.

--- a/.changeset/code-block-template-children.md
+++ b/.changeset/code-block-template-children.md
@@ -1,0 +1,16 @@
+---
+'@tsrx/ripple': patch
+---
+
+Support `@{ … }` code blocks in template children position, each with its own
+lexical scope. Code-block children of elements, fragments, and control-flow
+branches were silently dropped on the client, and the server kept their render
+output while losing the setup statements (referencing undeclared variables at
+runtime). The lowering pays only for what a block uses: a template-only block
+merges statically into the parent template (no `_$_.expression`, no inline
+component), a code-only block becomes a plain `{ … }` statement block, and a
+block with both setup code and render output becomes a scoped inline component
+(`(() => @{ … })()`, the same lowering as value-position blocks). Nested
+blocks (`@{ @{ … } }`) shadow correctly instead of collapsing into one scope,
+share a single closure and `with_scope` wrapper per chain, and empty chains
+compile to nothing.

--- a/packages/ripple/tests/client/code-block-children.test.tsrx
+++ b/packages/ripple/tests/client/code-block-children.test.tsrx
@@ -1,0 +1,180 @@
+import { describe, it, expect } from 'vitest';
+import { flushSync, track } from 'ripple';
+
+describe('code blocks in template children position', () => {
+	it('renders a code block child with setup statements and output', () => {
+		function App() @{
+			<>
+				<span class="a">{'a'}</span>
+				@{
+					const x = 1;
+					<span class="x">{x}</span>
+				}
+			</>
+		}
+
+		render(App);
+
+		expect(container.querySelector('.a').textContent).toBe('a');
+		expect(container.querySelector('.x').textContent).toBe('1');
+	});
+
+	it('renders deeply nested code block children in source position', () => {
+		function App() @{
+			<>
+				<span class="a">{'a'}</span>
+				@{
+					const x = 1;
+					@{
+						const y = 2;
+						@{
+							<span class="sum">
+								{x + y}
+							</span>
+						}
+					}
+				}
+				<span class="b">{'b'}</span>
+			</>
+		}
+
+		render(App);
+
+		expect(container.textContent).toBe('a3b');
+		expect(container.querySelector('.sum').textContent).toBe('3');
+	});
+
+	it('renders nothing for empty nested code blocks', () => {
+		function App() @{
+			<>
+				<span>{'a'}</span>
+				<span>{'b'}</span>
+				@{
+					@{
+						@{}
+					}
+				}
+			</>
+		}
+
+		render(App);
+
+		expect(container.textContent).toBe('ab');
+	});
+
+	it('keeps code block render output reactive', () => {
+		function App() @{
+			const count = track(0);
+			<>
+				<button onClick={() => count.value++}>{'+'}</button>
+				@{
+					const doubled = () => count.value * 2;
+					<span class="doubled">{doubled()}</span>
+				}
+			</>
+		}
+
+		render(App);
+
+		expect(container.querySelector('.doubled').textContent).toBe('0');
+
+		container.querySelector('button').click();
+		flushSync();
+
+		expect(container.querySelector('.doubled').textContent).toBe('2');
+	});
+
+	it('renders a code block child inside an @if branch', () => {
+		function App() @{
+			const show = track(true);
+			<>
+				<button onClick={() => (show.value = !show.value)}>{'toggle'}</button>
+				@if (show.value) {
+					@{
+						const label = 'shown';
+						<span class="label">{label}</span>
+					}
+				}
+			</>
+		}
+
+		render(App);
+
+		expect(container.querySelector('.label').textContent).toBe('shown');
+
+		container.querySelector('button').click();
+		flushSync();
+
+		expect(container.querySelector('.label')).toBeNull();
+	});
+
+	it('gives each code block its own lexical scope', () => {
+		function App() @{
+			const y = 10;
+			<>
+				<span class="a">{'a'}</span>
+				@{
+					const x = 1;
+					@{
+						const x = 2;
+						@{
+							<span class="sum">
+								{x + y}
+							</span>
+						}
+					}
+				}
+			</>
+		}
+
+		render(App);
+
+		// The innermost block sees the shadowing `x = 2` and the component's `y`.
+		expect(container.querySelector('.sum').textContent).toBe('12');
+	});
+
+	it('scopes code-only block statements', () => {
+		function App() @{
+			const items: number[] = [];
+			<>
+				@{
+					const scoped = 1;
+					items.push(scoped);
+				}
+				@{
+					const scoped = 2;
+					items.push(scoped);
+				}
+				<span class="len">{items.join(',')}</span>
+			</>
+		}
+
+		render(App);
+
+		expect(container.querySelector('.len').textContent).toBe('1,2');
+	});
+
+	it('renders nested code block chains without extra component levels', () => {
+		function App() @{
+			<>
+				<span class="a">{'a'}</span>
+				@{
+					const x = 1;
+					@{
+						const y = 2;
+						@{
+							<span class="sum">
+								{x + y}
+							</span>
+						}
+					}
+				}
+			</>
+		}
+
+		render(App);
+
+		expect(container.textContent).toBe('a3');
+		expect(container.querySelector('.sum').textContent).toBe('3');
+	});
+});

--- a/packages/ripple/tests/server/code-block-children.test.tsrx
+++ b/packages/ripple/tests/server/code-block-children.test.tsrx
@@ -1,0 +1,126 @@
+describe('code blocks in template children position', () => {
+	it('renders a code block child with setup statements and output', async () => {
+		function App() @{
+			<>
+				<span class="a">{'a'}</span>
+				@{
+					const x = 1;
+					<span class="x">{x}</span>
+				}
+			</>
+		}
+
+		const { body } = await render(App);
+
+		expect(body).toBeHtml('<span class="a">a</span><span class="x">1</span>');
+	});
+
+	it('renders deeply nested code block children in source position', async () => {
+		function App() @{
+			<>
+				<span class="a">{'a'}</span>
+				@{
+					const x = 1;
+					@{
+						const y = 2;
+						@{
+							<span class="sum">
+								{x + y}
+							</span>
+						}
+					}
+				}
+				<span class="b">{'b'}</span>
+			</>
+		}
+
+		const { body } = await render(App);
+
+		expect(body).toBeHtml(
+			'<span class="a">a</span><span class="sum">3</span><span class="b">b</span>',
+		);
+	});
+
+	it('renders nothing for empty nested code blocks', async () => {
+		function App() @{
+			<>
+				<span>{'a'}</span>
+				<span>{'b'}</span>
+				@{
+					@{
+						@{}
+					}
+				}
+			</>
+		}
+
+		const { body } = await render(App);
+
+		expect(body).toBeHtml('<span>a</span><span>b</span>');
+	});
+
+	it('renders a code block child inside an @if branch', async () => {
+		function App() @{
+			const show = true;
+			<>
+				@if (show) {
+					@{
+						const label = 'shown';
+						<span class="label">{label}</span>
+					}
+				}
+			</>
+		}
+
+		const { body } = await render(App);
+
+		expect(body).toBeHtml('<span class="label">shown</span>');
+	});
+
+	it('gives each code block its own lexical scope', async () => {
+		function App() @{
+			const y = 10;
+			<>
+				<span class="a">{'a'}</span>
+				@{
+					const x = 1;
+					@{
+						const x = 2;
+						@{
+							<span class="sum">
+								{x + y}
+							</span>
+						}
+					}
+				}
+			</>
+		}
+
+		const { body } = await render(App);
+
+		expect(body).toBeHtml('<span class="a">a</span><span class="sum">12</span>');
+	});
+
+	it('renders nested code block chains without extra component levels', async () => {
+		function App() @{
+			<>
+				<span class="a">{'a'}</span>
+				@{
+					const x = 1;
+					@{
+						const y = 2;
+						@{
+							<span class="sum">
+								{x + y}
+							</span>
+						}
+					}
+				}
+			</>
+		}
+
+		const { body } = await render(App);
+
+		expect(body).toBeHtml('<span class="a">a</span><span class="sum">3</span>');
+	});
+});

--- a/packages/tsrx-preact/tests/basic.test.js
+++ b/packages/tsrx-preact/tests/basic.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+	runSharedCodeBlockChildrenTests,
 	runSharedCompileDiagnosticsTests,
 	runSharedCompileTests,
 	runSharedTsxExpressionTsrxTests,
@@ -17,6 +18,7 @@ runSharedSourceMappingTests({
 runSharedTsxExpressionTsrxTests({ compile, name: 'preact', classAttrName: 'class' });
 runSharedCompileTests({ compile, name: 'preact', classAttrName: 'class' });
 runSharedCompileDiagnosticsTests({ compile_to_volar_mappings, name: 'preact' });
+runSharedCodeBlockChildrenTests({ compile, name: 'preact' });
 
 describe('@tsrx/preact basic', () => {
 	it('imports Suspense from preact/compat when try/pending is used', () => {

--- a/packages/tsrx-react/tests/basic.test.js
+++ b/packages/tsrx-react/tests/basic.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+	runSharedCodeBlockChildrenTests,
 	runSharedCompileDiagnosticsTests,
 	runSharedCompileTests,
 	runSharedTsxExpressionTsrxTests,
@@ -23,6 +24,7 @@ runSharedCompileTests({
 	generatedClassAttrName: 'className',
 });
 runSharedCompileDiagnosticsTests({ compile_to_volar_mappings, name: 'react' });
+runSharedCodeBlockChildrenTests({ compile, name: 'react' });
 
 /**
  * @import { CodeMapping } from '@tsrx/core/types';

--- a/packages/tsrx-ripple/src/transform/client/index.js
+++ b/packages/tsrx-ripple/src/transform/client/index.js
@@ -64,6 +64,7 @@ import {
 	is_dom_property,
 	is_declared_function_within_component,
 	is_inside_call_expression,
+	unwrap_single_return_iife,
 	is_value_static,
 	is_void_element,
 	is_element_dom_element,
@@ -1589,6 +1590,15 @@ const visitors = {
 			context.state.metadata.tracking = true;
 		}
 
+		// A generated inline-component IIFE for a `@{ … }` block: after the
+		// block's statements lower into the component callback, the wrapper
+		// scope holds a lone `return _$_.tsrx_element(…)` — collapse it to the
+		// component value. Constructing the value reads no scope, so no
+		// `with_scope` is needed either.
+		if (!context.state.to_ts && node.metadata?.tsrx_code_block_component) {
+			return unwrap_single_return_iife(/** @type {AST.Expression} */ (context.next()));
+		}
+
 		// Handle direct calls to ripple-imported functions: effect(), untrack(), RippleArray(), etc.
 		if (!context.state.to_ts && callee.type === 'Identifier' && is_ripple_import(callee, context)) {
 			const ripple_runtime_method = get_ripple_namespace_call_name(callee.name);
@@ -1692,17 +1702,25 @@ const visitors = {
 			}
 		}
 
-		return b.call(
-			'_$_.with_scope',
-			b.id('__block'),
-			b.thunk({
-				...node,
-				callee: /** @type {AST.Expression} */ (context.visit(callee)),
-				arguments: /** @type {(AST.Expression | AST.SpreadElement)[]} */ (
-					node.arguments.map((arg) => context.visit(arg))
-				),
-			}),
-		);
+		const visited_call = {
+			...node,
+			callee: /** @type {AST.Expression} */ (context.visit(callee)),
+			arguments: /** @type {(AST.Expression | AST.SpreadElement)[]} */ (
+				node.arguments.map((arg) => context.visit(arg))
+			),
+		};
+
+		// A generated code-block scope IIFE is already a zero-argument
+		// closure — use its arrow as the with_scope callback directly instead
+		// of thunking the call (`() => (() => { … })()`).
+		if (
+			node.metadata?.tsrx_code_block_scope &&
+			visited_call.callee.type === 'ArrowFunctionExpression'
+		) {
+			return b.call('_$_.with_scope', b.id('__block'), visited_call.callee);
+		}
+
+		return b.call('_$_.with_scope', b.id('__block'), b.thunk(visited_call));
 	},
 
 	TSTypeAliasDeclaration(_, context) {
@@ -4967,7 +4985,10 @@ function transform_children(children, context) {
 					(node.id.type !== 'Identifier' || !is_element_dom_element(node))),
 		) ||
 		(normalized.filter(
-			(node) => node.type !== 'VariableDeclaration' && node.type !== 'EmptyStatement',
+			(node) =>
+				node.type !== 'VariableDeclaration' &&
+				node.type !== 'BlockStatement' &&
+				node.type !== 'EmptyStatement',
 		).length === 1 &&
 			normalized.some(
 				(node) =>
@@ -4984,7 +5005,10 @@ function transform_children(children, context) {
 					/** @type {AST.TSRXExpression} */ (node).expression.type !== 'Literal',
 			)) ||
 		normalized.filter(
-			(node) => node.type !== 'VariableDeclaration' && node.type !== 'EmptyStatement',
+			(node) =>
+				node.type !== 'VariableDeclaration' &&
+				node.type !== 'BlockStatement' &&
+				node.type !== 'EmptyStatement',
 		).length > 1;
 	/** @type {AST.Identifier | null} */
 	let initial = null;
@@ -5163,6 +5187,7 @@ function transform_children(children, context) {
 
 		if (
 			node.type === 'VariableDeclaration' ||
+			node.type === 'BlockStatement' ||
 			node.type === 'ExpressionStatement' ||
 			node.type === 'ThrowStatement' ||
 			node.type === 'FunctionDeclaration' ||

--- a/packages/tsrx-ripple/src/transform/server/index.js
+++ b/packages/tsrx-ripple/src/transform/server/index.js
@@ -74,6 +74,7 @@ import {
 	rewrite_lazy_member_base,
 	should_guard_regular_js_statement,
 	strip_tsrx_style_elements,
+	unwrap_single_return_iife,
 	wrap_code_block_in_iife,
 	is_code_block_function_body,
 } from '../../utils.js';
@@ -1164,6 +1165,7 @@ function transform_children(children, context) {
 		}
 		if (
 			node.type === 'VariableDeclaration' ||
+			node.type === 'BlockStatement' ||
 			node.type === 'ExpressionStatement' ||
 			node.type === 'ThrowStatement' ||
 			node.type === 'FunctionDeclaration' ||
@@ -1541,6 +1543,14 @@ const visitors = {
 		}
 
 		const callee = node.callee;
+
+		// A generated inline-component IIFE for a `@{ … }` block: after the
+		// block's statements lower into the component callback, the wrapper
+		// scope holds a lone `return _$_.tsrx_element(…)` — collapse it to
+		// the component value.
+		if (!state.to_ts && node.metadata?.tsrx_code_block_component) {
+			return unwrap_single_return_iife(/** @type {AST.Expression} */ (context.next()));
+		}
 
 		// Handle direct calls to ripple-imported functions: effect(), untrack(), RippleArray(), etc.
 		if (callee.type === 'Identifier' && is_ripple_import(callee, context)) {

--- a/packages/tsrx-ripple/src/utils.js
+++ b/packages/tsrx-ripple/src/utils.js
@@ -183,7 +183,38 @@ export function wrap_code_block_in_iife(code_block) {
 	// Match the parser's `() => @{ … }` shape: a code-block body is treated as a
 	// block, not a concise expression body.
 	arrow.expression = false;
-	return b.call(arrow);
+	const call = /** @type {AST.SimpleCallExpression} */ (b.call(arrow));
+	// Marks a generated inline-component IIFE so the runtime transforms can
+	// collapse it once the block's statements have moved into the component
+	// callback (`unwrap_single_return_iife`).
+	call.metadata = { ...call.metadata, tsrx_code_block_component: true };
+	return call;
+}
+
+/**
+ * Collapse a transformed zero-argument IIFE whose body is a single
+ * `return <expr>;` into the returned expression. Used for generated
+ * code-block component IIFEs after their setup statements have been lowered
+ * into the component callback, leaving the wrapper scope empty.
+ * @param {AST.Expression} call
+ * @returns {AST.Expression}
+ */
+export function unwrap_single_return_iife(call) {
+	if (call?.type !== 'CallExpression' || call.arguments.length !== 0) {
+		return call;
+	}
+	const callee = call.callee;
+	if (callee.type !== 'ArrowFunctionExpression' || callee.async || callee.params.length !== 0) {
+		return call;
+	}
+	const body = callee.body;
+	if (body.type === 'BlockStatement' && body.body.length === 1) {
+		const statement = body.body[0];
+		if (statement.type === 'ReturnStatement' && statement.argument) {
+			return statement.argument;
+		}
+	}
+	return call;
 }
 
 /**
@@ -1413,6 +1444,19 @@ export function is_inside_call_expression(context) {
 			type === 'ArrowFunctionExpression' ||
 			type === 'FunctionDeclaration'
 		) {
+			// A call inside a nested function generally runs later, after
+			// `with_scope` has restored the previous scope, so it needs its
+			// own wrapper. A code-block scope IIFE runs synchronously inside
+			// its own `with_scope` wrapper, though — see through it.
+			const maybe_iife = context.path[i - 1];
+			if (
+				type === 'ArrowFunctionExpression' &&
+				maybe_iife?.type === 'CallExpression' &&
+				maybe_iife.callee === context_node &&
+				maybe_iife.metadata?.tsrx_code_block_scope
+			) {
+				continue;
+			}
 			return false;
 		}
 		if (type === 'CallExpression') {
@@ -2445,7 +2489,7 @@ function jsx_to_ripple_fragment(node, inherited_path = []) {
 	const fragment = /** @type {AST.TsrxFragment} */ (
 		/** @type {unknown} */ ({
 			type: 'TsrxFragment',
-			children: normalize_jsx_tsrx_children(node.children || [], inherited_path),
+			children: normalize_jsx_tsrx_template_children(node.children || [], inherited_path),
 			openingElement: node.openingFragment,
 			closingElement: node.closingFragment,
 			selfClosing: false,
@@ -2484,10 +2528,10 @@ function jsx_control_expression_to_statement(node, inherited_path = []) {
 	}
 
 	if (statement.consequent?.type === 'BlockStatement') {
-		statement.consequent.body = normalize_jsx_tsrx_children(statement.consequent.body || [], [
-			...inherited_path,
-			statement,
-		]);
+		statement.consequent.body = normalize_jsx_tsrx_template_children(
+			statement.consequent.body || [],
+			[...inherited_path, statement],
+		);
 	} else if (statement.consequent) {
 		statement.consequent = normalize_jsx_tsrx_node(statement.consequent, [
 			...inherited_path,
@@ -2495,10 +2539,10 @@ function jsx_control_expression_to_statement(node, inherited_path = []) {
 		]);
 	}
 	if (statement.alternate?.type === 'BlockStatement') {
-		statement.alternate.body = normalize_jsx_tsrx_children(statement.alternate.body || [], [
-			...inherited_path,
-			statement,
-		]);
+		statement.alternate.body = normalize_jsx_tsrx_template_children(
+			statement.alternate.body || [],
+			[...inherited_path, statement],
+		);
 	} else if (statement.alternate) {
 		statement.alternate = normalize_jsx_tsrx_node(statement.alternate, [
 			...inherited_path,
@@ -2512,44 +2556,44 @@ function jsx_control_expression_to_statement(node, inherited_path = []) {
 		}
 	}
 	if (statement.body?.type === 'BlockStatement') {
-		statement.body.body = normalize_jsx_tsrx_children(statement.body.body || [], [
+		statement.body.body = normalize_jsx_tsrx_template_children(statement.body.body || [], [
 			...inherited_path,
 			statement,
 		]);
 	}
 	if (statement.empty?.type === 'BlockStatement') {
-		statement.empty.body = normalize_jsx_tsrx_children(statement.empty.body || [], [
+		statement.empty.body = normalize_jsx_tsrx_template_children(statement.empty.body || [], [
 			...inherited_path,
 			statement,
 		]);
 	}
 	if (statement.block?.type === 'BlockStatement') {
-		statement.block.body = normalize_jsx_tsrx_children(statement.block.body || [], [
+		statement.block.body = normalize_jsx_tsrx_template_children(statement.block.body || [], [
 			...inherited_path,
 			statement,
 		]);
 	}
 	if (statement.pending?.type === 'BlockStatement') {
-		statement.pending.body = normalize_jsx_tsrx_children(statement.pending.body || [], [
+		statement.pending.body = normalize_jsx_tsrx_template_children(statement.pending.body || [], [
 			...inherited_path,
 			statement,
 		]);
 	}
 	if (statement.handler?.body?.type === 'BlockStatement') {
-		statement.handler.body.body = normalize_jsx_tsrx_children(statement.handler.body.body || [], [
-			...inherited_path,
-			statement,
-		]);
+		statement.handler.body.body = normalize_jsx_tsrx_template_children(
+			statement.handler.body.body || [],
+			[...inherited_path, statement],
+		);
 	}
 	if (statement.finalizer?.type === 'BlockStatement') {
-		statement.finalizer.body = normalize_jsx_tsrx_children(statement.finalizer.body || [], [
-			...inherited_path,
-			statement,
-		]);
+		statement.finalizer.body = normalize_jsx_tsrx_template_children(
+			statement.finalizer.body || [],
+			[...inherited_path, statement],
+		);
 	}
 	if (Array.isArray(statement.cases)) {
 		for (const switch_case of statement.cases) {
-			switch_case.consequent = normalize_jsx_tsrx_children(switch_case.consequent || [], [
+			switch_case.consequent = normalize_jsx_tsrx_template_children(switch_case.consequent || [], [
 				...inherited_path,
 				statement,
 			]);
@@ -2607,6 +2651,113 @@ function normalize_jsx_tsrx_children(children, inherited_path = []) {
 }
 
 /**
+ * Lower a `@{ … }` code block that appears in a template children list. Each
+ * code block is its own lexical scope, so it never flattens into the
+ * surrounding scope, but the lowering only pays for what the block uses:
+ *
+ * - no setup code: the scope is unobservable, so the render output merges
+ *   statically into the parent template — no `_$_.expression`, no inline
+ *   component, no anchor;
+ * - code-only: a plain `BlockStatement` — statements run in source order,
+ *   scoped, render nothing;
+ * - setup code + render output: an inline anonymous component expression
+ *   (`(() => @{ … })()`, the same lowering as value-position code blocks),
+ *   since the setup may feed the output — `_$_.expression` is the right tool
+ *   for a dynamic child value;
+ * - nested chains (`@{ @{ … } }`): intermediate levels with statements merge
+ *   into one IIFE as nested plain `{ … }` blocks (one closure, not one per
+ *   level), and only the innermost render-bearing level becomes the inline
+ *   component.
+ * @param {AST.JSXCodeBlock} block — internals already normalized
+ * @param {AST.Node[]} inherited_path
+ * @returns {AST.Node | null}
+ */
+function code_block_to_template_child(block, inherited_path) {
+	const body = block.body || [];
+	const render = block.render;
+
+	// `@{ @{ … } }` — normalize wrapped the already-lowered inner chain in a
+	// synthetic fragment for render-slot consumers (function bodies, value
+	// positions). As a template child, unwrap it instead of stacking an
+	// inline component per nesting level.
+	if (render?.type === 'TsrxFragment' && render.metadata.tsrx_code_block_chain) {
+		const inner_child = render.children[0];
+		if (body.length === 0) {
+			return inner_child;
+		}
+		if (inner_child.type === 'BlockStatement') {
+			const statement = b.block(
+				[...body, inner_child],
+				/** @type {AST.NodeWithLocation} */ (block),
+			);
+			statement.metadata = { path: inherited_path };
+			return statement;
+		}
+		if (inner_child.type !== 'TSRXExpression') {
+			// Unreachable by construction — the chain wrapper only ever holds
+			// a statement block or an expression child.
+			return inner_child;
+		}
+		// The inner level is either one of our scope IIFEs (fold its body in
+		// as a nested plain block instead of a nested closure, so a whole
+		// chain shares a single function) or the inline component (return its
+		// value from this level's scope).
+		const inner_expression = inner_child.expression;
+		const scope_body =
+			inner_expression.type === 'CallExpression' &&
+			inner_expression.metadata?.tsrx_code_block_scope &&
+			inner_expression.callee.type === 'ArrowFunctionExpression' &&
+			inner_expression.callee.body.type === 'BlockStatement'
+				? [...body, inner_expression.callee.body]
+				: [...body, b.return(inner_expression)];
+		const scope_call = /** @type {AST.SimpleCallExpression} */ (
+			b.call(b.arrow([], b.block(scope_body, /** @type {AST.NodeWithLocation} */ (block))))
+		);
+		scope_call.metadata = { ...scope_call.metadata, tsrx_code_block_scope: true };
+		return b.tsrx_expression(scope_call, /** @type {AST.NodeWithLocation} */ (block));
+	}
+
+	if (render == null) {
+		if (body.length === 0) {
+			return null;
+		}
+		const statement = b.block(body, /** @type {AST.NodeWithLocation} */ (block));
+		statement.metadata = { path: inherited_path };
+		return statement;
+	}
+
+	if (body.length === 0) {
+		// No setup code — the block's scope is unobservable, so the render
+		// output merges statically into the parent template.
+		return render;
+	}
+
+	return b.tsrx_expression(
+		wrap_code_block_in_iife(block),
+		/** @type {AST.NodeWithLocation} */ (block),
+	);
+}
+
+/**
+ * Normalize a template children list (fragment/element children, control-flow
+ * branch bodies), lowering `@{ … }` code-block children into their scoped
+ * template-child form. Statement arrays that are not template children
+ * (function bodies, program body) must keep using
+ * `normalize_jsx_tsrx_children` so statement-position code blocks stay
+ * lexical blocks.
+ * @param {any[]} children
+ * @param {AST.Node[]} [inherited_path]
+ * @returns {AST.Node[]}
+ */
+function normalize_jsx_tsrx_template_children(children, inherited_path = []) {
+	return normalize_jsx_tsrx_children(children, inherited_path)
+		.map((child) =>
+			child.type === 'JSXCodeBlock' ? code_block_to_template_child(child, inherited_path) : child,
+		)
+		.filter((child) => child != null);
+}
+
+/**
  * @param {any} node
  * @param {AST.Node[]} [inherited_path]
  * @returns {any}
@@ -2637,6 +2788,41 @@ function normalize_jsx_tsrx_node(node, inherited_path = []) {
 	}
 	if (node.type === 'JSXExpressionContainer') {
 		return jsx_to_ripple_node(node, inherited_path);
+	}
+	if (node.type === 'JSXCodeBlock') {
+		// Each `@{ … }` is its own lexical scope, so nested blocks never merge
+		// into their parent. A block whose render output is itself a code block
+		// (`@{ @{ … } }`) keeps the nesting: the inner block is lowered like a
+		// template child inside a synthetic fragment so it gets its own scope.
+		const path = [...inherited_path, node];
+		node.body = normalize_jsx_tsrx_children(node.body || [], path);
+		if (node.render?.type === 'JSXCodeBlock') {
+			const inner = normalize_jsx_tsrx_node(node.render, path);
+			const inner_child = code_block_to_template_child(inner, path);
+			// An inner block that is empty all the way down renders nothing —
+			// drop it so the outer block becomes code-only (and prunable too).
+			if (inner_child == null) {
+				node.render = null;
+			} else if (is_native_tsrx_template_node(inner_child)) {
+				// The inner chain collapsed to a plain template node (its scope
+				// was unobservable) — it becomes this block's render directly,
+				// with no wrapper fragment.
+				node.render = inner_child;
+			} else {
+				const fragment = b.tsrx_fragment(
+					[inner_child],
+					/** @type {AST.NodeWithLocation} */ (inner),
+				);
+				fragment.metadata.path = path;
+				// Mark the wrapper so template-children lowering can unwrap it
+				// instead of stacking an inline component per nesting level.
+				fragment.metadata.tsrx_code_block_chain = true;
+				node.render = fragment;
+			}
+		} else if (node.render) {
+			node.render = normalize_jsx_tsrx_node(node.render, path);
+		}
+		return node;
 	}
 
 	for (const key in node) {
@@ -2789,10 +2975,10 @@ export function jsx_to_ripple_node(node, inherited_path = []) {
 		}
 
 		element.children = /** @type {AST.Node[]} */ (
-			/** @type {AST.Node[]} */ (node.children)
-				.map((child) => normalize_jsx_tsrx_node(child, [...inherited_path, element]))
-				.flat()
-				.filter(Boolean)
+			normalize_jsx_tsrx_template_children(/** @type {AST.Node[]} */ (node.children), [
+				...inherited_path,
+				element,
+			]).filter(Boolean)
 		);
 
 		return element;
@@ -2833,10 +3019,10 @@ export function jsx_to_ripple_node(node, inherited_path = []) {
 
 	if (node.type === 'JSXFragment') {
 		return /** @type {AST.Node[]} */ (
-			/** @type {AST.Node[]} */ (node.children)
-				.map((child) => normalize_jsx_tsrx_node(child, inherited_path))
-				.flat()
-				.filter(Boolean)
+			normalize_jsx_tsrx_template_children(
+				/** @type {AST.Node[]} */ (node.children),
+				inherited_path,
+			).filter(Boolean)
 		);
 	}
 

--- a/packages/tsrx-ripple/tests/code-block-children.test.js
+++ b/packages/tsrx-ripple/tests/code-block-children.test.js
@@ -1,0 +1,248 @@
+import { compile, compile_to_volar_mappings } from '../src/index.js';
+import { describe, expect, it } from 'vitest';
+
+describe('@tsrx/ripple code blocks in template children position', () => {
+	const with_statements = `function App() @{
+	<>
+		<span class="a">{'a'}</span>
+		@{
+			const x = 1;
+			<span class="x">{x}</span>
+		}
+	</>
+}`;
+
+	it('lowers a render-bearing code block child to a scoped inline component (client)', () => {
+		const { code, errors } = compile(with_statements, 'App.tsrx');
+		expect(errors).toEqual([]);
+		// The block's render output replaces the block at its source position.
+		expect(code).toContain(`<span class="a">a</span><!>`);
+		// Statements live inside the inline component callback — the wrapper
+		// IIFE collapses once they move there.
+		const component = code.search(/_\$_\.tsrx_element\(\(__anchor, __block\) => \{\s*const x = 1;/);
+		expect(component).toBeGreaterThan(-1);
+		expect(code.indexOf('_$_.expression(')).toBeLessThan(component);
+		expect(code).toContain('() => x');
+		expect(code).not.toContain('(() => {');
+	});
+
+	it('lowers a render-bearing code block child to a scoped inline component (server)', () => {
+		const { code, errors } = compile(with_statements, 'App.tsrx', { mode: 'server' });
+		expect(errors).toEqual([]);
+		expect(code).toContain('_$_.render_expression');
+		const x_decl = code.indexOf('const x = 1;');
+		const span_x = code.indexOf('_$_.escape(x)');
+		expect(x_decl).toBeGreaterThan(code.indexOf('_$_.render_expression'));
+		expect(span_x).toBeGreaterThan(x_decl);
+	});
+
+	it('keeps the block scoped and its render output typed in the TS view', () => {
+		const { code } = compile_to_volar_mappings(with_statements, 'App.tsrx');
+		const iife = code.indexOf('(() => {');
+		expect(iife).toBeGreaterThan(-1);
+		expect(code.indexOf('const x = 1;')).toBeGreaterThan(iife);
+		expect(code).toContain('<span class="x">{x}</span>');
+	});
+
+	const shadowing = `function App() @{
+	const y = 10;
+	<>
+		<span class="a">{'a'}</span>
+		@{
+			const x = 1;
+			@{
+				const x = 2;
+				@{
+					<span class="sum">{x + y}</span>
+				}
+			}
+		}
+	</>
+}`;
+
+	it('gives each nested code block its own lexical scope (client)', () => {
+		const { code, errors } = compile(shadowing, 'App.tsrx');
+		expect(errors).toEqual([]);
+		// Shadowed declarations survive because each block is its own scope.
+		expect(code).toContain('const x = 1;');
+		expect(code).toContain('const x = 2;');
+		expect(code).toContain('() => x + y');
+		// Each nesting level becomes its own inline component scope.
+		expect(code.indexOf('const x = 2;')).toBeGreaterThan(code.indexOf('const x = 1;'));
+	});
+
+	it('gives each nested code block its own lexical scope (server)', () => {
+		const { code, errors } = compile(shadowing, 'App.tsrx', { mode: 'server' });
+		expect(errors).toEqual([]);
+		expect(code).toContain('const x = 1;');
+		expect(code).toContain('const x = 2;');
+		expect(code).toContain('_$_.escape(x + y)');
+	});
+
+	it('keeps nested code blocks flat: plain scopes, one inline component (client)', () => {
+		const { code } = compile(shadowing, 'App.tsrx');
+		// Component shell + fragment shell + the innermost render-bearing
+		// block. Intermediate chain levels are plain scopes, not inline
+		// components wrapped in synthetic fragments, and the whole chain runs
+		// synchronously inside a single scope wrapper.
+		expect(code.match(/_\$_\.tsrx_element\(/g)).toHaveLength(3);
+		expect(code.match(/_\$_\.template\(/g)).toHaveLength(3);
+		expect(code.match(/with_scope/g)).toHaveLength(1);
+		// The scope chain is the with_scope callback itself — no nested IIFEs.
+		expect(code).not.toContain('(() => {');
+	});
+
+	it('gives each nested code block its own lexical scope (TS view)', () => {
+		const { code } = compile_to_volar_mappings(shadowing, 'App.tsrx');
+		expect(code).toContain('const x = 1;');
+		expect(code).toContain('const x = 2;');
+		expect(code).toContain('<span class="sum">{x + y}</span>');
+	});
+
+	const empty_nested = `function App() @{
+	<>
+		<span>{'a'}</span>
+		<span>{'b'}</span>
+		@{@{@{}}}
+	</>
+}`;
+
+	it('prunes empty nested code blocks entirely (client)', () => {
+		const { code, errors } = compile(empty_nested, 'App.tsrx');
+		expect(errors).toEqual([]);
+		// No anchor among the spans, no inline component — the empty chain
+		// renders nothing.
+		expect(code).toContain('<span>a</span><span>b</span>');
+		expect(code).not.toContain('<span>a</span><span>b</span><!>');
+		expect(code).not.toContain('(() => {');
+	});
+
+	it('prunes empty nested code blocks entirely (server)', () => {
+		const { code, errors } = compile(empty_nested, 'App.tsrx', { mode: 'server' });
+		expect(errors).toEqual([]);
+		expect(code).not.toContain('render_expression');
+	});
+
+	const template_only = `function App() @{
+	<>
+		<span class="a">{'a'}</span>
+		@{<span class="x">{'x'}</span>}
+	</>
+}`;
+
+	const template_only_nested = `function App() @{
+	<>
+		<span class="a">{'a'}</span>
+		@{@{@{<span class="x">{'x'}</span>}}}
+	</>
+}`;
+
+	it('merges a template-only block statically into the parent template (client)', () => {
+		for (const source of [template_only, template_only_nested]) {
+			const { code, errors } = compile(source, 'App.tsrx');
+			expect(errors).toEqual([]);
+			// Identical to writing the element inline: no inline component, no
+			// expression anchor, no scope wrapper.
+			expect(code).toContain('<span class="a">a</span><span class="x">x</span>');
+			expect(code).not.toContain('(() => {');
+			expect(code).not.toContain('with_scope');
+		}
+	});
+
+	it('merges a template-only block statically into the output (server)', () => {
+		for (const source of [template_only, template_only_nested]) {
+			const { code, errors } = compile(source, 'App.tsrx', { mode: 'server' });
+			expect(errors).toEqual([]);
+			expect(code).toContain(`_$_.output_push(' class="x"')`);
+			expect(code).not.toContain('render_expression');
+		}
+	});
+
+	const code_only = `function App() @{
+	const items = [];
+	<>
+		@{
+			const scoped = 1;
+			items.push(scoped);
+		}
+		<span>{items.length}</span>
+	</>
+}`;
+
+	it('lowers a code-only block child to a scoped statement block (client)', () => {
+		const { code, errors } = compile(code_only, 'App.tsrx');
+		expect(errors).toEqual([]);
+		// The statements run in source order inside a real `{ }` block.
+		const block = code.indexOf('{\n\t\t\t\tconst scoped = 1;');
+		expect(block).toBeGreaterThan(-1);
+		expect(code.indexOf('items.length')).toBeGreaterThan(block);
+		// No inline component for code-only blocks.
+		expect(code).not.toContain('(() => {');
+	});
+
+	it('lowers a code-only block child to a scoped statement block (server)', () => {
+		const { code, errors } = compile(code_only, 'App.tsrx', { mode: 'server' });
+		expect(errors).toEqual([]);
+		const scoped_decl = code.indexOf('const scoped = 1;');
+		expect(scoped_decl).toBeGreaterThan(-1);
+		expect(code.indexOf('_$_.escape(items.length)')).toBeGreaterThan(scoped_decl);
+		expect(code).not.toContain('render_expression');
+	});
+
+	const nested_function_body = `function App() @{
+	const x = 1;
+	@{
+		const y = 2;
+		<div>{x + y}</div>
+	}
+}`;
+
+	it('scopes a nested code-block render chain in a function body (client)', () => {
+		const { code, errors } = compile(nested_function_body, 'App.tsrx');
+		expect(errors).toEqual([]);
+		// `x` is component setup; `y` lives in the nested block's own inline
+		// component scope behind the expression anchor.
+		const anchor = code.indexOf('_$_.expression(');
+		expect(anchor).toBeGreaterThan(-1);
+		expect(code.indexOf('const x = 1;')).toBeLessThan(anchor);
+		expect(code.indexOf('const y = 2;')).toBeGreaterThan(anchor);
+		expect(code).toContain('() => x + y');
+	});
+
+	it('scopes a nested code-block render chain in a function body (server)', () => {
+		const { code, errors } = compile(nested_function_body, 'App.tsrx', { mode: 'server' });
+		expect(errors).toEqual([]);
+		expect(code).toContain('_$_.render_expression');
+		expect(code.indexOf('const y = 2;')).toBeGreaterThan(code.indexOf('_$_.render_expression'));
+		expect(code).toContain('_$_.escape(x + y)');
+	});
+
+	const inside_if = `function App() @{
+	const show = true;
+	<>
+		@if (show) {
+			@{
+				const label = 'shown';
+				<span>{label}</span>
+			}
+		}
+	</>
+}`;
+
+	it('scopes code-block children inside control-flow branches (client)', () => {
+		const { code, errors } = compile(inside_if, 'App.tsrx');
+		expect(errors).toEqual([]);
+		// `label` lives inside the inline component within the @if branch.
+		const branch = code.indexOf('var consequent =');
+		const label = code.indexOf(`const label = 'shown';`);
+		expect(branch).toBeGreaterThan(-1);
+		expect(label).toBeGreaterThan(branch);
+	});
+
+	it('scopes code-block children inside control-flow branches (server)', () => {
+		const { code, errors } = compile(inside_if, 'App.tsrx', { mode: 'server' });
+		expect(errors).toEqual([]);
+		expect(code).toContain(`const label = 'shown';`);
+		expect(code).toContain('_$_.escape(label)');
+	});
+});

--- a/packages/tsrx-solid/tests/basic.test.js
+++ b/packages/tsrx-solid/tests/basic.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
 	runSharedClassFunctionComponentTests,
+	runSharedCodeBlockChildrenTests,
 	runSharedCompileDiagnosticsTests,
 	runSharedCompileTests,
 	runSharedComponentParamsTests,
@@ -20,6 +21,7 @@ runSharedSourceMappingTests({
 runSharedTsxExpressionTsrxTests({ compile, name: 'solid', classAttrName: 'class' });
 runSharedCompileTests({ compile, name: 'solid', classAttrName: 'class' });
 runSharedCompileDiagnosticsTests({ compile_to_volar_mappings, name: 'solid' });
+runSharedCodeBlockChildrenTests({ compile, name: 'solid' });
 runSharedClassFunctionComponentTests({ compile, compile_to_volar_mappings, name: 'solid' });
 runSharedComponentParamsTests({ compile, compile_to_volar_mappings, name: 'solid' });
 runSharedSwitchHelperHoistingTests({

--- a/packages/tsrx-vue/tests/basic.test.js
+++ b/packages/tsrx-vue/tests/basic.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
 	runSharedClassFunctionComponentTests,
+	runSharedCodeBlockChildrenTests,
 	runSharedCompileDiagnosticsTests,
 	runSharedComponentLoopControlFlowTests,
 	runSharedComponentParamsTests,
@@ -20,6 +21,7 @@ runSharedSourceMappingTests({
 runSharedTsxExpressionTsrxTests({ compile, name: 'vue', classAttrName: 'class' });
 runSharedComponentLoopControlFlowTests({ compile, name: 'vue' });
 runSharedCompileDiagnosticsTests({ compile_to_volar_mappings, name: 'vue' });
+runSharedCodeBlockChildrenTests({ compile, name: 'vue' });
 runSharedClassFunctionComponentTests({ compile, compile_to_volar_mappings, name: 'vue' });
 runSharedComponentParamsTests({ compile, compile_to_volar_mappings, name: 'vue' });
 runSharedSwitchHelperHoistingTests({

--- a/packages/tsrx/src/transform/jsx/index.js
+++ b/packages/tsrx/src/transform/jsx/index.js
@@ -146,10 +146,57 @@ function mark_nested_function_return_jsx(node, inside_function = false, seen = n
 }
 
 /**
- * Flatten a `@{ … }` code block that appears as an element/fragment child into
- * the element's children list: its setup statements followed by its single
- * render output. The render pipeline already handles interleaved setup
- * statements and JSX children. This is the element-scoped equivalent of
+ * Lower a `@{ … }` code block that appears as an element/fragment child,
+ * paying only for what the block uses while keeping each block its own
+ * lexical scope:
+ *
+ * - no setup code: the scope is unobservable, so the render output merges
+ *   directly into the children list (template-only chains collapse to the
+ *   innermost output, empty chains to nothing);
+ * - code-only: a plain `{ … }` statement block — statements run in source
+ *   order, scoped, and render nothing (the render pipeline already handles
+ *   statements interleaved with JSX children);
+ * - setup code + render output: kept as a `JSXCodeBlock` (with any nested
+ *   chain simplified) for the context-aware lowering into a scoped IIFE
+ *   (`transform_jsx_code_block` / `build_render_statements`).
+ *
+ * Always returns zero or one node.
+ * @param {any} block
+ * @returns {any[]}
+ */
+function lower_code_block_child(block) {
+	const body = block.body || [];
+	const render = block.render ?? null;
+
+	if (body.length === 0) {
+		if (render == null) return [];
+		if (render.type === 'JSXCodeBlock') return lower_code_block_child(render);
+		return [render];
+	}
+
+	if (render?.type === 'JSXCodeBlock') {
+		const inner = lower_code_block_child(render);
+		if (inner.length === 0) {
+			return [b.block(body, block)];
+		}
+		if (inner[0].type === 'BlockStatement') {
+			return [b.block([...body, inner[0]], block)];
+		}
+		// The chain still renders — simplify the render to the lowered inner
+		// node and leave the block for the context-aware lowering.
+		return [{ ...block, render: inner[0] }];
+	}
+
+	if (render == null) {
+		return [b.block(body, block)];
+	}
+
+	return [block];
+}
+
+/**
+ * Lower `@{ … }` code blocks that appear as element/fragment children (see
+ * `lower_code_block_child`). This is the element-scoped equivalent of
  * `transform_function`'s body lowering — function and arrow bodies are never
  * element children, so they are untouched here.
  * @param {any} node
@@ -170,9 +217,7 @@ function expand_child_code_blocks(node, seen = new Set()) {
 		node.children.some((/** @type {any} */ c) => c?.type === 'JSXCodeBlock')
 	) {
 		node.children = node.children.flatMap((/** @type {any} */ child) =>
-			child?.type === 'JSXCodeBlock'
-				? [...child.body, ...(child.render != null ? [child.render] : [])]
-				: [child],
+			child?.type === 'JSXCodeBlock' ? lower_code_block_child(child) : [child],
 		);
 	}
 
@@ -802,6 +847,79 @@ function build_component_statements(body_nodes, transform_context) {
 }
 
 /**
+ * Statements for one `@{ … }` scope level: the setup statements followed by
+ * the lowered chain continuation. A nested level that declares anything is
+ * kept in a nested plain `{ … }` block, so a whole chain shares a single
+ * closure while still scoping each level; the generated `return` exits that
+ * closure.
+ * @param {any} block
+ * @param {TransformContext} transform_context
+ * @returns {{ statements: any[], has_render: boolean }}
+ */
+function code_block_scope_statements(block, transform_context) {
+	const statements = [...(block.body || [])];
+	const render = block.render ?? null;
+
+	if (render == null) {
+		return { statements, has_render: false };
+	}
+
+	if (render.type === 'JSXCodeBlock') {
+		const inner = code_block_scope_statements(render, transform_context);
+		if (inner.statements.length > 0) {
+			if ((render.body || []).length > 0) {
+				statements.push(b.block(inner.statements, render));
+			} else {
+				statements.push(...inner.statements);
+			}
+		}
+		return { statements, has_render: inner.has_render };
+	}
+
+	return {
+		statements: [...statements, ...build_render_statements([render], true, transform_context)],
+		has_render: true,
+	};
+}
+
+/**
+ * Lower a `@{ … }` code block that appears in a component/IIFE statement
+ * stream, keeping each block its own lexical scope:
+ *
+ * - no setup code: the scope is unobservable, so the render output (if any)
+ *   merges directly into the stream;
+ * - code-only: a plain `{ … }` statement block;
+ * - setup code + render output: a scoped IIFE expression child whose value is
+ *   the render output, with nested chains folded into the one closure.
+ *
+ * Always returns zero or one node.
+ * @param {any} block
+ * @param {TransformContext} transform_context
+ * @returns {any[]}
+ */
+function lower_code_block_stream_node(block, transform_context) {
+	const body = block.body || [];
+	const render = block.render ?? null;
+
+	if (body.length === 0) {
+		if (render == null) return [];
+		if (render.type === 'JSXCodeBlock') {
+			return lower_code_block_stream_node(render, transform_context);
+		}
+		return [render];
+	}
+
+	const { statements, has_render } = code_block_scope_statements(block, transform_context);
+
+	if (!has_render) {
+		return [b.block(statements, block)];
+	}
+
+	const iife = b.call(b.arrow([], b.block(statements, block)));
+	return [to_jsx_expression_container(iife, block)];
+}
+
+/**
  * @param {any[]} body_nodes
  * @param {boolean} return_null_when_empty
  * @param {TransformContext} transform_context
@@ -809,9 +927,7 @@ function build_component_statements(body_nodes, transform_context) {
  */
 function build_render_statements(body_nodes, return_null_when_empty, transform_context) {
 	body_nodes = body_nodes.flatMap((node) =>
-		node?.type === 'JSXCodeBlock'
-			? [...node.body, ...(node.render != null ? [node.render] : [])]
-			: [node],
+		node?.type === 'JSXCodeBlock' ? lower_code_block_stream_node(node, transform_context) : [node],
 	);
 
 	const statements = [];

--- a/packages/tsrx/src/utils/builders.js
+++ b/packages/tsrx/src/utils/builders.js
@@ -1250,6 +1250,44 @@ export function jsx_fragment(children = [], attributes = []) {
 }
 
 /**
+ * Ripple's internal fragment template node (the normalized form of a
+ * `JSXFragment`).
+ * @param {AST.Node[]} [children]
+ * @param {AST.NodeWithLocation} [loc_info]
+ * @returns {AST.TsrxFragment}
+ */
+export function tsrx_fragment(children = [], loc_info) {
+	const node = /** @type {AST.TsrxFragment} */ (
+		/** @type {unknown} */ ({
+			type: 'TsrxFragment',
+			children,
+			attributes: [],
+			selfClosing: false,
+			metadata: { path: [] },
+		})
+	);
+
+	return set_location(node, loc_info);
+}
+
+/**
+ * Ripple's internal expression template child (the normalized form of a
+ * `JSXExpressionContainer` child).
+ * @param {AST.Expression} expression
+ * @param {AST.NodeWithLocation} [loc_info]
+ * @returns {AST.TSRXExpression}
+ */
+export function tsrx_expression(expression, loc_info) {
+	const node = /** @type {AST.TSRXExpression} */ ({
+		type: 'TSRXExpression',
+		expression,
+		metadata: { path: [] },
+	});
+
+	return set_location(node, loc_info);
+}
+
+/**
  * @param {AST.Expression | ESTreeJSX.JSXEmptyExpression} expression
  * @param {AST.NodeWithLocation} [loc_info]
  * @returns {ESTreeJSX.JSXExpressionContainer}

--- a/packages/tsrx/tests/shared/compile.js
+++ b/packages/tsrx/tests/shared/compile.js
@@ -3477,3 +3477,123 @@ export function optionalFn(bar: string, baz?: string) {
 		},
 	);
 }
+
+/**
+ * `@{ … }` code blocks in template children position: each block is its own
+ * lexical scope, and the lowering pays only for what the block uses —
+ * template-only blocks merge statically into the parent, code-only blocks
+ * become a plain `{ … }` statement block, and blocks with both setup code and
+ * render output become a scoped IIFE child. Nested chains (`@{ @{ … } }`)
+ * fold into a single closure with nested plain blocks, so shadowed
+ * declarations stay scoped per level.
+ *
+ * @param {{ compile: CompileHarness['compile'], name: string }} harness
+ */
+export function runSharedCodeBlockChildrenTests({ compile, name }) {
+	describe(`[${name}] code blocks in template children position`, () => {
+		it('compiles empty nested code blocks to nothing at any depth', () => {
+			for (const block of ['@{}', '@{@{}}', '@{@{@{}}}']) {
+				const { code, errors } = compile(
+					`function StatusBadge() @{
+						<>
+							<>{a}</>
+							<>{b}</>
+							${block}
+						</>
+					}`,
+					'App.tsrx',
+				);
+				expect(errors ?? []).toEqual([]);
+				expect(code).toContain('{a}');
+				expect(code).toContain('{b}');
+				expect(code).not.toContain('_tsrx_child_');
+				expect(code).not.toContain('(() => {');
+			}
+		});
+
+		it('merges a template-only block statically into its parent', () => {
+			for (const block of [
+				`@{<span class="x">{'x'}</span>}`,
+				`@{@{@{<span class="x">{'x'}</span>}}}`,
+			]) {
+				const { code } = compile(
+					`function App() @{
+						<>
+							<span class="a">{'a'}</span>
+							${block}
+						</>
+					}`,
+					'App.tsrx',
+				);
+				expect(code).toContain('<span class="x">');
+				expect(code).not.toContain('(() => {');
+				expect(code).not.toContain('_tsrx_child_');
+			}
+		});
+
+		it('lowers a code-only block to a scoped statement block in source order', () => {
+			const { code } = compile(
+				`function App() @{
+					const items: number[] = [];
+					<>
+						@{
+							const scoped = 1;
+							items.push(scoped);
+						}
+						<span class="len">{items.length}</span>
+					</>
+				}`,
+				'App.tsrx',
+			);
+			// The statements run in source order inside a real `{ … }` block —
+			// no inline IIFE needed.
+			expect(code).toMatch(/\{\s*const scoped = 1;/);
+			expect(code.indexOf('items.length')).toBeGreaterThan(code.indexOf('const scoped = 1;'));
+			expect(code).not.toContain('(() => {');
+		});
+
+		it('lowers a block with setup code and render output to a scoped IIFE child', () => {
+			const { code } = compile(
+				`function App() @{
+					<>
+						<span class="a">{'a'}</span>
+						@{
+							const x = 1;
+							<span class="x">{x}</span>
+						}
+					</>
+				}`,
+				'App.tsrx',
+			);
+			expect(code).toMatch(/\(\(\) => \{\s*const x = 1;/);
+			expect(code).toContain('return <span class="x">{x}</span>');
+		});
+
+		it('gives each nested code block its own lexical scope in one closure', () => {
+			const { code } = compile(
+				`function App() @{
+					const y = 10;
+					<>
+						<span class="a">{'a'}</span>
+						@{
+							const x = 1;
+							@{
+								const x = 2;
+								@{
+									<span class="sum">{x + y}</span>
+								}
+							}
+						}
+					</>
+				}`,
+				'App.tsrx',
+			);
+			// Shadowed declarations survive: each chain level is its own scope,
+			// folded into a single closure with nested plain blocks.
+			expect(code).toContain('const x = 1;');
+			expect(code).toContain('const x = 2;');
+			expect(code).toContain('<span class="sum">{x + y}</span>');
+			expect(count_substring(code, '(() => {')).toBe(1);
+		});
+	});
+}

--- a/packages/tsrx/types/index.d.ts
+++ b/packages/tsrx/types/index.d.ts
@@ -170,6 +170,17 @@ declare module 'estree' {
 	interface SimpleCallExpression {
 		metadata: BaseNodeMetaData & {
 			hash?: string;
+			/**
+			 * A generated `(() => @{ … })()` inline-component IIFE for a code
+			 * block; collapsible once the block's statements lower into the
+			 * component callback.
+			 */
+			tsrx_code_block_component?: boolean;
+			/**
+			 * A generated zero-argument scope IIFE for a `@{ … }` code-block
+			 * chain level; runs synchronously inside its `with_scope` wrapper.
+			 */
+			tsrx_code_block_scope?: boolean;
 		};
 	}
 
@@ -323,7 +334,14 @@ declare module 'estree' {
 		closingElement?: ESTreeJSX.JSXClosingFragment | null;
 		selfClosing?: boolean;
 		attributes?: Array<Attribute | SpreadAttribute>;
-		metadata: BaseNodeMetaData;
+		metadata: BaseNodeMetaData & {
+			/**
+			 * A synthetic wrapper for a nested code-block render chain
+			 * (`@{ @{ … } }`), so render-slot consumers see a template node;
+			 * template-children lowering unwraps it.
+			 */
+			tsrx_code_block_chain?: boolean;
+		};
 		start: number;
 		end: number;
 	}


### PR DESCRIPTION
closes #1250
closes #1251

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core compile lowering for a widely used template syntax across multiple targets; behavior is heavily tested but regressions could affect generated output or reactivity at template boundaries.
> 
> **Overview**
> Fixes **`@{ … }` code blocks used as template children** (between elements, in fragments, and in control-flow branches) across the shared JSX transform (React, Preact, Solid, Vue) and Ripple.
> 
> Previously, child code blocks were **flattened** into the parent statement stream, which broke **lexical scoping** (shadowed `const` names) and mishandled **deep nesting** (leaked raw blocks, spurious `_tsrx_child_*` / discarded IIFEs on shared targets; Ripple client dropped children, server kept markup but dropped setup).
> 
> The transforms now **lower each block by shape**: template-only blocks merge into the parent with no extra wrapper; code-only blocks become scoped `{ … }` statements; blocks with setup plus markup become a **scoped IIFE child** (shared) or Ripple **inline component** / expression path. Nested `@{ @{ … } }` chains fold into **one closure** with nested plain blocks, share one `with_scope` on Ripple, and **empty chains compile away**.
> 
> Adds **`runSharedCodeBlockChildrenTests`** for react/preact/solid/vue, Ripple compile plus client/server runtime tests, AST metadata for generated IIFEs, and patch changesets for `@tsrx/core` and `@tsrx/ripple`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ed93759f31b047ea8363ef9d73f9eddf3ed75cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->