### PR TITLE
fix: stringified values should not print nullish

### DIFF
--- a/.changeset/fix-nullish-text-interpolation.md
+++ b/.changeset/fix-nullish-text-interpolation.md
@@ -1,0 +1,13 @@
+---
+'@tsrx/ripple': patch
+---
+
+Never render `null` or `undefined` as text in interpolated template output.
+
+When adjacent text and expressions are merged for concatenation, a dynamic
+value was coerced with `String(value)`, so a nullish value printed the literal
+string `"null"`/`"undefined"` (e.g. `<h1>Welcome,{user.name}</h1>` rendered
+`Welcome,null`). The merge now coerces via `String(value ?? '')` so nullish
+values render as empty text. This applies to both the client and server
+targets. An author-written `String(...)` is unaffected and still stringifies
+nullish explicitly.

--- a/packages/ripple/tests/client/basic/basic.rendering.test.tsrx
+++ b/packages/ripple/tests/client/basic/basic.rendering.test.tsrx
@@ -235,6 +235,47 @@ second
 		]);
 	});
 
+	it('never prints nullish (null/undefined) in interpolated text', () => {
+		function Basic() @{
+			const nothing = null;
+			const missing = undefined;
+			<>
+				<div class="null">value: {nothing}</div>
+				<div class="undefined">value: {missing}</div>
+				<div class="explicit">raw: {String(nothing)}</div>
+			</>
+		}
+
+		render(Basic);
+
+		expect(container.querySelector('.null').textContent).toBe('value: ');
+		expect(container.querySelector('.undefined').textContent).toBe('value: ');
+		// An explicit `String(...)` is the author's own coercion and is left
+		// untouched, so it still stringifies nullish to "null".
+		expect(container.querySelector('.explicit').textContent).toBe('raw: null');
+	});
+
+	it('reactively clears interpolated text when a value becomes nullish', () => {
+		function Basic() @{
+			let &[name] = track<string | null>('Ada');
+			<>
+				<div class="label">Name: {name}</div>
+				<button onClick={() => (name = name == null ? 'Ada' : null)}>toggle</button>
+			</>
+		}
+
+		render(Basic);
+		expect(container.querySelector('.label').textContent).toBe('Name: Ada');
+
+		container.querySelector('button').click();
+		flushSync();
+		expect(container.querySelector('.label').textContent).toBe('Name: ');
+
+		container.querySelector('button').click();
+		flushSync();
+		expect(container.querySelector('.label').textContent).toBe('Name: Ada');
+	});
+
 	it('does not render unreachable statements after an ASI return', () => {
 		function Basic() {
 			return;

--- a/packages/ripple/tests/client/return.test.tsrx
+++ b/packages/ripple/tests/client/return.test.tsrx
@@ -139,9 +139,9 @@ describe('function returns in client components', () => {
 			const ready = true;
 			return <>
 				@if (ready) {
-					<div class="yielded">{'yielded'}</div>
+					<div class="yielded">yielded</div>
 				}
-				<span class="outer">{'outer'}</span>
+				<span class="outer">outer</span>
 			</>;
 		}
 
@@ -155,9 +155,9 @@ describe('function returns in client components', () => {
 			const ready = true;
 			return <div class="root">
 				@if (ready) {
-					<p class="inner">{'inner'}</p>
+					<p class="inner">inner</p>
 				}
-				<span class="outer">{'outer'}</span>
+				<span class="outer">outer</span>
 			</div>;
 		}
 
@@ -173,7 +173,7 @@ describe('function returns in client components', () => {
 				@for (const item of items) {
 					<li class="item">{item}</li>
 				}
-				<span class="outer">{'outer'}</span>
+				<span class="outer">outer</span>
 			</>;
 		}
 
@@ -190,12 +190,9 @@ describe('function returns in client components', () => {
 		function Dashboard({ user }: { user: Tracked<string | null> }) {
 			return <>
 				@if (!user.value) {
-					<p class="empty">{'No user found'}</p>
+					<p class="empty">No user found</p>
 				}
-				<h1 class="welcome">
-					{'Welcome,'}
-					{user.value}
-				</h1>
+				<h1 class="welcome">Welcome,{user.value}</h1>
 			</>;
 		}
 
@@ -203,13 +200,13 @@ describe('function returns in client components', () => {
 			let &[user, userTracked] = track<string | null>(null);
 			return <>
 				<Dashboard user={userTracked} />
-				<button onClick={() => (user = user === 'Adam' ? null : 'Adam')}>{'Toggle'}</button>
+				<button onClick={() => (user = user === 'Adam' ? null : 'Adam')}>Toggle</button>
 			</>;
 		}
 
 		render(App);
 		expect(container.querySelector('.empty')?.textContent).toBe('No user found');
-		expect(container.querySelector('.welcome')?.textContent).toBe('Welcome,null');
+		expect(container.querySelector('.welcome')?.textContent).toBe('Welcome,');
 
 		container.querySelector('button')?.click();
 		flushSync();

--- a/packages/ripple/tests/hydration/compiled/client/basic.js
+++ b/packages/ripple/tests/hydration/compiled/client/basic.js
@@ -196,7 +196,7 @@ export function Greeting(props) {
 		}
 
 		_$_.render(() => {
-			_$_.set_text(expression, 'Hello ' + _$_.with_scope(__block, () => String(props.name)));
+			_$_.set_text(expression, 'Hello ' + _$_.with_scope(__block, () => String(props.name ?? '')));
 		});
 
 		_$_.append(__anchor, div_6);

--- a/packages/ripple/tests/hydration/compiled/client/if-children.js
+++ b/packages/ripple/tests/hydration/compiled/client/if-children.js
@@ -384,7 +384,7 @@ export function DomChildrenThenStaticSiblings() {
 			_$_.next();
 
 			_$_.render(() => {
-				_$_.set_text(expression_3, 'Item count: ' + _$_.with_scope(__block, () => String(lazy_6.value)));
+				_$_.set_text(expression_3, 'Item count: ' + _$_.with_scope(__block, () => String(lazy_6.value ?? '')));
 			});
 
 			_$_.append(__anchor, fragment_9, true);

--- a/packages/ripple/tests/hydration/compiled/server/basic.js
+++ b/packages/ripple/tests/hydration/compiled/server/basic.js
@@ -204,7 +204,7 @@ export function Greeting(props) {
 			_$_.output_push('>');
 
 			{
-				_$_.output_push(_$_.escape('Hello ' + String(props.name)));
+				_$_.output_push(_$_.escape('Hello ' + String(props.name ?? '')));
 			}
 
 			_$_.output_push('</div>');

--- a/packages/ripple/tests/hydration/compiled/server/if-children.js
+++ b/packages/ripple/tests/hydration/compiled/server/if-children.js
@@ -513,7 +513,7 @@ export function DomChildrenThenStaticSiblings() {
 						_$_.output_push('>');
 
 						{
-							_$_.output_push(_$_.escape('Item count: ' + String(lazy_6.value)));
+							_$_.output_push(_$_.escape('Item count: ' + String(lazy_6.value ?? '')));
 						}
 
 						_$_.output_push('</li>');

--- a/packages/ripple/tests/server/basic.test.tsrx
+++ b/packages/ripple/tests/server/basic.test.tsrx
@@ -24,6 +24,25 @@ describe('basic client', () => {
 		expect(body).toBeHtml('<div>&lt;span>Not HTML&lt;/span></div>');
 	});
 
+	it('never prints nullish (null/undefined) in interpolated text', async () => {
+		function Basic() @{
+			const nothing = null;
+			const missing = undefined;
+			<>
+				<div class="null">value: {nothing}</div>
+				<div class="undefined">value: {missing}</div>
+				<div class="explicit">raw: {String(nothing)}</div>
+			</>
+		}
+
+		const { body } = await render(Basic);
+
+		expect(body).toBeHtml(
+			'<div class="null">value: </div>' + '<div class="undefined">value: </div>' +
+				'<div class="explicit">raw: null</div>',
+		);
+	});
+
 	it('renders direct JSX text children as text', async () => {
 		function Basic() @{
 			<>

--- a/packages/tsrx-ripple/src/utils.js
+++ b/packages/tsrx-ripple/src/utils.js
@@ -1816,7 +1816,7 @@ export function normalize_children(children, context) {
 				prev_child.expression = b.binary(
 					'+',
 					prev_child.expression,
-					b.call('String', child.expression),
+					b.call('String', b.logical('??', child.expression, b.literal(''))),
 				);
 			}
 			normalized.splice(i, 1);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> This is a visible rendering behavior change across the compiler and both targets; apps that relied on seeing "null"/"undefined" in interpolated text will differ, though the change is narrow and well-tested.
> 
> **Overview**
> **Interpolated template text** no longer shows the literal strings `"null"` or `"undefined"` when a dynamic value is `null` or `undefined` (e.g. `Welcome,{user.value}` now renders `Welcome,` instead of `Welcome,null`).
> 
> The compiler change is in **`normalize_children`**: when adjacent static text and expressions are merged for concatenation, coercion uses `String(value ?? '')` instead of `String(value)`. That flows through **client and server** codegen (including hydration fixtures). Author-written **`String(...)`** is still left alone, so explicit coercion can still print `"null"`.
> 
> Tests add **client/server** coverage for static nullish interpolation, a **reactive** case when a tracked value becomes nullish, and update expectations in return/welcome scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d8be23239e69efac77f50a61472b8f401adc6ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->