### PR TITLE
fix(parser): keep significant whitespace before a `@{ … }` code block

### DIFF
--- a/.changeset/spotty-spies-grin.md
+++ b/.changeset/spotty-spies-grin.md
@@ -1,0 +1,11 @@
+---
+'@tsrx/core': patch
+---
+
+fix(parser): keep significant whitespace before a `@{ … }` code block
+
+The native template body skipped leading whitespace when repositioning onto a
+`@{ … }` code block, so `<>   @{<b>123</b>}   </>` lost its leading edge space
+(only the trailing one survived). The whitespace is now emitted as a text child,
+matching the equivalent plain-element case; layout indentation (whitespace
+containing a newline) is still dropped.

--- a/packages/tsrx/src/plugin.js
+++ b/packages/tsrx/src/plugin.js
@@ -4383,22 +4383,29 @@ export function TSRXPlugin(config) {
 			parseTemplateBody(body) {
 				const current_template_node = this.#currentNativeTemplateNode();
 				if (!current_template_node) return;
-				// Outside a `@{ … }` block every element/fragment body is plain JSX (§2,
-				// §5). There is no script section and no `---` fence to infer — text is
-				// text, and setup code lives only inside a code block.
 				current_template_node.metadata ??= { path: [] };
 				current_template_node.metadata.templateMode = 'template';
 
-				// `@{ … }` code block as element/fragment content (§2 rule 1). Sibling
-				// code blocks are allowed, so this is not gated on an empty body;
-				// reposition onto the `@` if leading whitespace was tokenized ahead of it.
 				if (this.#atCodeBlockStart()) {
 					const at_index = skip_whitespace_from(this.input, this.start);
 					if (this.start !== at_index) {
+						const ws_start = this.start;
+						const ws_start_loc = this.startLoc;
+						const ws_value = this.input.slice(ws_start, at_index);
+						const text_node = /** @type {ESTreeJSX.JSXText} */ (
+							this.startNodeAt(ws_start, ws_start_loc)
+						);
+						text_node.value = ws_value;
+						text_node.raw = ws_value;
 						const loc = acorn.getLineInfo(this.input, at_index);
+						const at_position = new acorn.Position(loc.line, loc.column);
+						this.finishNodeAt(text_node, 'JSXText', at_index, at_position);
+						if (this.#shouldKeepTemplateTextNode(text_node)) {
+							body.push(text_node);
+						}
 						this.pos = at_index;
 						this.start = at_index;
-						this.startLoc = new acorn.Position(loc.line, loc.column);
+						this.startLoc = at_position;
 						this.curLine = loc.line;
 						this.lineStart = at_index - loc.column;
 					}

--- a/packages/tsrx/tests/utils/parser.test.js
+++ b/packages/tsrx/tests/utils/parser.test.js
@@ -424,6 +424,24 @@ abc
 		expect(block.render.openingElement.name.name).toBe('span');
 	});
 
+	it('preserves significant whitespace before a code block in a fragment', () => {
+		const fragment = findNode('let a = <>   @{<b>123</b>}   </>;', 'JSXFragment');
+
+		expect(fragment.children.map((child) => child.type)).toEqual([
+			'JSXText',
+			'JSXCodeBlock',
+			'JSXText',
+		]);
+		expect(fragment.children[0].value).toBe('   ');
+		expect(fragment.children[2].value).toBe('   ');
+	});
+
+	it('drops layout whitespace before a code block in a fragment', () => {
+		const fragment = findNode('let a = <>\n   @{<b>123</b>}\n</>;', 'JSXFragment');
+
+		expect(fragment.children.map((child) => child.type)).toEqual(['JSXCodeBlock']);
+	});
+
 	it('parses an @if directive inside an element nested in an expression container', () => {
 		const directive = findNode(
 			inExpressionContainer(`@if (ok) { <span>x</span> }`),


### PR DESCRIPTION
fixes #1280 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized parser change with targeted tests; no auth, runtime, or API surface changes.
> 
> **Overview**
> Fixes a **parser bug** where native template bodies dropped **leading whitespace** immediately before a `@{ … }` code block (e.g. `<>   @{<b>123</b>}   </>` kept only the trailing spaces).
> 
> In `parseTemplateBody`, when skipping ahead to the `@` of a code block, the skipped span is now built as a **`JSXText` child** (via `#shouldKeepTemplateTextNode`) before the `JSXCodeBlock`, matching plain-element behavior. **Layout whitespace** (contains a newline) is still omitted.
> 
> Adds fragment parser tests for both preserved inline spaces and dropped layout indentation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba6feb7e546f3a23a113ac0c362cf01ad7ed4212. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->