### PR TITLE
feat: add snapshot non-reactive shallow copy for RippleArray and RippleObject

### DIFF
--- a/packages/ripple/src/runtime/index-client.js
+++ b/packages/ripple/src/runtime/index-client.js
@@ -178,6 +178,8 @@ export {
 	peek_tracked as peek,
 } from './internal/client/runtime.js';
 
+export { snapshot } from './proxy.js';
+
 export { RippleArray } from './array.js';
 
 export { RippleObject } from './object.js';

--- a/packages/ripple/src/runtime/index-server.js
+++ b/packages/ripple/src/runtime/index-server.js
@@ -17,6 +17,19 @@ export {
 } from './internal/client/constants.js';
 export { isRefProp } from '@tsrx/core/runtime/ref';
 
+/**
+ * Server values are never proxied, so a snapshot is just a shallow copy.
+ * @template {Iterable<unknown> | object} T
+ * @param {T} value
+ * @returns {T}
+ */
+export function snapshot(value) {
+	if (typeof value !== 'object' || value === null) {
+		return value;
+	}
+	return /** @type {T} */ (Array.isArray(value) ? [...value] : { ...value });
+}
+
 export const effect = noop;
 export const createRefKey = noop;
 export const on = noop;

--- a/packages/ripple/src/runtime/proxy.js
+++ b/packages/ripple/src/runtime/proxy.js
@@ -1,7 +1,7 @@
 /** @import { Block, Tracked } from '#client' */
 /** @import { RippleArray, RippleObject } from '#public' */
 
-import { get, set, tracked } from './internal/client/runtime.js';
+import { get, set, tracked, untrack } from './internal/client/runtime.js';
 import {
 	array_prototype,
 	get_descriptor,
@@ -15,6 +15,22 @@ import {
 	TRACKED_OBJECT,
 	UNINITIALIZED,
 } from './internal/client/constants.js';
+
+/**
+ * Returns a shallow, detached plain copy of a reactive array or object.
+ * Values are read without registering any reactivity.
+ *
+ * @template {Iterable<unknown> | object} T
+ * @param {T} value
+ * @returns {T}
+ */
+export function snapshot(value) {
+	if (typeof value !== 'object' || value === null) {
+		return value;
+	}
+
+	return untrack(() => /** @type {T} */ (is_array(value) ? [...value] : { ...value }));
+}
 
 /**
  * @template T

--- a/packages/ripple/tests/client/object.test.tsrx
+++ b/packages/ripple/tests/client/object.test.tsrx
@@ -1,4 +1,4 @@
-import { RippleObject, flushSync } from 'ripple';
+import { RippleObject, effect, flushSync, snapshot } from 'ripple';
 import { TRACKED_OBJECT } from '../../src/runtime/internal/client/constants.js';
 
 describe('RippleObject', () => {
@@ -193,5 +193,51 @@ describe('RippleObject', () => {
 
 		expect(pre1.textContent).toBe('1');
 		expect(pre3.textContent).toBe('{"a":1,"b":1,"c":{"d":{"e":8}}}');
+	});
+
+	it('snapshot() returns a detached plain copy of current values', () => {
+		let snap: any;
+
+		function ObjectTest() @{
+			const obj = new RippleObject({ a: 1, b: 2 });
+			obj.a = 10;
+			snap = snapshot(obj);
+			// a later mutation must not affect the snapshot
+			obj.a = 99;
+			<div />
+		}
+
+		render(ObjectTest);
+
+		expect(snap).toEqual({ a: 10, b: 2 });
+		// detached: a plain object, not a proxy
+		expect(TRACKED_OBJECT in snap).toBe(false);
+		expect(snap.a).toBe(10);
+	});
+
+	it('snapshot() reads without registering reactivity', () => {
+		let runs = 0;
+
+		function ObjectTest() @{
+			const obj = new RippleObject({ a: 0 });
+			effect(() => {
+				snapshot(obj);
+				runs++;
+			});
+			<button
+				onClick={() => {
+					obj.a++;
+				}}
+			>{'Increment A'}</button>
+		}
+
+		render(ObjectTest);
+		flushSync();
+		expect(runs).toBe(1);
+
+		container.querySelectorAll('button')[0].click();
+		flushSync();
+		// snapshot did not subscribe, so the effect must not re-run
+		expect(runs).toBe(1);
 	});
 });

--- a/packages/ripple/types/index.d.ts
+++ b/packages/ripple/types/index.d.ts
@@ -69,6 +69,8 @@ export function tick(): Promise<void>;
 
 export function untrack<T>(fn: () => T): T;
 
+export function snapshot<T extends Iterable<unknown> | object>(value: T): T;
+
 export function flushSync<T>(fn?: () => T): T;
 
 export function effect(fn: (() => void) | (() => () => void)): void;

--- a/website-new/docs/guide/reactivity.md
+++ b/website-new/docs/guide/reactivity.md
@@ -390,6 +390,37 @@ export function App() @{
 
 </Code>
 
+## Snapshotting State
+
+Sometimes you need the current data behind a reactive array or object as plain,
+non-reactive data — for example to log it, serialize it, send it over the network,
+or hand it to non-Ripple code. Use `snapshot` to take a detached shallow copy.
+
+The values are read _without_ subscribing, so calling `snapshot` inside an effect
+or derived will not create a dependency. The result is a plain array or object
+(not a Ripple proxy), so later mutations to the source don't affect it. The copy
+is shallow: nested values are shared by reference, which matches Ripple's shallow
+reactivity.
+
+<Code console>
+
+```tsrx
+import { RippleObject, effect, snapshot } from 'ripple';
+
+export function App() @{
+  const settings = new RippleObject({ theme: 'dark', fontSize: 14 });
+
+  effect(() => {
+    // Reads the current values without subscribing — this effect runs once.
+    console.log(snapshot(settings));
+  });
+
+  <button onClick={() => settings.fontSize++}>{'Bigger'}</button>
+}
+```
+
+</Code>
+
 ## Reactive Collection Primitives
 
 Because Ripple isn't based on Signals, there is no mechanism with which we can

--- a/website-new/public/llms.txt
+++ b/website-new/public/llms.txt
@@ -153,6 +153,21 @@ export function Counter() @{
 Use `untrack(fn)` when an effect or derived value needs to read something without
 subscribing to it.
 
+Use `snapshot(value)` to take a plain, detached shallow copy of a reactive array
+or object. Values are read without subscribing, so it is safe to call inside an
+effect or derived. The copy is a plain array or object (not a proxy); nested
+values are shared by reference.
+
+```tsrx
+import { RippleObject, snapshot } from 'ripple';
+
+export function Settings() @{
+	const settings = new RippleObject({ theme: 'dark', fontSize: 14 });
+
+	<button onClick={() => console.log(snapshot(settings))}>{'Log settings'}</button>
+}
+```
+
 ## Reactive Collections
 
 Use Ripple collection classes when collection operations should update rendered

--- a/website/docs/guide/reactivity.md
+++ b/website/docs/guide/reactivity.md
@@ -390,6 +390,37 @@ export function App() @{
 
 </Code>
 
+## Snapshotting State
+
+Sometimes you need the current data behind a reactive array or object as plain,
+non-reactive data — for example to log it, serialize it, send it over the network,
+or hand it to non-Ripple code. Use `snapshot` to take a detached shallow copy.
+
+The values are read _without_ subscribing, so calling `snapshot` inside an effect
+or derived will not create a dependency. The result is a plain array or object
+(not a Ripple proxy), so later mutations to the source don't affect it. The copy
+is shallow: nested values are shared by reference, which matches Ripple's shallow
+reactivity.
+
+<Code console>
+
+```tsrx
+import { RippleObject, effect, snapshot } from 'ripple';
+
+export function App() @{
+  const settings = new RippleObject({ theme: 'dark', fontSize: 14 });
+
+  effect(() => {
+    // Reads the current values without subscribing — this effect runs once.
+    console.log(snapshot(settings));
+  });
+
+  <button onClick={() => settings.fontSize++}>{'Bigger'}</button>
+}
+```
+
+</Code>
+
 ## Reactive Collection Primitives
 
 Because Ripple isn't based on Signals, there is no mechanism with which we can

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -153,6 +153,21 @@ export function Counter() @{
 Use `untrack(fn)` when an effect or derived value needs to read something without
 subscribing to it.
 
+Use `snapshot(value)` to take a plain, detached shallow copy of a reactive array
+or object. Values are read without subscribing, so it is safe to call inside an
+effect or derived. The copy is a plain array or object (not a proxy); nested
+values are shared by reference.
+
+```tsrx
+import { RippleObject, snapshot } from 'ripple';
+
+export function Settings() @{
+	const settings = new RippleObject({ theme: 'dark', fontSize: 14 });
+
+	<button onClick={() => console.log(snapshot(settings))}>{'Log settings'}</button>
+}
+```
+
 ## Reactive Collections
 
 Use Ripple collection classes when collection operations should update rendered


### PR DESCRIPTION
closes #1208 

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Additive public API with focused runtime logic and tests; no changes to proxy tracking behavior beyond the new helper.
> 
> **Overview**
> Adds a public **`snapshot`** API so **`RippleArray`** / **`RippleObject`** (and plain objects/arrays) can be read as **detached, shallow plain data** for logging, serialization, or non-Ripple consumers.
> 
> On the **client**, `snapshot` in `proxy.js` wraps a shallow spread in **`untrack`**, so reads do not subscribe—safe inside effects/derived values. The result is a normal array/object (not a proxy); later source mutations do not change the copy. **Nested values stay shared by reference** (shallow semantics).
> 
> **Server** runtime exposes the same name with a simple shallow copy (no proxies). **`snapshot`** is re-exported from client/server entry points, typed in `index.d.ts`, covered by **`RippleObject`** tests (detachment + no reactive subscription), and documented in reactivity guides and `llms.txt`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d31cef7c41b1b4e12067a0b41cee8dc60033ea1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->