### PR TITLE
fix: empty expression in fragment

### DIFF
--- a/.changeset/empty-expression-container-fragment.md
+++ b/.changeset/empty-expression-container-fragment.md
@@ -1,0 +1,6 @@
+---
+'@tsrx/core': patch
+'@tsrx/solid': patch
+---
+
+Keep an empty expression container fragment in expression position: `let c = <>{}</>` (and `<>{/* comment */}</>`) now stays `<></>` instead of collapsing to a bare empty expression (`let c = ;`), which was a syntax error. Applies to the React, Preact, Solid, and Vue to_ts targets (Ripple already produced `<></>`).

--- a/packages/tsrx-ripple/tests/jsx-runtime-types.test.js
+++ b/packages/tsrx-ripple/tests/jsx-runtime-types.test.js
@@ -146,6 +146,8 @@ function App() @{
 		);
 		expect(compile('let c = <></>;')).toContain('let c = <></>;');
 		expect(compile('let e = <><></></>;')).toContain('let e = <><></></>;');
+		// An empty expression container fragment must not collapse to `let f = ;`.
+		expect(compile('let f = <>{}</>;')).toContain('let f = <></>;');
 		expect(compile('let d = <pre> <b>1</b> <b>2</b> </pre>;')).toContain(
 			"let d = <pre>{' '}<b>1</b> <b>2</b>{' '}</pre>;",
 		);

--- a/packages/tsrx-solid/src/transform.js
+++ b/packages/tsrx-solid/src/transform.js
@@ -10,6 +10,7 @@ import {
 	toJsxAttribute,
 	validateAtMostOneRefAttribute,
 	addJsxSetupDeclaration as add_jsx_setup_declaration,
+	buildReturnExpression as build_return_expression,
 	collectParamBindings as collect_param_bindings,
 	collectStatementBindings as collect_statement_bindings,
 	extractJsxSetupDeclarations as extract_jsx_setup_declarations,
@@ -19,8 +20,6 @@ import {
 	NORMALIZE_SPREAD_PROPS_FOR_REF_ATTR_INTERNAL_NAME,
 	NORMALIZE_SPREAD_PROPS_INTERNAL_NAME,
 	returnValueBodyToExpression as return_value_body_to_expression,
-	tsxNodeToJsxExpression as tsx_node_to_jsx_expression,
-	// Shared AST builders (truly platform-agnostic utilities).
 	clone_expression_node,
 	clone_identifier,
 	clone_jsx_name,
@@ -2216,36 +2215,5 @@ function to_jsx_expression_container(expression, source_node = expression) {
 			metadata: { path: [] },
 		}),
 		source_node,
-	);
-}
-
-/**
- * @param {any[]} render_nodes
- * @returns {any}
- */
-function build_return_expression(render_nodes) {
-	if (render_nodes.length === 0) return null;
-	if (render_nodes.length === 1) {
-		const only = render_nodes[0];
-		if (only.type === 'JSXExpressionContainer') return only.expression;
-		if (only.type === 'JSXText') {
-			const value = (only.value ?? '').trim();
-			return b.literal(value, JSON.stringify(value), only);
-		}
-		return only;
-	}
-	const first = render_nodes[0];
-	const last = render_nodes[render_nodes.length - 1];
-	return set_loc(
-		/** @type {any} */ ({
-			type: 'JSXFragment',
-			openingFragment: { type: 'JSXOpeningFragment', metadata: { path: [] } },
-			closingFragment: { type: 'JSXClosingFragment', metadata: { path: [] } },
-			children: render_nodes,
-			metadata: { path: [] },
-		}),
-		first?.loc && last?.loc
-			? { start: first.start, end: last.end, loc: { start: first.loc.start, end: last.loc.end } }
-			: undefined,
 	);
 }

--- a/packages/tsrx/src/index.js
+++ b/packages/tsrx/src/index.js
@@ -147,6 +147,7 @@ export {
 	create_hook_safe_helper as createHookSafeHelper,
 	create_element_ref_target_type as createElementRefTargetType,
 	create_element_ref_target_type_for_name as createElementRefTargetTypeForName,
+	build_return_expression as buildReturnExpression,
 	createJsxTransform,
 	extract_jsx_setup_declarations as extractJsxSetupDeclarations,
 	is_component_like_element,
@@ -164,7 +165,6 @@ export {
 export {
 	in_jsx_child_context as inJsxChildContext,
 	is_empty_jsx_fragment as isEmptyJsxFragment,
-	tsx_node_to_jsx_expression as tsxNodeToJsxExpression,
 	tsx_with_ts_locations as tsxWithTsLocations,
 	is_template_if_node as isTemplateIfNode,
 	is_template_for_of_node as isTemplateForOfNode,

--- a/packages/tsrx/src/transform/jsx/helpers.js
+++ b/packages/tsrx/src/transform/jsx/helpers.js
@@ -51,45 +51,6 @@ export function set_node_path_metadata(node, path) {
 }
 
 /**
- * Flatten a JSX-compatible island's children into a single expression. In a
- * JSX-child position, a JSXExpressionContainer `{expr}` is valid and must stay
- * wrapped. In an expression position (e.g. `return ...`), `{expr}` parses as
- * a block/object literal, so unwrap to `expr`.
- *
- * @param {any} node
- * @param {boolean} [in_jsx_child]
- * @returns {any}
- */
-export function tsx_node_to_jsx_expression(node, in_jsx_child = false) {
-	const children = (node.children || []).filter(
-		(/** @type {any} */ child) => child.type !== 'JSXText' || child.value.trim() !== '',
-	);
-
-	if (
-		children.length === 1 &&
-		children[0].type !== 'JSXText' &&
-		// Reactive-block containers (dynamic tags) must stay expression
-		// children so the host JSX compiler wraps them in a render block;
-		// unwrapping to a bare call would evaluate them once.
-		children[0].metadata?.tsrx_reactive_block !== true
-	) {
-		const only = children[0];
-		if (only.type === 'JSXExpressionContainer' && !in_jsx_child) {
-			return only.expression;
-		}
-		return only;
-	}
-
-	return /** @type {any} */ ({
-		type: 'JSXFragment',
-		openingFragment: { type: 'JSXOpeningFragment', metadata: { path: [] } },
-		closingFragment: { type: 'JSXClosingFragment', metadata: { path: [] } },
-		children,
-		metadata: { path: [] },
-	});
-}
-
-/**
  * Wrap esrap's `tsx()` printer with location markers for nodes whose spans
  * (e.g. the leading `new ` of a NewExpression or the angle-bracket delimiters
  * around generic arguments) are otherwise invisible to the source map.

--- a/packages/tsrx/src/transform/jsx/index.js
+++ b/packages/tsrx/src/transform/jsx/index.js
@@ -5937,16 +5937,16 @@ function value_has_unmappable_jsx_loc(value) {
  * @param {boolean} [in_jsx_child]
  * @returns {any}
  */
-function build_return_expression(render_nodes, in_jsx_child = false) {
+export function build_return_expression(render_nodes, in_jsx_child = false) {
 	if (render_nodes.length === 0) return null;
 	if (render_nodes.length === 1) {
 		const only = render_nodes[0];
 		if (only.type === 'JSXExpressionContainer') {
-			// Reactive-block containers (dynamic tags) must stay expression
-			// children so the host JSX compiler wraps them in a render block;
-			// returning the bare call would evaluate them once.
 			if (only.metadata?.tsrx_reactive_block === true) {
 				return set_loc(b.jsx_fragment([only]), only.loc ? only : undefined);
+			}
+			if (only.expression?.type === 'JSXEmptyExpression') {
+				return set_loc(b.jsx_fragment([]), only.loc ? only : undefined);
 			}
 			return only.expression;
 		}

--- a/packages/tsrx/tests/shared/compile.js
+++ b/packages/tsrx/tests/shared/compile.js
@@ -1782,6 +1782,32 @@ export function runSharedCompileTests({
 
 			expect(code).toContain('let c = <><></></>;');
 		});
+
+		it('keeps an empty expression container fragment as a fragment in expression position', () => {
+			const { code } = compile(
+				`function App() @{
+					let c = <>{}</>;
+					<div />
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('let c = <></>;');
+			expect(code).not.toMatch(/let c = ;/);
+		});
+
+		it('keeps a comment-only container fragment as a fragment in expression position', () => {
+			const { code } = compile(
+				`function App() @{
+					let c = <>{/* note */}</>;
+					<div />
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('let c = <></>;');
+			expect(code).not.toMatch(/let c = ;/);
+		});
 	});
 
 	describe(`[${name}] component export shapes`, () => {


### PR DESCRIPTION
fixes #1285 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow JSX lowering change with regression tests; no auth, data, or broad architectural impact.
> 
> **Overview**
> Fixes invalid emitted JS when a TSRX fragment in **expression position** only contains an empty JSX expression (`<>{}</>`) or a comment-only container (`<>{/* … */}</>`). Those cases used to unwrap to nothing and print as `let c = ;`.
> 
> **`build_return_expression`** in `@tsrx/core` is now exported and treats a sole `JSXExpressionContainer` whose expression is **`JSXEmptyExpression`** as an **empty fragment** (`<></>`) instead of returning a bare empty expression. Reactive-block containers still become fragment wrappers as before.
> 
> **Solid** drops its local copy of this helper and imports **`buildReturnExpression`** from core. **`tsx_node_to_jsx_expression`** is removed from `helpers.js` and is no longer part of the public API.
> 
> Shared compile tests and a Ripple Volar mapping assertion lock in `let f = <></>;` for `<>{}</>`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f440ba8f59422cb57dbcc3e36dc5e63a5bb41f58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->