### PR TITLE
fix(parser): @{} is always a JSXCodeBlock

### DIFF
--- a/.changeset/code-block-after-template-text.md
+++ b/.changeset/code-block-after-template-text.md
@@ -1,0 +1,11 @@
+---
+'@tsrx/core': patch
+---
+
+Always parse `@{ … }` in template text position as a `JSXCodeBlock`. A code
+block preceded by text on the same line (e.g. `Hello @{props.username}`) was
+split into JSX text ending in a literal `@` plus a `{ … }` expression
+container, because the template raw-text scan only stopped at `<`, `{`, `}`,
+and control-flow directives. The scan now also stops at a `@{` code-block
+start, so inline blocks after text parse the same as blocks at the start of a
+body. A lone `@` not directly followed by `{` remains plain text.

--- a/packages/tsrx/src/plugin.js
+++ b/packages/tsrx/src/plugin.js
@@ -600,6 +600,7 @@ export function TSRXPlugin(config) {
 						ch === CharCode.lessThan ||
 						ch === CharCode.openBrace ||
 						ch === CharCode.closeBrace ||
+						this.#isCodeBlockStart(index) ||
 						this.#isJSXControlFlowDirectiveAt(index)
 					) {
 						break;

--- a/packages/tsrx/tests/utils/parser.test.js
+++ b/packages/tsrx/tests/utils/parser.test.js
@@ -842,6 +842,60 @@ abc
 		expect(block.render.openingElement.name.name).toBe('div');
 	});
 
+	it('parses a `@{ }` block preceded by text as a code block, not text plus expression container', () => {
+		const ast = parseModule(
+			`function Foo(props) @{
+				<>
+					Hello @{props.username}
+				</>
+			}`,
+			'App.tsrx',
+		);
+		const fragment = ast.body[0].body.render;
+
+		expect(fragment.children.map((child) => child.type)).toEqual(['JSXText', 'JSXCodeBlock']);
+		expect(fragment.children[0].value).toContain('Hello ');
+		const block = fragment.children[1];
+		expect(block.body.map((child) => child.type)).toEqual(['ExpressionStatement']);
+		expect(block.body[0].expression.property.name).toBe('username');
+		expect(block.render).toBeNull();
+	});
+
+	it('parses inline `@{ }` blocks between text siblings and keeps the surrounding spaces', () => {
+		const returned = getReturned(`function App() { return <div>a @{x} b @{y} c</div>; }`);
+
+		expect(returned.children.map((child) => child.type)).toEqual([
+			'JSXText',
+			'JSXCodeBlock',
+			'JSXText',
+			'JSXCodeBlock',
+			'JSXText',
+		]);
+		expect(returned.children[0].value).toBe('a ');
+		expect(returned.children[2].value).toBe(' b ');
+		expect(returned.children[4].value).toBe(' c');
+	});
+
+	it('parses a `@{ }` block preceded by text inside an element nested in an expression container', () => {
+		const span = findElement(
+			`function App() { return <div>{cond ? <span>p @{q}</span> : null}</div>; }`,
+			'span',
+		);
+
+		expect(span.children.map((child) => child.type)).toEqual(['JSXText', 'JSXCodeBlock']);
+		expect(span.children[0].value).toBe('p ');
+	});
+
+	it('keeps a lone `@` followed by a spaced expression container as text', () => {
+		const returned = getReturned(`function App() { return <div>at @ {x}</div>; }`);
+
+		expect(returned.children.map((child) => child.type)).toEqual([
+			'JSXText',
+			'JSXExpressionContainer',
+		]);
+		expect(returned.children[0].value).toBe('at @ ');
+	});
+
 	it('keeps locations aligned for plain JSX expression children', () => {
 		const source = `function App() {
 	return <>


### PR DESCRIPTION
closes #1253

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single boundary check in template raw-text scanning with focused parser tests; no auth, data, or runtime behavior changes beyond AST shape for affected templates.
> 
> **Overview**
> Fixes template parsing so **`@{ … }` immediately after text** (e.g. `Hello @{props.username}`) is always a **`JSXCodeBlock`**, not **`JSXText`** ending in `@` plus a **`{ … }`** expression container.
> 
> The template raw-text scan in **`#parseTemplateRawText`** now stops at **`@{`** (via existing **`#isCodeBlockStart`**) in addition to `<`, `{`, `}`, and control-flow directives. **`@` not directly followed by `{`** (e.g. `at @ {x}`) is unchanged and stays plain text plus an expression container.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bb66415af3baaae0284c8ada10cd1cc6fc3aec8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->