### PR TITLE
fix: mark non-stand-alone css class as unused when <style> is assigned to a vr

### DIFF
--- a/.changeset/style-expression-prune-unreachable-selectors.md
+++ b/.changeset/style-expression-prune-unreachable-selectors.md
@@ -5,9 +5,11 @@
 
 Prune unreachable selectors from variable-assigned `<style>` blocks. A style
 expression (`const styles = <style> … </style>`) only exposes standalone class
-selectors through its generated class map, but the emitted CSS still contained
-every selector — element selectors, compound selectors, and descendant chains
-that no element could ever match. Those top-level selectors are now commented
-out as unused, while standalone classes, `:global(…)` selectors, and rules
-nested inside a reachable rule (e.g. `&:hover`) are kept. Free-standing
-`<style>` blocks are unaffected.
+selectors through its generated class map — scoped (`.x`) or global-wrapped
+(`:global(.x)`) — but the emitted CSS still contained every selector: element
+selectors, compound selectors, descendant chains, and global tag selectors that
+nothing reachable through the class map could ever match. Top-level selectors
+that don't contribute a class map entry are now commented out as unused, while
+standalone classes, `:global(.x)` selectors, and rules nested inside a
+reachable rule (e.g. `&:hover`) are kept. Free-standing `<style>` blocks keep
+the existing behavior.

--- a/.changeset/style-expression-prune-unreachable-selectors.md
+++ b/.changeset/style-expression-prune-unreachable-selectors.md
@@ -1,0 +1,13 @@
+---
+'@tsrx/core': patch
+'@tsrx/ripple': patch
+---
+
+Prune unreachable selectors from variable-assigned `<style>` blocks. A style
+expression (`const styles = <style> … </style>`) only exposes standalone class
+selectors through its generated class map, but the emitted CSS still contained
+every selector — element selectors, compound selectors, and descendant chains
+that no element could ever match. Those top-level selectors are now commented
+out as unused, while standalone classes, `:global(…)` selectors, and rules
+nested inside a reachable rule (e.g. `&:hover`) are kept. Free-standing
+`<style>` blocks are unaffected.

--- a/.changeset/style-expression-prune-unreachable-selectors.md
+++ b/.changeset/style-expression-prune-unreachable-selectors.md
@@ -3,13 +3,17 @@
 '@tsrx/ripple': patch
 ---
 
-Prune unreachable selectors from variable-assigned `<style>` blocks. A style
-expression (`const styles = <style> … </style>`) only exposes standalone class
-selectors through its generated class map — scoped (`.x`) or global-wrapped
-(`:global(.x)`) — but the emitted CSS still contained every selector: element
-selectors, compound selectors, descendant chains, and global tag selectors that
-nothing reachable through the class map could ever match. Top-level selectors
-that don't contribute a class map entry are now commented out as unused, while
-standalone classes, `:global(.x)` selectors, and rules nested inside a
-reachable rule (e.g. `&:hover`) are kept. Free-standing `<style>` blocks keep
-the existing behavior.
+Prune unreachable selectors from `<style>` blocks consistently across targets.
+
+For a style expression (`const styles = <style> … </style>`), only standalone
+class selectors — scoped (`.x`) or global-wrapped (`:global(.x)`) — end up in
+the generated class map, but the emitted CSS still contained every selector.
+Top-level selectors that don't contribute a class map entry (element selectors,
+compound selectors, descendant chains, global tag selectors) are now commented
+out as unused, while standalone classes, `:global(.x)` selectors, and rules
+nested inside a reachable rule (e.g. `&:hover`) are kept.
+
+Free-standing `<style>` blocks in the shared JSX targets (react, preact, solid,
+vue) now prune selectors that match no element, the same way the Ripple target
+always has, instead of keeping every authored selector. Selector matching also
+recognizes `className` as the class attribute for React-style targets.

--- a/packages/bun-plugin-preact/tests/basic.test.js
+++ b/packages/bun-plugin-preact/tests/basic.test.js
@@ -127,7 +127,7 @@ describe('@tsrx/bun-plugin-preact', () => {
 				file_path,
 				`export function App() @{
 					<>
-						<div>{'Hello world'}</div>
+						<div class="div">{'Hello world'}</div>
 
 						<style>
 							.div {

--- a/packages/bun-plugin-react/tests/basic.test.js
+++ b/packages/bun-plugin-react/tests/basic.test.js
@@ -127,7 +127,7 @@ describe('@tsrx/bun-plugin-react', () => {
 				file_path,
 				`export function App() @{
 					<>
-					<div>{'Hello world'}</div>
+					<div className="div">{'Hello world'}</div>
 
 					<style>
 						.div {

--- a/packages/bun-plugin-solid/tests/basic.test.js
+++ b/packages/bun-plugin-solid/tests/basic.test.js
@@ -78,7 +78,7 @@ describe('@tsrx/bun-plugin-solid', () => {
 			await writeFile(
 				file_path,
 				`export function App({ name }: { name: string }) { return <>
-					<div>{name}</div>
+					<div class="div">{name}</div>
 
 					<style>
 						.div {

--- a/packages/bun-plugin-vue/tests/basic.test.js
+++ b/packages/bun-plugin-vue/tests/basic.test.js
@@ -140,7 +140,7 @@ describe('@tsrx/bun-plugin-vue', () => {
 				file_path,
 				`export function App() @{
 					<>
-						<div>{'Hello world'}</div>
+						<div class="div">{'Hello world'}</div>
 
 						<style>
 							.div {

--- a/packages/ripple/tests/client/css/style-identifier.test.tsrx
+++ b/packages/ripple/tests/client/css/style-identifier.test.tsrx
@@ -270,5 +270,73 @@ export function App() @{
 			expect(code).toContain('highlight');
 			expect(code).toMatch(/tsrx-[a-z0-9]+ highlight/);
 		});
+
+		const unreachable_selectors_source = `
+export function App() @{
+	const styles = <style>
+		div {
+			color: red;
+		}
+		.parent .card {
+			font-weight: bold;
+		}
+		.card {
+			color: green;
+			&:hover {
+				color: blue;
+			}
+		}
+		:global(body) {
+			margin: 0;
+		}
+	</style>;
+
+	<div class={styles.card}>{'text'}</div>
+}`;
+
+		it('prunes style expression selectors the class map cannot reach in client mode', () => {
+			const { css, cssHash } = compile(unreachable_selectors_source, 'test.tsrx');
+
+			expect(css).toContain('/* (unused) div {');
+			expect(css).toContain('/* (unused) .parent .card {');
+			expect(css).toContain(`.card.${cssHash}`);
+			expect(css).toContain('&:hover {');
+			expect(css).toContain('body {');
+		});
+
+		it('prunes style expression selectors the class map cannot reach in server mode', () => {
+			const { css, cssHash } = compile(unreachable_selectors_source, 'test.tsrx', {
+				mode: 'server',
+			});
+
+			expect(css).toContain('/* (unused) div {');
+			expect(css).toContain('/* (unused) .parent .card {');
+			expect(css).toContain(`.card.${cssHash}`);
+			expect(css).toContain('&:hover {');
+			expect(css).toContain('body {');
+		});
+
+		it('keeps all selectors of a free-standing style block', () => {
+			const source = `
+export function App() @{
+	<>
+		<div class="card">{'text'}</div>
+
+		<style>
+			div {
+				color: red;
+			}
+			.card {
+				color: green;
+			}
+		</style>
+	</>
+}`;
+			const { css, cssHash } = compile(source, 'test.tsrx');
+
+			expect(css).not.toContain('(unused)');
+			expect(css).toContain(`div.${cssHash}`);
+			expect(css).toContain(`.card.${cssHash}`);
+		});
 	});
 });

--- a/packages/ripple/tests/client/css/style-identifier.test.tsrx
+++ b/packages/ripple/tests/client/css/style-identifier.test.tsrx
@@ -286,6 +286,9 @@ export function App() @{
 				color: blue;
 			}
 		}
+		:global(.badge) {
+			padding: 0;
+		}
 		:global(body) {
 			margin: 0;
 		}
@@ -301,7 +304,9 @@ export function App() @{
 			expect(css).toContain('/* (unused) .parent .card {');
 			expect(css).toContain(`.card.${cssHash}`);
 			expect(css).toContain('&:hover {');
-			expect(css).toContain('body {');
+			expect(css).toContain('.badge {');
+			expect(css).not.toContain(`.badge.${cssHash}`);
+			expect(css).toContain('/* (unused) :global(body) {');
 		});
 
 		it('prunes style expression selectors the class map cannot reach in server mode', () => {
@@ -313,7 +318,9 @@ export function App() @{
 			expect(css).toContain('/* (unused) .parent .card {');
 			expect(css).toContain(`.card.${cssHash}`);
 			expect(css).toContain('&:hover {');
-			expect(css).toContain('body {');
+			expect(css).toContain('.badge {');
+			expect(css).not.toContain(`.badge.${cssHash}`);
+			expect(css).toContain('/* (unused) :global(body) {');
 		});
 
 		it('keeps all selectors of a free-standing style block', () => {

--- a/packages/ripple/tests/server/style-identifier.test.tsrx
+++ b/packages/ripple/tests/server/style-identifier.test.tsrx
@@ -336,5 +336,60 @@ export function App() @{
 			expect(body).toMatch(/tsrx-[a-z0-9]+/);
 			expect(body).toContain('styled');
 		});
+
+		it('prunes style expression selectors the class map cannot reach', () => {
+			const source = `
+export function App() @{
+	const styles = <style>
+		div {
+			color: red;
+		}
+		.parent .card {
+			font-weight: bold;
+		}
+		.card {
+			color: green;
+			&:hover {
+				color: blue;
+			}
+		}
+		:global(body) {
+			margin: 0;
+		}
+	</style>;
+
+	<div class={styles.card}>{'text'}</div>
+}`;
+			const { css, cssHash } = compile(source, 'test.tsrx', { mode: 'server' });
+
+			expect(css).toContain('/* (unused) div {');
+			expect(css).toContain('/* (unused) .parent .card {');
+			expect(css).toContain(`.card.${cssHash}`);
+			expect(css).toContain('&:hover {');
+			expect(css).toContain('body {');
+		});
+
+		it('keeps all selectors of a free-standing style block', () => {
+			const source = `
+export function App() @{
+	<>
+		<div class="card">{'text'}</div>
+
+		<style>
+			div {
+				color: red;
+			}
+			.card {
+				color: green;
+			}
+		</style>
+	</>
+}`;
+			const { css, cssHash } = compile(source, 'test.tsrx', { mode: 'server' });
+
+			expect(css).not.toContain('(unused)');
+			expect(css).toContain(`div.${cssHash}`);
+			expect(css).toContain(`.card.${cssHash}`);
+		});
 	});
 });

--- a/packages/ripple/tests/server/style-identifier.test.tsrx
+++ b/packages/ripple/tests/server/style-identifier.test.tsrx
@@ -353,6 +353,9 @@ export function App() @{
 				color: blue;
 			}
 		}
+		:global(.badge) {
+			padding: 0;
+		}
 		:global(body) {
 			margin: 0;
 		}
@@ -366,7 +369,9 @@ export function App() @{
 			expect(css).toContain('/* (unused) .parent .card {');
 			expect(css).toContain(`.card.${cssHash}`);
 			expect(css).toContain('&:hover {');
-			expect(css).toContain('body {');
+			expect(css).toContain('.badge {');
+			expect(css).not.toContain(`.badge.${cssHash}`);
+			expect(css).toContain('/* (unused) :global(body) {');
 		});
 
 		it('keeps all selectors of a free-standing style block', () => {

--- a/packages/rspack-plugin-preact/tests/basic.test.js
+++ b/packages/rspack-plugin-preact/tests/basic.test.js
@@ -102,7 +102,7 @@ describe('@tsrx/rspack-plugin-preact css-loader', () => {
 		const id = '/virtual/App.tsrx';
 		const source = `export function App() @{
 			<>
-				<div>{'Hello world'}</div>
+				<div class="div">{'Hello world'}</div>
 
 				<style>
 					.div {

--- a/packages/rspack-plugin-react/tests/basic.test.js
+++ b/packages/rspack-plugin-react/tests/basic.test.js
@@ -73,7 +73,7 @@ describe('@tsrx/rspack-plugin-react css-loader', () => {
 		const id = '/virtual/App.tsrx';
 		const source = `export function App() @{
 			<>
-			<div>{'Hello world'}</div>
+			<div className="div">{'Hello world'}</div>
 
 			<style>
 				.div {

--- a/packages/rspack-plugin-solid/tests/basic.test.js
+++ b/packages/rspack-plugin-solid/tests/basic.test.js
@@ -71,7 +71,7 @@ describe('@tsrx/rspack-plugin-solid css-loader', () => {
 	it('returns the compiled scoped css text', async () => {
 		const id = '/virtual/App.tsrx';
 		const source = `export function App() { return <>
-			<div>{'Hello world'}</div>
+			<div class="div">{'Hello world'}</div>
 
 			<style>
 				.div {

--- a/packages/rspack-plugin-vue/tests/basic.test.js
+++ b/packages/rspack-plugin-vue/tests/basic.test.js
@@ -102,7 +102,7 @@ describe('@tsrx/rspack-plugin-vue css-loader', () => {
 		const id = '/virtual/App.tsrx';
 		const source = `export function App() @{
 			<>
-				<div>{'Hello world'}</div>
+				<div class="div">{'Hello world'}</div>
 
 				<style>
 					.div {

--- a/packages/tsrx-react/tests/basic.test.js
+++ b/packages/tsrx-react/tests/basic.test.js
@@ -243,7 +243,7 @@ describe('@tsrx/react basic', () => {
 			`export function App() @{
 				<>
 					@if (true) {
-						<div>{'inside'}</div>
+						<div className="div">{'inside'}</div>
 					}
 
 					<style>
@@ -257,8 +257,8 @@ describe('@tsrx/react basic', () => {
 		);
 
 		expect(css).not.toBe('');
-		expect(code).toContain(`className="${cssHash}"`);
-		expect(code).toContain(`App__static1 = <div className="${cssHash}">`);
+		expect(code).toContain(`className="div ${cssHash}"`);
+		expect(code).toContain(`App__static1 = <div className="div ${cssHash}">`);
 		expect(css).toContain(`.div.${cssHash}`);
 	});
 

--- a/packages/tsrx-ripple/src/transform/client/index.js
+++ b/packages/tsrx-ripple/src/transform/client/index.js
@@ -242,7 +242,7 @@ function build_style_class_map_expression(node, context) {
 	}
 
 	analyzeCss(stylesheet);
-	context.state.stylesheets.push(prepareStylesheetForRender(stylesheet));
+	context.state.stylesheets.push(prepareStylesheetForRender(stylesheet, true));
 	const class_map = createStyleClassMapFromStylesheet(stylesheet);
 	if (!context.state.to_ts) {
 		return class_map;

--- a/packages/tsrx-ripple/src/transform/server/index.js
+++ b/packages/tsrx-ripple/src/transform/server/index.js
@@ -214,7 +214,7 @@ function build_style_class_map_expression(node, context) {
 	}
 
 	analyzeCss(stylesheet);
-	context.state.stylesheets.push(prepareStylesheetForRender(stylesheet));
+	context.state.stylesheets.push(prepareStylesheetForRender(stylesheet, true));
 	return create_server_style_class_map_expression(stylesheet);
 }
 

--- a/packages/tsrx/src/analyze/prune.js
+++ b/packages/tsrx/src/analyze/prune.js
@@ -756,11 +756,13 @@ function attribute_matches(node, name, expected_value, operator, case_insensitiv
 		if (attribute.type !== 'JSXAttribute') continue;
 
 		const lowerCaseName = name.toLowerCase();
+		const accepted_names = [lowerCaseName, `$${lowerCaseName}`];
+		if (lowerCaseName === 'class') {
+			// React-style targets author the class attribute as `className`.
+			accepted_names.push('classname');
+		}
 		const attributeName = get_attribute_name(attribute);
-		if (
-			!attributeName ||
-			![lowerCaseName, `$${lowerCaseName}`].includes(attributeName.toLowerCase())
-		) {
+		if (!attributeName || !accepted_names.includes(attributeName.toLowerCase())) {
 			continue;
 		}
 

--- a/packages/tsrx/src/transform/jsx/index.js
+++ b/packages/tsrx/src/transform/jsx/index.js
@@ -1921,8 +1921,10 @@ function prepare_tsrx_fragment_styles(node, transform_context) {
 	if (!css) return null;
 
 	const style_refs = collect_style_ref_attributes(node);
+	// `prune_css` inside marks the matching selectors as used/scoped; selectors
+	// that match no element render commented out, like the Ripple target.
 	apply_css_definition_metadata(node, css, transform_context, style_refs.length > 0);
-	transform_context.stylesheets.push(prepare_stylesheet_for_render(css));
+	transform_context.stylesheets.push(css);
 	const fragment = annotate_tsrx_with_hash(
 		node,
 		css.hash,

--- a/packages/tsrx/src/transform/jsx/index.js
+++ b/packages/tsrx/src/transform/jsx/index.js
@@ -441,15 +441,6 @@ export function createJsxTransform(platform) {
 					return next() ?? node;
 				}
 
-				if (is_style_element(node) && is_style_expression_position(path)) {
-					const stylesheet = get_style_element_stylesheet(node);
-					if (stylesheet) {
-						analyze_css(stylesheet);
-						state.stylesheets.push(stylesheet);
-						return /** @type {any} */ (create_style_expression_value(node, stylesheet, state));
-					}
-				}
-
 				// Capture raw children BEFORE the walker transforms them so platform
 				// hooks can inspect the original JSX child shape.
 				const raw_children = /** @type {any} */ (node.children || []).map(
@@ -487,7 +478,7 @@ export function createJsxTransform(platform) {
 					const stylesheet = get_style_element_stylesheet(node);
 					if (stylesheet) {
 						analyze_css(stylesheet);
-						state.stylesheets.push(stylesheet);
+						state.stylesheets.push(prepare_stylesheet_for_render(stylesheet, true));
 						return /** @type {any} */ (create_style_expression_value(node, stylesheet, state));
 					}
 				}
@@ -561,9 +552,7 @@ export function createJsxTransform(platform) {
 			sourceMapContent: source,
 		});
 
-		const { css, cssHash } = render_css_result(
-			/** @type {any} */ (stylesheets.map(prepare_stylesheet_for_render)),
-		);
+		const { css, cssHash } = render_css_result(/** @type {any} */ (stylesheets));
 
 		return { ast: final_program, code: result.code, map: result.map, css, cssHash };
 	}
@@ -1935,7 +1924,7 @@ function prepare_tsrx_fragment_styles(node, transform_context) {
 
 	const style_refs = collect_style_ref_attributes(node);
 	apply_css_definition_metadata(node, css, transform_context, style_refs.length > 0);
-	transform_context.stylesheets.push(css);
+	transform_context.stylesheets.push(prepare_stylesheet_for_render(css));
 	const fragment = annotate_tsrx_with_hash(
 		node,
 		css.hash,

--- a/packages/tsrx/src/transform/jsx/index.js
+++ b/packages/tsrx/src/transform/jsx/index.js
@@ -482,12 +482,10 @@ export function createJsxTransform(platform) {
 						return /** @type {any} */ (create_style_expression_value(node, stylesheet, state));
 					}
 				}
-				return /** @type {any} */ (
-					b.jsx_element(
-						/** @type {ESTreeJSX.JSXElement} */ ({ ...node, type: 'JSXElement', children: [] }),
-						node.openingElement?.attributes ?? [],
-						[],
-					)
+				return b.jsx_element(
+					/** @type {ESTreeJSX.JSXElement} */ ({ ...node, type: 'JSXElement', children: [] }),
+					node.openingElement?.attributes ?? [],
+					[],
 				);
 			},
 

--- a/packages/tsrx/src/transform/scoping.js
+++ b/packages/tsrx/src/transform/scoping.js
@@ -7,20 +7,45 @@
 
 import { walk } from 'zimmerframe';
 import * as b from '../utils/builders.js';
+import { get_standalone_class_selector } from './style-ref.js';
 
 /**
- * Mark every selector inside the stylesheet as "used" so `renderStylesheets`
- * does not comment it out. We skip selector-pruning because component
- * boundaries can be dynamic — any selector authored inside the component's
- * `<style>` block is considered intentional.
+ * Mark selectors inside the stylesheet as "used" so `renderStylesheets` does
+ * not comment them out.
+ *
+ * For a free-standing `<style>` block every selector is marked: we skip
+ * selector-pruning because component boundaries can be dynamic — any selector
+ * authored inside the component's `<style>` block is considered intentional.
+ *
+ * When the `<style>` block is assigned to a variable (`is_style_expression`),
+ * the only scoped selectors reachable through the generated class map are
+ * standalone class selectors, so anything else at the top level — element
+ * selectors, compound selectors, descendant chains — can never match and stays
+ * unused for `renderStylesheets` to comment out. Global selectors and selectors
+ * of nested rules are kept: globals match without the class map, and nested
+ * rules are pruned together with their parent rule when the parent itself is
+ * unreachable.
  *
  * @param {any} stylesheet
+ * @param {boolean} [is_style_expression]
  * @returns {any}
  */
-export function prepare_stylesheet_for_render(stylesheet) {
+export function prepare_stylesheet_for_render(stylesheet, is_style_expression = false) {
 	walk(stylesheet, null, {
 		_(node, { next }) {
 			if (node && node.metadata && typeof node.metadata === 'object') {
+				if (
+					is_style_expression &&
+					node.type === 'ComplexSelector' &&
+					!node.metadata.used &&
+					node.metadata.rule?.metadata?.parent_rule == null &&
+					get_standalone_class_selector(node) === null
+				) {
+					// Unreachable via the class map: leave the subtree untouched — no
+					// `used`, and no `scoped` marks that would splice the hash into
+					// pruned output.
+					return;
+				}
 				node.metadata.used = true;
 				if (node.type === 'RelativeSelector' && !node.metadata.is_global) {
 					node.metadata.scoped = true;

--- a/packages/tsrx/src/transform/scoping.js
+++ b/packages/tsrx/src/transform/scoping.js
@@ -7,7 +7,7 @@
 
 import { walk } from 'zimmerframe';
 import * as b from '../utils/builders.js';
-import { get_standalone_class_selector } from './style-ref.js';
+import { mark_class_map_selectors } from './style-ref.js';
 
 /**
  * Mark selectors inside the stylesheet as "used" so `renderStylesheets` does
@@ -18,32 +18,34 @@ import { get_standalone_class_selector } from './style-ref.js';
  * authored inside the component's `<style>` block is considered intentional.
  *
  * When the `<style>` block is assigned to a variable (`is_style_expression`),
- * the only scoped selectors reachable through the generated class map are
- * standalone class selectors, so anything else at the top level — element
- * selectors, compound selectors, descendant chains — can never match and stays
- * unused for `renderStylesheets` to comment out. Global selectors and selectors
- * of nested rules are kept: globals match without the class map, and nested
- * rules are pruned together with their parent rule when the parent itself is
- * unreachable.
+ * the only selectors reachable through the generated class map are standalone
+ * class selectors — scoped (`.x`) or global-wrapped (`:global(.x)`). Anything
+ * else at the top level — element selectors, compound selectors, descendant
+ * chains, global tag selectors — never ends up in the class map and is marked
+ * unused for `renderStylesheets` to comment out. Selectors of nested rules ride
+ * along with their parent: they apply where the parent's class matched, and the
+ * whole rule is pruned when the parent itself is unreachable.
  *
  * @param {any} stylesheet
  * @param {boolean} [is_style_expression]
  * @returns {any}
  */
 export function prepare_stylesheet_for_render(stylesheet, is_style_expression = false) {
+	if (is_style_expression) {
+		mark_class_map_selectors(stylesheet);
+	}
 	walk(stylesheet, null, {
-		_(node, { next }) {
+		_(node, { next, path }) {
 			if (node && node.metadata && typeof node.metadata === 'object') {
 				if (
 					is_style_expression &&
 					node.type === 'ComplexSelector' &&
-					!node.metadata.used &&
-					node.metadata.rule?.metadata?.parent_rule == null &&
-					get_standalone_class_selector(node) === null
+					is_unreachable_via_class_map(node, path)
 				) {
-					// Unreachable via the class map: leave the subtree untouched — no
-					// `used`, and no `scoped` marks that would splice the hash into
-					// pruned output.
+					// Not in the generated class map. The analyzer pre-marks global
+					// selectors as used, so reset, and leave the subtree untouched —
+					// no `scoped` marks that would splice the hash into pruned output.
+					node.metadata.used = false;
 					return;
 				}
 				node.metadata.used = true;
@@ -55,6 +57,37 @@ export function prepare_stylesheet_for_render(stylesheet, is_style_expression = 
 		},
 	});
 	return stylesheet;
+}
+
+/**
+ * True when a selector of a style expression should be pruned because nothing
+ * reachable through the generated class map can match it. The class map
+ * collection in `style-ref.js` is the single decider of what the map exposes:
+ * it marks the carrying prelude-level selectors with `class_map_selector`.
+ * The remaining cases are structural, not class-shaped: selectors of nested
+ * rules ride along with their parent (the whole rule is pruned when the parent
+ * is unreachable), selectors inside another selector's arguments belong to
+ * their enclosing prelude-level selector, and a bare `:global` block prelude
+ * is kept because its contents render unscoped as authored and cannot be
+ * pruned selector-by-selector.
+ *
+ * @param {any} complex_selector
+ * @param {any[]} path
+ * @returns {boolean}
+ */
+function is_unreachable_via_class_map(complex_selector, path) {
+	if (complex_selector.metadata.class_map_selector) return false;
+	if (complex_selector.metadata.rule?.metadata?.parent_rule != null) return false;
+	if (path.some((parent) => parent.type === 'ComplexSelector')) return false;
+
+	if (complex_selector.children?.length === 1) {
+		const first = complex_selector.children[0]?.selectors?.[0];
+		if (first?.type === 'PseudoClassSelector' && first.name === 'global' && first.args === null) {
+			return false;
+		}
+	}
+
+	return true;
 }
 
 /**

--- a/packages/tsrx/src/transform/style-ref.js
+++ b/packages/tsrx/src/transform/style-ref.js
@@ -261,21 +261,42 @@ function collect_style_class_map_entries(css) {
 }
 
 /**
- * @param {any} node
- * @param {Map<string, any>} entries
+ * Stamp `class_map_selector` on the prelude-level selectors whose classes the
+ * class map exposes, without building the map. Runs the same collection as
+ * `create_style_class_map_from_stylesheet`, so marking and the generated map
+ * always agree; calling both is harmless.
+ *
+ * @param {any} css
  * @returns {void}
  */
-function collect_rule_class_map_entries(node, entries) {
+export function mark_class_map_selectors(css) {
+	collect_rule_class_map_entries(css, new Map());
+}
+
+/**
+ * @param {any} node
+ * @param {Map<string, any>} entries
+ * @param {any} [enclosing_selector] the nearest prelude-level selector; classes
+ *   found inside another selector (e.g. in `:global(...)` args) mark it as the
+ *   selector that carries their class map entry
+ * @returns {void}
+ */
+function collect_rule_class_map_entries(node, entries, enclosing_selector = null) {
 	if (!node || typeof node !== 'object') return;
 
 	if (Array.isArray(node)) {
-		for (const child of node) collect_rule_class_map_entries(child, entries);
+		for (const child of node) collect_rule_class_map_entries(child, entries, enclosing_selector);
 		return;
 	}
 
 	if (node.type === 'ComplexSelector') {
+		enclosing_selector ??= node;
 		const class_selector = get_standalone_class_selector(node);
 		if (class_selector) {
+			// Mark the prelude-level selector for every occurrence (not just the
+			// deduped first) so the render preparation of style expressions keeps
+			// exactly the selectors whose classes the map exposes.
+			(enclosing_selector.metadata ??= {}).class_map_selector = true;
 			const name = class_selector.name.replace(regex_backslash_and_following_character, '$1');
 			if (!entries.has(name)) {
 				entries.set(name, {
@@ -295,7 +316,7 @@ function collect_rule_class_map_entries(node, entries) {
 		if (key === 'loc' || key === 'start' || key === 'end' || key === 'metadata') {
 			continue;
 		}
-		collect_rule_class_map_entries(node[key], entries);
+		collect_rule_class_map_entries(node[key], entries, enclosing_selector);
 	}
 }
 
@@ -303,7 +324,7 @@ function collect_rule_class_map_entries(node, entries) {
  * @param {any} complex_selector
  * @returns {any | null}
  */
-export function get_standalone_class_selector(complex_selector) {
+function get_standalone_class_selector(complex_selector) {
 	if (complex_selector?.children?.length !== 1) return null;
 	const relative_selector = complex_selector.children[0];
 	if (

--- a/packages/tsrx/src/transform/style-ref.js
+++ b/packages/tsrx/src/transform/style-ref.js
@@ -303,7 +303,7 @@ function collect_rule_class_map_entries(node, entries) {
  * @param {any} complex_selector
  * @returns {any | null}
  */
-function get_standalone_class_selector(complex_selector) {
+export function get_standalone_class_selector(complex_selector) {
 	if (complex_selector?.children?.length !== 1) return null;
 	const relative_selector = complex_selector.children[0];
 	if (

--- a/packages/tsrx/tests/shared/compile.js
+++ b/packages/tsrx/tests/shared/compile.js
@@ -3465,6 +3465,50 @@ export function optionalFn(bar: string, baz?: string) {
 			expect(css).toContain('margin: 5px;');
 			expect(code).toContain('card');
 		});
+
+		it('prunes style expression selectors that the class map cannot reach', () => {
+			const { css, cssHash } = compile(
+				`export function App() @{
+						const styles = <style>
+							div { color: red; }
+							.parent .card { font-weight: bold; }
+							.card {
+								color: green;
+								&:hover { color: blue; }
+							}
+							:global(body) { margin: 0; }
+						</style>;
+						<div class={styles.card} />
+					}`,
+				'App.tsrx',
+			);
+
+			expect(css).toContain('/* (unused) div { color: red; }*/');
+			expect(css).toContain('/* (unused) .parent .card { font-weight: bold; }*/');
+			expect(css).toContain(`.card.${cssHash}`);
+			expect(css).toContain('&:hover { color: blue; }');
+			expect(css).toContain('body { margin: 0; }');
+		});
+
+		it('keeps all selectors of a free-standing style block', () => {
+			const { css, cssHash } = compile(
+				`export function App() @{
+						<>
+							<div ${generatedClassAttrName}="card">{'Foo'}</div>
+
+							<style>
+								div { color: red; }
+								.card { color: green; }
+							</style>
+						</>
+					}`,
+				'App.tsrx',
+			);
+
+			expect(css).not.toContain('(unused)');
+			expect(css).toContain(`div.${cssHash}`);
+			expect(css).toContain(`.card.${cssHash}`);
+		});
 	});
 
 	describe.runIf(['react', 'preact'].includes(name))(

--- a/packages/tsrx/tests/shared/compile.js
+++ b/packages/tsrx/tests/shared/compile.js
@@ -3476,6 +3476,7 @@ export function optionalFn(bar: string, baz?: string) {
 								color: green;
 								&:hover { color: blue; }
 							}
+							:global(.badge) { padding: 0; }
 							:global(body) { margin: 0; }
 						</style>;
 						<div class={styles.card} />
@@ -3487,7 +3488,9 @@ export function optionalFn(bar: string, baz?: string) {
 			expect(css).toContain('/* (unused) .parent .card { font-weight: bold; }*/');
 			expect(css).toContain(`.card.${cssHash}`);
 			expect(css).toContain('&:hover { color: blue; }');
-			expect(css).toContain('body { margin: 0; }');
+			expect(css).toContain('.badge { padding: 0; }');
+			expect(css).not.toContain(`.badge.${cssHash}`);
+			expect(css).toContain('/* (unused) :global(body) { margin: 0; }*/');
 		});
 
 		it('keeps all selectors of a free-standing style block', () => {

--- a/packages/tsrx/tests/shared/compile.js
+++ b/packages/tsrx/tests/shared/compile.js
@@ -3255,7 +3255,7 @@ export function optionalFn(bar: string, baz?: string) {
 			const { code, css, cssHash } = compile(
 				`export function App() @{
 					<>
-						<div>{'Hello world'}</div>
+						<div ${generatedClassAttrName}="div">{'Hello world'}</div>
 
 						<style>
 							.div { color: red; }
@@ -3267,7 +3267,7 @@ export function optionalFn(bar: string, baz?: string) {
 
 			expect(css).not.toBe('');
 			expect(code).toContain("{'Hello world'}");
-			expect(code).toContain(`${generatedClassAttrName}="${cssHash}"`);
+			expect(code).toContain(`${generatedClassAttrName}="div ${cssHash}"`);
 			expect(css).toContain(`.div.${cssHash}`);
 			expect(css).toContain('color: red;');
 		});
@@ -3493,7 +3493,28 @@ export function optionalFn(bar: string, baz?: string) {
 			expect(css).toContain('/* (unused) :global(body) { margin: 0; }*/');
 		});
 
-		it('keeps all selectors of a free-standing style block', () => {
+		it('matches free-standing selectors for both class and className attributes', () => {
+			const { css, cssHash } = compile(
+				`export function App() @{
+						<>
+							<div class="a">{'a'}</div>
+							<span className="b">{'b'}</span>
+
+							<style>
+								.a { color: red; }
+								.b { color: blue; }
+							</style>
+						</>
+					}`,
+				'App.tsrx',
+			);
+
+			expect(css).toContain(`.a.${cssHash}`);
+			expect(css).toContain(`.b.${cssHash}`);
+			expect(css).not.toContain('(unused)');
+		});
+
+		it('prunes free-standing selectors that match no element', () => {
 			const { css, cssHash } = compile(
 				`export function App() @{
 						<>
@@ -3502,15 +3523,18 @@ export function optionalFn(bar: string, baz?: string) {
 							<style>
 								div { color: red; }
 								.card { color: green; }
+								span { color: gray; }
+								:global(.test) { color: black; }
 							</style>
 						</>
 					}`,
 				'App.tsrx',
 			);
 
-			expect(css).not.toContain('(unused)');
 			expect(css).toContain(`div.${cssHash}`);
 			expect(css).toContain(`.card.${cssHash}`);
+			expect(css).toContain('/* (unused) span { color: gray; }*/');
+			expect(css).toContain('.test { color: black; }');
 		});
 	});
 

--- a/packages/vite-plugin-preact/tests/basic.test.js
+++ b/packages/vite-plugin-preact/tests/basic.test.js
@@ -7,7 +7,7 @@ describe('@tsrx/vite-plugin-preact basic', () => {
 		const id = '/virtual/App.tsrx';
 		const source = `export function App() @{
 			<>
-				<div>{'Hello world'}</div>
+				<div class="div">{'Hello world'}</div>
 
 				<style>
 					.div {

--- a/packages/vite-plugin-react/tests/basic.test.js
+++ b/packages/vite-plugin-react/tests/basic.test.js
@@ -6,7 +6,7 @@ describe('@tsrx/vite-plugin-react basic', () => {
 		const id = '/virtual/App.tsrx';
 		const source = `export function App() @{
 			<>
-			<div>{'Hello world'}</div>
+			<div className="div">{'Hello world'}</div>
 
 			<style>
 				.div {


### PR DESCRIPTION
closes #1235
and fixes a few other issues found along the way.
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which CSS rules are emitted at compile time across React, Preact, Solid, Vue, and Ripple; apps that depended on “dead” selectors in style expressions or unmatched free-standing rules will see those rules commented out instead of shipped.
> 
> **Overview**
> Aligns **emitted CSS** with what style class maps and template markup can actually use, across `@tsrx/core` and Ripple.
> 
> For **`const styles = <style>…</style>`**, preparation now marks only prelude-level selectors that contribute to the generated class map (standalone `.x` and `:global(.x)`), plus nested rules under those parents. Top-level rules that never appear on the map—`div`, `.parent .card`, `:global(body)`, etc.—are left **unused** and render as `/* (unused) … */` comments. Ripple client/server transforms pass `prepareStylesheetForRender(…, true)` for these blocks.
> 
> For **free-standing `<style>`** in shared JSX targets, the compiler no longer treats every selector as intentionally used. Selectors that **don’t match any element** in the component (via `class` / `className`) are pruned the same way Ripple already did; `prune.js` now treats **`className`** like `class` when matching.
> 
> Stylesheet handling is centralized: style expressions are prepared when pushed onto `state.stylesheets`, and final CSS render uses those prepared sheets without re-walking everything as “all used.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b6f08d028258bb68278445f01d2c6f123694e55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->