### PR TITLE
fix: keep {<></>} instead of {null}

### DIFF
--- a/.changeset/clever-moles-fold.md
+++ b/.changeset/clever-moles-fold.md
@@ -1,0 +1,6 @@
+---
+'@tsrx/ripple': patch
+'@tsrx/core': patch
+---
+
+Print empty fragements as is inside expressions {<></>} instead of {null}

--- a/packages/tsrx-ripple/src/transform/client/index.js
+++ b/packages/tsrx-ripple/src/transform/client/index.js
@@ -3789,8 +3789,26 @@ function transform_tsrx_tsx_child(node, context) {
 	}
 
 	if (node.type === 'TSRXExpression') {
+		// An EMPTY fragment that is the container's expression (`<b>{<></>}</b>`) must
+		// stay `<></>`: the `{}` already supplies the wrapper, so the default
+		// `in_jsx_child = false` lowering to a bare `null` drops the source fragment.
+		// Build it as a JSX child instead. Non-empty fragments keep their existing
+		// lowering (e.g. `{<>{a}</>}` still unwraps to `{a}`). This matches the JSX
+		// targets and how the same fragment survives in an attribute value.
+		const expr = node.expression;
+		const is_empty_fragment =
+			expr?.type === 'TsrxFragment' &&
+			!(expr.children || []).some(
+				(/** @type {any} */ child) =>
+					child &&
+					child.type !== 'EmptyStatement' &&
+					(child.type !== 'Text' || String(child.expression?.value ?? '') !== ''),
+			);
+		const expression = is_empty_fragment
+			? build_tsrx_to_ts_expression(/** @type {AST.TsrxFragment} */ (expr), context, true)
+			: /** @type {AST.Expression} */ (context.visit(node.expression, context.state));
 		return b.jsx_expression_container(
-			/** @type {AST.Expression} */ (context.visit(node.expression, context.state)),
+			/** @type {AST.Expression} */ (expression),
 			get_tsrx_expression_container_location(node),
 		);
 	}

--- a/packages/tsrx-ripple/tests/jsx-runtime-types.test.js
+++ b/packages/tsrx-ripple/tests/jsx-runtime-types.test.js
@@ -123,6 +123,18 @@ function StatusBadge() @{
 		expect(code).not.toContain('<>aa</>');
 	});
 
+	it('keeps an empty fragment inside a container in the TS view', () => {
+		const source = `
+function App() @{
+	<b>{<></>}</b>
+}
+`;
+		const { code } = compile_to_volar_mappings(source, 'App.tsrx', { loose: true });
+
+		expect(code).toContain('<b>{<></>}</b>');
+		expect(code).not.toContain('{null}');
+	});
+
 	it('matches the JSX targets for text, fragments and edge whitespace', () => {
 		const compile = (src) => compile_to_volar_mappings(src, 'App.tsrx', { loose: true }).code;
 

--- a/packages/tsrx/src/transform/jsx/index.js
+++ b/packages/tsrx/src/transform/jsx/index.js
@@ -429,7 +429,23 @@ export function createJsxTransform(platform) {
 
 				const style_context = prepare_tsrx_fragment_styles(node, state);
 				const target = style_context?.fragment ?? next() ?? node;
-				const in_jsx_child = in_jsx_child_context(path);
+				// An EMPTY fragment that is the sole expression of a `{ … }` container in a
+				// JSX child slot (`<b>{<></>}</b>`) must stay `<></>`: the container already
+				// supplies the `{}` wrapper, so lowering it to a bare `null` (the default
+				// expression-position behavior) drops the source fragment. This matches how
+				// the same fragment is preserved in an attribute value (`a={<></>}`).
+				// Non-empty fragments keep their existing lowering.
+				const immediate_parent = /** @type {any} */ (path[path.length - 1]);
+				const is_empty_container_child =
+					immediate_parent?.type === 'JSXExpressionContainer' &&
+					in_jsx_child_context(path.slice(0, -1)) &&
+					!(target.children || []).some(
+						(/** @type {any} */ child) =>
+							child &&
+							child.type !== 'EmptyStatement' &&
+							(child.type !== 'JSXText' || child.value !== ''),
+					);
+				const in_jsx_child = in_jsx_child_context(path) || is_empty_container_child;
 				const expression = tsrx_node_to_jsx_expression(target, state, in_jsx_child);
 				for (const statement of create_tsrx_style_ref_setup_statements(
 					target,

--- a/packages/tsrx/tests/shared/compile.js
+++ b/packages/tsrx/tests/shared/compile.js
@@ -1743,6 +1743,20 @@ export function runSharedCompileTests({
 			expect(code).not.toContain('<>{a}a</>');
 			expect(code).not.toContain('<>aa</>');
 		});
+
+		// Regression: an empty fragment as a container's expression must stay
+		// `{<></>}`, not be lowered to the bare `{null}` of expression position.
+		it('keeps an empty fragment inside a container as a fragment', () => {
+			const { code } = compile(
+				`function App() @{
+					<b>{<></>}</b>
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('<b>{<></>}</b>');
+			expect(code).not.toContain('{null}');
+		});
 	});
 
 	describe(`[${name}] component export shapes`, () => {


### PR DESCRIPTION
fixes #1279 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized JSX/TS-view lowering change with targeted tests; no auth, data, or runtime behavior beyond emitted shape for this edge case.
> 
> **Overview**
> Fixes **#1279**: an **empty fragment** used as the sole expression inside a JSX child slot (e.g. `<b>{<></>}</b>`) is no longer compiled to **`{null}`**; output keeps **`{<></>}`**, aligned with attribute values like `a={<></>}` and other JSX targets.
> 
> The **Ripple client `to_ts` path** and **`@tsrx/core` JSX lowering** both detect an empty `TsrxFragment` in that `JSXExpressionContainer` context and treat it as a JSX child instead of expression-position `null`. **Non-empty** fragments and standalone `let c = <></>;` → `null` behavior are unchanged.
> 
> Patch releases for **`@tsrx/ripple`** and **`@tsrx/core`**; regression tests cover compile and Volar TS view output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e28a65ba069bdbde909ea0ecb06e11ec760d9ee4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->