### PR TITLE
fix: regular js stays regular, disallow early return in @ control flow

### DIFF
--- a/.changeset/forbid-return-in-at-control-flow.md
+++ b/.changeset/forbid-return-in-at-control-flow.md
@@ -1,0 +1,19 @@
+---
+'@tsrx/core': patch
+'@tsrx/ripple': patch
+'@tsrx/react': patch
+'@tsrx/preact': patch
+'@tsrx/solid': patch
+'@tsrx/vue': patch
+---
+
+Disallow `return` statements inside `@try`/`@catch`/`@pending` blocks.
+
+`return` is only valid in the JS setup at the top of a `@{ … }` code block —
+never inside a `@`-directive block. `@if`/`@for`/`@switch` already rejected
+returns; `@try`/`@catch`/`@pending` previously allowed `return <markup>` (lowering
+it into a reactive boundary fallback). They now reject any `return` (with or
+without an argument) with the same `Return statements are not allowed inside TSRX
+templates` diagnostic, consistently across every target (ripple, react, preact,
+solid, vue). Render markup by writing it as the block's output instead of
+returning it. Returns inside nested ordinary functions are unaffected.

--- a/.changeset/plain-js-control-flow-returns-jsx.md
+++ b/.changeset/plain-js-control-flow-returns-jsx.md
@@ -1,0 +1,31 @@
+---
+'ripple': patch
+'@tsrx/core': patch
+'@tsrx/ripple': patch
+'@tsrx/solid': patch
+---
+
+Treat plain JS control flow inside `@{ … }` as ordinary JavaScript that returns
+JSX.
+
+Only `@`-directives (`@if`/`@for`/`@switch`/`@try`) lower to template control
+flow. Plain `if`/`for`/`for…of`/`for…in`/`while`/`do…while`/`switch`/`try`
+inside a code block are now compiled exactly like the same control flow in a
+regular `function C() { …; return <jsx> }` body — their JSX returns become
+`tsrx_element` values rather than being template-ized.
+
+Previously these plain statements were mis-routed into the template transform:
+on **ripple** an early-return guard produced a `_$_.if`/`_$_.switch`/`_$_.try`
+wrapper (with dead code in the `switch`/`try` cases) and plain loops threw a
+compile error; on **solid** they produced `<Show>`/`<Switch>`/`<For>`/`<Errored>`
+(dropping trailing output for `try`). They now stay as plain control flow, so
+early-return guards and loops behave like normal JavaScript.
+
+As part of this, the ripple client and server targets no longer emit the
+`return_guard` bookkeeping variable: a plain early `return` is a real early
+return, so subsequent template output is naturally skipped without a guard flag.
+
+On **solid**, this means a plain guard (`if (signal()) return …`) inside a
+component body now runs once at setup — exactly like a regular Solid component —
+instead of being lifted into a reactive `<Show>`. Use `@if` (or another
+`@`-directive) when you want reactive conditional rendering.

--- a/packages/ripple/tests/client/return.test.tsrx
+++ b/packages/ripple/tests/client/return.test.tsrx
@@ -16,6 +16,24 @@ describe('returns in restricted scopes', () => {
 		).toThrow('Return statements are not allowed at the top level of a module.');
 	});
 
+	it('throws error when return is used inside @try/@catch/@pending blocks', () => {
+		for (const source of [
+			`function App() @{
+				@try { return <div>{'ok'}</div>; } @catch (e) { <div>{'err'}</div> }
+			}`,
+			`function App() @{
+				@try { <div>{'ok'}</div> } @catch (e) { return <div>{'err'}</div>; }
+			}`,
+			`function App() @{
+				@try { <div>{'ok'}</div> } @pending { return <div>{'load'}</div>; } @catch (e) { <div>{'err'}</div> }
+			}`,
+		]) {
+			expect(() => compile(source, 'App.tsrx', { mode: 'client' })).toThrow(
+				'Return statements are not allowed inside TSRX templates',
+			);
+		}
+	});
+
 	it('allows returns inside regular functions declared in TSRX templates', () => {
 		expect(
 			() => compile(

--- a/packages/ripple/tests/hydration/compiled/client/return.js
+++ b/packages/ripple/tests/hydration/compiled/client/return.js
@@ -6,7 +6,6 @@ var root_1 = _$_.template(`<div class="ready">ready</div>`, 1, 1);
 
 export function GuardReturnRenders() {
 	return _$_.tsrx_element((__anchor, __block) => {
-		var return_guard = false;
 		const ready = true;
 
 		if (!ready) {
@@ -21,7 +20,6 @@ export function GuardReturnRenders() {
 
 export function GuardReturnNull() {
 	return _$_.tsrx_element((__anchor, __block) => {
-		var return_guard = false;
 		const ready = false;
 
 		if (!ready) {

--- a/packages/ripple/tests/hydration/compiled/server/return.js
+++ b/packages/ripple/tests/hydration/compiled/server/return.js
@@ -3,7 +3,6 @@ import * as _$_ from 'ripple/internal/server';
 
 export function GuardReturnRenders() {
 	return _$_.tsrx_element(() => {
-		var return_guard = false;
 		const ready = true;
 
 		if (!ready) {
@@ -11,28 +10,21 @@ export function GuardReturnRenders() {
 		}
 
 		_$_.regular_block(() => {
-			_$_.output_push('<!--[-->');
+			_$_.output_push('<div');
+			_$_.output_push(' class="ready"');
+			_$_.output_push('>');
 
-			if (!return_guard) {
-				_$_.output_push('<div');
-				_$_.output_push(' class="ready"');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('ready');
-				}
-
-				_$_.output_push('</div>');
+			{
+				_$_.output_push('ready');
 			}
 
-			_$_.output_push('<!--]-->');
+			_$_.output_push('</div>');
 		});
 	});
 }
 
 export function GuardReturnNull() {
 	return _$_.tsrx_element(() => {
-		var return_guard = false;
 		const ready = false;
 
 		if (!ready) {
@@ -40,21 +32,15 @@ export function GuardReturnNull() {
 		}
 
 		_$_.regular_block(() => {
-			_$_.output_push('<!--[-->');
+			_$_.output_push('<div');
+			_$_.output_push(' class="ready"');
+			_$_.output_push('>');
 
-			if (!return_guard) {
-				_$_.output_push('<div');
-				_$_.output_push(' class="ready"');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('ready');
-				}
-
-				_$_.output_push('</div>');
+			{
+				_$_.output_push('ready');
 			}
 
-			_$_.output_push('<!--]-->');
+			_$_.output_push('</div>');
 		});
 	});
 }

--- a/packages/ripple/tests/setup-client.js
+++ b/packages/ripple/tests/setup-client.js
@@ -6,7 +6,7 @@ import { beforeEach, afterEach } from 'vitest';
 import { mount } from 'ripple';
 
 /**
- * @param {Component} component
+ * @param {Component | (() => any)} component
  */
 globalThis.render = function render(component) {
 	mount(component, {

--- a/packages/tsrx-ripple/src/analyze/index.js
+++ b/packages/tsrx-ripple/src/analyze/index.js
@@ -438,8 +438,14 @@ function is_inside_component_for_of(path) {
 		if (is_function_or_class_boundary(node)) {
 			return false;
 		}
-		if (node.type === 'ForOfStatement' || node.type === 'JSXForExpression') {
+		if (node.type === 'JSXForExpression') {
 			return true;
+		}
+		// The nearest enclosing for-of owns this statement. Only a `@for` template
+		// directive enforces the no-return/no-continue rule; a plain JS `for…of`
+		// is ordinary JavaScript, so stop and report it as not template-owned.
+		if (node.type === 'ForOfStatement') {
+			return node.metadata?.tsrxDirective === 'for';
 		}
 	}
 	return false;
@@ -498,8 +504,11 @@ function break_targets_component_loop(path) {
 		if (node.type === 'SwitchStatement') {
 			return false;
 		}
+		// A `break` targets the nearest enclosing loop (or switch, handled above).
+		// Only a `@for` template directive forbids it; plain JS loops are ordinary
+		// JavaScript where `break` is allowed.
 		if (is_loop_statement(node)) {
-			return true;
+			return node.type === 'ForOfStatement' && node.metadata?.tsrxDirective === 'for';
 		}
 	}
 	return false;
@@ -1850,15 +1859,10 @@ const visitors = {
 	},
 
 	ForStatement(node, context) {
-		if (is_inside_component(context) && !context.state.regular_js && !node.metadata?.regular_js) {
-			validateTsrxUnsupportedLoopStatement(
-				node,
-				context.state.analysis.module.filename,
-				context.state.collect ? context.state.analysis.errors : undefined,
-				context.state.analysis.comments,
-			);
-		}
-
+		// `for`/`for…in`/`while`/`do…while` have no template directive form, so
+		// they are always ordinary JavaScript — render via `@for` (a `for…of`) or
+		// return JSX from inside the loop. Don't reject them; let them lower as
+		// regular control flow.
 		context.next();
 	},
 
@@ -2373,41 +2377,14 @@ const visitors = {
 	},
 
 	ForInStatement(node, context) {
-		if (is_inside_component(context) && !context.state.regular_js && !node.metadata?.regular_js) {
-			validateTsrxUnsupportedLoopStatement(
-				node,
-				context.state.analysis.module.filename,
-				context.state.collect ? context.state.analysis.errors : undefined,
-				context.state.analysis.comments,
-			);
-		}
-
 		context.next();
 	},
 
 	WhileStatement(node, context) {
-		if (is_inside_component(context) && !context.state.regular_js && !node.metadata?.regular_js) {
-			validateTsrxUnsupportedLoopStatement(
-				node,
-				context.state.analysis.module.filename,
-				context.state.collect ? context.state.analysis.errors : undefined,
-				context.state.analysis.comments,
-			);
-		}
-
 		context.next();
 	},
 
 	DoWhileStatement(node, context) {
-		if (is_inside_component(context) && !context.state.regular_js && !node.metadata?.regular_js) {
-			validateTsrxUnsupportedLoopStatement(
-				node,
-				context.state.analysis.module.filename,
-				context.state.collect ? context.state.analysis.errors : undefined,
-				context.state.analysis.comments,
-			);
-		}
-
 		context.next();
 	},
 

--- a/packages/tsrx-ripple/src/transform/client/index.js
+++ b/packages/tsrx-ripple/src/transform/client/index.js
@@ -84,12 +84,10 @@ import {
 	strip_class_typescript_syntax,
 	strip_typescript_expression_wrappers,
 	jsx_to_ripple_node,
-	tracked_get,
 	build_index_read,
 	build_index_write,
 	build_index_update,
 	create_native_tsrx_render_function,
-	generate_local_name,
 	get_native_tsrx_function_body,
 	get_indexed_reactive_target,
 	is_native_tsrx_function_node,
@@ -101,7 +99,6 @@ import {
 	dynamic_element_import_local,
 	lower_dynamic_element,
 	rewrite_lazy_member_base,
-	should_guard_regular_js_statement,
 	strip_tsrx_style_elements,
 	wrap_code_block_in_iife,
 } from '../../utils.js';
@@ -3210,53 +3207,6 @@ const visitors = {
 		const id = context.state.flush_node?.();
 		const statements = [];
 
-		if (node.metadata?.lone_return && context.state.return_flags) {
-			const consequent_body =
-				node.consequent.type === 'BlockStatement' ? node.consequent.body : [node.consequent];
-			const ret = /** @type {AST.ReturnStatement} */ (consequent_body[0]);
-			const info = context.state.return_flags.get(ret);
-
-			if (info) {
-				/** @type {AST.Statement[]} */
-				const callback_body = [];
-
-				if (info.tracked) {
-					callback_body.push(b.stmt(b.call('_$_.set', b.id(info.name), b.false)));
-					callback_body.push(
-						b.if(
-							/** @type {AST.Expression} */ (
-								context.visit(node.test, {
-									...context.state,
-									metadata: { ...context.state.metadata },
-								})
-							),
-							b.stmt(b.call('_$_.set', b.id(info.name), b.true)),
-						),
-					);
-				} else {
-					callback_body.push(b.stmt(b.assignment('=', b.id(info.name), b.false)));
-					callback_body.push(
-						b.if(
-							/** @type {AST.Expression} */ (
-								context.visit(node.test, {
-									...context.state,
-									metadata: { ...context.state.metadata },
-								})
-							),
-							b.stmt(b.assignment('=', b.id(info.name), b.true)),
-						),
-					);
-				}
-
-				statements.push(
-					b.stmt(b.call('_$_.if', id, b.arrow([b.id('__render')], b.block(callback_body)))),
-				);
-
-				context.state.init?.push(b.block(statements));
-				return;
-			}
-		}
-
 		const consequent_scope =
 			/** @type {ScopeInterface} */ (context.state.scopes.get(node.consequent)) ||
 			context.state.scope;
@@ -3296,19 +3246,6 @@ const visitors = {
 
 		/** @type {AST.Statement[]} */
 		const callback_body = [];
-
-		if (node.metadata?.has_return && context.state.return_flags) {
-			for (const info of get_unique_return_infos(
-				node.metadata.returns || [],
-				context.state.return_flags,
-			)) {
-				if (info.tracked) {
-					callback_body.push(b.stmt(b.call('_$_.set', b.id(info.name), b.false)));
-				} else {
-					callback_body.push(b.stmt(b.assignment('=', b.id(info.name), b.false)));
-				}
-			}
-		}
 
 		callback_body.push(
 			b.if(
@@ -3366,16 +3303,6 @@ const visitors = {
 					: undefined,
 				/** @type {AST.NodeWithLocation} */ (node),
 			);
-		}
-		if (!is_inside_component(context)) {
-			return context.next();
-		}
-		const info = context.state.return_flags?.get(node);
-		if (info) {
-			if (info.tracked) {
-				return b.stmt(b.call('_$_.set', b.id(info.name), b.true));
-			}
-			return b.stmt(b.assignment('=', b.id(info.name), b.true));
 		}
 		return context.next();
 	},
@@ -4612,105 +4539,6 @@ function is_template_or_control_flow(node) {
 }
 
 /**
- * Builds a negated AND condition from return flag info.
- * @param {{ name: string, tracked: boolean }[]} flags
- * @returns {AST.Expression}
- */
-function build_return_guard(flags) {
-	/** @param {{ name: string, tracked: boolean }} flag */
-	const negate_flag = (flag) =>
-		flag.tracked ? b.unary('!', tracked_get(b.id(flag.name))) : b.unary('!', b.id(flag.name));
-
-	/** @type {AST.Expression} */
-	let condition = negate_flag(flags[0]);
-	for (let i = 1; i < flags.length; i++) {
-		condition = b.logical('&&', condition, negate_flag(flags[i]));
-	}
-	return condition;
-}
-
-/**
- * Builds a positive OR condition from return flag info.
- * @param {{ name: string, tracked: boolean }[]} flags
- * @returns {AST.Expression}
- */
-function build_positive_return_guard(flags) {
-	/** @param {{ name: string, tracked: boolean }} flag */
-	const read_flag = (flag) => (flag.tracked ? tracked_get(b.id(flag.name)) : b.id(flag.name));
-
-	/** @type {AST.Expression} */
-	let condition = read_flag(flags[0]);
-	for (let i = 1; i < flags.length; i++) {
-		condition = b.logical('||', condition, read_flag(flags[i]));
-	}
-	return condition;
-}
-
-/**
- * @param {AST.Node} node
- * @param {Map<AST.ReturnStatement, { name: string, tracked: boolean }>} return_flags
- * @returns {{ name: string, tracked: boolean } | null}
- */
-function get_returned_child_info(node, return_flags) {
-	const source = /** @type {AST.ReturnStatement | undefined} */ (
-		node.metadata?.returned_tsrx_return
-	);
-	return source ? (return_flags.get(source) ?? null) : null;
-}
-
-/**
- * Collects all unique valid return statements from direct children.
- * @param {AST.Node[]} children
- * @returns {AST.ReturnStatement[]}
- */
-function collect_returns_from_children(children) {
-	/** @type {AST.ReturnStatement[]} */
-	const returns = [];
-	const seen = new Set();
-	for (let index = 0; index < children.length; index++) {
-		const node = children[index];
-		if (
-			node.type === 'ReturnStatement' &&
-			index !== children.length - 1 &&
-			!node.metadata?.invalid_tsrx_template_return
-		) {
-			if (!seen.has(node)) {
-				seen.add(node);
-				returns.push(node);
-			}
-		}
-		if (node.metadata?.returns) {
-			for (const ret of node.metadata.returns) {
-				if (!ret.metadata?.invalid_tsrx_template_return && !seen.has(ret)) {
-					seen.add(ret);
-					returns.push(ret);
-				}
-			}
-		}
-	}
-	return returns;
-}
-
-/**
- * @param {AST.ReturnStatement[]} returns
- * @param {Map<AST.ReturnStatement, { name: string, tracked: boolean }>} return_flags
- * @returns {{ name: string, tracked: boolean }[]}
- */
-function get_unique_return_infos(returns, return_flags) {
-	/** @type {{ name: string, tracked: boolean }[]} */
-	const infos = [];
-	const seen = new Set();
-	for (const ret of returns) {
-		const info = return_flags.get(ret);
-		if (info && !seen.has(info.name)) {
-			seen.add(info.name);
-			infos.push(info);
-		}
-	}
-	return infos;
-}
-
-/**
  * @param {AST.Node} node
  * @returns {boolean}
  */
@@ -4931,54 +4759,12 @@ function transform_children(children, context) {
 		...context,
 		state: { ...state, keep_component_style: state.to_ts ? true : state.keep_component_style },
 	});
-	const effective_normalized = normalized.filter(
-		(node) => !(node.metadata?.regular_js && is_dead_native_tsrx_expression_statement(node)),
-	);
 
 	const head_elements = /** @type {AST.Element[]} */ (
 		children.filter(
 			(node) => node.type === 'Element' && node.id.type === 'Identifier' && node.id.name === 'head',
 		)
 	);
-
-	const all_returns = collect_returns_from_children(effective_normalized);
-	/** @type {Map<AST.ReturnStatement, { name: string, tracked: boolean }>} */
-	const return_flags = new Map([...(state.return_flags || [])]);
-	/** @type {AST.ReturnStatement[]} */
-	const new_returns = [];
-	for (const ret of all_returns) {
-		if (!return_flags.has(ret)) {
-			new_returns.push(ret);
-		}
-	}
-
-	const return_guard_scope = (state.component && state.scopes.get(state.component)) || state.scope;
-	const shared_return_info =
-		new_returns.length > 0
-			? {
-					name: generate_local_name(return_guard_scope, 'return_guard'),
-					tracked: new_returns.some((ret) => ret.metadata?.is_reactive ?? false),
-				}
-			: null;
-	if (shared_return_info !== null) {
-		for (const ret of new_returns) {
-			return_flags.set(ret, shared_return_info);
-		}
-	}
-
-	if (!state.to_ts && shared_return_info !== null) {
-		if (shared_return_info.tracked) {
-			state.init?.unshift(
-				b.var(b.id(shared_return_info.name), b.call('_$_.track', b.false, b.id('__block'))),
-			);
-		} else {
-			state.init?.unshift(b.var(b.id(shared_return_info.name), b.false));
-		}
-	}
-
-	/** @type {{ name: string, tracked: boolean }[]} */
-	const accumulated_return_flags = [];
-	const has_returns = all_returns.length > 0;
 
 	const is_fragment =
 		normalized.some(
@@ -5052,85 +4838,14 @@ function transform_children(children, context) {
 		state.init?.push(b.var(id, b.call(template_id)));
 	};
 
-	/** @type {AST.Node[]} */
-	let pending_group = [];
-	/** @type {{ name: string, tracked: boolean }[]} */
-	let pending_guard_flags = [];
-	let pending_guard_positive = false;
 	let fragment_hop_count = 0;
 
 	let skipped = 0;
-
-	const flush_pending_group = () => {
-		if (pending_group.length === 0) return;
-
-		const guard_flags = pending_guard_flags;
-		const guard_positive = pending_guard_positive;
-		const group_nodes = pending_group;
-		pending_group = [];
-		pending_guard_flags = [];
-		pending_guard_positive = false;
-
-		state.template?.push('<!>');
-		if (is_fragment) {
-			fragment_hop_count += 1;
-		}
-
-		if (initial === null && root) {
-			create_initial(group_nodes[0]);
-		}
-
-		const current_prev = prev;
-		/** @type {AST.Identifier | null} */
-		let cached_anchor = null;
-		const group_flush_node = () => {
-			if (cached_anchor) return cached_anchor;
-			const id = b.id(state.scope.generate('node'));
-			if (current_prev !== null) {
-				state.init?.push(b.var(id, b.call('_$_.sibling', current_prev())));
-			} else if (initial !== null) {
-				if (is_fragment) {
-					state.init?.push(b.var(id, b.call('_$_.first_child_frag', initial)));
-				} else {
-					cached_anchor = initial;
-					return initial;
-				}
-			} else if (state.flush_node !== null) {
-				state.init?.push(b.var(id, b.call('_$_.child', state.flush_node?.())));
-			}
-			cached_anchor = id;
-			return id;
-		};
-
-		prev = group_flush_node;
-
-		const anchor = group_flush_node();
-		const body = transform_body(group_nodes, {
-			...context,
-			state: { ...context.state, flush_node: null, return_flags },
-		});
-
-		const content_id = state.scope.generate('content');
-		const guard_condition = guard_positive
-			? build_positive_return_guard(guard_flags)
-			: build_return_guard(guard_flags);
-
-		/** @type {AST.Statement[]} */
-		const callback_body = [
-			b.if(guard_condition, b.stmt(b.call(b.id('__render'), b.id(content_id)))),
-		];
-
-		state.init?.push(b.var(b.id(content_id), b.arrow([b.id('__anchor')], b.block(body))));
-		state.init?.push(
-			b.stmt(b.call('_$_.if', anchor, b.arrow([b.id('__render')], b.block(callback_body)))),
-		);
-	};
 
 	for (let node_idx = 0; node_idx < normalized.length; node_idx++) {
 		const node = normalized[node_idx];
 
 		if (node.metadata?.regular_js && !state.to_ts) {
-			flush_pending_group();
 			if (is_dead_native_tsrx_expression_statement(node)) {
 				continue;
 			}
@@ -5147,46 +4862,10 @@ function transform_children(children, context) {
 					regular_node.type.endsWith('Statement') || regular_node.type.endsWith('Declaration')
 						? /** @type {AST.Statement} */ (regular_node)
 						: b.stmt(/** @type {AST.Expression} */ (regular_node));
-				state.init?.push(
-					accumulated_return_flags.length > 0 && should_guard_regular_js_statement(statement)
-						? b.if(build_return_guard(accumulated_return_flags), statement)
-						: statement,
-				);
+				state.init?.push(statement);
 			}
 			continue;
 		}
-
-		if (accumulated_return_flags.length > 0 && is_template_or_control_flow(node) && !state.to_ts) {
-			const returned_child_info = get_returned_child_info(node, return_flags);
-			const guard_flags = returned_child_info ? [returned_child_info] : accumulated_return_flags;
-			const guard_positive = returned_child_info !== null;
-			const guard_key = guard_flags.map((flag) => flag.name).join(',');
-			const pending_guard_key = pending_guard_flags.map((flag) => flag.name).join(',');
-			if (
-				pending_group.length > 0 &&
-				(pending_guard_positive !== guard_positive || pending_guard_key !== guard_key)
-			) {
-				flush_pending_group();
-			}
-			if (pending_group.length === 0) {
-				pending_guard_flags = [...guard_flags];
-				pending_guard_positive = guard_positive;
-			}
-			pending_group.push(node);
-
-			if (node.metadata?.has_return && node.metadata.returns) {
-				flush_pending_group();
-				for (const ret of node.metadata.returns) {
-					const info = return_flags.get(ret);
-					if (info && !accumulated_return_flags.some((f) => f.name === info.name)) {
-						accumulated_return_flags.push(info);
-					}
-				}
-			}
-			continue;
-		}
-
-		flush_pending_group();
 
 		if (is_fragment && is_template_or_control_flow(node)) {
 			fragment_hop_count += 1;
@@ -5205,15 +4884,7 @@ function transform_children(children, context) {
 			node.type === 'ReturnStatement' ||
 			is_native_tsrx_function_node(node)
 		) {
-			state.init?.push(/** @type {AST.Statement} */ (visit(node, { ...state, return_flags })));
-			if (!state.to_ts) {
-				if (node.type === 'ReturnStatement') {
-					const info = return_flags.get(node);
-					if (info && !accumulated_return_flags.some((f) => f.name === info.name)) {
-						accumulated_return_flags.push(info);
-					}
-				}
-			}
+			state.init?.push(/** @type {AST.Statement} */ (visit(node, state)));
 		} else if (state.to_ts) {
 			transform_ts_child(node, /** @type {VisitorClientContext} */ ({ visit, state }));
 		} else {
@@ -5342,7 +5013,6 @@ function transform_children(children, context) {
 
 				visit(node, {
 					...state,
-					return_flags,
 					flush_node: /** @type {TransformClientState['flush_node']} */ (flush_node),
 					namespace: state.namespace,
 				});
@@ -5408,7 +5078,6 @@ function transform_children(children, context) {
 
 				visit(node, {
 					...state,
-					return_flags,
 					flush_node: /** @type {TransformClientState['flush_node']} */ (flush_node),
 					namespace: state.namespace,
 				});
@@ -5482,7 +5151,6 @@ function transform_children(children, context) {
 				node.is_controlled = is_controlled;
 				visit(node, {
 					...state,
-					return_flags,
 					flush_node: /** @type {TransformClientState['flush_node']} */ (flush_node),
 					namespace: state.namespace,
 				});
@@ -5491,7 +5159,6 @@ function transform_children(children, context) {
 				node.is_controlled = is_controlled;
 				visit(node, {
 					...state,
-					return_flags,
 					flush_node: /** @type {TransformClientState['flush_node']} */ (flush_node),
 					namespace: state.namespace,
 				});
@@ -5519,18 +5186,7 @@ function transform_children(children, context) {
 				debugger;
 			}
 		}
-
-		if (has_returns && node.metadata?.has_return && node.metadata.returns) {
-			for (const ret of node.metadata.returns) {
-				const info = return_flags.get(ret);
-				if (info && !accumulated_return_flags.some((f) => f.name === info.name)) {
-					accumulated_return_flags.push(info);
-				}
-			}
-		}
 	}
-
-	flush_pending_group();
 
 	for (let i = 0; i < head_elements.length; i++) {
 		const head_element = head_elements[i];

--- a/packages/tsrx-ripple/src/transform/server/index.js
+++ b/packages/tsrx-ripple/src/transform/server/index.js
@@ -69,10 +69,8 @@ import {
 	build_index_write,
 	build_index_update,
 	expression_contains_call,
-	generate_local_name,
 	get_indexed_reactive_target,
 	rewrite_lazy_member_base,
-	should_guard_regular_js_statement,
 	strip_tsrx_style_elements,
 	unwrap_single_return_iife,
 	wrap_code_block_in_iife,
@@ -927,96 +925,6 @@ function visit_ripple_fragment_element(node, context) {
 }
 
 /**
- * Builds a negated AND condition from return flag names: !__r_1 && !__r_2 && ...
- * @param {string[]} flags
- * @returns {AST.Expression}
- */
-function build_return_guard(flags) {
-	/** @type {AST.Expression} */
-	let condition = b.unary('!', b.id(flags[0]));
-	for (let i = 1; i < flags.length; i++) {
-		condition = b.logical('&&', condition, b.unary('!', b.id(flags[i])));
-	}
-	return condition;
-}
-
-/**
- * Builds a positive OR condition from return flag names.
- * @param {string[]} flags
- * @returns {AST.Expression}
- */
-function build_positive_return_guard(flags) {
-	/** @type {AST.Expression} */
-	let condition = b.id(flags[0]);
-	for (let i = 1; i < flags.length; i++) {
-		condition = b.logical('||', condition, b.id(flags[i]));
-	}
-	return condition;
-}
-
-/**
- * @param {AST.Node} node
- * @param {Map<AST.ReturnStatement, { name: string, tracked: boolean }>} return_flags
- * @returns {string | null}
- */
-function get_returned_child_flag_name(node, return_flags) {
-	const source = /** @type {AST.ReturnStatement | undefined} */ (
-		node.metadata?.returned_tsrx_return
-	);
-	return source ? (return_flags.get(source)?.name ?? null) : null;
-}
-
-/**
- * Collects all unique valid return statements from the direct children of a body.
- * @param {AST.Node[]} children
- * @returns {AST.ReturnStatement[]}
- */
-function collect_returns_from_children(children) {
-	/** @type {AST.ReturnStatement[]} */
-	const returns = [];
-	const seen = new Set();
-	for (let index = 0; index < children.length; index++) {
-		const node = children[index];
-		if (
-			node.type === 'ReturnStatement' &&
-			index !== children.length - 1 &&
-			!node.metadata?.invalid_tsrx_template_return
-		) {
-			if (!seen.has(node)) {
-				seen.add(node);
-				returns.push(node);
-			}
-		}
-		if (node.metadata?.returns) {
-			for (const ret of node.metadata.returns) {
-				if (!ret.metadata?.invalid_tsrx_template_return && !seen.has(ret)) {
-					seen.add(ret);
-					returns.push(ret);
-				}
-			}
-		}
-	}
-	return returns;
-}
-
-/**
- * @param {AST.ReturnStatement[]} returns
- * @param {Map<AST.ReturnStatement, { name: string, tracked: boolean }>} return_flags
- * @returns {string[]}
- */
-function get_unique_return_flag_names(returns, return_flags) {
-	/** @type {string[]} */
-	const names = [];
-	for (const ret of returns) {
-		const info = return_flags.get(ret);
-		if (info && !names.includes(info.name)) {
-			names.push(info.name);
-		}
-	}
-	return names;
-}
-
-/**
  * @param {AST.Node} node
  * @returns {boolean}
  */
@@ -1078,47 +986,8 @@ function transform_variable_declaration(node, context) {
 function transform_children(children, context) {
 	const { visit, state } = context;
 	const normalized = normalize_children(children, context);
-	const effective_normalized = normalized.filter(
-		(node) => !(node.metadata?.regular_js && is_dead_native_tsrx_expression_statement(node)),
-	);
 	const should_wrap_in_regular_block =
 		state.component !== undefined && !state.skip_regular_blocks && !state.in_regular_block;
-
-	const all_returns = collect_returns_from_children(effective_normalized);
-	/** @type {Map<AST.ReturnStatement, { name: string, tracked: boolean }>} */
-	const return_flags = new Map([...(state.return_flags || [])]);
-	/** @type {AST.ReturnStatement[]} */
-	const new_returns = [];
-	for (const ret of all_returns) {
-		if (!return_flags.has(ret)) {
-			new_returns.push(ret);
-		}
-	}
-
-	if (new_returns.length > 0) {
-		const return_guard_scope =
-			(state.component && state.scopes.get(state.component)) || state.scope;
-		const info = { name: generate_local_name(return_guard_scope, 'return_guard'), tracked: false };
-		for (const ret of new_returns) {
-			return_flags.set(ret, info);
-		}
-		state.init?.push(b.var(b.id(info.name), b.false));
-	}
-
-	/** @type {string[]} */
-	let accumulated_flags = [];
-
-	/**
-	 * @param {AST.ReturnStatement[] | undefined} returns
-	 */
-	const push_return_flags = (returns) => {
-		if (!returns) return;
-		for (const name of get_unique_return_flag_names(returns, return_flags)) {
-			if (!accumulated_flags.includes(name)) {
-				accumulated_flags.push(name);
-			}
-		}
-	};
 
 	/**
 	 * @param {AST.Statement[]} statements
@@ -1146,11 +1015,7 @@ function transform_children(children, context) {
 					regular_node.type.endsWith('Statement') || regular_node.type.endsWith('Declaration')
 						? /** @type {AST.Statement} */ (regular_node)
 						: b.stmt(/** @type {AST.Expression} */ (regular_node));
-				state.init?.push(
-					accumulated_flags.length > 0 && should_guard_regular_js_statement(statement)
-						? b.if(build_return_guard(accumulated_flags), statement)
-						: statement,
-				);
+				state.init?.push(statement);
 			}
 			return;
 		}
@@ -1182,57 +1047,11 @@ function transform_children(children, context) {
 							...context,
 							state: local_state,
 						})
-					: /** @type {AST.Statement} */ (visit(node, { ...local_state, return_flags })),
+					: /** @type {AST.Statement} */ (visit(node, local_state)),
 			);
-			if (node.type === 'ReturnStatement') {
-				const info = return_flags.get(node);
-				if (info && !accumulated_flags.includes(info.name)) {
-					accumulated_flags.push(info.name);
-				}
-			}
 		} else {
-			visit(node, { ...local_state, return_flags, template_child: true });
+			visit(node, { ...local_state, template_child: true });
 		}
-	};
-
-	/** @type {AST.Node[]} */
-	let pending_group = [];
-	/** @type {string[]} */
-	let pending_guard_flags = [];
-	let pending_guard_positive = false;
-
-	const flush_pending_group = () => {
-		if (pending_group.length === 0) return;
-
-		const group = pending_group;
-		const guard_flags = pending_guard_flags;
-		const guard_positive = pending_guard_positive;
-		pending_group = [];
-		pending_guard_flags = [];
-		pending_guard_positive = false;
-
-		/** @type {AST.Statement[]} */
-		const wrapped = [];
-		const saved_init = state.init;
-		state.init = wrapped;
-
-		for (const group_node of group) {
-			process_node(group_node, { ...state, init: wrapped, in_regular_block: true });
-		}
-
-		state.init = saved_init;
-		if (wrapped.length === 0) return;
-
-		const guard = guard_positive
-			? build_positive_return_guard(guard_flags)
-			: build_return_guard(guard_flags);
-		state.init?.push(
-			...wrap_regular_block([
-				b.stmt(b.call(b.id('_$_.output_push'), b.literal(BLOCK_OPEN))),
-				b.if(guard, b.block(wrapped)),
-				b.stmt(b.call(b.id('_$_.output_push'), b.literal(BLOCK_CLOSE))),
-			]),
-		);
 	};
 
 	/**
@@ -1258,46 +1077,15 @@ function transform_children(children, context) {
 		const node = normalized[idx];
 
 		if (is_head_element(node)) {
-			flush_pending_group();
 			continue;
 		}
-
-		if (accumulated_flags.length > 0 && should_wrap_node_in_regular_block(node)) {
-			const returned_child_flag = get_returned_child_flag_name(node, return_flags);
-			const guard_flags = returned_child_flag ? [returned_child_flag] : accumulated_flags;
-			const guard_positive = returned_child_flag !== null;
-			const guard_key = guard_flags.join(',');
-			const pending_guard_key = pending_guard_flags.join(',');
-			if (
-				pending_group.length > 0 &&
-				(pending_guard_positive !== guard_positive || pending_guard_key !== guard_key)
-			) {
-				flush_pending_group();
-			}
-			if (pending_group.length === 0) {
-				pending_guard_flags = [...guard_flags];
-				pending_guard_positive = guard_positive;
-			}
-			pending_group.push(node);
-
-			if (node.metadata?.has_return && node.metadata.returns) {
-				flush_pending_group();
-				push_return_flags(node.metadata.returns);
-			}
-			continue;
-		}
-
-		flush_pending_group();
 
 		if (should_wrap_node_in_regular_block(node)) {
 			process_wrapped_template_or_control_flow(node);
 		} else {
 			process_node(node);
 		}
-		push_return_flags(node.metadata?.has_return ? node.metadata.returns : undefined);
 	}
-
-	flush_pending_group();
 
 	const head_elements = /** @type {AST.Element[]} */ (
 		children.filter((node) => is_head_element(node))
@@ -2626,6 +2414,19 @@ const visitors = {
 	},
 
 	ReturnStatement(node, context) {
+		// A `return <markup>` produces a renderable value — lower it to a server
+		// `tsrx_element`, exactly like control flow returning JSX in a regular
+		// function. `@try`/`@pending`/`@catch` blocks legitimately return markup
+		// this way (the only `@`-blocks that allow native returns).
+		if (!context.state.to_ts && is_native_tsrx_template_node(node.argument)) {
+			return b.return(
+				build_template_node_to_tsrx_element(
+					/** @type {AST.Element | AST.TsrxFragment} */ (/** @type {unknown} */ (node.argument)),
+					context,
+				),
+				/** @type {AST.NodeWithLocation} */ (node),
+			);
+		}
 		if (!is_inside_component(context)) {
 			if (node.argument) {
 				return b.return(
@@ -2636,10 +2437,6 @@ const visitors = {
 				);
 			}
 			return context.next();
-		}
-		const info = context.state.return_flags?.get(node);
-		if (info) {
-			return b.stmt(b.assignment('=', b.id(info.name), b.true));
 		}
 		return context.next();
 	},

--- a/packages/tsrx-ripple/src/utils.js
+++ b/packages/tsrx-ripple/src/utils.js
@@ -57,6 +57,30 @@ export function should_guard_regular_js_statement(statement) {
 }
 
 /**
+ * Plain JS control flow (`if`/`for`/`while`/`switch`/`try`, etc.) that is NOT an
+ * `@if`/`@for`/`@switch`/`@try` template directive. Only directives carry
+ * `metadata.tsrxDirective`; everything else is ordinary JavaScript that may
+ * return JSX, and must lower exactly like control flow in a regular function.
+ * @param {AST.Node} node
+ * @returns {boolean}
+ */
+export function is_plain_js_control_flow(node) {
+	if (node.metadata?.tsrxDirective) {
+		return false;
+	}
+	return (
+		node.type === 'IfStatement' ||
+		node.type === 'SwitchStatement' ||
+		node.type === 'TryStatement' ||
+		node.type === 'ForOfStatement' ||
+		node.type === 'ForInStatement' ||
+		node.type === 'ForStatement' ||
+		node.type === 'WhileStatement' ||
+		node.type === 'DoWhileStatement'
+	);
+}
+
+/**
  * Generate a name that is unique inside the current transform scope without
  * reserving it for the entire module.
  * @param {ScopeInterface} scope
@@ -724,6 +748,13 @@ function create_return_argument_child(argument, statement) {
 function expand_native_tsrx_return_statement(statement, omit_control_return = false) {
 	if (statement.metadata?.returned_tsrx_child) {
 		return [statement];
+	}
+
+	// Plain JS control flow is ordinary JavaScript — leave it intact (its JSX
+	// returns lower to `_$_.tsrx_element` via the regular-JS path) instead of
+	// expanding it into template children. Only `@`-directives template-ize.
+	if (is_plain_js_control_flow(statement)) {
+		return [mark_regular_js_statement(statement)];
 	}
 
 	if (!node_contains_component_return(statement)) {

--- a/packages/tsrx-ripple/tests/basic.test.js
+++ b/packages/tsrx-ripple/tests/basic.test.js
@@ -1168,7 +1168,7 @@ describe('@tsrx/ripple nested function fragment returns', () => {
 		expect(code).not.toContain('Return statements are not allowed');
 	});
 
-	it('uses one return guard for multiple component return branches', () => {
+	it('compiles multiple component guard returns as plain control flow', () => {
 		const source = `function Test({ done }) @{
 			if (done.value) {
 				return <p>Done</p>;
@@ -1188,22 +1188,23 @@ describe('@tsrx/ripple nested function fragment returns', () => {
 		const server = compile(source, 'App.tsrx', { mode: 'server' });
 		const tsx = compile_to_volar_mappings(source, 'App.tsrx', { loose: true });
 
-		expect(client.code).toContain('var return_guard = false;');
+		// Plain JS guards are ordinary early returns now — no `return_guard`
+		// bookkeeping. Each guard returns a `tsrx_element` directly.
+		expect(client.code).not.toContain('return_guard');
+		expect(client.code).toContain('if (done.value)');
+		expect(client.code).toContain("} else if (done.value === 'test')");
+		expect(client.code).toContain('return _$_.tsrx_element((__anchor, __block) =>');
 		expect(client.code).toContain('_$_.for(');
 		expect(client.code).toContain('_$_.render_tsrx_element(_$_.with_scope(__block, loop),');
-		expect(client.code).not.toContain('_$_.expression(expression_2, loop)');
-		expect(client.code).not.toContain('return_guard_1');
-		expect(client.code).not.toContain('!return_guard &&');
-		expect(server.code).toContain('var return_guard = false;');
+		expect(server.code).not.toContain('return_guard');
+		expect(server.code).toContain('if (done.value)');
+		expect(server.code).toContain('return _$_.tsrx_element(() =>');
 		expect(server.code).toContain('_$_.render_tsrx_element(loop())');
-		expect(server.code).not.toContain('_$_.render_expression(loop())');
-		expect(server.code).not.toContain('return_guard_1');
-		expect(server.code).not.toContain('!return_guard &&');
 		expect(tsx.code).toContain('if (done.value)');
-		expect(tsx.code).toContain('return;');
+		expect(tsx.code).toContain('return <p>Done</p>');
 	});
 
-	it('keeps return guard names local to each compiled function', () => {
+	it('compiles guard returns in separate functions as plain control flow', () => {
 		const source = `function First(flag) @{
 			if (flag) {
 				return <p>first</p>;
@@ -1220,13 +1221,13 @@ describe('@tsrx/ripple nested function fragment returns', () => {
 		const client = compile(source, 'App.tsrx');
 		const server = compile(source, 'App.tsrx', { mode: 'server' });
 
-		expect(client.code.match(/var return_guard = false;/g)).toHaveLength(2);
-		expect(client.code).not.toContain('return_guard_1');
-		expect(server.code.match(/var return_guard = false;/g)).toHaveLength(2);
-		expect(server.code).not.toContain('return_guard_1');
+		expect(client.code).not.toContain('return_guard');
+		expect(client.code.match(/if \(flag\) \{/g)).toHaveLength(2);
+		expect(server.code).not.toContain('return_guard');
+		expect(server.code.match(/if \(flag\) \{/g)).toHaveLength(2);
 	});
 
-	it('still avoids user return_guard bindings inside a compiled function', () => {
+	it('does not synthesize a return_guard binding that could clash with user names', () => {
 		const source = `function Test(return_guard) @{
 			if (return_guard) {
 				return <p>done</p>;
@@ -1236,8 +1237,12 @@ describe('@tsrx/ripple nested function fragment returns', () => {
 		const client = compile(source, 'App.tsrx');
 		const server = compile(source, 'App.tsrx', { mode: 'server' });
 
-		expect(client.code).toContain('var return_guard_1 = false;');
-		expect(server.code).toContain('var return_guard_1 = false;');
+		// No compiler-generated return_guard binding exists, so the user's
+		// `return_guard` parameter is used as-is with no `_1` suffix.
+		expect(client.code).not.toContain('return_guard_1');
+		expect(client.code).toContain('if (return_guard)');
+		expect(server.code).not.toContain('return_guard_1');
+		expect(server.code).toContain('if (return_guard)');
 	});
 });
 
@@ -1292,8 +1297,10 @@ describe('@tsrx/ripple unified function and component compilation', () => {
 
 		expect(client.code).toContain('if (flag) return;');
 		expect(client.code).toContain('_$_.with_scope(__block, sideEffect);');
-		expect(client.code).not.toContain('if (!return_guard) _$_.with_scope(__block, sideEffect)');
-		expect(server.code).toContain('if (!return_guard) sideEffect();');
+		expect(client.code).not.toContain('return_guard');
+		expect(server.code).toContain('if (flag) return;');
+		expect(server.code).toContain('sideEffect();');
+		expect(server.code).not.toContain('return_guard');
 	});
 
 	it('preserves ordinary control flow for plain functions returning templates', () => {

--- a/packages/tsrx-solid/src/transform.js
+++ b/packages/tsrx-solid/src/transform.js
@@ -33,6 +33,10 @@ import {
 	is_bare_render_expression,
 	is_jsx_child,
 	set_loc,
+	isTemplateIfNode as is_template_if_node,
+	isTemplateForOfNode as is_template_for_of_node,
+	isTemplateSwitchNode as is_template_switch_node,
+	isTemplateTryNode as is_template_try_node,
 } from '@tsrx/core';
 
 import { builders as b } from '@tsrx/core';
@@ -472,54 +476,6 @@ function is_loop_statement(node) {
 		node?.type === 'JSXForExpression' ||
 		node?.type === 'WhileStatement' ||
 		node?.type === 'DoWhileStatement'
-	);
-}
-
-/**
- * @param {any} node
- * @returns {boolean}
- */
-function is_template_if_node(node) {
-	return (
-		node?.type === 'JSXIfExpression' ||
-		node?.metadata?.tsrxDirective === 'if' ||
-		(node?.type === 'IfStatement' && node?.statementType === 'IfStatement')
-	);
-}
-
-/**
- * @param {any} node
- * @returns {boolean}
- */
-function is_template_for_of_node(node) {
-	return (
-		node?.type === 'JSXForExpression' ||
-		node?.metadata?.tsrxDirective === 'for' ||
-		(node?.type === 'ForOfStatement' && node?.statementType === 'ForOfStatement')
-	);
-}
-
-/**
- * @param {any} node
- * @returns {boolean}
- */
-function is_template_switch_node(node) {
-	return (
-		node?.type === 'JSXSwitchExpression' ||
-		node?.metadata?.tsrxDirective === 'switch' ||
-		(node?.type === 'SwitchStatement' && node?.statementType === 'SwitchStatement')
-	);
-}
-
-/**
- * @param {any} node
- * @returns {boolean}
- */
-function is_template_try_node(node) {
-	return (
-		node?.type === 'JSXTryExpression' ||
-		node?.metadata?.tsrxDirective === 'try' ||
-		(node?.type === 'TryStatement' && node?.statementType === 'TryStatement')
 	);
 }
 
@@ -1417,13 +1373,8 @@ function rewrite_solid_native_component_function(fn, parent, transform_context) 
 	}
 
 	const source_body = fn.body.body || [];
-	const early_body = rewrite_early_return_guard_body(source_body, transform_context);
-	const effective_body =
-		early_body ??
-		(() => {
-			const lowered = lower_solid_component_statement_list(source_body);
-			return lowered.changed ? lowered.nodes : null;
-		})();
+	const lowered = lower_solid_component_statement_list(source_body);
+	const effective_body = lowered.changed ? lowered.nodes : null;
 
 	if (effective_body === null) {
 		return;
@@ -1444,140 +1395,6 @@ function rewrite_solid_native_component_function(fn, parent, transform_context) 
 	} finally {
 		transform_context.available_bindings = saved_bindings;
 	}
-}
-
-/**
- * Preserve the old Solid setup-once behavior for early guard returns: setup
- * statements after the guard stay in the outer function, while render output is
- * lifted into a reactive `<Show>`.
- *
- * @param {any[]} body
- * @param {TransformContext} transform_context
- * @returns {any[] | null}
- */
-function rewrite_early_return_guard_body(body, transform_context) {
-	const early_idx = body.findIndex((node) => get_component_returning_if_info(node) !== null);
-	if (early_idx === -1) {
-		return null;
-	}
-
-	const early_if = body[early_idx];
-	const early_info = /** @type {{ consequent_body: any[], return_index: number }} */ (
-		get_component_returning_if_info(early_if)
-	);
-	const before = body.slice(0, early_idx);
-	const after = body.slice(early_idx + 1);
-	const lowered_after = lower_solid_component_statement_list(after);
-	const effective_after = lowered_after.changed ? lowered_after.nodes : after;
-	const branch_has_content_before_return = early_info.consequent_body.length > 0;
-	const early_interleaved = is_interleaved_body([...before, ...after]);
-
-	/** @type {any[]} */
-	const before_non_jsx = [];
-	/** @type {any[]} */
-	const before_jsx = [];
-	/** @type {any[]} */
-	const after_non_jsx = [];
-	/** @type {any[]} */
-	const after_jsx = [];
-	let early_capture_index = 0;
-
-	/**
-	 * @param {any[]} nodes
-	 * @param {any[]} outer
-	 * @param {any[]} jsx_bucket
-	 */
-	const collect = (nodes, outer, jsx_bucket) => {
-		for (const child of nodes) {
-			const return_nodes = return_statement_to_render_nodes(child);
-			if (return_nodes) {
-				jsx_bucket.push(...return_nodes);
-				continue;
-			}
-
-			if (is_solid_render_child(child)) {
-				if (get_component_returning_if_info(child) !== null) {
-					jsx_bucket.push(child);
-					continue;
-				}
-				if (early_interleaved) {
-					const jsx = to_jsx_child(child, transform_context);
-					outer.push(...extract_jsx_setup_declarations(jsx));
-					if (is_capturable_jsx_child(jsx)) {
-						const { declaration, reference } = captureJsxChild(jsx, early_capture_index++);
-						outer.push(declaration);
-						jsx_bucket.push(reference);
-					} else {
-						jsx_bucket.push(jsx);
-					}
-				} else {
-					jsx_bucket.push(child);
-				}
-			} else if (is_bare_render_expression(child)) {
-				jsx_bucket.push(to_jsx_expression_container(child, child));
-			} else {
-				outer.push(child);
-			}
-		}
-	};
-
-	collect(before, before_non_jsx, before_jsx);
-	collect(effective_after, after_non_jsx, after_jsx);
-
-	const next_body = [...before_non_jsx, ...before_jsx, ...after_non_jsx];
-
-	if (branch_has_content_before_return) {
-		transform_context.needs_show = true;
-		const branch_body = body_to_jsx_child(early_info.consequent_body, transform_context);
-		const fallback_body =
-			after_jsx.length > 0
-				? body_to_component_early_return_jsx_child(after_jsx, transform_context)
-				: null;
-		next_body.push(build_show_element(early_if.test, branch_body, fallback_body));
-	} else if (after_jsx.length > 0) {
-		transform_context.needs_show = true;
-		const show_body = body_to_component_early_return_jsx_child(after_jsx, transform_context);
-		next_body.push(build_show_element(negate_expression(early_if.test), show_body, null));
-	} else {
-		return null;
-	}
-
-	return next_body;
-}
-
-/**
- * @param {any[]} body_nodes
- * @param {TransformContext} transform_context
- * @returns {any}
- */
-function body_to_component_early_return_jsx_child(body_nodes, transform_context) {
-	const early_idx = body_nodes.findIndex((node) => get_component_returning_if_info(node) !== null);
-	if (early_idx === -1) {
-		return body_to_jsx_child(body_nodes, transform_context);
-	}
-
-	const early_if = body_nodes[early_idx];
-	const early_info = /** @type {{ consequent_body: any[], return_index: number }} */ (
-		get_component_returning_if_info(early_if)
-	);
-	const before = body_nodes.slice(0, early_idx);
-	const after = body_nodes.slice(early_idx + 1);
-	const branch_has_content_before_return = early_info.consequent_body.length > 0;
-	const children = [...before];
-
-	if (branch_has_content_before_return) {
-		transform_context.needs_show = true;
-		const branch_body = body_to_jsx_child(early_info.consequent_body, transform_context);
-		const fallback_body =
-			after.length > 0 ? body_to_component_early_return_jsx_child(after, transform_context) : null;
-		children.push(build_show_element(early_if.test, branch_body, fallback_body));
-	} else if (after.length > 0) {
-		transform_context.needs_show = true;
-		const show_body = body_to_component_early_return_jsx_child(after, transform_context);
-		children.push(build_show_element(negate_expression(early_if.test), show_body, null));
-	}
-
-	return body_to_jsx_child(children, transform_context);
 }
 
 /**
@@ -1622,11 +1439,62 @@ function lower_solid_component_statement_list(statements) {
 }
 
 /**
+ * Detects a `throw` reachable as a plain statement inside this control-flow node
+ * — through `if`/`switch`/`try`/block structure but not into nested functions,
+ * JSX, or expressions. This is what the lowering treats as a render-affecting
+ * terminal, so such control flow stays reactive even when written as plain JS.
+ * @param {any} node
+ * @returns {boolean}
+ */
+function control_flow_has_render_throw(node) {
+	if (!node || typeof node !== 'object') {
+		return false;
+	}
+	switch (node.type) {
+		case 'ThrowStatement':
+			return true;
+		case 'BlockStatement':
+			return (node.body || []).some(control_flow_has_render_throw);
+		case 'IfStatement':
+			return (
+				control_flow_has_render_throw(node.consequent) ||
+				control_flow_has_render_throw(node.alternate)
+			);
+		case 'SwitchStatement':
+			return (node.cases || []).some((/** @type {any} */ switch_case) =>
+				(switch_case.consequent || []).some(control_flow_has_render_throw),
+			);
+		case 'TryStatement':
+			return (
+				control_flow_has_render_throw(node.block) ||
+				control_flow_has_render_throw(node.handler?.body) ||
+				control_flow_has_render_throw(node.finalizer) ||
+				control_flow_has_render_throw(node.pending)
+			);
+		default:
+			return false;
+	}
+}
+
+/**
  * @param {any} statement
  * @param {any[]} rest
  * @returns {{ node: any, terminal: boolean, consumesRest?: boolean } | null}
  */
 function lower_solid_component_control_statement(statement, rest) {
+	// A plain guard that *returns* JSX is ordinary JavaScript and must behave
+	// exactly like control flow in a regular `function C() { …; return <jsx> }` —
+	// setup-once, not lifted into a reactive `<Show>`. So plain control flow is
+	// left untouched. The exceptions, which still lower into Solid's reactive
+	// render forms, are:
+	//   - `@`-directives (`@if`/`@for`/`@switch`/`@try`), which carry
+	//     `statementType` / `tsrxDirective` (see `is_template_*_node`); and
+	//   - control flow that `throw`s, so a `@try` boundary keeps re-catching when
+	//     the throwing condition changes (a setup-once throw could never re-fire).
+	if (!is_solid_render_control(statement) && !control_flow_has_render_throw(statement)) {
+		return null;
+	}
+
 	if (statement?.type === 'IfStatement') {
 		return lower_solid_component_if_statement(statement, rest);
 	}
@@ -1932,29 +1800,6 @@ function solid_component_body_nodes_to_function_statements(body_nodes, transform
 	}
 
 	return statements;
-}
-
-/**
- * @param {any} node
- * @returns {{ consequent_body: any[], return_index: number } | null}
- */
-function get_component_returning_if_info(node) {
-	if (!node || node.type !== 'IfStatement' || node.alternate) return null;
-	const consequent_body = get_statement_body(node.consequent);
-	const return_index = consequent_body.findIndex((child) =>
-		return_statement_to_render_nodes(child),
-	);
-	if (return_index === -1) {
-		return null;
-	}
-
-	return {
-		consequent_body: [
-			...consequent_body.slice(0, return_index),
-			.../** @type {any[]} */ (return_statement_to_render_nodes(consequent_body[return_index])),
-		],
-		return_index,
-	};
 }
 
 /**

--- a/packages/tsrx-solid/tests/basic.test.js
+++ b/packages/tsrx-solid/tests/basic.test.js
@@ -440,7 +440,10 @@ describe('@tsrx/solid basic', () => {
 			expect(code).not.toContain('if (cond)');
 		});
 
-		it('component-body plain if return uses trailing render output as <Show> fallback', () => {
+		it('component-body plain if return stays ordinary JS (no reactive <Show>)', () => {
+			// A plain JS `if` guard is not a `@if` directive, so it must compile to
+			// ordinary control flow returning JSX — identical to the same guard in a
+			// regular `function C() { … }` body. Only `@`-directives lower to <Show>.
 			const { code } = compile(
 				`function StatusBadge(props) @{
 					if (props.disabled) {
@@ -452,10 +455,11 @@ describe('@tsrx/solid basic', () => {
 				'StatusBadge.tsrx',
 			);
 
-			expect(code).toContain("import { Show } from 'solid-js'");
-			expect(code).toContain('<Show when={props.disabled} fallback={StatusBadge__static2}>');
-			expect(code).toContain('{StatusBadge__static1}</Show>');
-			expect(code).not.toContain('<>{StatusBadge__static2}<Show');
+			expect(code).toContain('if (props.disabled)');
+			expect(code).toContain('return StatusBadge__static1;');
+			expect(code).toContain('return StatusBadge__static2;');
+			expect(code).not.toContain('<Show');
+			expect(code).not.toContain("import { Show } from 'solid-js'");
 		});
 
 		it('preserves ordinary control flow for plain functions returning templates', () => {

--- a/packages/tsrx/src/index.js
+++ b/packages/tsrx/src/index.js
@@ -164,6 +164,10 @@ export {
 	in_jsx_child_context as inJsxChildContext,
 	tsx_node_to_jsx_expression as tsxNodeToJsxExpression,
 	tsx_with_ts_locations as tsxWithTsLocations,
+	is_template_if_node as isTemplateIfNode,
+	is_template_for_of_node as isTemplateForOfNode,
+	is_template_switch_node as isTemplateSwitchNode,
+	is_template_try_node as isTemplateTryNode,
 } from './transform/jsx/helpers.js';
 export {
 	collect_style_ref_attributes as collectStyleRefAttributes,

--- a/packages/tsrx/src/plugin.js
+++ b/packages/tsrx/src/plugin.js
@@ -3650,15 +3650,17 @@ export function TSRXPlugin(config) {
 			}
 
 			/**
-			 * `@try`/`@pending`/`@catch` blocks lower their direct `return`
-			 * values into reactive boundary fallbacks, so unlike `@if`/`@for`/`@switch`
-			 * blocks they legitimately allow `return <markup>` statements. Set the flag
-			 * immediately before parsing each such block so its body sees it.
+			 * `@try`/`@pending`/`@catch` blocks are template control-flow blocks like
+			 * `@if`/`@for`/`@switch`: `return` is not allowed inside them. A `return`
+			 * is only valid in the JS setup at the top of a `@{ … }` code block, never
+			 * inside a `@`-directive block. Report any direct `return` with the same
+			 * template-return diagnostic used elsewhere.
 			 * @returns {AST.BlockStatement}
 			 */
 			#parseTemplateControlFlowReturnBlock(createNewLexicalScope = true) {
-				this.#controlFlowBlockAllowsNativeReturn = true;
-				return this.#parseTemplateControlFlowBlock(createNewLexicalScope);
+				const block = this.#parseTemplateControlFlowBlock(createNewLexicalScope);
+				this.#report_invalid_template_return_statements(block.body);
+				return block;
 			}
 
 			/**

--- a/packages/tsrx/src/transform/jsx/helpers.js
+++ b/packages/tsrx/src/transform/jsx/helpers.js
@@ -260,3 +260,51 @@ export function tsx_with_ts_locations() {
 
 	return { ...base, ...wrappers };
 }
+
+/**
+ * @param {any} node
+ * @returns {boolean}
+ */
+export function is_template_if_node(node) {
+	return (
+		node?.type === 'JSXIfExpression' ||
+		node?.metadata?.tsrxDirective === 'if' ||
+		(node?.type === 'IfStatement' && node?.statementType === 'IfStatement')
+	);
+}
+
+/**
+ * @param {any} node
+ * @returns {boolean}
+ */
+export function is_template_for_of_node(node) {
+	return (
+		node?.type === 'JSXForExpression' ||
+		node?.metadata?.tsrxDirective === 'for' ||
+		(node?.type === 'ForOfStatement' && node?.statementType === 'ForOfStatement')
+	);
+}
+
+/**
+ * @param {any} node
+ * @returns {boolean}
+ */
+export function is_template_switch_node(node) {
+	return (
+		node?.type === 'JSXSwitchExpression' ||
+		node?.metadata?.tsrxDirective === 'switch' ||
+		(node?.type === 'SwitchStatement' && node?.statementType === 'SwitchStatement')
+	);
+}
+
+/**
+ * @param {any} node
+ * @returns {boolean}
+ */
+export function is_template_try_node(node) {
+	return (
+		node?.type === 'JSXTryExpression' ||
+		node?.metadata?.tsrxDirective === 'try' ||
+		(node?.type === 'TryStatement' && node?.statementType === 'TryStatement')
+	);
+}

--- a/packages/tsrx/src/transform/jsx/index.js
+++ b/packages/tsrx/src/transform/jsx/index.js
@@ -10,8 +10,11 @@ import { prune_css } from '../../analyze/prune.js';
 import {
 	in_jsx_child_context,
 	set_node_path_metadata,
-	tsx_node_to_jsx_expression,
 	tsx_with_ts_locations,
+	is_template_if_node,
+	is_template_for_of_node,
+	is_template_switch_node,
+	is_template_try_node,
 } from './helpers.js';
 import {
 	add_extra_source_mappings_from_matching_expression,
@@ -4483,54 +4486,6 @@ function validate_if_body_control_flow(node, transform_context) {
 		}
 		validate_if_body_control_flow(node[key], transform_context);
 	}
-}
-
-/**
- * @param {any} node
- * @returns {boolean}
- */
-function is_template_if_node(node) {
-	return (
-		node?.type === 'JSXIfExpression' ||
-		node?.metadata?.tsrxDirective === 'if' ||
-		(node?.type === 'IfStatement' && node?.statementType === 'IfStatement')
-	);
-}
-
-/**
- * @param {any} node
- * @returns {boolean}
- */
-function is_template_for_of_node(node) {
-	return (
-		node?.type === 'JSXForExpression' ||
-		node?.metadata?.tsrxDirective === 'for' ||
-		(node?.type === 'ForOfStatement' && node?.statementType === 'ForOfStatement')
-	);
-}
-
-/**
- * @param {any} node
- * @returns {boolean}
- */
-function is_template_switch_node(node) {
-	return (
-		node?.type === 'JSXSwitchExpression' ||
-		node?.metadata?.tsrxDirective === 'switch' ||
-		(node?.type === 'SwitchStatement' && node?.statementType === 'SwitchStatement')
-	);
-}
-
-/**
- * @param {any} node
- * @returns {boolean}
- */
-function is_template_try_node(node) {
-	return (
-		node?.type === 'JSXTryExpression' ||
-		node?.metadata?.tsrxDirective === 'try' ||
-		(node?.type === 'TryStatement' && node?.statementType === 'TryStatement')
-	);
 }
 
 /**

--- a/packages/tsrx/tests/shared/compile.js
+++ b/packages/tsrx/tests/shared/compile.js
@@ -245,6 +245,62 @@ export function runSharedCompileDiagnosticsTests({ compile_to_volar_mappings, na
 			}
 		});
 
+		it('rejects return statements inside @try/@catch/@pending blocks', () => {
+			for (const source of [
+				`function Test() @{
+					@try {
+						return <div>{'ok'}</div>;
+					} @catch (e) {
+						<div>{'err'}</div>
+					}
+				}`,
+				`function Test() @{
+					@try {
+						<div>{'ok'}</div>
+					} @catch (e) {
+						return <div>{'err'}</div>;
+					}
+				}`,
+				`function Test() @{
+					@try {
+						<div>{'ok'}</div>
+					} @pending {
+						return <div>{'loading'}</div>;
+					} @catch (e) {
+						<div>{'err'}</div>
+					}
+				}`,
+				`function Test() @{
+					@try {
+						return;
+					} @catch (e) {
+						<div>{'err'}</div>
+					}
+				}`,
+			]) {
+				const result = compile_to_volar_mappings(source, 'App.tsrx');
+
+				expect(result.errors.map((error) => error.message)).toContain(TSRX_TEMPLATE_RETURN_ERROR);
+			}
+		});
+
+		it('allows @try/@catch/@pending blocks without return statements', () => {
+			const result = compile_to_volar_mappings(
+				`function Test() @{
+					@try {
+						<div>{'ok'}</div>
+					} @pending {
+						<div>{'loading'}</div>
+					} @catch (e) {
+						<div>{'err'}</div>
+					}
+				}`,
+				'App.tsrx',
+			);
+
+			expect(result.errors).toEqual([]);
+		});
+
 		it('allows return statements inside nested ordinary functions in statement containers', () => {
 			const result = compile_to_volar_mappings(
 				`function Test() @{

--- a/packages/vite-plugin-solid/tests/runtime.test.tsrx
+++ b/packages/vite-plugin-solid/tests/runtime.test.tsrx
@@ -1263,14 +1263,18 @@ describe('tsrx-solid runtime', () => {
 		expect(text('.page')).toBe('404');
 	});
 
-	it('renders trailing component output for guard return cases', async () => {
+	it('evaluates a plain guard return once at setup (non-reactive)', async () => {
 		await render(GuardTrailingReturnApp);
 		expect(text('.guard-rest')).toBe('rest');
 		expect(container.querySelector('.guard-result')).toBeNull();
 
+		// `if (kind() === 'done') return …` is plain JS that runs once during
+		// component setup, exactly like any Solid component body. Flipping the
+		// signal does not re-run the guard, so the trailing output stays put.
+		// Reactive conditional rendering is done with `@if`.
 		await click('.guard-done');
-		expect(text('.guard-result')).toBe('done');
-		expect(container.querySelector('.guard-rest')).toBeNull();
+		expect(text('.guard-rest')).toBe('rest');
+		expect(container.querySelector('.guard-result')).toBeNull();
 	});
 
 	// ── Composite children ──
@@ -1491,19 +1495,25 @@ describe('tsrx-solid runtime', () => {
 		expect(text('.scope-result')).toBe('18');
 	});
 
-	it('component guard return before signals updates reactively', async () => {
-		await render(GuardReturnWithSignalsApp);
-		expect(text('.early-count')).toBe('0');
-		expect(text('.early-doubled')).toBe('0');
+	it(
+		'keeps reactive expressions after a plain guard return, but the guard is setup-once',
+		async () => {
+			await render(GuardReturnWithSignalsApp);
+			expect(text('.early-count')).toBe('0');
+			expect(text('.early-doubled')).toBe('0');
 
-		await click('.early-inc');
-		expect(text('.early-count')).toBe('1');
-		expect(text('.early-doubled')).toBe('2');
+			// Reactive JSX expressions in the trailing output still update...
+			await click('.early-inc');
+			expect(text('.early-count')).toBe('1');
+			expect(text('.early-doubled')).toBe('2');
 
-		await click('.early-skip');
-		expect(container.querySelector('.early-count')).toBeNull();
-		expect(container.querySelector('.early-doubled')).toBeNull();
-	});
+			// ...but `if (skip()) return null` ran once at setup, so flipping `skip`
+			// does not unmount the early output.
+			await click('.early-skip');
+			expect(text('.early-count')).toBe('1');
+			expect(text('.early-doubled')).toBe('2');
+		},
+	);
 
 	it('conditional branch template updates reactively', async () => {
 		await render(ConditionalBranchTemplateApp);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> This is a breaking semantic change for anyone relying on reactive plain-`if` guards or `return` inside `@try` blocks; compiler output and Solid/Ripple runtime behavior shift in core template lowering paths.
> 
> **Overview**
> **Aligns template semantics** so only `@if` / `@for` / `@switch` / `@try` lower to template control flow; plain `if` / loops / `switch` / `try` in `@{ … }` compile like normal function bodies (JSX `return` → `tsrx_element`), and **`return` inside `@try` / `@catch` / `@pending` is rejected** with the same template-return diagnostic as other `@`-blocks.
> 
> On **Ripple**, the compiler drops **`return_guard`** and related `_$_.if` wrapping: early `return` is a real early return, so trailing markup is skipped without guard flags (client/server snapshots updated). Analysis no longer errors on plain loops; **`break` / `continue` / return rules** apply only when the enclosing loop is a `@for` (`metadata.tsrxDirective === 'for'`).
> 
> On **Solid**, plain guards like `if (signal()) return …` are **no longer lifted to `<Show>`**—they run once at setup; reactive conditionals require `@if`. `@`-directives and control flow that can **`throw`** still lower reactively. Shared **`isTemplate*Node`** helpers move to `@tsrx/core` for consistent directive detection.
> 
> Tests and runtime expectations are updated for the new guard behavior (e.g. Vite Solid: flipping a signal after a plain guard does not swap branches).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c7cd936f450741434a5540920f0379e38893d2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->