### PR TITLE
fix(tsrx-ripple): invalid declaration @{} transform

### DIFF
--- a/.changeset/code-only-block-value-position.md
+++ b/.changeset/code-only-block-value-position.md
@@ -1,0 +1,13 @@
+---
+'@tsrx/ripple': patch
+---
+
+Lower a code-only `@{ … }` block in value position to a `tsrx_element`. The
+value-position IIFE wrap was gated on the block having render output, so a
+render-less block assigned to a variable or returned (e.g.
+`const Test = @{ const y = 1; };`) was lowered to a bare `BlockStatement` and
+printed as a malformed object literal (`const Test = { const y = 1; };`) in
+client, server, and `to_ts` output. The wrap now applies regardless of render
+output, so a code-only block gets the same lowering as a render-bearing one —
+a `tsrx_element` whose setup runs on render and which renders nothing (an
+immediately-invoked arrow in the `to_ts` view).

--- a/packages/tsrx-ripple/src/transform/client/index.js
+++ b/packages/tsrx-ripple/src/transform/client/index.js
@@ -1959,15 +1959,15 @@ const visitors = {
 	},
 
 	JSXCodeBlock(node, context) {
-		// A `@{ … }` block that produces render output but sits in a value
-		// position (assigned to a variable, returned, …) is wrapped in an
-		// immediately-invoked arrow so it flows through the function-body path
-		// (`transform_native_tsrx_function`) rather than reaching the printer as a
-		// raw `JSXCodeBlock`. Applies to runtime and `to_ts` output alike. The
-		// function-body guard keeps `transform_native_tsrx_function`'s own visit of
-		// the body (in `to_ts`) from re-wrapping it endlessly.
+		// A `@{ … }` block that sits in a value position (assigned to a variable,
+		// returned, …) is wrapped in an immediately-invoked arrow so it flows
+		// through the function-body path (`transform_native_tsrx_function`) rather
+		// than reaching the printer as a raw `JSXCodeBlock` — a code-only block
+		// would otherwise print as an invalid `{ … }` "expression". Applies to
+		// runtime and `to_ts` output alike. The function-body guard keeps
+		// `transform_native_tsrx_function`'s own visit of the body (in `to_ts`)
+		// from re-wrapping it endlessly.
 		if (
-			node.render != null &&
 			!is_code_block_function_body(node, context.path.at(-1)) &&
 			is_native_tsrx_value_position(context.path)
 		) {

--- a/packages/tsrx-ripple/src/transform/server/index.js
+++ b/packages/tsrx-ripple/src/transform/server/index.js
@@ -1621,14 +1621,14 @@ const visitors = {
 	},
 
 	JSXCodeBlock(node, context) {
-		// A `@{ … }` block that produces render output but sits in a value
-		// position (assigned to a variable, returned, …) is wrapped in an
-		// immediately-invoked arrow so it flows through the function-body path
-		// (`transform_native_tsrx_function`) rather than reaching the printer as a
-		// raw `JSXCodeBlock`. The function-body guard excludes a code block that is
-		// itself the function body (handled by `transform_native_tsrx_function`).
+		// A `@{ … }` block that sits in a value position (assigned to a variable,
+		// returned, …) is wrapped in an immediately-invoked arrow so it flows
+		// through the function-body path (`transform_native_tsrx_function`) rather
+		// than reaching the printer as a raw `JSXCodeBlock` — a code-only block
+		// would otherwise print as an invalid `{ … }` "expression". The
+		// function-body guard excludes a code block that is itself the function
+		// body (handled by `transform_native_tsrx_function`).
 		if (
-			node.render != null &&
 			!is_code_block_function_body(node, context.path.at(-1)) &&
 			is_native_tsrx_value_position(context.path)
 		) {

--- a/packages/tsrx-ripple/tests/basic.test.js
+++ b/packages/tsrx-ripple/tests/basic.test.js
@@ -201,6 +201,31 @@ describe('@tsrx/ripple lowers `@{ … }` code blocks in expression position', ()
 		});
 	}
 
+	const code_only = `const Test = @{
+	const y = 1;
+};`;
+
+	for (const mode of /** @type {const} */ (['client', 'server'])) {
+		it(`compiles a code-only block in value position to a tsrx_element (${mode})`, () => {
+			const { code, errors } = compile(code_only, 'App.tsrx', { mode });
+			expect(errors).toEqual([]);
+			// A render-less block in value position must not print as a bare
+			// `= { … }` block (a malformed object literal); it lowers to the same
+			// tsrx_element shape as a render-bearing block, just with no output.
+			expect(code).toContain('_$_.tsrx_element');
+			expect(code).toContain('const y = 1;');
+			expect(code).not.toMatch(/=\s*\{\s*\n\s*const/);
+		});
+	}
+
+	it('emits valid to_ts for a code-only block in value position', () => {
+		const { code } = compile_to_volar_mappings(code_only, 'App.tsrx', { loose: true });
+		expect(code).toContain('(() => {');
+		expect(code).toContain('const y = 1;');
+		expect(code).not.toContain('JSXCodeBlock');
+		expect(code).not.toMatch(/=\s*\{\s*\n\s*const/);
+	});
+
 	it('keeps setup and variable identifiers navigable in to_ts output', () => {
 		const source = `function App() {
 	const view = @{


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Narrow compiler lowering change with mirrored client/server logic and targeted tests; no auth or runtime API surface changes.
> 
> **Overview**
> Fixes invalid emitted JS/TS when a **render-less** `@{ … }` block is used as an expression (e.g. `const Test = @{ const y = 1; };`).
> 
> Previously the value-position IIFE wrap only ran when the block had render output; code-only blocks fell through to a bare `BlockStatement` and printed like a broken object literal (`= { const y = 1; }`). **Client and server** `JSXCodeBlock` visitors now apply `wrap_code_block_in_iife` for any value-position block (same guards as before: not the function body itself). That routes lowering through `transform_native_tsrx_function` and produces a `_$_.tsrx_element` (or `(() => { … })()` in `to_ts`) with setup running on render and no UI output.
> 
> Tests cover client/server compile and `to_ts` / Volar mappings for the code-only case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd6c9bd5c873f87dbf836b95be8d249613b21d3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->