### PR TITLE
fix(parser): white space handling

### DIFF
--- a/.changeset/lazy-fragments-mingle.md
+++ b/.changeset/lazy-fragments-mingle.md
@@ -1,0 +1,12 @@
+---
+'@tsrx/core': patch
+---
+
+Fix parsing of sibling fragments/elements separated by template text. A `<>` or
+`<tag>` opening that follows template text (e.g. `<> <></> 2 <></> </>`) arrives
+as a relational `<` token; the JSX re-entry fallback now pushes the same
+tokenizer contexts a real `jsxTagStart` would, so the terminating `>` — including
+the lone `>` of a nameless fragment — is read as `jsxTagEnd` instead of a
+relational operator. Also preserve an inline space that separates two sibling
+elements on the same line (`<> <></>  <></>x </>`) as significant JSX text;
+only layout whitespace spanning a newline is still collapsed.

--- a/.changeset/wise-fragments-whisper.md
+++ b/.changeset/wise-fragments-whisper.md
@@ -1,0 +1,28 @@
+---
+'@tsrx/core': patch
+'@tsrx/ripple': patch
+---
+
+Preserve significant whitespace and keep fragments faithful in TSRX template
+output.
+
+- Parser: a sibling after a closing tag (`<b>1</b> 2`, `<> <>x</> y <>z</> </>`)
+  now reads as JSX text at the source, so significant inline whitespace is kept
+  instead of being eaten by `skipSpace`. This fixes the leading space being
+  dropped (`" 2 "` not `"2 "`) and removes several closing-tag whitespace/context
+  workarounds.
+- Transform: a single-text fragment used as a JSX child stays a fragment
+  (`<>123</>` instead of `{'123'}`), and an empty fragment child stays `<></>`
+  instead of `{null}`. Expression/return-position single-text fragments still
+  lower to a string (`return <>x</>` -> `return "x"`). Whitespace at a
+  fragment/element's content edges is wrapped in a `{' '}` container so it survives
+  formatting/JSX collapsing; whitespace between siblings stays bare
+  (`<b/> <i/>`). The edge rule is shared (`wrapEdgeWhitespace`) across the
+  React/Preact/Solid transforms and the Ripple to_ts view.
+- Ripple target: whitespace-only text that is a significant inline space is kept
+  rather than dropped, so edge and inter-element spaces survive in client
+  templates and SSR output. The to_ts / Volar type-checking view now matches the
+  JSX targets — literal text stays bare (not `{"123"}`), single-text fragments
+  stay `<>123</>`, empty fragments stay `<></>` (not `{null}`), `{a}` expression
+  containers are preserved for type visibility, and edge whitespace prints as
+  single-quote `{' '}`.

--- a/packages/tsrx-ripple/src/transform/client/index.js
+++ b/packages/tsrx-ripple/src/transform/client/index.js
@@ -54,6 +54,7 @@ import {
 	formatComment,
 	setLocation,
 	createElementRefTargetTypeForName as create_element_ref_target_type_for_name,
+	wrapEdgeWhitespace as wrap_edge_whitespace,
 } from '@tsrx/core';
 const b = builders;
 import {
@@ -3619,6 +3620,7 @@ function join_template(items) {
  * @typedef {AST.Statement | ESTreeJSX.JSXElement | ESTreeJSX.JSXFragment} TsrxTsStatement
  * @typedef {AST.Expression | ESTreeJSX.JSXElement | ESTreeJSX.JSXFragment} TsrxTsExpression
  * @typedef {ESTreeJSX.JSXElement['children'][number]} TsrxTsxChild
+ * @typedef {TsrxTsExpression | ESTreeJSX.JSXText | ESTreeJSX.JSXExpressionContainer} TsrxTsViewNode
  */
 
 /**
@@ -3637,24 +3639,28 @@ function statement_to_tsrx_ts_expression(statement) {
 }
 
 /**
- * @param {TsrxTsExpression[]} children
- * @returns {TsrxTsExpression}
+ * @param {TsrxTsxChild[]} children
+ * @param {boolean} in_jsx_child
+ * @param {AST.NodeWithLocation} loc_node
+ * @returns {TsrxTsViewNode}
  */
-function build_tsrx_ts_return_expression(children) {
-	return children.length === 0
-		? b.literal(null)
-		: children.length === 1
-			? children[0]
-			: b.jsx_fragment(
-					// A plain expression placed directly as a JSX child reads as JSX text
-					// in the TS view (`<>{a}{b}</>` would become `<>ab</>`), so it needs
-					// an expression container to stay visible to TypeScript.
-					children.map((child) =>
-						child.type === 'JSXElement' || child.type === 'JSXFragment'
-							? child
-							: b.jsx_expression_container(child),
-					),
-				);
+function build_tsrx_ts_return_expression(children, in_jsx_child, loc_node) {
+	if (children.length === 0) {
+		return in_jsx_child ? setLocation(b.jsx_fragment([]), loc_node) : b.literal(null);
+	}
+	if (children.length === 1) {
+		const only = children[0];
+		if (only.type === 'JSXText') {
+			return in_jsx_child
+				? setLocation(b.jsx_fragment([only]), /** @type {AST.NodeWithLocation} */ (only))
+				: b.literal(only.value);
+		}
+		if (only.type === 'JSXExpressionContainer' && !in_jsx_child) {
+			return only.expression;
+		}
+		return /** @type {TsrxTsViewNode} */ (only);
+	}
+	return b.jsx_fragment(children);
 }
 
 /**
@@ -3680,79 +3686,21 @@ function transform_tsrx_ts_children(children, context) {
 }
 
 /**
- * @param {TsrxTsStatement[]} statements
- * @param {AST.TsrxFragment} loc_node
- * @param {TransformClientState} state
- * @returns {TsrxTsExpression}
- */
-function build_tsrx_ts_expression_from_statements(statements, loc_node, state) {
-	const inline_children = statements.map(statement_to_tsrx_ts_expression);
-
-	if (inline_children.every(Boolean)) {
-		return build_tsrx_ts_return_expression(/** @type {TsrxTsExpression[]} */ (inline_children));
-	}
-
-	/** @type {AST.Statement[]} */
-	const body = [];
-	const has_children = inline_children.some(Boolean);
-	const children_id = has_children ? state.scope.generate('children') : null;
-	if (children_id !== null) {
-		body.push(
-			b.const(
-				b.id(children_id),
-				b.ts_as(
-					b.array([]),
-					b.ts_type_reference(
-						b.id('Array'),
-						b.ts_type_parameter_instantiation([b.ts_keyword_type('any')]),
-					),
-				),
-			),
-		);
-	}
-	for (const statement of statements) {
-		const child = statement_to_tsrx_ts_expression(statement);
-		if (child) {
-			if (children_id !== null) {
-				body.push(
-					b.stmt(
-						b.call(b.member(b.id(children_id), 'push'), /** @type {AST.Expression} */ (child)),
-					),
-				);
-			}
-		} else {
-			body.push(/** @type {AST.Statement} */ (statement));
-		}
-	}
-
-	body.push(
-		b.return(
-			children_id === null
-				? b.literal(null)
-				: /** @type {AST.Expression} */ (
-						b.jsx_fragment([b.jsx_expression_container(b.id(children_id))])
-					),
-			/** @type {AST.NodeWithLocation} */ (loc_node),
-		),
-	);
-
-	return b.call(b.arrow([], b.block(body)));
-}
-
-/**
  * Builds a TSX expression for Volar/TypeScript output. Pure template children can
  * remain inline JSX; fragments with setup statements need an IIFE so declarations
  * stay in statement position.
  *
  * @param {AST.TsrxFragment} node
  * @param {VisitorClientContext} context
- * @returns {TsrxTsExpression}
+ * @param {boolean} [in_jsx_child]
+ * @returns {TsrxTsViewNode}
  */
-function build_tsrx_to_ts_expression(node, context) {
-	return build_tsrx_ts_expression_from_statements(
-		transform_tsrx_ts_children(/** @type {AST.Node[]} */ (node.children), context),
-		node,
-		context.state,
+function build_tsrx_to_ts_expression(node, context, in_jsx_child = false) {
+	const children = transform_tsrx_tsx_children(/** @type {AST.Node[]} */ (node.children), context);
+	return build_tsrx_ts_return_expression(
+		children,
+		in_jsx_child,
+		/** @type {AST.NodeWithLocation} */ (/** @type {unknown} */ (node)),
 	);
 }
 
@@ -3821,7 +3769,7 @@ function transform_tsrx_tsx_children(children, context) {
 	}
 
 	flush_pending_statement_children();
-	return transformed_children;
+	return /** @type {TsrxTsxChild[]} */ (wrap_edge_whitespace(transformed_children));
 }
 
 /**
@@ -3858,11 +3806,19 @@ function transform_tsrx_tsx_child(node, context) {
 	}
 
 	if (node.type === 'TsrxFragment') {
-		const expression = build_tsrx_to_ts_expression(node, context);
-		if (expression.type === 'JSXElement' || expression.type === 'JSXFragment') {
-			return /** @type {TsrxTsxChild} */ (expression);
+		// `in_jsx_child` mode already returns a valid JSX child (a fragment, or a
+		// `{expr}` container kept for type visibility), so use it as-is. Only a bare
+		// expression (which can happen in other positions) needs wrapping.
+		const expression = build_tsrx_to_ts_expression(node, context, true);
+		if (
+			expression.type === 'JSXElement' ||
+			expression.type === 'JSXFragment' ||
+			expression.type === 'JSXExpressionContainer' ||
+			expression.type === 'JSXText'
+		) {
+			return expression;
 		}
-		return b.jsx_expression_container(/** @type {AST.Expression} */ (expression));
+		return b.jsx_expression_container(expression);
 	}
 
 	return undefined;

--- a/packages/tsrx-ripple/src/utils.js
+++ b/packages/tsrx-ripple/src/utils.js
@@ -3021,20 +3021,12 @@ export function jsx_to_ripple_node(node, inherited_path = []) {
 
 	if (node.type === 'JSXText') {
 		const value = normalize_jsx_text_value(node.value);
-		if (value.trim() === '') return null;
-		return /** @type {AST.Node} */ ({
-			type: 'Text',
-			expression: {
-				type: 'Literal',
-				value,
-				raw: JSON.stringify(value),
-				start: node.start,
-				end: node.end,
-			},
-			metadata: {},
-			start: node.start,
-			end: node.end,
-		});
+		if (value === '') {
+			return null;
+		}
+		return /** @type {AST.Node} */ (
+			b.text(value, /** @type {AST.NodeWithLocation} */ (/** @type {unknown} */ (node)))
+		);
 	}
 
 	if (node.type === 'JSXExpressionContainer') {

--- a/packages/tsrx-ripple/tests/jsx-runtime-types.test.js
+++ b/packages/tsrx-ripple/tests/jsx-runtime-types.test.js
@@ -119,9 +119,22 @@ function StatusBadge() @{
 `;
 		const { code } = compile_to_volar_mappings(source, 'App.tsrx', { loose: true });
 
-		// Bare expressions as fragment children would read as JSX text (`<>aa</>`),
-		// hiding both identifiers from TypeScript.
-		expect(code).toContain('<>{a}{a}</>');
+		expect(code).toContain("<>{a} {a}{' '}</>");
 		expect(code).not.toContain('<>aa</>');
+	});
+
+	it('matches the JSX targets for text, fragments and edge whitespace', () => {
+		const compile = (src) => compile_to_volar_mappings(src, 'App.tsrx', { loose: true }).code;
+
+		expect(compile('let a = <> <>123</> 2 <>123</> </>;')).toContain(
+			"let a = <>{' '}<>123</> 2 <>123</>{' '}</>;",
+		);
+		expect(compile('let b = <> <></> 2 <></> </>;')).toContain(
+			"let b = <>{' '}<></> 2 <></>{' '}</>;",
+		);
+		expect(compile('let c = <></>;')).toContain('let c = null;');
+		expect(compile('let d = <pre> <b>1</b> <b>2</b> </pre>;')).toContain(
+			"let d = <pre>{' '}<b>1</b> <b>2</b>{' '}</pre>;",
+		);
 	});
 });

--- a/packages/tsrx/src/index.js
+++ b/packages/tsrx/src/index.js
@@ -159,6 +159,7 @@ export {
 	rewrite_loop_continues_to_bare_returns as rewriteLoopContinuesToBareReturns,
 	to_jsx_attribute as toJsxAttribute,
 	validate_at_most_one_ref_attribute as validateAtMostOneRefAttribute,
+	wrap_edge_whitespace as wrapEdgeWhitespace,
 } from './transform/jsx/index.js';
 export {
 	in_jsx_child_context as inJsxChildContext,

--- a/packages/tsrx/src/plugin.js
+++ b/packages/tsrx/src/plugin.js
@@ -5,12 +5,7 @@
  */
 
 import * as acorn from 'acorn';
-import {
-	skipWhitespace,
-	isWhitespaceTextNode,
-	BINDING_TYPES,
-	DestructuringErrors,
-} from './parse/index.js';
+import { isWhitespaceTextNode, BINDING_TYPES, DestructuringErrors } from './parse/index.js';
 import { parse_style } from './parse/style.js';
 import { regex_newline_characters } from './utils/patterns.js';
 import { error } from './errors.js';
@@ -549,7 +544,6 @@ export function TSRXPlugin(config) {
 				while (index < this.input.length) {
 					if (this.#isTemplateLineCommentStart(index, start)) {
 						const comment_start = index;
-						const comment_start_loc = acorn.getLineInfo(this.input, comment_start);
 						index += 2;
 						while (
 							index < this.input.length &&
@@ -558,20 +552,9 @@ export function TSRXPlugin(config) {
 						) {
 							index++;
 						}
-						if (this.options.onComment && comment_start >= token_end) {
-							const comment_end_loc = acorn.getLineInfo(this.input, index);
-							// Pass null metadata so position-based attachment places the comment
-							// as a leading comment on the following child (which the JSX printers
-							// emit), rather than on the container's `elementLeadingComments`.
-							this.options.onComment(
-								false,
-								this.input.slice(comment_start + 2, index),
-								comment_start,
-								index,
-								new acorn.Position(comment_start_loc.line, comment_start_loc.column),
-								new acorn.Position(comment_end_loc.line, comment_end_loc.column),
-								/** @type {any} */ (null),
-							);
+
+						if (comment_start >= token_end) {
+							this.#emitTemplateLineComment(comment_start, index, null);
 						}
 						continue;
 					}
@@ -590,7 +573,7 @@ export function TSRXPlugin(config) {
 								index,
 								new acorn.Position(comment_start_loc.line, comment_start_loc.column),
 								new acorn.Position(comment_end_loc.line, comment_end_loc.column),
-								/** @type {any} */ (null),
+								null,
 							);
 						}
 						continue;
@@ -638,6 +621,62 @@ export function TSRXPlugin(config) {
 					return true;
 				}
 				return node.value !== '' && !regex_newline_characters.test(node.value);
+			}
+
+			#skipTrailingLayoutWhitespace() {
+				let index = this.start;
+				let has_newline = false;
+				while (index < this.input.length) {
+					const ch = this.input.charCodeAt(index);
+					if (ch === CharCode.lineFeed || ch === CharCode.carriageReturn) {
+						has_newline = true;
+						index++;
+					} else if (ch === CharCode.space || ch === CharCode.tab) {
+						index++;
+					} else if (ch === CharCode.slash && this.input.charCodeAt(index + 1) === CharCode.slash) {
+						const comment_start = index;
+						while (index < this.input.length && !this.#isNewlineCharCode(index)) {
+							index++;
+						}
+						this.#emitTemplateLineComment(comment_start, index, null);
+					} else {
+						break;
+					}
+				}
+				if (!has_newline) return;
+				const loc = acorn.getLineInfo(this.input, index);
+				this.start = index;
+				this.startLoc = new acorn.Position(loc.line, loc.column);
+				if (this.pos <= index) {
+					this.curLine = loc.line;
+					this.lineStart = index - loc.column;
+				}
+			}
+
+			/**
+			 * @param {number} index
+			 */
+			#isNewlineCharCode(index) {
+				const ch = this.input.charCodeAt(index);
+				return ch === CharCode.lineFeed || ch === CharCode.carriageReturn;
+			}
+
+			/**
+			 * @param {number} start
+			 * @param {number} end
+			 * @param {Parse.CommentMetaData | null} metadata
+			 */
+			#emitTemplateLineComment(start, end, metadata) {
+				if (!this.options.onComment) return;
+				this.options.onComment(
+					false,
+					this.input.slice(start + 2, end),
+					start,
+					end,
+					acorn.getLineInfo(this.input, start),
+					acorn.getLineInfo(this.input, end),
+					metadata,
+				);
 			}
 
 			#isSwitchCaseScriptStatementStart() {
@@ -4430,50 +4469,58 @@ export function TSRXPlugin(config) {
 						this.context.pop();
 					}
 					return;
-				} else if (
-					this.type === tstt.jsxTagStart ||
-					this.input.charCodeAt(this.start) === CharCode.lessThan
-				) {
+				} else if (this.type === tstt.jsxTagStart) {
 					const startPos = this.start;
 					const startLoc = this.startLoc;
-					if (this.type === tstt.jsxTagStart) {
-						this.next();
-					} else {
-						// A control-flow block inside a native template can leave the tokenizer
-						// in normal JS mode, so a closing tag may arrive as a relational
-						// `<` token. Re-enter JSX closing-tag parsing manually.
-						this.pos = startPos + 1;
-						this.type = tstt.jsxTagStart;
-						this.start = startPos;
-						this.startLoc = startLoc;
-						this.exprAllowed = false;
-						// A genuine `jsxTagStart` pushes `tc_expr` + `tc_oTag` in its
-						// `updateContext`; faking the token here skips those pushes. That is
-						// harmless for an opening tag (the next token is the tag name), but a
-						// closing tag (`</`) immediately runs `context.length -= 2` in the
-						// slash `updateContext`, which would underflow the context stack and
-						// throw "Invalid array length" (e.g. `<>@if (a) { … } done</>`). Push
-						// the two contexts a real `jsxTagStart` would have added so the closing
-						// tag pops its own contexts instead of the enclosing template's.
-						if (this.input.charCodeAt(this.pos) === CharCode.slash) {
-							this.context.push(tstc.tc_expr);
-							this.context.push(tstc.tc_oTag);
-						}
-						this.next();
-					}
+					this.next();
 					if (this.value === '/' || this.type === tt.slash) {
 						// Consume '/'
 						this.next();
 
-						let closingElement;
+						const closingNode = this.startNodeAt(startPos, startLoc);
+						const inside_parent_template =
+							this.#jsxExpressionContainerDepth === 0 &&
+							this.#templateScriptParsingDepth === 0 &&
+							this.#path.slice(0, -1).some((node) => this.#isNativeTemplateNode(node));
 						this.#closingNativeTemplateNode = true;
+						/** @type {ReturnType<Parse.Parser['jsx_parseElementName']>} */
+						let closingName;
 						try {
-							closingElement = /** @type {ESTreeJSX.JSXClosingElement & AST.NodeWithLocation} */ (
-								this.jsx_parseClosingElementAt(startPos, startLoc)
-							);
+							closingName = this.jsx_parseElementName();
 						} finally {
 							this.#closingNativeTemplateNode = false;
 						}
+						if (closingName) {
+							/** @type {ESTreeJSX.JSXClosingElement} */ (closingNode).name =
+								/** @type {ESTreeJSX.JSXIdentifier} */ (closingName);
+						}
+						const current = /** @type {ESTreeJSX.JSXFragment | ESTreeJSX.JSXElement} */ (
+							this.#path[this.#path.length - 1]
+						);
+						const current_name = this.#isNativeTemplateNode(current)
+							? current.type === 'JSXFragment'
+								? ''
+								: current.openingElement?.name
+									? this.getElementName(current.openingElement.name)
+									: null
+							: null;
+						const closing_name_str = !closingName
+							? ''
+							: closingName.type === 'JSXNamespacedName'
+								? closingName.namespace.name + ':' + closingName.name.name
+								: this.getElementName(closingName);
+						if (!(inside_parent_template && current_name === closing_name_str)) {
+							this.#closingNativeTemplateNode = true;
+						}
+						this.expect(tstt.jsxTagEnd);
+						this.#closingNativeTemplateNode = false;
+						const closingElement =
+							/** @type {ESTreeJSX.JSXClosingElement & AST.NodeWithLocation} */ (
+								this.finishNode(
+									closingNode,
+									closingName ? 'JSXClosingElement' : 'JSXClosingFragment',
+								)
+							);
 						if (this.#isDynamicJSXElementName(closingElement.name)) {
 							/** @type {any} */ (closingElement).isDynamic = true;
 						}
@@ -4586,7 +4633,7 @@ export function TSRXPlugin(config) {
 						}
 
 						this.#path.pop();
-						skipWhitespace(this);
+						this.#skipTrailingLayoutWhitespace();
 						return;
 					}
 					const node = this.parseElement();

--- a/packages/tsrx/src/transform/jsx/index.js
+++ b/packages/tsrx/src/transform/jsx/index.js
@@ -74,6 +74,16 @@ const TSRX_IF_CONTINUE_ERROR =
 	'Continue statements are not allowed inside TSRX template @if blocks. Filter before rendering or use conditional output instead.';
 const DYNAMIC_IMPORT_LOCAL = 'TsrxDynamic';
 const DYNAMIC_FACTORY_LOCAL = '_tsrx_dynamic';
+const LEADING_INLINE_WHITESPACE = /^[ \t]+/;
+const TRAILING_INLINE_WHITESPACE = /[ \t]+$/;
+
+/**
+ * @param {string | undefined} ch
+ * @returns {boolean}
+ */
+function is_newline_char(ch) {
+	return ch === '\n' || ch === '\r';
+}
 
 /**
  * @param {AST.Node} node
@@ -2413,9 +2423,7 @@ function mark_native_pretransformed_jsx(node, seen = new Set()) {
 function get_tsrx_render_children(node) {
 	return (node.children || []).filter(
 		(/** @type {any} */ child) =>
-			child &&
-			child.type !== 'EmptyStatement' &&
-			(child.type !== 'JSXText' || child.value.trim() !== ''),
+			child && child.type !== 'EmptyStatement' && (child.type !== 'JSXText' || child.value !== ''),
 	);
 }
 
@@ -3399,7 +3407,9 @@ function create_element_children(children, transform_context) {
 		const saved_inside_element_child = transform_context.inside_element_child;
 		transform_context.inside_element_child = true;
 		try {
-			return children.map((/** @type {any} */ child) => to_jsx_child(child, transform_context));
+			return wrap_edge_whitespace(
+				children.map((/** @type {any} */ child) => to_jsx_child(child, transform_context)),
+			);
 		} finally {
 			transform_context.inside_element_child = saved_inside_element_child;
 		}
@@ -3950,6 +3960,67 @@ function is_try_control_node(node) {
 }
 
 /**
+ * Wrap the inline whitespace at a fragment/element's content edges in `{' '}`
+ * containers. A bare leading/trailing space is fragile: once the output is
+ * line-wrapped (by prettier or the host JSX compiler) it becomes newline-adjacent
+ * and is trimmed away, dropping a significant space. Whitespace BETWEEN siblings
+ * stays bare text — it is not at an edge and is preserved as-is. Only spaces/tabs
+ * are pulled out; whitespace runs containing a newline are layout indentation and
+ * are left for the host compiler to collapse.
+ *
+ * @param {any[]} nodes
+ * @returns {any[]}
+ */
+export function wrap_edge_whitespace(nodes) {
+	const length = nodes.length;
+	if (length === 0) {
+		return nodes;
+	}
+
+	const first = nodes[0];
+	const last = nodes[length - 1];
+	if (first?.type !== 'JSXText' && last?.type !== 'JSXText') {
+		return nodes;
+	}
+
+	/** @type {(ESTreeJSX.JSXExpressionContainer | ESTreeJSX.JSXText)[]} */
+	const out = [];
+	for (let i = 0; i < length; i++) {
+		const node = nodes[i];
+		const at_start = i === 0;
+		const at_end = i === length - 1;
+		if (!node || node.type !== 'JSXText' || (!at_start && !at_end)) {
+			out.push(node);
+			continue;
+		}
+		let value = /** @type {string} */ (node.value);
+		if (at_start) {
+			const lead = LEADING_INLINE_WHITESPACE.exec(value);
+			if (lead && !is_newline_char(value[lead[0].length])) {
+				out.push(to_jsx_expression_container(b.literal(lead[0]), node));
+				value = value.slice(lead[0].length);
+			}
+		}
+		/** @type {ESTreeJSX.JSXExpressionContainer | null} */
+		let trailing = null;
+		if (at_end) {
+			const trail = TRAILING_INLINE_WHITESPACE.exec(value);
+			if (trail && !is_newline_char(value[value.length - trail[0].length - 1])) {
+				trailing = to_jsx_expression_container(b.literal(trail[0]), node);
+				value = value.slice(0, value.length - trail[0].length);
+			}
+		}
+		if (value !== '') {
+			out.push(b.jsx_text(value, value));
+		}
+		if (trailing) {
+			out.push(trailing);
+		}
+	}
+	return out;
+}
+
+/**
  * @param {any} node
  * @param {TransformContext} transform_context
  * @returns {any}
@@ -4034,15 +4105,15 @@ function to_jsx_child(node, transform_context) {
 function tsrx_node_to_jsx_expression(node, transform_context, in_jsx_child = false) {
 	const children = (node.children || []).filter(
 		(/** @type {any} */ child) =>
-			child &&
-			child.type !== 'EmptyStatement' &&
-			(child.type !== 'JSXText' || child.value.trim() !== ''),
+			child && child.type !== 'EmptyStatement' && (child.type !== 'JSXText' || child.value !== ''),
 	);
 
 	/** @type {any} */
 	let expression;
 	if (children.length === 0) {
-		expression = create_null_literal();
+		expression = in_jsx_child
+			? set_loc(b.jsx_fragment([]), node.loc ? node : undefined)
+			: create_null_literal();
 	} else {
 		expression = return_value_body_to_expression(children, node, transform_context);
 	}
@@ -4052,10 +4123,10 @@ function tsrx_node_to_jsx_expression(node, transform_context, in_jsx_child = fal
 			const saved_inside_element_child = transform_context.inside_element_child;
 			transform_context.inside_element_child = true;
 			try {
-				const render_nodes = children.map((/** @type {any} */ child) =>
-					to_jsx_child(child, transform_context),
+				const render_nodes = wrap_edge_whitespace(
+					children.map((/** @type {any} */ child) => to_jsx_child(child, transform_context)),
 				);
-				expression = build_return_expression(render_nodes) || create_null_literal();
+				expression = build_return_expression(render_nodes, in_jsx_child) || create_null_literal();
 			} finally {
 				transform_context.inside_element_child = saved_inside_element_child;
 			}
@@ -5839,9 +5910,10 @@ function value_has_unmappable_jsx_loc(value) {
 
 /**
  * @param {any[]} render_nodes
+ * @param {boolean} [in_jsx_child]
  * @returns {any}
  */
-function build_return_expression(render_nodes) {
+function build_return_expression(render_nodes, in_jsx_child = false) {
 	if (render_nodes.length === 0) return null;
 	if (render_nodes.length === 1) {
 		const only = render_nodes[0];
@@ -5855,6 +5927,9 @@ function build_return_expression(render_nodes) {
 			return only.expression;
 		}
 		if (only.type === 'JSXText') {
+			if (in_jsx_child) {
+				return set_loc(b.jsx_fragment([only]), only.loc ? only : undefined);
+			}
 			const value = (only.value ?? '').trim();
 			return b.literal(value, JSON.stringify(value), only);
 		}

--- a/packages/tsrx/src/utils/builders.js
+++ b/packages/tsrx/src/utils/builders.js
@@ -369,6 +369,26 @@ export function literal(value, raw, loc_info) {
 }
 
 /**
+ * Ripple template `Text` node wrapping a string literal of `value`. Used by the
+ * Ripple normalizer when lowering a JSX text child to a template Text node.
+ *
+ * Remove once Ripple transformers move to the parser's JSX AST
+ *
+ * @param {string} value
+ * @param {AST.NodeWithLocation} [loc_info]
+ * @returns {AST.Text}
+ */
+export function text(value, loc_info) {
+	const node = /** @type {AST.Text} */ ({
+		type: 'Text',
+		expression: literal(value, JSON.stringify(value), loc_info),
+		metadata: { path: [] },
+	});
+
+	return set_location(node, loc_info);
+}
+
+/**
  * @param {AST.Expression | AST.Super} object
  * @param {string | AST.Expression | AST.PrivateIdentifier} property
  * @param {boolean} computed

--- a/packages/tsrx/tests/shared/compile.js
+++ b/packages/tsrx/tests/shared/compile.js
@@ -58,10 +58,8 @@ export function runSharedCompileDiagnosticsTests({ compile_to_volar_mappings, na
 				{ loose: true },
 			);
 
-			// Bare expressions as fragment children would read as JSX text
-			// (`<>{a}a</>`), hiding the identifiers from TypeScript.
 			expect(result.errors).toEqual([]);
-			expect(result.code).toContain('<>{a}{a}</>');
+			expect(result.code).toContain('{a} {a}');
 			expect(result.code).not.toContain('<>{a}a</>');
 		});
 
@@ -1726,7 +1724,9 @@ export function runSharedCompileTests({
 				'App.tsrx',
 			);
 
-			expect(code).toContain('<>{a}{b}</>');
+			// The inline space between the two expressions is interior, so it stays
+			// bare; only fragment-edge whitespace becomes `{' '}`.
+			expect(code).toContain('<>{a} {b}</>');
 			expect(code).not.toContain('<>{a}b</>');
 		});
 
@@ -1739,7 +1739,7 @@ export function runSharedCompileTests({
 				'App.tsrx',
 			);
 
-			expect(code).toContain('<>{a}{a}</>');
+			expect(code).toContain('{a} {a}');
 			expect(code).not.toContain('<>{a}a</>');
 			expect(code).not.toContain('<>aa</>');
 		});
@@ -1979,8 +1979,8 @@ export function runSharedCompileTests({
 				'App.tsrx',
 			);
 
-			expect(code).toContain('"Hello Ripple"');
-			expect(code).toContain('"Hello React"');
+			expect(code).toContain('Hello Ripple');
+			expect(code).toContain('Hello React');
 			expect(code).not.toContain('return null;');
 		});
 

--- a/packages/tsrx/tests/utils/parser.test.js
+++ b/packages/tsrx/tests/utils/parser.test.js
@@ -1429,6 +1429,7 @@ foo();`;
 			'JSXExpressionContainer',
 			'JSXText',
 			'JSXFragment',
+			'JSXText',
 		]);
 		expect(level2.children[0].expression.name).toBe('a');
 
@@ -1439,6 +1440,59 @@ foo();`;
 		expect(level4.type).toBe('JSXFragment');
 		expect(level4.children.map((child) => child.type)).toEqual(['JSXExpressionContainer']);
 		expect(level4.children[0].expression.name).toBe('a');
+	});
+
+	it('parses sibling fragments separated by template text', () => {
+		const withText = findNode('let a = <> <>123</> 2 <>456</> </>', 'JSXFragment');
+		expect(withText.children.map((child) => child.type)).toEqual([
+			'JSXText',
+			'JSXFragment',
+			'JSXText',
+			'JSXFragment',
+			'JSXText',
+		]);
+		expect(withText.children[0].value).toBe(' ');
+		expect(withText.children[2].value).toBe(' 2 ');
+		expect(withText.children[4].value).toBe(' ');
+
+		const emptySiblings = findNode('let b = <> <></> 2 <></> </>', 'JSXFragment');
+		expect(emptySiblings.children.map((child) => child.type)).toEqual([
+			'JSXText',
+			'JSXFragment',
+			'JSXText',
+			'JSXFragment',
+			'JSXText',
+		]);
+		expect(withText.children[0].value).toBe(' ');
+		expect(withText.children[2].value).toBe(' 2 ');
+		expect(withText.children[4].value).toBe(' ');
+	});
+
+	it('keeps an inline space between adjacent sibling fragments', () => {
+		const fragment = findNode('let c = <> <></>  <></>something </>', 'JSXFragment');
+		expect(fragment.children.map((child) => child.type)).toEqual([
+			'JSXText',
+			'JSXFragment',
+			'JSXText',
+			'JSXFragment',
+			'JSXText',
+		]);
+		expect(fragment.children[2].value).toBe('  ');
+		expect(fragment.children[4].value).toBe('something ');
+	});
+
+	it('keeps inline spaces around and between sibling elements', () => {
+		const pre = findElement('const a = <pre> <b>1</b> <b>2</b> </pre>;', 'pre');
+		expect(pre.children.map((child) => child.type)).toEqual([
+			'JSXText',
+			'JSXElement',
+			'JSXText',
+			'JSXElement',
+			'JSXText',
+		]);
+		expect(pre.children[0].value).toBe(' ');
+		expect(pre.children[2].value).toBe(' ');
+		expect(pre.children[4].value).toBe(' ');
 	});
 
 	it('parses parenthesized conditional JSX spread attributes in render output', () => {


### PR DESCRIPTION
closes #1274
closes #1275

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core template parsing and all JSX/Ripple emit paths; behavior changes affect rendered output and type-checking views, though scope is whitespace/fragment representation rather than auth or data.
> 
> **Overview**
> Fixes **significant inline whitespace** being dropped in TSRX templates and aligns **parser, JSX transforms, Ripple runtime, and Volar `to_ts` output** on how fragments and spaces are represented.
> 
> **Parser (`plugin.js`):** Siblings after a closing tag are kept as `JSXText` instead of being swallowed by generic `skipSpace`; only **newline-spanning layout** whitespace is collapsed via `#skipTrailingLayoutWhitespace`. Inline spaces between fragments/elements on one line (e.g. `<> <></> 2 <></>`) stay in the AST. Native-template closing-tag handling is refactored (manual close parse + `jsxTagEnd`) in place of the old relational-`<` re-entry workaround.
> 
> **Transform (`wrap_edge_whitespace`):** Leading/trailing **inline** space at element/fragment content edges is emitted as `{' '}` so Prettier/JSX compilers do not trim it; spaces **between** siblings stay bare. Empty/single-text fragments used as **JSX children** stay `<>…</>` / `<></>` instead of lowering to `{null}` or a bare string; return/expression positions still lower single-text fragments to string literals where appropriate. JSX text children are no longer filtered with `.trim() === ''`.
> 
> **Ripple:** Whitespace-only significant inline text is retained in templates (not dropped when `trim()` is empty). The **`to_ts` / Volar view** is simplified (no IIFE for pure children) and updated to match JSX targets: bare text, fragment shapes, expression containers for type visibility, and `wrap_edge_whitespace` on TSX children.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7349a130ef81d3730e7613b2195d29c7989310e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->