### PR TITLE
fix(jsx transform): style block declarations outside of functions

### DIFF
--- a/.changeset/code-block-expression-style-elements.md
+++ b/.changeset/code-block-expression-style-elements.md
@@ -1,0 +1,13 @@
+---
+'@tsrx/core': patch
+---
+
+Lower TSRX-only nodes inside expression-position `@{ … }` code blocks. Setup
+statements of a code block used as an expression (e.g. `const Test = @{ … }`)
+were carried into the generated scoped IIFE verbatim without re-visiting them,
+so a style expression (`const styles = <style> … </style>`) or a nested
+`@{ … }` block inside the setup reached the printer as a raw `JSXStyleElement`
+/ `JSXCodeBlock` node and failed with "Not implemented: JSXStyleElement". The
+lowered scope is now re-visited the same way function-body code blocks are, so
+style expressions compile to their class maps (with the CSS emitted) and
+nested blocks lower into their own scopes.

--- a/packages/tsrx/src/transform/jsx/index.js
+++ b/packages/tsrx/src/transform/jsx/index.js
@@ -1378,10 +1378,10 @@ function transform_return_statement(node, { next, visit, state, path }) {
 
 /**
  * @param {any} node
- * @param {{ state: TransformContext, path: AST.Node[] }} context
+ * @param {{ state: TransformContext, path: AST.Node[], visit: (node: any, state?: TransformContext) => any }} context
  * @returns {any}
  */
-function transform_jsx_code_block(node, { state, path }) {
+function transform_jsx_code_block(node, { state, path, visit }) {
 	const body_nodes = get_jsx_code_block_body_nodes(node, state);
 	const parent = /** @type {any} */ (path.at(-1));
 
@@ -1398,10 +1398,22 @@ function transform_jsx_code_block(node, { state, path }) {
 	}
 
 	const expression = b.call(
-		b.arrow([], b.block(build_render_statements(body_nodes, true, state), node)),
+		b.arrow(
+			[],
+			b.block(
+				mark_native_pretransformed_jsx(build_render_statements(body_nodes, true, state)),
+				node,
+			),
+		),
 	);
 
-	return in_jsx_child_context(path) ? to_jsx_expression_container(expression, node) : expression;
+	// Setup statements were carried over verbatim, so re-visit the lowered
+	// scope: TSRX-only nodes they contain (style elements, nested `@{ … }`
+	// blocks) still need their own lowering before printing.
+	const result = in_jsx_child_context(path)
+		? to_jsx_expression_container(expression, node)
+		: expression;
+	return visit(result, state);
 }
 
 /**

--- a/packages/tsrx/tests/shared/compile.js
+++ b/packages/tsrx/tests/shared/compile.js
@@ -3432,6 +3432,39 @@ export function optionalFn(bar: string, baz?: string) {
 			expect(css).not.toBe('');
 			expect(code).toContain('accent-tone');
 		});
+
+		it('lowers style expressions inside an expression-position code block', () => {
+			const { code, css, cssHash } = compile(
+				`const Test = @{
+						const styles = <style>
+							.card { margin: 5px; }
+						</style>;
+						<div class={styles.card} />
+					};`,
+				'App.tsrx',
+			);
+
+			expect(css).not.toBe('');
+			const hash = cssHash.split(' ').find((h) => code.includes(`${h} card`));
+			expect(hash).toBeTruthy();
+			expect(css).toContain(`.card.${hash}`);
+			expect(code).toContain(`${classAttrName}={styles.card}`);
+			expect(code).not.toContain('JSXStyleElement');
+		});
+
+		it('lowers a style expression that is the only content of an expression-position code block', () => {
+			const { code, css } = compile(
+				`const Test = @{
+						const styles = <style>
+							.card { margin: 5px; }
+						</style>
+					};`,
+				'App.tsrx',
+			);
+
+			expect(css).toContain('margin: 5px;');
+			expect(code).toContain('card');
+		});
 	});
 
 	describe.runIf(['react', 'preact'].includes(name))(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Targeted JSX transform change for expression-position code blocks with new compile tests; no auth, data, or broad architectural impact.
> 
> **Overview**
> Fixes compile failures when **`@{ … }` is used as an expression** (e.g. `const Test = @{ … }`) and the block’s setup includes a **`<style>` expression** or nested **`@{ … }`**.
> 
> Previously those setups were folded into a scoped IIFE **without a second transform pass**, so **`JSXStyleElement` / `JSXCodeBlock` nodes reached the printer** and triggered **"Not implemented: JSXStyleElement"**. Expression-position lowering now **marks the generated scope like function-body blocks** and **`visit`s the result** so styles become class maps with emitted CSS and nested blocks lower correctly.
> 
> Adds compile tests for style-only and style-plus-JSX expression-position code blocks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3658aeb69ac2ccf66aec410ecf6d5a3137ac16e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->