### PR TITLE
fix: nested lazy destructure

### DIFF
--- a/.changeset/lazy-destructuring-nested-scopes.md
+++ b/.changeset/lazy-destructuring-nested-scopes.md
@@ -1,0 +1,22 @@
+---
+'@tsrx/core': patch
+---
+
+Apply lazy `&{ … }` / `&[ … ]` destructuring inside nested `@{ … }` code blocks
+and `@if` / `@for` / `@switch` / `@try` directive bodies (React, Preact, Solid,
+and Vue production output), instead of leaving the lazy declaration as a plain
+destructure while its references go unrewritten.
+
+These scopes lower to compiler-generated function boundaries — scoped IIFEs,
+`.map(...)` callbacks, and `<Show>` / `<For>` / `<Match>` render closures — that
+did not exist when `has_lazy_descendants` was first stamped, so the lazy
+transform's fast-path skipped them. The descendant flag is now re-derived over
+the fully lowered tree before the transform runs, so a `let &{ name } = props`
+declared in a nested block or directive body is rewritten to
+`let __lazy0 = props` + `__lazy0.name` exactly as it is in a flat component body.
+A `@switch` case body's lazy bindings are now collected too (the shared switch
+block scope), so a reference like `{value}` becomes `{__lazy0.value}` rather than
+a half-transformed `let __lazy0 = props` with a dangling `value`.
+
+Type-only (virtual TSX) output is unchanged: it never runs the lazy transform, so
+the pattern keeps printing as a plain destructure.

--- a/packages/tsrx-react/tests/basic.test.js
+++ b/packages/tsrx-react/tests/basic.test.js
@@ -1728,6 +1728,24 @@ describe('lazy destructuring', () => {
 		expect(code).not.toContain('App__Continue');
 	});
 
+	it('leaves lazy destructuring inside nested scopes untouched in type-only output', () => {
+		const { code } = compile_to_volar_mappings(
+			`export function App(props) @{
+				@{
+					let &{ name } = props;
+					<div>{name}</div>
+				}
+			}`,
+			'App.tsrx',
+		);
+
+		// Type-only (virtual TSX) output must not run the lazy transform: the
+		// pattern prints as a plain destructure and no generated `__lazy` source
+		// id appears, even when the lazy declaration sits in a nested code block.
+		expect(code).not.toContain('__lazy');
+		expect(code).toContain('let { name } = props');
+	});
+
 	describe('ref attributes', () => {
 		it('passes a single ref={expr} through unchanged with no helper import', () => {
 			const { code } = compile(

--- a/packages/tsrx/src/transform/jsx/index.js
+++ b/packages/tsrx/src/transform/jsx/index.js
@@ -747,6 +747,12 @@ export function createJsxTransform(platform) {
 			inject_try_imports(expanded, transform_context, platform, suspense_source);
 		}
 
+		// Lower any `@{ … }` code blocks left in generated helper bodies before the
+		// lazy transform runs, so every `@{ … }` block / `@`-directive has already
+		// been lowered to its final closure / block shape. The lazy transform can
+		// then walk the complete function structure in one pass.
+		lower_remaining_jsx_code_blocks(expanded, transform_context);
+
 		// Apply lazy destructuring transforms to module-level code (top-level function
 		// declarations, arrow functions, etc.).
 		// In type-only mode, the lazy patterns survive untouched: esrap ignores the
@@ -754,12 +760,25 @@ export function createJsxTransform(platform) {
 		// = expr` prints as `let [a] = expr`, and the bare statement-level form
 		// `&[x] = expr;` (used when `x` is already declared) prints as `[x] =
 		// expr;` — a valid destructuring assignment to the existing binding.
+		//
+		// Re-run `preallocate_lazy_ids` first. The initial pre-walk pass stamps
+		// `metadata.has_lazy_descendants` (the fast-path gate that tells
+		// `apply_lazy_transforms` a function body is worth walking) on the function
+		// boundaries that existed in the source. Lowering `@{ … }` blocks and
+		// `@if`/`@for`/`@switch`/`@try` directives introduces NEW function
+		// boundaries — scoped IIFEs and `.map(...)` callbacks — that wrap those same
+		// lazy patterns but were never stamped. Re-running over the lowered tree
+		// stamps them too (it is idempotent: already-allocated `lazy_id`s are kept),
+		// so lazy bindings declared inside a nested block or directive body are
+		// rewritten just like a flat function body.
+		if (!transform_context.typeOnly) {
+			preallocate_lazy_ids(/** @type {any} */ (expanded), transform_context);
+		}
 		const final_program = /** @type {any} */ (
 			transform_context.typeOnly
 				? expanded
 				: apply_lazy_transforms(/** @type {any} */ (expanded), new Map())
 		);
-		lower_remaining_jsx_code_blocks(final_program, transform_context);
 
 		const result = print(/** @type {any} */ (final_program), tsx_with_ts_locations(), {
 			sourceMapSource: filename,

--- a/packages/tsrx/src/transform/lazy.js
+++ b/packages/tsrx/src/transform/lazy.js
@@ -669,16 +669,36 @@ export function apply_lazy_transforms(node, lazy_bindings) {
 	}
 
 	if (node.type === 'SwitchStatement') {
+		// All case consequents share one lexical block scope, and `@switch`
+		// case bodies are flattened (the `{ … }` wrapper is dropped), so a
+		// `let &[x] = …` / `let &{ … } = …` declared in a case body is scoped to
+		// the whole switch block. Collect names and lazy bindings across every
+		// consequent — like the BlockStatement handler does for a block body — so
+		// references in any case resolve to the generated id, and an inner
+		// declaration shadowing an outer lazy name is dropped.
+		const all_consequents = node.cases.flatMap(
+			(/** @type {any} */ switch_case) => switch_case.consequent,
+		);
+		const block_shadowed = collect_block_shadowed_names(all_consequents, lazy_bindings);
+		const after_shadow =
+			block_shadowed.size > 0 ? remove_shadowed(lazy_bindings, block_shadowed) : lazy_bindings;
+
+		/** @type {Map<string, LazyBinding>} */
+		const block_lazy = new Map();
+		collect_lazy_bindings_from_statements(all_consequents, block_lazy);
+		const effective_bindings =
+			block_lazy.size > 0 ? new Map([...after_shadow, ...block_lazy]) : after_shadow;
+
 		let changed = false;
-		const new_discriminant = apply_lazy_transforms(node.discriminant, lazy_bindings);
+		// The discriminant is evaluated before any case body runs, so it sees the
+		// bindings visible at the switch (outer, minus inner shadows), not a lazy
+		// binding declared inside a case body.
+		const new_discriminant = apply_lazy_transforms(node.discriminant, after_shadow);
 		if (new_discriminant !== node.discriminant) changed = true;
 		const new_cases = node.cases.map((/** @type {any} */ switch_case) => {
-			const case_bindings = collect_block_shadowed_names(switch_case.consequent, lazy_bindings);
-			const effective_bindings =
-				case_bindings.size > 0 ? remove_shadowed(lazy_bindings, case_bindings) : lazy_bindings;
 			let case_changed = false;
 			const new_test = switch_case.test
-				? apply_lazy_transforms(switch_case.test, lazy_bindings)
+				? apply_lazy_transforms(switch_case.test, effective_bindings)
 				: null;
 			if (new_test !== switch_case.test) case_changed = true;
 			const new_consequent = switch_case.consequent.map((/** @type {any} */ stmt) => {

--- a/packages/tsrx/tests/shared/compile.js
+++ b/packages/tsrx/tests/shared/compile.js
@@ -944,6 +944,155 @@ export function runSharedNestedLazyDestructuringTests({ compile, name }) {
 }
 
 /**
+ * Lazy `&{...}` / `&[...]` declarations inside a nested `@{ ... }` code block or a
+ * `@if` / `@for` / `@switch` directive body must be rewritten exactly as they are
+ * in a flat component body. These scopes lower to generated function boundaries
+ * (scoped IIFEs, `.map(...)` callbacks, `<Show>` / `<For>` / `<Match>` render
+ * closures), so the lazy transform has to descend into them rather than stopping
+ * at the component function. Assertions check only the framework-agnostic member
+ * accessor (`__lazy0.x` / `__lazy0[0]`), so they hold whichever way each target
+ * lowers the control flow.
+ *
+ * @param {Pick<CompileHarness, 'compile' | 'name'>} harness
+ */
+export function runSharedLazyScopeNestingTests({ compile, name }) {
+	describe(`[${name}] lazy destructuring across nested scopes`, () => {
+		it('transforms lazy object destructuring inside a nested code block', () => {
+			const { code } = compile(
+				`export function App(props) @{
+					@{
+						let &{ name } = props;
+						<div>{name}</div>
+					}
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('__lazy0 = props');
+			expect(code).toContain('__lazy0.name');
+			// The lazy declaration must not survive as a plain destructure.
+			expect(code).not.toContain('let { name } = props');
+		});
+
+		it('transforms lazy array destructuring inside a nested code block', () => {
+			const { code } = compile(
+				`export function App() @{
+					@{
+						let &[val] = getState();
+						<div>{val}</div>
+					}
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('__lazy0 = getState()');
+			expect(code).toContain('__lazy0[0]');
+			expect(code).not.toContain('let [val] = getState()');
+		});
+
+		it('transforms lazy destructuring through two levels of nested code blocks', () => {
+			const { code } = compile(
+				`export function App(props) @{
+					@{
+						@{
+							let &{ a } = props;
+							<div>{a}</div>
+						}
+					}
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('__lazy0 = props');
+			expect(code).toContain('__lazy0.a');
+		});
+
+		it('transforms lazy destructuring declared inside a @for body', () => {
+			const { code } = compile(
+				`export function App(props) @{
+					@for (const row of props.rows) {
+						let &{ name } = row;
+						<div>{name}</div>
+					}
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('__lazy0 = row');
+			expect(code).toContain('__lazy0.name');
+			expect(code).not.toContain('let { name } = row');
+		});
+
+		it('transforms lazy destructuring declared inside a @if body', () => {
+			const { code } = compile(
+				`export function App(props) @{
+					@if (props.show) {
+						let &{ label } = props;
+						<div>{label}</div>
+					}
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('__lazy0 = props');
+			expect(code).toContain('__lazy0.label');
+			expect(code).not.toContain('let { label } = props');
+		});
+
+		it('transforms lazy destructuring declared inside a @switch case body', () => {
+			const { code } = compile(
+				`export function App(props) @{
+					let &{ kind } = props;
+					@switch (kind) {
+						@case 'a': {
+							let &{ value } = props;
+							<div>{value}</div>
+						}
+					}
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('__lazy0.kind');
+			expect(code).toContain('__lazy1.value');
+			expect(code).not.toContain('let { value } = props');
+		});
+
+		it('rewrites an outer lazy binding referenced inside a nested code block', () => {
+			const { code } = compile(
+				`export function App(props) @{
+					let &{ name } = props;
+					@{
+						<div>{name}</div>
+					}
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('__lazy0 = props');
+			expect(code).toContain('__lazy0.name');
+		});
+
+		it('keeps a nested binding that shadows an outer lazy name unrewritten', () => {
+			const { code } = compile(
+				`export function App(props) @{
+					let &{ name } = props;
+					@{
+						let name = 'x';
+						<div>{name}</div>
+					}
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain("let name = 'x'");
+			// The shadowed reference resolves to the local `name`, never the lazy source.
+			expect(code).not.toContain('__lazy0.name');
+		});
+	});
+}
+
+/**
  * @param {Pick<CompileHarness, 'compile' | 'name'>} harness
  */
 export function runSharedFragmentExpressionRenderTests({ compile, name }) {
@@ -1758,6 +1907,7 @@ export function runSharedCompileTests({
 
 	runSharedComponentLoopControlFlowTests({ compile, name });
 	runSharedNestedLazyDestructuringTests({ compile, name });
+	runSharedLazyScopeNestingTests({ compile, name });
 
 	describe(`[${name}] fragment expression children`, () => {
 		// A bare expression placed directly as a JSX child reads as JSX text


### PR DESCRIPTION
fixes #1295 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Reorders JSX lowering vs lazy transform and broadens switch-scope semantics in the compiler; behavior is well covered by shared tests but touches core transform ordering for all production targets.
> 
> **Overview**
> Fixes lazy `&{…}` / `&[…]` destructuring when it appears inside nested `@{…}` blocks or `@if` / `@for` / `@switch` / `@try` bodies, where production output could keep a plain destructure while uses of those names were not rewritten.
> 
> The JSX pipeline now **lowers remaining `@{…}` blocks before** the lazy pass (instead of after), then **re-runs `preallocate_lazy_ids`** on that lowered AST so compiler-generated closures (IIFEs, `.map` callbacks, etc.) get `has_lazy_descendants` and the lazy transform walks them. **`SwitchStatement` handling in `lazy.js`** treats all case consequents as one lexical block—collecting lazy bindings and shadowing across cases—so `@switch` case bodies rewrite references like `{value}` to `__lazyN.value`.
> 
> Type-only (virtual TSX) output still skips the lazy transform; a React test and shared harness `runSharedLazyScopeNestingTests` cover nested scopes, directives, shadowing, and type-only behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52d2d5d171b36baaa9250dd2b32338ab7925084c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->