### PR TITLE
fix: lazy for components

### DIFF
--- a/.changeset/lazy-destructuring-nested-scopes.md
+++ b/.changeset/lazy-destructuring-nested-scopes.md
@@ -18,5 +18,20 @@ A `@switch` case body's lazy bindings are now collected too (the shared switch
 block scope), so a reference like `{value}` becomes `{__lazy0.value}` rather than
 a half-transformed `let __lazy0 = props` with a dangling `value`.
 
+Also rewrite a lazy binding used as a JSX element/component name to a member
+expression (`function Comp(&{ Item }) @{ <Item></Item> }` →
+`function Comp(__lazy0) { return <__lazy0.Item></__lazy0.Item>; }`). The bound
+name is no longer a local once the param/declaration is replaced with the
+generated `__lazy0` source, so `<Item>` had been leaking a reference to an
+undefined identifier; it now reads the component off the lazy source like every
+other reference does.
+
+An untyped lazy object param no longer gets a synthesized `{ … : any }` type. The
+source specified no type, so the generated param is left implicitly `any`
+(`function Comp(__lazy0)`) instead of carrying a fabricated object shape; a param
+with an author-provided type still keeps it (`function Comp(__lazy0: Props)`).
+
 Type-only (virtual TSX) output is unchanged: it never runs the lazy transform, so
-the pattern keeps printing as a plain destructure.
+the param keeps printing as a plain destructure (`{ Item }`, untyped) and `<Item>`
+keeps referencing that in-scope binding, which preserves identity-style source
+mappings for editor features.

--- a/packages/tsrx-react/tests/basic.test.js
+++ b/packages/tsrx-react/tests/basic.test.js
@@ -1746,6 +1746,22 @@ describe('lazy destructuring', () => {
 		expect(code).toContain('let { name } = props');
 	});
 
+	it('keeps a lazy binding used as a JSX name unrewritten in type-only output', () => {
+		const { code } = compile_to_volar_mappings(
+			`export function Comp(&{ Item }) @{
+				<Item></Item>
+			}`,
+			'App.tsrx',
+		);
+
+		// The param stays a bare destructure (so `Item` maps identity-style to
+		// source) and `<Item>` keeps referencing that in-scope binding — no rename
+		// to `__lazy0.Item`, which only happens in production output.
+		expect(code).not.toContain('__lazy');
+		expect(code).toContain('{ Item }');
+		expect(code).toContain('<Item>');
+	});
+
 	describe('ref attributes', () => {
 		it('passes a single ref={expr} through unchanged with no helper import', () => {
 			const { code } = compile(

--- a/packages/tsrx/src/transform/lazy.js
+++ b/packages/tsrx/src/transform/lazy.js
@@ -100,38 +100,6 @@ function get_lazy_pattern_mapping_range(pattern) {
 }
 
 /**
- * Synthesize an object-shaped annotation for untyped lazy object params so the
- * virtual TSX can expose prop names to TypeScript completions.
- *
- * @param {any} pattern
- * @returns {any | null}
- */
-function create_lazy_object_type_annotation(pattern) {
-	if (pattern.type !== 'ObjectPattern') return null;
-
-	const members = [];
-	for (const prop of pattern.properties || []) {
-		if (prop.type === 'RestElement' || prop.computed) continue;
-
-		const key = prop.key;
-		if (key.type !== 'Identifier' && key.type !== 'Literal') continue;
-
-		const member_key =
-			key.type === 'Identifier'
-				? create_generated_identifier(key.name, key)
-				: set_source_location({ ...key, metadata: { path: [] } }, key);
-
-		members.push(
-			b.ts_property_signature(member_key, b.ts_type_annotation(b.ts_keyword_type('any'))),
-		);
-	}
-
-	if (members.length === 0) return null;
-
-	return b.ts_type_annotation(b.ts_type_literal(members));
-}
-
-/**
  * @param {any} node
  * @returns {string | null}
  */
@@ -348,12 +316,14 @@ function visit_topmost_lazy_patterns(pattern, visit) {
 
 /**
  * Build the replacement identifier for a lazy pattern. When `is_top` is true
- * (the pattern is itself a function parameter) we attach the original
- * `typeAnnotation`, synthesize an object-shaped annotation for untyped object
- * params so TypeScript sees prop names, and register source-mapping info.
- * Nested replacements (inside a non-lazy outer destructure) can't carry an
- * inline type annotation — that's not valid syntax — so they get a plain
- * identifier with just source-range info.
+ * (the pattern is itself a function parameter) we carry over the author's
+ * `typeAnnotation` if one was written and register source-mapping info. An
+ * untyped lazy object param gets NO synthesized annotation: since the source
+ * specified no type, the generated param is left implicitly `any` rather than
+ * being given a fabricated `{ … : any }` object type. Nested replacements
+ * (inside a non-lazy outer destructure) can't carry an inline type annotation —
+ * that's not valid syntax — so they get a plain identifier with just source-range
+ * info.
  *
  * @param {any} pattern
  * @param {boolean} is_top
@@ -372,9 +342,6 @@ function build_lazy_id_for_pattern(pattern, is_top) {
 	if (!is_top) return lazy_id;
 	if (pattern.typeAnnotation) {
 		lazy_id.typeAnnotation = pattern.typeAnnotation;
-	} else {
-		const type_annotation = create_lazy_object_type_annotation(pattern);
-		if (type_annotation) lazy_id.typeAnnotation = type_annotation;
 	}
 	set_lazy_param_binding_mappings(lazy_id, pattern);
 	return lazy_id;
@@ -509,6 +476,53 @@ export function preallocate_lazy_ids(root, context) {
 	};
 
 	visit(root);
+}
+
+/**
+ * Convert an ESTree member-access chain (`__lazy0.Item`, `__lazy0.a.b`) into the
+ * equivalent JSX element-name node (a `JSXIdentifier` or `JSXMemberExpression`),
+ * so a lazy binding used as a component/element name (`<Item>`) can be rewritten
+ * to `<__lazy0.Item>`. Returns null for a computed access (`__lazy0[0]`, from an
+ * array destructure), which has no JSX-name form.
+ *
+ * @param {any} expr
+ * @param {any} [source]
+ * @returns {any | null}
+ */
+function estree_member_to_jsx_name(expr, source) {
+	if (expr.type === 'Identifier') {
+		return set_source_location(b.jsx_id(expr.name), source);
+	}
+	if (expr.type === 'MemberExpression' && !expr.computed && expr.property?.type === 'Identifier') {
+		const object = estree_member_to_jsx_name(expr.object, source);
+		if (!object) return null;
+		return set_source_location(b.jsx_member(object, b.jsx_id(expr.property.name)), source);
+	}
+	return null;
+}
+
+/**
+ * If a JSX element/component name references a lazy binding, return the rewritten
+ * JSX name (`<Item>` → `<__lazy0.Item>`, `<Item.Sub>` → `<__lazy0.Item.Sub>`).
+ * Returns null when the name does not reference a lazy binding (or the access has
+ * no JSX-name form), so the caller leaves the original name untouched.
+ *
+ * @param {any} name
+ * @param {Map<string, LazyBinding>} lazy_bindings
+ * @returns {any | null}
+ */
+function rewrite_lazy_jsx_name(name, lazy_bindings) {
+	if (!name) return null;
+	if (name.type === 'JSXIdentifier') {
+		const binding = lazy_bindings.get(name.name);
+		if (!binding) return null;
+		return estree_member_to_jsx_name(binding.read(name), name);
+	}
+	if (name.type === 'JSXMemberExpression') {
+		const new_object = rewrite_lazy_jsx_name(name.object, lazy_bindings);
+		return new_object ? { ...name, object: new_object } : null;
+	}
+	return null;
 }
 
 /**
@@ -842,6 +856,21 @@ export function apply_lazy_transforms(node, lazy_bindings) {
 		if (key === 'name' && node.type === 'JSXAttribute') continue;
 		// Skip VariableDeclarator id (already handled above).
 		if (key === 'id' && node.type === 'VariableDeclarator') continue;
+
+		// A JSX element/component name that resolves to a lazy binding becomes a
+		// JSX member expression (`<Item>` → `<__lazy0.Item>`): the bound name is no
+		// longer a local, it is a property of the synthesized lazy source.
+		if (
+			key === 'name' &&
+			(node.type === 'JSXOpeningElement' || node.type === 'JSXClosingElement')
+		) {
+			const jsx_name = rewrite_lazy_jsx_name(node[key], lazy_bindings);
+			if (jsx_name) {
+				clone[key] = jsx_name;
+				changed = true;
+				continue;
+			}
+		}
 
 		const new_value = apply_lazy_transforms(node[key], lazy_bindings);
 		if (new_value !== node[key]) {

--- a/packages/tsrx/tests/shared/compile.js
+++ b/packages/tsrx/tests/shared/compile.js
@@ -1093,6 +1093,77 @@ export function runSharedLazyScopeNestingTests({ compile, name }) {
 }
 
 /**
+ * A lazy binding used as a JSX element/component name must be rewritten to a JSX
+ * member expression in production output (`<Item>` → `<__lazy0.Item>`), because
+ * the bound name is no longer a local — it is a property of the synthesized lazy
+ * source. The element shape is identical across targets, so the assertions are
+ * framework-agnostic.
+ *
+ * @param {Pick<CompileHarness, 'compile' | 'name'>} harness
+ */
+export function runSharedLazyJsxNameTests({ compile, name }) {
+	describe(`[${name}] lazy binding as a JSX name`, () => {
+		it('rewrites a lazy object param used as a component name', () => {
+			const { code } = compile(
+				`export function Comp(&{ Item }) @{
+					<Item></Item>
+				}`,
+				'App.tsrx',
+			);
+
+			// Untyped lazy object param is left implicitly `any` — no synthesized type.
+			expect(code).toContain('function Comp(__lazy0)');
+			expect(code).not.toContain('{ Item: any }');
+			expect(code).toContain('<__lazy0.Item>');
+			expect(code).toContain('</__lazy0.Item>');
+			// The bare element name must not survive — it would reference a local that
+			// no longer exists (the param is now `__lazy0`).
+			expect(code).not.toContain('<Item>');
+			expect(code).not.toContain('</Item>');
+		});
+
+		it('rewrites a self-closing lazy component name', () => {
+			const { code } = compile(
+				`export function Comp(&{ Item }) @{
+					<Item />
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('<__lazy0.Item />');
+			expect(code).not.toContain('<Item ');
+		});
+
+		it('rewrites a lazy component name declared with let', () => {
+			const { code } = compile(
+				`export function Comp(props) @{
+					let &{ Item } = props;
+					<Item></Item>
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('__lazy0 = props');
+			expect(code).toContain('<__lazy0.Item>');
+			expect(code).not.toContain('<Item>');
+		});
+
+		it('rewrites a lazy component name alongside its attributes and children', () => {
+			const { code } = compile(
+				`export function Comp(&{ Item, label }) @{
+					<Item title={label}>{label}</Item>
+				}`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('<__lazy0.Item');
+			expect(code).toContain('title={__lazy0.label}');
+			expect(code).toContain('{__lazy0.label}');
+		});
+	});
+}
+
+/**
  * @param {Pick<CompileHarness, 'compile' | 'name'>} harness
  */
 export function runSharedFragmentExpressionRenderTests({ compile, name }) {
@@ -1908,6 +1979,7 @@ export function runSharedCompileTests({
 	runSharedComponentLoopControlFlowTests({ compile, name });
 	runSharedNestedLazyDestructuringTests({ compile, name });
 	runSharedLazyScopeNestingTests({ compile, name });
+	runSharedLazyJsxNameTests({ compile, name });
 
 	describe(`[${name}] fragment expression children`, () => {
 		// A bare expression placed directly as a JSX child reads as JSX text
@@ -3335,7 +3407,7 @@ export function optionalFn(bar: string, baz?: string) {
 		// component scope, but locals with the same name must shadow — the
 		// shared `applyLazyTransforms` helper in @tsrx/core handles this.
 
-		it('gives untyped lazy object params an object-shaped generated type', () => {
+		it('leaves an untyped lazy object param implicitly any (no synthesized type)', () => {
 			const { code } = compile(
 				`export function App(&{ name, age }) @{
 					<div>{name}{age}</div>
@@ -3343,12 +3415,15 @@ export function optionalFn(bar: string, baz?: string) {
 				'App.tsrx',
 			);
 
-			expect(code).toContain('function App(__lazy0: { name: any; age: any })');
+			// No type was written, so the generated param carries none either — it is
+			// left implicitly `any` rather than getting a fabricated `{ … : any }`.
+			expect(code).toContain('function App(__lazy0)');
+			expect(code).not.toContain('{ name: any; age: any }');
 			expect(code).toContain('__lazy0.name');
 			expect(code).toContain('__lazy0.age');
 		});
 
-		it('uses the source property name for aliased lazy object params', () => {
+		it('reads an aliased lazy object binding off its source property name', () => {
 			const { code } = compile(
 				`export function App(&{ name: displayName }) @{
 					<div>{displayName}</div>
@@ -3356,7 +3431,8 @@ export function optionalFn(bar: string, baz?: string) {
 				'App.tsrx',
 			);
 
-			expect(code).toContain('function App(__lazy0: { name: any })');
+			// The binding `displayName` resolves through the source property `name`.
+			expect(code).toContain('function App(__lazy0)');
 			expect(code).toContain('__lazy0.name');
 			expect(code).not.toContain('__lazy0.displayName');
 		});


### PR DESCRIPTION
fixes #1294 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core lazy-transform emission for params and JSX names across React/Preact/Solid/Vue production builds; behavior is well-tested but affects generated component signatures and tag resolution.
> 
> **Overview**
> Fixes lazy `&{ … }` destructuring when a bound name is used as a **JSX tag** in production output: `<Item>` becomes `<__lazy0.Item>` (and matching closing tags), so the tag no longer references a local that was replaced by `__lazy0`. **Type-only (virtual TSX) output** still skips this rewrite so params stay as `{ Item }` and `<Item>` keeps identity-style mappings for the editor.
> 
> **Untyped** lazy object params no longer get a compiler-synthesized `{ …: any }` annotation; emitted signatures are `function Comp(__lazy0)` while author-written types on the param are still preserved.
> 
> Shared compile tests cover JSX-name rewriting (params, `let`, attributes/children) and updated expectations for implicit `any` params; React adds a type-only test that `<Item>` stays unrewritten.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 141312cd64f57e6ddd4c9e808aacaa9724f5e6a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->