### PR TITLE
fix(tsrx-ripple): returning tsrx in regular functions broken

### DIFF
--- a/.changeset/fix-returned-template-directive-branches.md
+++ b/.changeset/fix-returned-template-directive-branches.md
@@ -1,0 +1,17 @@
+---
+'@tsrx/ripple': patch
+---
+
+Fix client crash when a `function C() { return <jsx> }` component renders a
+template control-flow directive (`@if`/`@for`/`@switch`/`@try`).
+
+The block-statement return form is transformed via the generic function path,
+which never sets the `component` render state. A directive-branch element in
+statement position (e.g. `@if (cond) { <p>…</p> }`) then matched the
+out-of-component "bare template statement" rule and was double-wrapped: its
+content compiled into an orphaned template while the template the branch
+actually referenced was left empty, crashing at runtime with
+`Cannot read properties of null (reading 'cloneNode')`. A synthetic children
+render arrow now establishes itself as the component boundary when no enclosing
+component is set, so directive branches inline their content correctly. The
+`@{ … }` form and the server target were already correct.

--- a/packages/ripple/tests/client/return.test.tsrx
+++ b/packages/ripple/tests/client/return.test.tsrx
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { track, flushSync, type Tracked } from 'ripple';
 import { compile } from '@tsrx/ripple';
 
 describe('returns in restricted scopes', () => {
@@ -131,5 +132,92 @@ describe('function returns in client components', () => {
 
 		render(App);
 		expect(container.textContent).toBe('hello');
+	});
+
+	it('renders a template directive branch and siblings from a returned fragment', () => {
+		function App() {
+			const ready = true;
+			return <>
+				@if (ready) {
+					<div class="yielded">{'yielded'}</div>
+				}
+				<span class="outer">{'outer'}</span>
+			</>;
+		}
+
+		render(App);
+		expect(container.querySelector('.yielded')?.textContent).toBe('yielded');
+		expect(container.querySelector('.outer')?.textContent).toBe('outer');
+	});
+
+	it('renders a template directive branch inside a returned single element', () => {
+		function App() {
+			const ready = true;
+			return <div class="root">
+				@if (ready) {
+					<p class="inner">{'inner'}</p>
+				}
+				<span class="outer">{'outer'}</span>
+			</div>;
+		}
+
+		render(App);
+		expect(container.querySelector('.inner')?.textContent).toBe('inner');
+		expect(container.querySelector('.outer')?.textContent).toBe('outer');
+	});
+
+	it('renders a returned @for loop body alongside siblings', () => {
+		function App() {
+			const items = [1, 2, 3];
+			return <>
+				@for (const item of items) {
+					<li class="item">{item}</li>
+				}
+				<span class="outer">{'outer'}</span>
+			</>;
+		}
+
+		render(App);
+		expect([...container.querySelectorAll('.item')].map((n) => n.textContent)).toEqual([
+			'1',
+			'2',
+			'3',
+		]);
+		expect(container.querySelector('.outer')?.textContent).toBe('outer');
+	});
+
+	it('reactively toggles a returned @if branch driven by a tracked prop', () => {
+		function Dashboard({ user }: { user: Tracked<string | null> }) {
+			return <>
+				@if (!user.value) {
+					<p class="empty">{'No user found'}</p>
+				}
+				<h1 class="welcome">
+					{'Welcome,'}
+					{user.value}
+				</h1>
+			</>;
+		}
+
+		function App() {
+			let &[user, userTracked] = track<string | null>(null);
+			return <>
+				<Dashboard user={userTracked} />
+				<button onClick={() => (user = user === 'Adam' ? null : 'Adam')}>{'Toggle'}</button>
+			</>;
+		}
+
+		render(App);
+		expect(container.querySelector('.empty')?.textContent).toBe('No user found');
+		expect(container.querySelector('.welcome')?.textContent).toBe('Welcome,null');
+
+		container.querySelector('button')?.click();
+		flushSync();
+		expect(container.querySelector('.empty')).toBeNull();
+		expect(container.querySelector('.welcome')?.textContent).toBe('Welcome,Adam');
+
+		container.querySelector('button')?.click();
+		flushSync();
+		expect(container.querySelector('.empty')?.textContent).toBe('No user found');
 	});
 });

--- a/packages/tsrx-ripple/src/transform/client/index.js
+++ b/packages/tsrx-ripple/src/transform/client/index.js
@@ -887,7 +887,14 @@ function transform_native_tsrx_function(node, context) {
 		state: {
 			...context.state,
 			flush_node: null,
-			component: is_synthetic_children ? context.state.component : node,
+			// A synthetic children render arrow is itself a tsrx_element render
+			// context, so it inherits the enclosing component. When the enclosing
+			// function is a `function C() { return <jsx> }` component (transformed
+			// via the generic function path, which never sets `component`), there is
+			// no component to inherit. Fall back to this arrow as the component
+			// boundary so directive-branch elements in statement position are not
+			// misread as out-of-component template statements and double-wrapped.
+			component: is_synthetic_children ? (context.state.component ?? node) : node,
 			metadata,
 			scope: component_scope,
 			is_tsrx_element: false,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core client codegen boundary logic for synthetic render arrows; scope is narrow but incorrect component state could affect other return-JSX paths.
> 
> **Overview**
> Fixes a **client runtime crash** (`Cannot read properties of null (reading 'cloneNode')`) when components written as `function C() { return <jsx> }` include template control flow (`@if`, `@for`, `@switch`, `@try`) in the returned markup.
> 
> Those components go through the generic function transform path, which never sets render `component` state. Directive branches in statement position were then treated as out-of-component “bare template” nodes and **double-wrapped**, leaving the real template empty. The client transform now uses **`context.state.component ?? node`** for synthetic children render arrows when no enclosing component exists, so directive branches compile inline like native `@{ … }` components.
> 
> Adds **client tests** for returned fragments/elements with `@if`/`@for` and reactive `@if` with tracked props.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b390817f318877bb9235f5043330b10bf5a66c12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->