### PR TITLE
fix(parser): new lines and text with elements causing stack overflow

### DIFF
--- a/.changeset/silly-pugs-attack.md
+++ b/.changeset/silly-pugs-attack.md
@@ -1,0 +1,13 @@
+---
+'@tsrx/core': patch
+---
+
+Fix a parser stack overflow on a text-then-element sibling that follows
+newline-separated sibling elements (e.g. `<pre><b>2</b>\n<b>3</b>1<b>4</b></pre>`).
+The newline between two siblings leaves a stale `jsxText` token anchored on the
+next `<`; recovering from it used to clear *every* JSX children context —
+including the parent element's own — so the later `text<tag>` sibling tokenized
+its `<` as a relational operator that `parseTemplateBody` has no branch for,
+recursing forever. The recovery now keeps one children context per still-open
+ancestor when the `<` opens a child/sibling tag, and only clears the full run
+when it opens a closing `</tag>`.

--- a/packages/tsrx/src/plugin.js
+++ b/packages/tsrx/src/plugin.js
@@ -4416,8 +4416,23 @@ export function TSRXPlugin(config) {
 					// text never starts at `<`, so drop the leaked context and re-read the
 					// tag instead of emitting an empty node.
 					if (this.input.charCodeAt(this.start) === CharCode.lessThan) {
-						while (this.curContext() === tstc.tc_expr) {
-							this.context.pop();
+						if (this.input.charCodeAt(this.start + 1) === CharCode.slash) {
+							while (this.curContext() === tstc.tc_expr) {
+								this.context.pop();
+							}
+						} else {
+							let native_depth = 0;
+							for (const node of this.#path) {
+								if (this.#isNativeTemplateNode(node)) native_depth++;
+							}
+							let tc_expr_depth = 0;
+							for (const context of this.context) {
+								if (context === tstc.tc_expr) tc_expr_depth++;
+							}
+							while (tc_expr_depth > native_depth && this.curContext() === tstc.tc_expr) {
+								this.context.pop();
+								tc_expr_depth--;
+							}
 						}
 						this.pos = this.start;
 						this.exprAllowed = true;

--- a/packages/tsrx/tests/utils/parser.test.js
+++ b/packages/tsrx/tests/utils/parser.test.js
@@ -1495,6 +1495,28 @@ foo();`;
 		expect(pre.children[4].value).toBe(' ');
 	});
 
+	it('parses a text-then-element sibling after newline-separated elements', () => {
+		const pre = findElement('let a = <pre><b>2</b>\n<b>3</b>1<b>4</b></pre>;', 'pre');
+		expect(pre.children.map((child) => child.type)).toEqual([
+			'JSXElement',
+			'JSXElement',
+			'JSXText',
+			'JSXElement',
+		]);
+		expect(pre.children[2].value).toBe('1');
+	});
+
+	it('parses indented multi-line markup with a text-then-element sibling', () => {
+		const source =
+			'let a  = <pre> \n\n    <b>2</b>   \n    <b>3</b> \n    \n    1<b>4</b>\n</pre>;';
+		const pre = findElement(source, 'pre');
+		expect(pre.children.filter((child) => child.type === 'JSXElement')).toHaveLength(3);
+		const text = pre.children.find(
+			(child) => child.type === 'JSXText' && child.value.includes('1'),
+		);
+		expect(text.value).toBe('1');
+	});
+
 	it('parses parenthesized conditional JSX spread attributes in render output', () => {
 		const returned = getReturned(`function App() { return <div>@{
 			let &[enabled] = track(true);


### PR DESCRIPTION
fixes #1278 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Targets tokenizer/context recovery in native template body parsing; wrong pop logic could break other sibling-tag or closing-tag edge cases, though behavior is narrowed with new tests.
> 
> **Overview**
> Fixes a **stack overflow** when parsing markup like `<pre><b>2</b>\n<b>3</b>1<b>4</b></pre>` — sibling elements separated by a newline, then **text immediately before the next tag**.
> 
> After nested elements close, whitespace/newlines can leave a stale `jsxText` token whose start sits on the following `<`. Recovery already rewinds and re-tokenizes, but it used to **pop every** `tc_expr` context, including the parent element’s. The next `1<b>4</b>` then saw `<` as a relational operator, and `parseTemplateBody` had no matching branch, causing **infinite recursion**.
> 
> Recovery now **branches on the next character**: for `</tag>` it still clears all leaked `tc_expr` contexts; for an opening child/sibling tag it only pops **extra** `tc_expr` entries so **one remains per open native template ancestor** (by comparing `#path` native depth to `tc_expr` depth on the context stack).
> 
> Adds regression tests for compact and indented multi-line cases with a text-then-element sibling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62794128ce65e76d19b54641cde9f0f0129f2ada. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->