### PR TITLE
fix: template literal inside @{}

### DIFF
--- a/.changeset/code-block-template-literal.md
+++ b/.changeset/code-block-template-literal.md
@@ -1,0 +1,5 @@
+---
+'@tsrx/core': patch
+---
+
+Fix a parser crash when a template literal is the first thing in a `@{ … }` code block: `let c = @{`123`}` (and `@{ `${x}` }`) threw "Unterminated template" while `@{ '123' }` parsed fine. The code block's opening brace reads the next token ahead, and a template literal's backtick pushes its own tokenizer context; the setup-statement parser then shadowed (or stranded, after a prior statement) that context, so the template body tokenized as ordinary code and never closed. The backtick is now detected so the template-literal context stays on top and the body parses correctly.

--- a/packages/tsrx/src/plugin.js
+++ b/packages/tsrx/src/plugin.js
@@ -232,6 +232,7 @@ export function TSRXPlugin(config) {
 		// If we push an undefined context, Acorn's tokenizer will later crash reading `.override`.
 		const b_stat = tc.b_stat || acorn.tokContexts.b_stat;
 		const b_expr = tc.b_expr || acorn.tokContexts.b_expr;
+		const q_tmpl = tc.q_tmpl || acorn.tokContexts.q_tmpl;
 		const tstt = Parser.acornTypeScript.tokTypes;
 		const tstc = Parser.acornTypeScript.tokContexts;
 
@@ -1272,14 +1273,21 @@ export function TSRXPlugin(config) {
 			 */
 			#parseCodeBlockSetupStatement() {
 				const previous_context = this.context;
-				this.context = previous_context.filter(
-					(context) =>
-						context !== tstc.tc_expr && context !== tstc.tc_oTag && context !== tstc.tc_cTag,
-				);
+				const at_template_literal = this.type === tt.backQuote;
 				let pushed_statement_context = false;
-				if (this.curContext() !== b_stat) {
-					this.context.push(b_stat);
-					pushed_statement_context = true;
+				if (at_template_literal) {
+					if (this.curContext() !== q_tmpl) {
+						this.context.push(q_tmpl);
+					}
+				} else {
+					this.context = previous_context.filter(
+						(context) =>
+							context !== tstc.tc_expr && context !== tstc.tc_oTag && context !== tstc.tc_cTag,
+					);
+					if (this.curContext() !== b_stat) {
+						this.context.push(b_stat);
+						pushed_statement_context = true;
+					}
 				}
 				this.exprAllowed = true;
 				const previous_path = this.#path;
@@ -1287,22 +1295,7 @@ export function TSRXPlugin(config) {
 				this.#templateScriptParsingDepth++;
 				let node;
 				try {
-					// A code-block/directive body is statements plus at most one render node —
-					// never bare text or markup tokens. If the tokenizer mis-read trailing
-					// code as JSX (raw text or a tag-name token — both can happen for a
-					// statement following the render node, depending on the leftover context),
-					// reposition to the token start and re-read it as code now that the
-					// template path is hidden. It then parses as a statement so the
-					// one-render-node rule reports a clear "statements cannot follow" error
-					// instead of a generic parse fault.
 					if (this.type === tstt.jsxText || this.type === tstt.jsxName) {
-						// Rewinding `pos` to the mis-read token's start must also rewind the
-						// line counter: a `jsxText` token can span newlines (e.g. the blank
-						// line before a following render node), and reading it already
-						// advanced `curLine`/`lineStart` to its end. Resetting only `pos`
-						// would leave the line counter ahead of `pos`, inflating the `loc`
-						// of this statement and every node after it (which crashes source-map
-						// mapping when the inflated end line runs past the file).
 						const loc = acorn.getLineInfo(this.input, this.start);
 						this.pos = this.start;
 						this.curLine = loc.line;
@@ -1316,7 +1309,9 @@ export function TSRXPlugin(config) {
 					if (pushed_statement_context && this.curContext() === b_stat) {
 						this.context.pop();
 					}
-					this.context = previous_context;
+					if (!at_template_literal) {
+						this.context = previous_context;
+					}
 				}
 				if (this.curContext() === tstc.tc_expr) {
 					this.context.pop();

--- a/packages/tsrx/tests/utils/parser.test.js
+++ b/packages/tsrx/tests/utils/parser.test.js
@@ -1141,6 +1141,31 @@ foo();`;
 		expect(block.body[1].declarations[0].init.regex.pattern).toBe('---');
 	});
 
+	it('parses a template literal as the sole content of a `@{ }` code block', () => {
+		const block = findNode('let c = @{ `a${x}b` };', 'JSXCodeBlock');
+
+		expect(block.type).toBe('JSXCodeBlock');
+		expect(block.render).toBeNull();
+		expect(block.body.map((child) => child.type)).toEqual(['ExpressionStatement']);
+		const template = block.body[0].expression;
+		expect(template.type).toBe('TemplateLiteral');
+		expect(template.quasis.map((quasi) => quasi.value.raw)).toEqual(['a', 'b']);
+		expect(template.expressions.map((expression) => expression.name)).toEqual(['x']);
+	});
+
+	it('parses a template literal after another statement in a `@{ }` code block', () => {
+		const block = findNode('let i = @{ const a = 1; `t${a}` };', 'JSXCodeBlock');
+
+		expect(block.body.map((child) => child.type)).toEqual([
+			'VariableDeclaration',
+			'ExpressionStatement',
+		]);
+		const template = block.body[1].expression;
+		expect(template.type).toBe('TemplateLiteral');
+		expect(template.quasis.map((quasi) => quasi.value.raw)).toEqual(['t', '']);
+		expect(template.expressions.map((expression) => expression.name)).toEqual(['a']);
+	});
+
 	it('does not treat tag-looking text inside setup regex literals as markup', () => {
 		const returned = getReturned(`function App() { return <div>@{
 			const x = /<span>/


### PR DESCRIPTION
fixes #1287 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized parser change in code-block setup statement handling with new regression tests; no auth, runtime, or API surface changes.
> 
> **Overview**
> Fixes a parser crash (**"Unterminated template"**) when a **template literal** is the first (or follows another) statement inside a `@{ … }` code block—e.g. `let c = @{ \`123\` }` or `@{ \`${x}\` }`, while string literals like `@{ '123' }` already worked.
> 
> In `#parseCodeBlockSetupStatement`, opening the code block and preparing setup statements used to **replace or shadow** Acorn’s template-literal tokenizer context (`q_tmpl`). The setup path now **detects a leading backtick** and keeps (or pushes) `q_tmpl` instead of only forcing statement/JSX-stripped contexts; context restore on exit is skipped for that case so the template body tokenizes correctly.
> 
> Adds parser tests for a template literal as the only code-block body and for one after another statement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ca46b57bc744f2149b7c73d861edf4122270e36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->