### PR TITLE
fix: empty fragments not converted to null

### DIFF
--- a/.changeset/empty-fragments-expression-position.md
+++ b/.changeset/empty-fragments-expression-position.md
@@ -1,0 +1,6 @@
+---
+'@tsrx/ripple': patch
+'@tsrx/core': patch
+---
+
+Keep empty fragments in expression position: `let b = <></>` stays `<></>` instead of `null`, and `let c = <><></></>` keeps both levels instead of collapsing to `<></>`. Applies to the React, Preact, Solid, Vue, and Ripple to_ts targets.

--- a/packages/tsrx-ripple/src/transform/client/index.js
+++ b/packages/tsrx-ripple/src/transform/client/index.js
@@ -48,6 +48,7 @@ import {
 	getStyleElementStylesheet,
 	getOriginalEventName,
 	isEventAttribute,
+	isEmptyJsxFragment as is_empty_jsx_fragment,
 	isInsideComponent as is_inside_component,
 	normalizeEventName,
 	shouldPreserveComment,
@@ -3646,7 +3647,10 @@ function statement_to_tsrx_ts_expression(statement) {
  */
 function build_tsrx_ts_return_expression(children, in_jsx_child, loc_node) {
 	if (children.length === 0) {
-		return in_jsx_child ? setLocation(b.jsx_fragment([]), loc_node) : b.literal(null);
+		// An empty fragment is a real value: keep it as `<></>` even in expression
+		// position. Lowering it to `null` (e.g. `let b = <></>`) drops the author's
+		// fragment; `<></>` is a valid value and matches the JSX targets' TS view.
+		return setLocation(b.jsx_fragment([]), loc_node);
 	}
 	if (children.length === 1) {
 		const only = children[0];
@@ -3657,6 +3661,11 @@ function build_tsrx_ts_return_expression(children, in_jsx_child, loc_node) {
 		}
 		if (only.type === 'JSXExpressionContainer' && !in_jsx_child) {
 			return only.expression;
+		}
+		if (is_empty_jsx_fragment(only)) {
+			// `<><></></>` — keep the outer fragment instead of collapsing to the bare
+			// inner `<></>`, matching the JSX targets and preserving author intent.
+			return setLocation(b.jsx_fragment([only]), loc_node);
 		}
 		return /** @type {TsrxTsViewNode} */ (only);
 	}

--- a/packages/tsrx-ripple/tests/jsx-runtime-types.test.js
+++ b/packages/tsrx-ripple/tests/jsx-runtime-types.test.js
@@ -144,7 +144,8 @@ function App() @{
 		expect(compile('let b = <> <></> 2 <></> </>;')).toContain(
 			"let b = <>{' '}<></> 2 <></>{' '}</>;",
 		);
-		expect(compile('let c = <></>;')).toContain('let c = null;');
+		expect(compile('let c = <></>;')).toContain('let c = <></>;');
+		expect(compile('let e = <><></></>;')).toContain('let e = <><></></>;');
 		expect(compile('let d = <pre> <b>1</b> <b>2</b> </pre>;')).toContain(
 			"let d = <pre>{' '}<b>1</b> <b>2</b>{' '}</pre>;",
 		);

--- a/packages/tsrx/src/index.js
+++ b/packages/tsrx/src/index.js
@@ -163,6 +163,7 @@ export {
 } from './transform/jsx/index.js';
 export {
 	in_jsx_child_context as inJsxChildContext,
+	is_empty_jsx_fragment as isEmptyJsxFragment,
 	tsx_node_to_jsx_expression as tsxNodeToJsxExpression,
 	tsx_with_ts_locations as tsxWithTsLocations,
 	is_template_if_node as isTemplateIfNode,

--- a/packages/tsrx/src/transform/jsx/helpers.js
+++ b/packages/tsrx/src/transform/jsx/helpers.js
@@ -20,6 +20,20 @@ export function in_jsx_child_context(path) {
 }
 
 /**
+ * @param {any} node
+ * @returns {boolean}
+ */
+export function is_empty_jsx_fragment(node) {
+	return (
+		node?.type === 'JSXFragment' &&
+		!(node.children || []).some(
+			(/** @type {any} */ child) =>
+				child && (child.type !== 'JSXText' || child.value.trim() !== ''),
+		)
+	);
+}
+
+/**
  * Match Ripple's transform path metadata shape: every node seen by the walker
  * carries its current ancestor path for downstream CSS pruning and mapping
  * helpers.

--- a/packages/tsrx/src/transform/jsx/index.js
+++ b/packages/tsrx/src/transform/jsx/index.js
@@ -9,6 +9,7 @@ import { analyze_css } from '../../analyze/css-analyze.js';
 import { prune_css } from '../../analyze/prune.js';
 import {
 	in_jsx_child_context,
+	is_empty_jsx_fragment,
 	set_node_path_metadata,
 	tsx_with_ts_locations,
 	is_template_if_node,
@@ -4127,9 +4128,16 @@ function tsrx_node_to_jsx_expression(node, transform_context, in_jsx_child = fal
 	/** @type {any} */
 	let expression;
 	if (children.length === 0) {
-		expression = in_jsx_child
-			? set_loc(b.jsx_fragment([]), node.loc ? node : undefined)
-			: create_null_literal();
+		// An empty fragment is a real value: keep it as `<></>` in BOTH child and
+		// expression position. Lowering it to a bare `null` in expression position
+		// (e.g. `let b = <></>`) drops the author's fragment and changes its type;
+		// `<></>` is a valid value and keeps the to_ts/runtime view faithful.
+		expression = set_loc(b.jsx_fragment([]), node.loc ? node : undefined);
+	} else if (children.length === 1 && is_empty_jsx_fragment(children[0])) {
+		// `<><></></>` — a fragment whose only child is an empty fragment. The generic
+		// single-child collapse below would unwrap it to the bare inner `<></>`,
+		// dropping the outer fragment the author wrote. Keep both levels.
+		expression = set_loc(b.jsx_fragment(children), node.loc ? node : undefined);
 	} else {
 		expression = return_value_body_to_expression(children, node, transform_context);
 	}

--- a/packages/tsrx/tests/shared/compile.js
+++ b/packages/tsrx/tests/shared/compile.js
@@ -1757,6 +1757,31 @@ export function runSharedCompileTests({
 			expect(code).toContain('<b>{<></>}</b>');
 			expect(code).not.toContain('{null}');
 		});
+
+		it('keeps an empty fragment in expression position as a fragment', () => {
+			const { code } = compile(
+				`function App() @{
+					let b = <></>;
+					<div />
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('let b = <></>;');
+			expect(code).not.toContain('let b = null;');
+		});
+
+		it('keeps the outer fragment of a nested empty fragment in expression position', () => {
+			const { code } = compile(
+				`function App() @{
+					let c = <><></></>;
+					<div />
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('let c = <><></></>;');
+		});
 	});
 
 	describe(`[${name}] component export shapes`, () => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Compiler-only JSX lowering for the TS view; behavior is covered by updated tests and matches other JSX targets.
> 
> **Overview**
> **Empty JSX fragments are no longer lowered to `null` when they appear as values** (e.g. `let b = <></>`), so the TypeScript/`to_ts` view stays aligned with React, Preact, Solid, Vue, and Ripple JSX targets.
> 
> The shared **`is_empty_jsx_fragment`** helper detects fragments with only whitespace text children. **`tsrx_node_to_jsx_expression`** (core) and **`build_tsrx_ts_return_expression`** (Ripple client) now always emit `<></>` for zero children, and **wrap a lone empty inner fragment** so `<><></></>` does not collapse to a single `<></>`. Tests and a changeset cover the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa35c432ea40afef01bf1de2c02278b46826f1d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->