### PR TITLE
chore: add rspack plugin support metadata

### DIFF
--- a/.changeset/four-rspack-plugins-support-links.md
+++ b/.changeset/four-rspack-plugins-support-links.md
@@ -1,0 +1,8 @@
+---
+'@tsrx/rspack-plugin-react': patch
+'@tsrx/rspack-plugin-vue': patch
+'@tsrx/rspack-plugin-solid': patch
+'@tsrx/rspack-plugin-preact': patch
+---
+
+Add npm homepage and bug tracker metadata for rspack plugin packages.

--- a/packages/rspack-plugin-preact/package.json
+++ b/packages/rspack-plugin-preact/package.json
@@ -13,6 +13,10 @@
     "url": "git+https://github.com/Ripple-TS/ripple.git",
     "directory": "packages/rspack-plugin-preact"
   },
+  "homepage": "https://github.com/Ripple-TS/ripple#readme",
+  "bugs": {
+    "url": "https://github.com/Ripple-TS/ripple/issues"
+  },
   "exports": {
     ".": {
       "types": "./types/index.d.ts",

--- a/packages/rspack-plugin-react/package.json
+++ b/packages/rspack-plugin-react/package.json
@@ -13,6 +13,10 @@
     "url": "git+https://github.com/Ripple-TS/ripple.git",
     "directory": "packages/rspack-plugin-react"
   },
+  "homepage": "https://github.com/Ripple-TS/ripple#readme",
+  "bugs": {
+    "url": "https://github.com/Ripple-TS/ripple/issues"
+  },
   "exports": {
     ".": {
       "types": "./types/index.d.ts",

--- a/packages/rspack-plugin-solid/package.json
+++ b/packages/rspack-plugin-solid/package.json
@@ -13,6 +13,10 @@
     "url": "git+https://github.com/Ripple-TS/ripple.git",
     "directory": "packages/rspack-plugin-solid"
   },
+  "homepage": "https://github.com/Ripple-TS/ripple#readme",
+  "bugs": {
+    "url": "https://github.com/Ripple-TS/ripple/issues"
+  },
   "exports": {
     ".": {
       "types": "./types/index.d.ts",

--- a/packages/rspack-plugin-vue/package.json
+++ b/packages/rspack-plugin-vue/package.json
@@ -13,6 +13,10 @@
     "url": "git+https://github.com/Ripple-TS/ripple.git",
     "directory": "packages/rspack-plugin-vue"
   },
+  "homepage": "https://github.com/Ripple-TS/ripple#readme",
+  "bugs": {
+    "url": "https://github.com/Ripple-TS/ripple/issues"
+  },
   "exports": {
     ".": {
       "types": "./types/index.d.ts",


### PR DESCRIPTION
## Summary
- Add npm \`homepage\` and \`bugs.url\` metadata for the rspack plugin packages:
  - \`@tsrx/rspack-plugin-react\`
  - \`@tsrx/rspack-plugin-vue\`
  - \`@tsrx/rspack-plugin-solid\`
  - \`@tsrx/rspack-plugin-preact\`
- Point homepage to the repository README and bug reports to the existing GitHub issues tracker.
- Include a patch changeset for the updated package metadata.

## Validation
- Confirmed the current published npm metadata for all four packages lacks \`homepage\` and \`bugs.url\`.
- Ran a metadata assertion for all four package manifests.
- \`pnpm install --frozen-lockfile --ignore-scripts\`
- \`pnpm format:check\`
- \`pnpm changeset:check\`
- \`npm pack --dry-run --ignore-scripts --json\` for each updated package
- \`git diff --check\`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Package.json metadata only; no runtime, build, or API behavior changes.
> 
> **Overview**
> Adds **`homepage`** (`https://github.com/Ripple-TS/ripple#readme`) and **`bugs.url`** (`https://github.com/Ripple-TS/ripple/issues`) to the published manifests for **`@tsrx/rspack-plugin-react`**, **`@tsrx/rspack-plugin-vue`**, **`@tsrx/rspack-plugin-solid`**, and **`@tsrx/rspack-plugin-preact`**.
> 
> Includes a **patch** changeset so the next release picks up the updated npm metadata only—no plugin source or export changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdaf20bd94fdc89878f0e4e608b230db096d9fa6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->