### PR TITLE
chore: 2x ripple ssr performance - less arr push, more str concat

### DIFF
--- a/.changeset/ssr-output-accumulator.md
+++ b/.changeset/ssr-output-accumulator.md
@@ -1,0 +1,10 @@
+---
+'@tsrx/ripple': patch
+---
+
+Server transform: accumulate each runtime block's output into a single `__out`
+string and push it once per block (flushing only before a child block) instead
+of emitting an `output_push` per element. Adjacent static + dynamic holes
+coalesce into one `__out += a + b + c`, and accumulation spans loops and control
+flow, so e.g. a whole `@for` feed renders in one push. Output is byte-identical;
+this only changes how the SSR string is assembled.

--- a/packages/ripple/tests/hydration/compiled/server/basic.js
+++ b/packages/ripple/tests/hydration/compiled/server/basic.js
@@ -6,14 +6,10 @@ import { track } from 'ripple/server';
 export function StaticText() {
 	return _$_.tsrx_element(() => {
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push('Hello World');
-			}
-
-			_$_.output_push('</div>');
+			__out += '<div>Hello World</div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -21,32 +17,10 @@ export function StaticText() {
 export function MultipleElements() {
 	return _$_.tsrx_element(() => {
 		_$_.regular_block(() => {
-			{
-				_$_.output_push('<h1');
-				_$_.output_push('>');
+			let __out = '';
 
-				{
-					_$_.output_push('Title');
-				}
-
-				_$_.output_push('</h1>');
-				_$_.output_push('<p');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('Paragraph text');
-				}
-
-				_$_.output_push('</p>');
-				_$_.output_push('<span');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('Span text');
-				}
-
-				_$_.output_push('</span>');
-			}
+			__out += '<h1>Title</h1><p>Paragraph text</p><span>Span text</span>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -54,30 +28,10 @@ export function MultipleElements() {
 export function NestedElements() {
 	return _$_.tsrx_element(() => {
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push(' class="outer"');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push('<div');
-				_$_.output_push(' class="inner"');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('<span');
-					_$_.output_push('>');
-
-					{
-						_$_.output_push('Nested content');
-					}
-
-					_$_.output_push('</span>');
-				}
-
-				_$_.output_push('</div>');
-			}
-
-			_$_.output_push('</div>');
+			__out += '<div class="outer"><div class="inner"><span>Nested content</span></div></div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -85,23 +39,10 @@ export function NestedElements() {
 export function WithAttributes() {
 	return _$_.tsrx_element(() => {
 		_$_.regular_block(() => {
-			{
-				_$_.output_push('<input');
-				_$_.output_push(' type="text"');
-				_$_.output_push(' placeholder="Enter text"');
-				_$_.output_push(' disabled');
-				_$_.output_push(' />');
-				_$_.output_push('<a');
-				_$_.output_push(' href="/link"');
-				_$_.output_push(' target="_blank"');
-				_$_.output_push('>');
+			let __out = '';
 
-				{
-					_$_.output_push('Link');
-				}
-
-				_$_.output_push('</a>');
-			}
+			__out += '<input type="text" placeholder="Enter text" disabled /><a href="/link" target="_blank">Link</a>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -109,15 +50,10 @@ export function WithAttributes() {
 export function ChildComponent() {
 	return _$_.tsrx_element(() => {
 		_$_.regular_block(() => {
-			_$_.output_push('<span');
-			_$_.output_push(' class="child"');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push('Child content');
-			}
-
-			_$_.output_push('</span>');
+			__out += '<span class="child">Child content</span>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -125,20 +61,23 @@ export function ChildComponent() {
 export function ParentWithChild() {
 	return _$_.tsrx_element(() => {
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push(' class="parent"');
-			_$_.output_push('>');
+			let __out = '';
+
+			__out += '<div class="parent">';
 
 			{
 				{
 					const comp = ChildComponent;
 					const args = [{}];
 
+					_$_.output_push(__out);
+					__out = '';
 					_$_.render_component(comp, ...args);
 				}
 			}
 
-			_$_.output_push('</div>');
+			__out += '</div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -146,15 +85,10 @@ export function ParentWithChild() {
 export function FirstSibling() {
 	return _$_.tsrx_element(() => {
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push(' class="first"');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push('First');
-			}
-
-			_$_.output_push('</div>');
+			__out += '<div class="first">First</div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -162,15 +96,10 @@ export function FirstSibling() {
 export function SecondSibling() {
 	return _$_.tsrx_element(() => {
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push(' class="second"');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push('Second');
-			}
-
-			_$_.output_push('</div>');
+			__out += '<div class="second">Second</div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -200,14 +129,10 @@ export function SiblingComponents() {
 export function Greeting(props) {
 	return _$_.tsrx_element(() => {
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push(_$_.escape('Hello ' + String(props.name ?? '')));
-			}
-
-			_$_.output_push('</div>');
+			__out += '<div>' + _$_.escape('Hello ' + String(props.name ?? '')) + '</div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -231,24 +156,18 @@ export function ExpressionContent() {
 		const label = 'computed';
 
 		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<div>' + _$_.escape(value) + '</div><span>';
+
 			{
-				_$_.output_push('<div');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push(_$_.escape(value));
-				}
-
-				_$_.output_push('</div>');
-				_$_.output_push('<span');
-				_$_.output_push('>');
-
-				{
-					_$_.render_expression(label.toUpperCase());
-				}
-
-				_$_.output_push('</span>');
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_expression(label.toUpperCase());
 			}
+
+			__out += '</span>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -256,15 +175,10 @@ export function ExpressionContent() {
 function NestedHelperItem({ item }) {
 	return _$_.tsrx_element(() => {
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push(' class="helper-item"');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push(_$_.escape(item));
-			}
-
-			_$_.output_push('</div>');
+			__out += '<div class="helper-item">' + _$_.escape(item) + '</div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -272,29 +186,23 @@ function NestedHelperItem({ item }) {
 function NestedTsxTsrxFragment({ label }) {
 	return _$_.tsrx_element(() => {
 		_$_.regular_block(() => {
-			{
-				_$_.output_push('<span');
-				_$_.output_push(' class="label"');
-				_$_.output_push('>');
+			let __out = '';
 
+			__out += '<span class="label">' + _$_.escape(label) + '</span><!--[-->';
+
+			for (const item of [1, 2, 3, 4]) {
 				{
-					_$_.output_push(_$_.escape(label));
+					const comp = NestedHelperItem;
+					const args = [{ item }];
+
+					_$_.output_push(__out);
+					__out = '';
+					_$_.render_component(comp, ...args);
 				}
-
-				_$_.output_push('</span>');
-				_$_.output_push('<!--[-->');
-
-				for (const item of [1, 2, 3, 4]) {
-					{
-						const comp = NestedHelperItem;
-						const args = [{ item }];
-
-						_$_.render_component(comp, ...args);
-					}
-				}
-
-				_$_.output_push('<!--]-->');
 			}
+
+			__out += '<!--]-->';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -302,36 +210,27 @@ function NestedTsxTsrxFragment({ label }) {
 export function NestedTsxTsrxExpressionValues() {
 	return _$_.tsrx_element(() => {
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push(' class="nested-expression-values"');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push('<!--[-->');
+			__out += '<div class="nested-expression-values"><!--[-->';
 
-				for (const item of [1, 2, 3]) {
-					_$_.output_push('<div');
-					_$_.output_push(' class="app-item"');
-					_$_.output_push('>');
-
-					{
-						_$_.output_push(_$_.escape(item));
-					}
-
-					_$_.output_push('</div>');
-				}
-
-				_$_.output_push('<!--]-->');
-
-				{
-					const comp = NestedTsxTsrxFragment;
-					const args = [{ label: "from helper" }];
-
-					_$_.render_component(comp, ...args);
-				}
+			for (const item of [1, 2, 3]) {
+				__out += '<div class="app-item">' + _$_.escape(item) + '</div>';
 			}
 
-			_$_.output_push('</div>');
+			__out += '<!--]-->';
+
+			{
+				const comp = NestedTsxTsrxFragment;
+				const args = [{ label: "from helper" }];
+
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_component(comp, ...args);
+			}
+
+			__out += '</div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -343,29 +242,19 @@ export function MixedTsrxCollectionText() {
 				_$_.render_expression([
 					'alpha ',
 					_$_.tsrx_element(() => {
-						_$_.output_push('<strong');
-						_$_.output_push(' class="middle"');
-						_$_.output_push('>');
+						let __out = '';
 
-						{
-							_$_.output_push('beta');
-						}
-
-						_$_.output_push('</strong>');
+						__out += '<strong class="middle">beta</strong>';
+						_$_.output_push(__out);
 					}),
 					' gamma ',
 					[
 						'delta ',
 						_$_.tsrx_element(() => {
-							_$_.output_push('<em');
-							_$_.output_push(' class="tail"');
-							_$_.output_push('>');
+							let __out = '';
 
-							{
-								_$_.output_push('epsilon');
-							}
-
-							_$_.output_push('</em>');
+							__out += '<em class="tail">epsilon</em>';
+							_$_.output_push(__out);
 						}),
 						' zeta'
 					]
@@ -374,15 +263,18 @@ export function MixedTsrxCollectionText() {
 		});
 
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push(' class="mixed-collection"');
-			_$_.output_push('>');
+			let __out = '';
+
+			__out += '<div class="mixed-collection">';
 
 			{
+				_$_.output_push(__out);
+				__out = '';
 				_$_.render_expression(content);
 			}
 
-			_$_.output_push('</div>');
+			__out += '</div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -394,29 +286,19 @@ export function MixedTsrxCollectionSplitServerText() {
 				_$_.render_expression([
 					'alpha ',
 					_$_.tsrx_element(() => {
-						_$_.output_push('<strong');
-						_$_.output_push(' class="middle"');
-						_$_.output_push('>');
+						let __out = '';
 
-						{
-							_$_.output_push('beta');
-						}
-
-						_$_.output_push('</strong>');
+						__out += '<strong class="middle">beta</strong>';
+						_$_.output_push(__out);
 					}),
 					' gamma ',
 					[
 						'delta ',
 						_$_.tsrx_element(() => {
-							_$_.output_push('<em');
-							_$_.output_push(' class="tail"');
-							_$_.output_push('>');
+							let __out = '';
 
-							{
-								_$_.output_push('epsilon');
-							}
-
-							_$_.output_push('</em>');
+							__out += '<em class="tail">epsilon</em>';
+							_$_.output_push(__out);
 						}),
 						' zeta'
 					]
@@ -425,15 +307,18 @@ export function MixedTsrxCollectionSplitServerText() {
 		});
 
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push(' class="mixed-collection-split"');
-			_$_.output_push('>');
+			let __out = '';
+
+			__out += '<div class="mixed-collection-split">';
 
 			{
+				_$_.output_push(__out);
+				__out = '';
 				_$_.render_expression(content);
 			}
 
-			_$_.output_push('</div>');
+			__out += '</div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -445,29 +330,19 @@ export function MixedTsrxCollectionSplitClientText() {
 				_$_.render_expression([
 					'alpha ',
 					_$_.tsrx_element(() => {
-						_$_.output_push('<strong');
-						_$_.output_push(' class="middle"');
-						_$_.output_push('>');
+						let __out = '';
 
-						{
-							_$_.output_push('beta');
-						}
-
-						_$_.output_push('</strong>');
+						__out += '<strong class="middle">beta</strong>';
+						_$_.output_push(__out);
 					}),
 					' gamma ',
 					[
 						'changed ',
 						_$_.tsrx_element(() => {
-							_$_.output_push('<em');
-							_$_.output_push(' class="tail"');
-							_$_.output_push('>');
+							let __out = '';
 
-							{
-								_$_.output_push('epsilon');
-							}
-
-							_$_.output_push('</em>');
+							__out += '<em class="tail">epsilon</em>';
+							_$_.output_push(__out);
 						}),
 						' zeta'
 					]
@@ -476,15 +351,18 @@ export function MixedTsrxCollectionSplitClientText() {
 		});
 
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push(' class="mixed-collection-split"');
-			_$_.output_push('>');
+			let __out = '';
+
+			__out += '<div class="mixed-collection-split">';
 
 			{
+				_$_.output_push(__out);
+				__out = '';
 				_$_.render_expression(content);
 			}
 
-			_$_.output_push('</div>');
+			__out += '</div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -499,30 +377,28 @@ export function MixedTsrxCollectionPrimitiveServerText() {
 					' / ',
 					true,
 					_$_.tsrx_element(() => {
-						_$_.output_push('<span');
-						_$_.output_push(' class="primitive-tail"');
-						_$_.output_push('>');
+						let __out = '';
 
-						{
-							_$_.output_push(' ok');
-						}
-
-						_$_.output_push('</span>');
+						__out += '<span class="primitive-tail"> ok</span>';
+						_$_.output_push(__out);
 					})
 				]);
 			});
 		});
 
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push(' class="mixed-collection-primitive"');
-			_$_.output_push('>');
+			let __out = '';
+
+			__out += '<div class="mixed-collection-primitive">';
 
 			{
+				_$_.output_push(__out);
+				__out = '';
 				_$_.render_expression(content);
 			}
 
-			_$_.output_push('</div>');
+			__out += '</div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -537,30 +413,28 @@ export function MixedTsrxCollectionPrimitiveClientText() {
 					' / ',
 					false,
 					_$_.tsrx_element(() => {
-						_$_.output_push('<span');
-						_$_.output_push(' class="primitive-tail"');
-						_$_.output_push('>');
+						let __out = '';
 
-						{
-							_$_.output_push(' ok');
-						}
-
-						_$_.output_push('</span>');
+						__out += '<span class="primitive-tail"> ok</span>';
+						_$_.output_push(__out);
 					})
 				]);
 			});
 		});
 
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push(' class="mixed-collection-primitive"');
-			_$_.output_push('>');
+			let __out = '';
+
+			__out += '<div class="mixed-collection-primitive">';
 
 			{
+				_$_.output_push(__out);
+				__out = '';
 				_$_.render_expression(content);
 			}
 
-			_$_.output_push('</div>');
+			__out += '</div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -574,15 +448,18 @@ export function DynamicArrayFromCall() {
 		const items = createPrimitiveItems();
 
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push(' class="dynamic-array-call"');
-			_$_.output_push('>');
+			let __out = '';
+
+			__out += '<div class="dynamic-array-call">';
 
 			{
+				_$_.output_push(__out);
+				__out = '';
 				_$_.render_expression(items);
 			}
 
-			_$_.output_push('</div>');
+			__out += '</div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -592,15 +469,18 @@ export function DynamicArrayFromTrack() {
 		let lazy = _$_.track(['start:', ['one', 2], true, null, false, ':end'], 'b5de6402');
 
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push(' class="dynamic-array-track"');
-			_$_.output_push('>');
+			let __out = '';
+
+			__out += '<div class="dynamic-array-track">';
 
 			{
+				_$_.output_push(__out);
+				__out = '';
 				_$_.render_expression(lazy.value);
 			}
 
-			_$_.output_push('</div>');
+			__out += '</div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -614,15 +494,18 @@ export function DynamicArrayFromConditional() {
 			: ['fallback'];
 
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push(' class="dynamic-array-conditional"');
-			_$_.output_push('>');
+			let __out = '';
+
+			__out += '<div class="dynamic-array-conditional">';
 
 			{
+				_$_.output_push(__out);
+				__out = '';
 				_$_.render_expression(items);
 			}
 
-			_$_.output_push('</div>');
+			__out += '</div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -633,15 +516,18 @@ export function DynamicArrayFromLogical() {
 		const items = condition && ['start:', ['one', 2], true, null, false, ':end'];
 
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push(' class="dynamic-array-logical"');
-			_$_.output_push('>');
+			let __out = '';
+
+			__out += '<div class="dynamic-array-logical">';
 
 			{
+				_$_.output_push(__out);
+				__out = '';
 				_$_.render_expression(items);
 			}
 
-			_$_.output_push('</div>');
+			__out += '</div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -650,23 +536,10 @@ export function NestedTsrxInsideTopLevelTsxExpression() {
 	return _$_.tsrx_element(() => {
 		const content = _$_.tsrx_element(() => {
 			_$_.regular_block(() => {
-				_$_.output_push('<section');
-				_$_.output_push(' class="outer"');
-				_$_.output_push('>');
+				let __out = '';
 
-				{
-					_$_.output_push('<div');
-					_$_.output_push(' class="inner"');
-					_$_.output_push('>');
-
-					{
-						_$_.output_push('from tsrx');
-					}
-
-					_$_.output_push('</div>');
-				}
-
-				_$_.output_push('</section>');
+				__out += '<section class="outer"><div class="inner">from tsrx</div></section>';
+				_$_.output_push(__out);
 			});
 		});
 
@@ -682,31 +555,10 @@ export function NestedTsrxElementsInsideTopLevelTsxValue() {
 	return _$_.tsrx_element(() => {
 		const content = _$_.tsrx_element(() => {
 			_$_.regular_block(() => {
-				_$_.output_push('<div');
-				_$_.output_push(' class="wrapper"');
-				_$_.output_push('>');
+				let __out = '';
 
-				{
-					_$_.output_push('<section');
-					_$_.output_push(' class="native"');
-					_$_.output_push('>');
-
-					{
-						_$_.output_push('<span');
-						_$_.output_push(' class="nested-tsrx"');
-						_$_.output_push('>');
-
-						{
-							_$_.output_push('inside nested tsrx');
-						}
-
-						_$_.output_push('</span>');
-					}
-
-					_$_.output_push('</section>');
-				}
-
-				_$_.output_push('</div>');
+				__out += '<div class="wrapper"><section class="native"><span class="nested-tsrx">inside nested tsrx</span></section></div>';
+				_$_.output_push(__out);
 			});
 		});
 
@@ -722,29 +574,27 @@ export function TsxDeclaredBeforeTopLevelTsx() {
 	return _$_.tsrx_element(() => {
 		const nested = _$_.tsrx_element(() => {
 			_$_.regular_block(() => {
-				_$_.output_push('<span');
-				_$_.output_push(' class="nested-tsx"');
-				_$_.output_push('>');
+				let __out = '';
 
-				{
-					_$_.output_push('inside nested tsx');
-				}
-
-				_$_.output_push('</span>');
+				__out += '<span class="nested-tsx">inside nested tsx</span>';
+				_$_.output_push(__out);
 			});
 		});
 
 		const content = _$_.tsrx_element(() => {
 			_$_.regular_block(() => {
-				_$_.output_push('<div');
-				_$_.output_push(' class="native"');
-				_$_.output_push('>');
+				let __out = '';
+
+				__out += '<div class="native">';
 
 				{
+					_$_.output_push(__out);
+					__out = '';
 					_$_.render_expression(nested);
 				}
 
-				_$_.output_push('</div>');
+				__out += '</div>';
+				_$_.output_push(__out);
 			});
 		});
 
@@ -759,15 +609,18 @@ export function TsxDeclaredBeforeTopLevelTsx() {
 function TextProp(__props) {
 	return _$_.tsrx_element(() => {
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push(' class="text-prop"');
-			_$_.output_push('>');
+			let __out = '';
+
+			__out += '<div class="text-prop">';
 
 			{
+				_$_.output_push(__out);
+				__out = '';
 				_$_.render_expression(__props.children);
 			}
 
-			_$_.output_push('</div>');
+			__out += '</div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -777,29 +630,27 @@ export function TextPropWithToggle() {
 		let lazy_1 = _$_.track(false, '1ba81c3b');
 
 		_$_.regular_block(() => {
+			let __out = '';
+
 			{
-				{
-					const comp = TextProp;
+				const comp = TextProp;
 
-					const args = [
-						{
-							children: _$_.normalize_children(lazy_1.value ? 'hello' : '')
-						}
-					];
+				_$_.output_push(__out);
+				__out = '';
 
-					_$_.render_component(comp, ...args);
-				}
+				const args = [
+					{
+						children: _$_.normalize_children(lazy_1.value ? 'hello' : '')
+					}
+				];
 
-				_$_.output_push('<button');
-				_$_.output_push(' class="show-text"');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('Show');
-				}
-
-				_$_.output_push('</button>');
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_component(comp, ...args);
 			}
+
+			__out += '<button class="show-text">Show</button>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -807,35 +658,10 @@ export function TextPropWithToggle() {
 function StaticHeader() {
 	return _$_.tsrx_element(() => {
 		_$_.regular_block(() => {
-			{
-				_$_.output_push('<h1');
-				_$_.output_push(' class="sr-only"');
-				_$_.output_push('>');
+			let __out = '';
 
-				{
-					_$_.output_push('heading');
-				}
-
-				_$_.output_push('</h1>');
-				_$_.output_push('<p');
-				_$_.output_push(' class="subtitle"');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('first paragraph');
-				}
-
-				_$_.output_push('</p>');
-				_$_.output_push('<p');
-				_$_.output_push(' class="subtitle"');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('second paragraph');
-				}
-
-				_$_.output_push('</p>');
-			}
+			__out += '<h1 class="sr-only">heading</h1><p class="subtitle">first paragraph</p><p class="subtitle">second paragraph</p>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -845,33 +671,19 @@ export function StaticChildWithSiblings() {
 		const foo = 'bar';
 
 		_$_.regular_block(() => {
+			let __out = '';
+
 			{
-				{
-					const comp = StaticHeader;
-					const args = [{}];
+				const comp = StaticHeader;
+				const args = [{}];
 
-					_$_.render_component(comp, ...args);
-				}
-
-				_$_.output_push('<span');
-				_$_.output_push(' class="sibling1"');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push(_$_.escape(foo));
-				}
-
-				_$_.output_push('</span>');
-				_$_.output_push('<span');
-				_$_.output_push(' class="sibling2"');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push(_$_.escape(foo));
-				}
-
-				_$_.output_push('</span>');
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_component(comp, ...args);
 			}
+
+			__out += '<span class="sibling1">' + _$_.escape(foo) + '</span><span class="sibling2">' + _$_.escape(foo) + '</span>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -879,31 +691,10 @@ export function StaticChildWithSiblings() {
 function Header() {
 	return _$_.tsrx_element(() => {
 		_$_.regular_block(() => {
-			{
-				_$_.output_push('<h1');
-				_$_.output_push(' class="sr-only"');
-				_$_.output_push('>');
+			let __out = '';
 
-				{
-					_$_.output_push('Ripple');
-				}
-
-				_$_.output_push('</h1>');
-				_$_.output_push('<img');
-				_$_.output_push(' src="/images/logo.png"');
-				_$_.output_push(' alt="Logo"');
-				_$_.output_push(' class="logo"');
-				_$_.output_push(' />');
-				_$_.output_push('<p');
-				_$_.output_push(' class="subtitle"');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('the elegant TypeScript UI framework');
-				}
-
-				_$_.output_push('</p>');
-			}
+			__out += '<h1 class="sr-only">Ripple</h1><img src="/images/logo.png" alt="Logo" class="logo" /><p class="subtitle">the elegant TypeScript UI framework</p>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -911,49 +702,23 @@ function Header() {
 function Actions({ playgroundVisible = false }) {
 	return _$_.tsrx_element(() => {
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push(' class="social-links"');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push('<a');
-				_$_.output_push(' href="https://github.com"');
-				_$_.output_push(' class="github-link"');
-				_$_.output_push('>');
+			__out += '<div class="social-links"><a href="https://github.com" class="github-link">GitHub</a><a href="https://discord.com" class="discord-link">Discord</a>';
+			_$_.output_push(__out);
+			__out = '';
 
-				{
-					_$_.output_push('GitHub');
-				}
+			_$_.render_expression(playgroundVisible
+				? _$_.tsrx_element(() => {
+					let __out = '';
 
-				_$_.output_push('</a>');
-				_$_.output_push('<a');
-				_$_.output_push(' href="https://discord.com"');
-				_$_.output_push(' class="discord-link"');
-				_$_.output_push('>');
+					__out += '<a href="/playground" class="playground-link">Playground</a>';
+					_$_.output_push(__out);
+				})
+				: null);
 
-				{
-					_$_.output_push('Discord');
-				}
-
-				_$_.output_push('</a>');
-
-				_$_.render_expression(playgroundVisible
-					? _$_.tsrx_element(() => {
-						_$_.output_push('<a');
-						_$_.output_push(' href="/playground"');
-						_$_.output_push(' class="playground-link"');
-						_$_.output_push('>');
-
-						{
-							_$_.output_push('Playground');
-						}
-
-						_$_.output_push('</a>');
-					})
-					: null);
-			}
-
-			_$_.output_push('</div>');
+			__out += '</div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -961,22 +726,18 @@ function Actions({ playgroundVisible = false }) {
 function Layout({ children }) {
 	return _$_.tsrx_element(() => {
 		_$_.regular_block(() => {
-			_$_.output_push('<main');
-			_$_.output_push('>');
+			let __out = '';
+
+			__out += '<main><div class="container">';
 
 			{
-				_$_.output_push('<div');
-				_$_.output_push(' class="container"');
-				_$_.output_push('>');
-
-				{
-					_$_.render_expression(children);
-				}
-
-				_$_.output_push('</div>');
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_expression(children);
 			}
 
-			_$_.output_push('</main>');
+			__out += '</div></main>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -984,22 +745,10 @@ function Layout({ children }) {
 function Content() {
 	return _$_.tsrx_element(() => {
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push(' class="content"');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push('<p');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('Some content here');
-				}
-
-				_$_.output_push('</p>');
-			}
-
-			_$_.output_push('</div>');
+			__out += '<div class="content"><p>Some content here</p></div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -1055,15 +804,10 @@ export function WebsiteIndex() {
 function LastChild() {
 	return _$_.tsrx_element(() => {
 		_$_.regular_block(() => {
-			_$_.output_push('<footer');
-			_$_.output_push(' class="last-child"');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push('I am the last child');
-			}
-
-			_$_.output_push('</footer>');
+			__out += '<footer class="last-child">I am the last child</footer>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -1071,37 +815,21 @@ function LastChild() {
 export function ComponentAsLastSibling() {
 	return _$_.tsrx_element(() => {
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push(' class="wrapper"');
-			_$_.output_push('>');
+			let __out = '';
+
+			__out += '<div class="wrapper"><h1>Header</h1><p>Some content</p>';
 
 			{
-				_$_.output_push('<h1');
-				_$_.output_push('>');
+				const comp = LastChild;
+				const args = [{}];
 
-				{
-					_$_.output_push('Header');
-				}
-
-				_$_.output_push('</h1>');
-				_$_.output_push('<p');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('Some content');
-				}
-
-				_$_.output_push('</p>');
-
-				{
-					const comp = LastChild;
-					const args = [{}];
-
-					_$_.render_component(comp, ...args);
-				}
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_component(comp, ...args);
 			}
 
-			_$_.output_push('</div>');
+			__out += '</div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -1109,29 +837,21 @@ export function ComponentAsLastSibling() {
 function InnerContent() {
 	return _$_.tsrx_element(() => {
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push(' class="inner"');
-			_$_.output_push('>');
+			let __out = '';
+
+			__out += '<div class="inner"><span>Inner text</span>';
 
 			{
-				_$_.output_push('<span');
-				_$_.output_push('>');
+				const comp = LastChild;
+				const args = [{}];
 
-				{
-					_$_.output_push('Inner text');
-				}
-
-				_$_.output_push('</span>');
-
-				{
-					const comp = LastChild;
-					const args = [{}];
-
-					_$_.render_component(comp, ...args);
-				}
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_component(comp, ...args);
 			}
 
-			_$_.output_push('</div>');
+			__out += '</div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -1139,29 +859,21 @@ function InnerContent() {
 export function NestedComponentAsLastSibling() {
 	return _$_.tsrx_element(() => {
 		_$_.regular_block(() => {
-			_$_.output_push('<section');
-			_$_.output_push(' class="outer"');
-			_$_.output_push('>');
+			let __out = '';
+
+			__out += '<section class="outer"><h2>Section title</h2>';
 
 			{
-				_$_.output_push('<h2');
-				_$_.output_push('>');
+				const comp = InnerContent;
+				const args = [{}];
 
-				{
-					_$_.output_push('Section title');
-				}
-
-				_$_.output_push('</h2>');
-
-				{
-					const comp = InnerContent;
-					const args = [{}];
-
-					_$_.render_component(comp, ...args);
-				}
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_component(comp, ...args);
 			}
 
-			_$_.output_push('</section>');
+			__out += '</section>';
+			_$_.output_push(__out);
 		});
 	});
 }

--- a/packages/ripple/tests/hydration/compiled/server/composite.js
+++ b/packages/ripple/tests/hydration/compiled/server/composite.js
@@ -4,15 +4,18 @@ import * as _$_ from 'ripple/internal/server';
 export function Layout(__props) {
 	return _$_.tsrx_element(() => {
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push(' class="layout"');
-			_$_.output_push('>');
+			let __out = '';
+
+			__out += '<div class="layout">';
 
 			{
+				_$_.output_push(__out);
+				__out = '';
 				_$_.render_expression(__props.children);
 			}
 
-			_$_.output_push('</div>');
+			__out += '</div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -20,17 +23,14 @@ export function Layout(__props) {
 export function TextWrappedLayout(__props) {
 	return _$_.tsrx_element(() => {
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push(' class="layout"');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push('before');
-				_$_.render_expression(__props.children);
-				_$_.output_push('after');
-			}
-
-			_$_.output_push('</div>');
+			__out += '<div class="layout">before';
+			_$_.output_push(__out);
+			__out = '';
+			_$_.render_expression(__props.children);
+			__out += 'after</div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -38,15 +38,10 @@ export function TextWrappedLayout(__props) {
 export function SingleChild() {
 	return _$_.tsrx_element(() => {
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push(' class="single"');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push('single');
-			}
-
-			_$_.output_push('</div>');
+			__out += '<div class="single">single</div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -54,24 +49,10 @@ export function SingleChild() {
 export function MultiRootChild() {
 	return _$_.tsrx_element(() => {
 		_$_.regular_block(() => {
-			{
-				_$_.output_push('<h1');
-				_$_.output_push('>');
+			let __out = '';
 
-				{
-					_$_.output_push('title');
-				}
-
-				_$_.output_push('</h1>');
-				_$_.output_push('<p');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('description');
-				}
-
-				_$_.output_push('</p>');
-			}
+			__out += '<h1>title</h1><p>description</p>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -126,22 +107,19 @@ export function LayoutWithMultipleChildren() {
 					{
 						children: _$_.tsrx_element(() => {
 							return _$_.tsrx_element(() => {
+								let __out = '';
+
 								{
 									const comp = SingleChild;
 									const args = [{}];
 
+									_$_.output_push(__out);
+									__out = '';
 									_$_.render_component(comp, ...args);
 								}
 
-								_$_.output_push('<div');
-								_$_.output_push(' class="extra"');
-								_$_.output_push('>');
-
-								{
-									_$_.output_push('extra');
-								}
-
-								_$_.output_push('</div>');
+								__out += '<div class="extra">extra</div>';
+								_$_.output_push(__out);
 							});
 						})
 					}
@@ -221,7 +199,10 @@ export function DynamicTagElement() {
 						class: "host",
 						children: _$_.tsrx_element(() => {
 							return _$_.tsrx_element(() => {
-								_$_.output_push('hello');
+								let __out = '';
+
+								__out += 'hello';
+								_$_.output_push(__out);
 							});
 						})
 					}

--- a/packages/ripple/tests/hydration/compiled/server/events.js
+++ b/packages/ripple/tests/hydration/compiled/server/events.js
@@ -8,31 +8,10 @@ export function ClickCounter() {
 		let lazy = _$_.track(0, 'a070e3a7');
 
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push('<button');
-				_$_.output_push(' class="increment"');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('Increment');
-				}
-
-				_$_.output_push('</button>');
-				_$_.output_push('<span');
-				_$_.output_push(' class="count"');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push(_$_.escape(lazy.value));
-				}
-
-				_$_.output_push('</span>');
-			}
-
-			_$_.output_push('</div>');
+			__out += '<div><button class="increment">Increment</button><span class="count">' + _$_.escape(lazy.value) + '</span></div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -42,40 +21,10 @@ export function IncrementDecrement() {
 		let lazy_1 = _$_.track(0, '87fcabdd');
 
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push('<button');
-				_$_.output_push(' class="decrement"');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('-');
-				}
-
-				_$_.output_push('</button>');
-				_$_.output_push('<span');
-				_$_.output_push(' class="count"');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push(_$_.escape(lazy_1.value));
-				}
-
-				_$_.output_push('</span>');
-				_$_.output_push('<button');
-				_$_.output_push(' class="increment"');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('+');
-				}
-
-				_$_.output_push('</button>');
-			}
-
-			_$_.output_push('</div>');
+			__out += '<div><button class="decrement">-</button><span class="count">' + _$_.escape(lazy_1.value) + '</span><button class="increment">+</button></div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -86,40 +35,10 @@ export function MultipleEvents() {
 		let lazy_3 = _$_.track(0, '72789f75');
 
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push('<button');
-				_$_.output_push(' class="target"');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('Target');
-				}
-
-				_$_.output_push('</button>');
-				_$_.output_push('<span');
-				_$_.output_push(' class="clicks"');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push(_$_.escape(lazy_2.value));
-				}
-
-				_$_.output_push('</span>');
-				_$_.output_push('<span');
-				_$_.output_push(' class="hovers"');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push(_$_.escape(lazy_3.value));
-				}
-
-				_$_.output_push('</span>');
-			}
-
-			_$_.output_push('</div>');
+			__out += '<div><button class="target">Target</button><span class="clicks">' + _$_.escape(lazy_2.value) + '</span><span class="hovers">' + _$_.escape(lazy_3.value) + '</span></div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -135,40 +54,10 @@ export function MultiStateUpdate() {
 		};
 
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push('<button');
-				_$_.output_push(' class="btn"');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('Click');
-				}
-
-				_$_.output_push('</button>');
-				_$_.output_push('<span');
-				_$_.output_push(' class="count"');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push(_$_.escape(lazy_4.value));
-				}
-
-				_$_.output_push('</span>');
-				_$_.output_push('<span');
-				_$_.output_push(' class="action"');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push(_$_.escape(lazy_5.value));
-				}
-
-				_$_.output_push('</span>');
-			}
-
-			_$_.output_push('</div>');
+			__out += '<div><button class="btn">Click</button><span class="count">' + _$_.escape(lazy_4.value) + '</span><span class="action">' + _$_.escape(lazy_5.value) + '</span></div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -178,22 +67,10 @@ export function ToggleButton() {
 		let lazy_6 = _$_.track(false, 'be823ec7');
 
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push('<button');
-				_$_.output_push(' class="toggle"');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push(_$_.escape(lazy_6.value ? 'ON' : 'OFF'));
-				}
-
-				_$_.output_push('</button>');
-			}
-
-			_$_.output_push('</div>');
+			__out += '<div><button class="toggle">' + _$_.escape(lazy_6.value ? 'ON' : 'OFF') + '</button></div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -201,15 +78,10 @@ export function ToggleButton() {
 export function ChildButton(props) {
 	return _$_.tsrx_element(() => {
 		_$_.regular_block(() => {
-			_$_.output_push('<button');
-			_$_.output_push(' class="child-btn"');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push(_$_.escape(props.label));
-			}
-
-			_$_.output_push('</button>');
+			__out += '<button class="child-btn">' + _$_.escape(props.label) + '</button>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -219,37 +91,29 @@ export function ParentWithChildButton() {
 		let lazy_7 = _$_.track(0, 'dcc2e0f9');
 
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push('>');
+			let __out = '';
+
+			__out += '<div>';
 
 			{
-				{
-					const comp = ChildButton;
+				const comp = ChildButton;
 
-					const args = [
-						{
-							onClick: () => {
-								_$_.update(lazy_7);
-							},
-							label: "Click me"
-						}
-					];
+				const args = [
+					{
+						onClick: () => {
+							_$_.update(lazy_7);
+						},
+						label: "Click me"
+					}
+				];
 
-					_$_.render_component(comp, ...args);
-				}
-
-				_$_.output_push('<span');
-				_$_.output_push(' class="count"');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push(_$_.escape(lazy_7.value));
-				}
-
-				_$_.output_push('</span>');
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_component(comp, ...args);
 			}
 
-			_$_.output_push('</div>');
+			__out += '<span class="count">' + _$_.escape(lazy_7.value) + '</span></div>';
+			_$_.output_push(__out);
 		});
 	});
 }

--- a/packages/ripple/tests/hydration/compiled/server/for.js
+++ b/packages/ripple/tests/hydration/compiled/server/for.js
@@ -8,27 +8,16 @@ export function StaticForLoop() {
 		const items = ['Apple', 'Banana', 'Cherry'];
 
 		_$_.regular_block(() => {
-			_$_.output_push('<ul');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push('<!--[-->');
+			__out += '<ul><!--[-->';
 
-				for (const item of items) {
-					_$_.output_push('<li');
-					_$_.output_push('>');
-
-					{
-						_$_.output_push(_$_.escape(item));
-					}
-
-					_$_.output_push('</li>');
-				}
-
-				_$_.output_push('<!--]-->');
+			for (const item of items) {
+				__out += '<li>' + _$_.escape(item) + '</li>';
 			}
 
-			_$_.output_push('</ul>');
+			__out += '<!--]--></ul>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -38,30 +27,25 @@ export function ForLoopWithIndex() {
 		const items = ['A', 'B', 'C'];
 
 		_$_.regular_block(() => {
-			_$_.output_push('<ul');
-			_$_.output_push('>');
+			let __out = '';
+
+			__out += '<ul>';
 
 			{
-				_$_.output_push('<!--[-->');
+				__out += '<!--[-->';
 
 				var i = 0;
 
 				for (const item of items) {
-					_$_.output_push('<li');
-					_$_.output_push('>');
-
-					{
-						_$_.output_push(_$_.escape(`${i}: ${item}`));
-					}
-
-					_$_.output_push('</li>');
+					__out += '<li>' + _$_.escape(`${i}: ${item}`) + '</li>';
 					i++;
 				}
 
-				_$_.output_push('<!--]-->');
+				__out += '<!--]-->';
 			}
 
-			_$_.output_push('</ul>');
+			__out += '</ul>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -75,27 +59,16 @@ export function KeyedForLoop() {
 		];
 
 		_$_.regular_block(() => {
-			_$_.output_push('<ul');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push('<!--[-->');
+			__out += '<ul><!--[-->';
 
-				for (const item of items) {
-					_$_.output_push('<li');
-					_$_.output_push('>');
-
-					{
-						_$_.output_push(_$_.escape(item.name));
-					}
-
-					_$_.output_push('</li>');
-				}
-
-				_$_.output_push('<!--]-->');
+			for (const item of items) {
+				__out += '<li>' + _$_.escape(item.name) + '</li>';
 			}
 
-			_$_.output_push('</ul>');
+			__out += '<!--]--></ul>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -105,38 +78,16 @@ export function ReactiveForLoopAdd() {
 		let lazy = _$_.track(['A', 'B'], 'e145678a');
 
 		_$_.regular_block(() => {
-			{
-				_$_.output_push('<button');
-				_$_.output_push(' class="add"');
-				_$_.output_push('>');
+			let __out = '';
 
-				{
-					_$_.output_push('Add');
-				}
+			__out += '<button class="add">Add</button><ul><!--[-->';
 
-				_$_.output_push('</button>');
-				_$_.output_push('<ul');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('<!--[-->');
-
-					for (const item of lazy.value) {
-						_$_.output_push('<li');
-						_$_.output_push('>');
-
-						{
-							_$_.output_push(_$_.escape(item));
-						}
-
-						_$_.output_push('</li>');
-					}
-
-					_$_.output_push('<!--]-->');
-				}
-
-				_$_.output_push('</ul>');
+			for (const item of lazy.value) {
+				__out += '<li>' + _$_.escape(item) + '</li>';
 			}
+
+			__out += '<!--]--></ul>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -146,38 +97,16 @@ export function ReactiveForLoopRemove() {
 		let lazy_1 = _$_.track(['A', 'B', 'C'], 'b4e9bd54');
 
 		_$_.regular_block(() => {
-			{
-				_$_.output_push('<button');
-				_$_.output_push(' class="remove"');
-				_$_.output_push('>');
+			let __out = '';
 
-				{
-					_$_.output_push('Remove');
-				}
+			__out += '<button class="remove">Remove</button><ul><!--[-->';
 
-				_$_.output_push('</button>');
-				_$_.output_push('<ul');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('<!--[-->');
-
-					for (const item of lazy_1.value) {
-						_$_.output_push('<li');
-						_$_.output_push('>');
-
-						{
-							_$_.output_push(_$_.escape(item));
-						}
-
-						_$_.output_push('</li>');
-					}
-
-					_$_.output_push('<!--]-->');
-				}
-
-				_$_.output_push('</ul>');
+			for (const item of lazy_1.value) {
+				__out += '<li>' + _$_.escape(item) + '</li>';
 			}
+
+			__out += '<!--]--></ul>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -187,48 +116,25 @@ export function ForLoopInteractive() {
 		let lazy_2 = _$_.track([0, 0, 0], '36f563df');
 
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push('>');
+			let __out = '';
+
+			__out += '<div>';
 
 			{
-				_$_.output_push('<!--[-->');
+				__out += '<!--[-->';
 
 				var i = 0;
 
 				for (const count of lazy_2.value) {
-					_$_.output_push('<div');
-					_$_.output_push(_$_.attr('class', `item-${i}`));
-					_$_.output_push('>');
-
-					{
-						_$_.output_push('<span');
-						_$_.output_push(' class="value"');
-						_$_.output_push('>');
-
-						{
-							_$_.output_push(_$_.escape(count));
-						}
-
-						_$_.output_push('</span>');
-						_$_.output_push('<button');
-						_$_.output_push(' class="increment"');
-						_$_.output_push('>');
-
-						{
-							_$_.output_push('+');
-						}
-
-						_$_.output_push('</button>');
-					}
-
-					_$_.output_push('</div>');
+					__out += '<div' + _$_.attr('class', `item-${i}`) + '><span class="value">' + _$_.escape(count) + '</span><button class="increment">+</button></div>';
 					i++;
 				}
 
-				_$_.output_push('<!--]-->');
+				__out += '<!--]-->';
 			}
 
-			_$_.output_push('</div>');
+			__out += '</div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -238,49 +144,40 @@ export function NestedForLoop() {
 		const grid = [[1, 2], [3, 4]];
 
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push(' class="grid"');
-			_$_.output_push('>');
+			let __out = '';
+
+			__out += '<div class="grid">';
 
 			{
-				_$_.output_push('<!--[-->');
+				__out += '<!--[-->';
 
 				var rowIndex = 0;
 
 				for (const row of grid) {
-					_$_.output_push('<div');
-					_$_.output_push(_$_.attr('class', `row-${rowIndex}`));
-					_$_.output_push('>');
+					__out += '<div' + _$_.attr('class', `row-${rowIndex}`) + '>';
 
 					{
-						_$_.output_push('<!--[-->');
+						__out += '<!--[-->';
 
 						var colIndex = 0;
 
 						for (const cell of row) {
-							_$_.output_push('<span');
-							_$_.output_push(_$_.attr('class', `cell-${rowIndex}-${colIndex}`));
-							_$_.output_push('>');
-
-							{
-								_$_.output_push(_$_.escape(cell));
-							}
-
-							_$_.output_push('</span>');
+							__out += '<span' + _$_.attr('class', `cell-${rowIndex}-${colIndex}`) + '>' + _$_.escape(cell) + '</span>';
 							colIndex++;
 						}
 
-						_$_.output_push('<!--]-->');
+						__out += '<!--]-->';
 					}
 
-					_$_.output_push('</div>');
+					__out += '</div>';
 					rowIndex++;
 				}
 
-				_$_.output_push('<!--]-->');
+				__out += '<!--]-->';
 			}
 
-			_$_.output_push('</div>');
+			__out += '</div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -290,28 +187,16 @@ export function EmptyForLoop() {
 		const items = [];
 
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push(' class="container"');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push('<!--[-->');
+			__out += '<div class="container"><!--[-->';
 
-				for (const item of items) {
-					_$_.output_push('<span');
-					_$_.output_push('>');
-
-					{
-						_$_.output_push(_$_.escape(item));
-					}
-
-					_$_.output_push('</span>');
-				}
-
-				_$_.output_push('<!--]-->');
+			for (const item of items) {
+				__out += '<span>' + _$_.escape(item) + '</span>';
 			}
 
-			_$_.output_push('</div>');
+			__out += '<!--]--></div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -324,45 +209,16 @@ export function ForLoopComplexObjects() {
 		];
 
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push('<!--[-->');
+			__out += '<div><!--[-->';
 
-				for (const user of users) {
-					_$_.output_push('<div');
-					_$_.output_push(_$_.attr('class', `user-${user.id}`));
-					_$_.output_push('>');
-
-					{
-						_$_.output_push('<span');
-						_$_.output_push(' class="name"');
-						_$_.output_push('>');
-
-						{
-							_$_.output_push(_$_.escape(user.name));
-						}
-
-						_$_.output_push('</span>');
-						_$_.output_push('<span');
-						_$_.output_push(' class="role"');
-						_$_.output_push('>');
-
-						{
-							_$_.output_push(_$_.escape(user.role));
-						}
-
-						_$_.output_push('</span>');
-					}
-
-					_$_.output_push('</div>');
-				}
-
-				_$_.output_push('<!--]-->');
+			for (const user of users) {
+				__out += '<div' + _$_.attr('class', `user-${user.id}`) + '><span class="name">' + _$_.escape(user.name) + '</span><span class="role">' + _$_.escape(user.role) + '</span></div>';
 			}
 
-			_$_.output_push('</div>');
+			__out += '<!--]--></div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -379,39 +235,16 @@ export function KeyedForLoopReorder() {
 		);
 
 		_$_.regular_block(() => {
-			{
-				_$_.output_push('<button');
-				_$_.output_push(' class="reorder"');
-				_$_.output_push('>');
+			let __out = '';
 
-				{
-					_$_.output_push('Reorder');
-				}
+			__out += '<button class="reorder">Reorder</button><ul><!--[-->';
 
-				_$_.output_push('</button>');
-				_$_.output_push('<ul');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('<!--[-->');
-
-					for (const item of lazy_3.value) {
-						_$_.output_push('<li');
-						_$_.output_push(_$_.attr('class', `item-${item.id}`));
-						_$_.output_push('>');
-
-						{
-							_$_.output_push(_$_.escape(item.name));
-						}
-
-						_$_.output_push('</li>');
-					}
-
-					_$_.output_push('<!--]-->');
-				}
-
-				_$_.output_push('</ul>');
+			for (const item of lazy_3.value) {
+				__out += '<li' + _$_.attr('class', `item-${item.id}`) + '>' + _$_.escape(item.name) + '</li>';
 			}
+
+			__out += '<!--]--></ul>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -421,39 +254,16 @@ export function KeyedForLoopUpdate() {
 		let lazy_4 = _$_.track([{ id: 1, name: 'Item 1' }, { id: 2, name: 'Item 2' }], '7a2c2ada');
 
 		_$_.regular_block(() => {
-			{
-				_$_.output_push('<button');
-				_$_.output_push(' class="update"');
-				_$_.output_push('>');
+			let __out = '';
 
-				{
-					_$_.output_push('Update');
-				}
+			__out += '<button class="update">Update</button><ul><!--[-->';
 
-				_$_.output_push('</button>');
-				_$_.output_push('<ul');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('<!--[-->');
-
-					for (const item of lazy_4.value) {
-						_$_.output_push('<li');
-						_$_.output_push(_$_.attr('class', `item-${item.id}`));
-						_$_.output_push('>');
-
-						{
-							_$_.output_push(_$_.escape(item.name));
-						}
-
-						_$_.output_push('</li>');
-					}
-
-					_$_.output_push('<!--]-->');
-				}
-
-				_$_.output_push('</ul>');
+			for (const item of lazy_4.value) {
+				__out += '<li' + _$_.attr('class', `item-${item.id}`) + '>' + _$_.escape(item.name) + '</li>';
 			}
+
+			__out += '<!--]--></ul>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -463,39 +273,16 @@ export function ForLoopMixedOperations() {
 		let lazy_5 = _$_.track(['A', 'B', 'C', 'D'], '3dd7c7b6');
 
 		_$_.regular_block(() => {
-			{
-				_$_.output_push('<button');
-				_$_.output_push(' class="shuffle"');
-				_$_.output_push('>');
+			let __out = '';
 
-				{
-					_$_.output_push('Shuffle');
-				}
+			__out += '<button class="shuffle">Shuffle</button><ul><!--[-->';
 
-				_$_.output_push('</button>');
-				_$_.output_push('<ul');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('<!--[-->');
-
-					for (const item of lazy_5.value) {
-						_$_.output_push('<li');
-						_$_.output_push(_$_.attr('class', `item-${item}`));
-						_$_.output_push('>');
-
-						{
-							_$_.output_push(_$_.escape(item));
-						}
-
-						_$_.output_push('</li>');
-					}
-
-					_$_.output_push('<!--]-->');
-				}
-
-				_$_.output_push('</ul>');
+			for (const item of lazy_5.value) {
+				__out += '<li' + _$_.attr('class', `item-${item}`) + '>' + _$_.escape(item) + '</li>';
 			}
+
+			__out += '<!--]--></ul>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -506,54 +293,22 @@ export function ForLoopInsideIf() {
 		let lazy_7 = _$_.track(['X', 'Y', 'Z'], 'bf375103');
 
 		_$_.regular_block(() => {
-			{
-				_$_.output_push('<button');
-				_$_.output_push(' class="toggle"');
-				_$_.output_push('>');
+			let __out = '';
 
-				{
-					_$_.output_push('Toggle List');
+			__out += '<button class="toggle">Toggle List</button><button class="add">Add Item</button><!--[-->';
+
+			if (lazy_6.value) {
+				__out += '<ul class="list"><!--[-->';
+
+				for (const item of lazy_7.value) {
+					__out += '<li>' + _$_.escape(item) + '</li>';
 				}
 
-				_$_.output_push('</button>');
-				_$_.output_push('<button');
-				_$_.output_push(' class="add"');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('Add Item');
-				}
-
-				_$_.output_push('</button>');
-				_$_.output_push('<!--[-->');
-
-				if (lazy_6.value) {
-					_$_.output_push('<ul');
-					_$_.output_push(' class="list"');
-					_$_.output_push('>');
-
-					{
-						_$_.output_push('<!--[-->');
-
-						for (const item of lazy_7.value) {
-							_$_.output_push('<li');
-							_$_.output_push('>');
-
-							{
-								_$_.output_push(_$_.escape(item));
-							}
-
-							_$_.output_push('</li>');
-						}
-
-						_$_.output_push('<!--]-->');
-					}
-
-					_$_.output_push('</ul>');
-				}
-
-				_$_.output_push('<!--]-->');
+				__out += '<!--]--></ul>';
 			}
+
+			__out += '<!--]-->';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -563,39 +318,16 @@ export function ForLoopEmptyToPopulated() {
 		let lazy_8 = _$_.track([], '525c5dbc');
 
 		_$_.regular_block(() => {
-			{
-				_$_.output_push('<button');
-				_$_.output_push(' class="populate"');
-				_$_.output_push('>');
+			let __out = '';
 
-				{
-					_$_.output_push('Populate');
-				}
+			__out += '<button class="populate">Populate</button><ul class="list"><!--[-->';
 
-				_$_.output_push('</button>');
-				_$_.output_push('<ul');
-				_$_.output_push(' class="list"');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('<!--[-->');
-
-					for (const item of lazy_8.value) {
-						_$_.output_push('<li');
-						_$_.output_push('>');
-
-						{
-							_$_.output_push(_$_.escape(item));
-						}
-
-						_$_.output_push('</li>');
-					}
-
-					_$_.output_push('<!--]-->');
-				}
-
-				_$_.output_push('</ul>');
+			for (const item of lazy_8.value) {
+				__out += '<li>' + _$_.escape(item) + '</li>';
 			}
+
+			__out += '<!--]--></ul>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -605,39 +337,16 @@ export function ForLoopPopulatedToEmpty() {
 		let lazy_9 = _$_.track(['One', 'Two', 'Three'], 'ee47f078');
 
 		_$_.regular_block(() => {
-			{
-				_$_.output_push('<button');
-				_$_.output_push(' class="clear"');
-				_$_.output_push('>');
+			let __out = '';
 
-				{
-					_$_.output_push('Clear');
-				}
+			__out += '<button class="clear">Clear</button><ul class="list"><!--[-->';
 
-				_$_.output_push('</button>');
-				_$_.output_push('<ul');
-				_$_.output_push(' class="list"');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('<!--[-->');
-
-					for (const item of lazy_9.value) {
-						_$_.output_push('<li');
-						_$_.output_push('>');
-
-						{
-							_$_.output_push(_$_.escape(item));
-						}
-
-						_$_.output_push('</li>');
-					}
-
-					_$_.output_push('<!--]-->');
-				}
-
-				_$_.output_push('</ul>');
+			for (const item of lazy_9.value) {
+				__out += '<li>' + _$_.escape(item) + '</li>';
 			}
+
+			__out += '<!--]--></ul>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -647,75 +356,40 @@ export function NestedForLoopReactive() {
 		let lazy_10 = _$_.track([[1, 2], [3, 4]], 'a2f41fb3');
 
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push(' class="nested-for-reactive"');
-			_$_.output_push('>');
+			let __out = '';
+
+			__out += '<div class="nested-for-reactive"><button class="add-row">Add Row</button><button class="update-cell">Update Cell</button><div class="grid">';
 
 			{
-				_$_.output_push('<button');
-				_$_.output_push(' class="add-row"');
-				_$_.output_push('>');
+				__out += '<!--[-->';
 
-				{
-					_$_.output_push('Add Row');
-				}
+				var rowIndex = 0;
 
-				_$_.output_push('</button>');
-				_$_.output_push('<button');
-				_$_.output_push(' class="update-cell"');
-				_$_.output_push('>');
+				for (const row of lazy_10.value) {
+					__out += '<div' + _$_.attr('class', `row-${rowIndex}`) + '>';
 
-				{
-					_$_.output_push('Update Cell');
-				}
+					{
+						__out += '<!--[-->';
 
-				_$_.output_push('</button>');
-				_$_.output_push('<div');
-				_$_.output_push(' class="grid"');
-				_$_.output_push('>');
+						var colIndex = 0;
 
-				{
-					_$_.output_push('<!--[-->');
-
-					var rowIndex = 0;
-
-					for (const row of lazy_10.value) {
-						_$_.output_push('<div');
-						_$_.output_push(_$_.attr('class', `row-${rowIndex}`));
-						_$_.output_push('>');
-
-						{
-							_$_.output_push('<!--[-->');
-
-							var colIndex = 0;
-
-							for (const cell of row) {
-								_$_.output_push('<span');
-								_$_.output_push(_$_.attr('class', `cell-${rowIndex}-${colIndex}`));
-								_$_.output_push('>');
-
-								{
-									_$_.output_push(_$_.escape(cell));
-								}
-
-								_$_.output_push('</span>');
-								colIndex++;
-							}
-
-							_$_.output_push('<!--]-->');
+						for (const cell of row) {
+							__out += '<span' + _$_.attr('class', `cell-${rowIndex}-${colIndex}`) + '>' + _$_.escape(cell) + '</span>';
+							colIndex++;
 						}
 
-						_$_.output_push('</div>');
-						rowIndex++;
+						__out += '<!--]-->';
 					}
 
-					_$_.output_push('<!--]-->');
+					__out += '</div>';
+					rowIndex++;
 				}
 
-				_$_.output_push('</div>');
+				__out += '<!--]-->';
 			}
 
-			_$_.output_push('</div>');
+			__out += '</div></div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -740,82 +414,28 @@ export function ForLoopDeeplyNested() {
 		];
 
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push(' class="org"');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push('<!--[-->');
+			__out += '<div class="org"><!--[-->';
 
-				for (const dept of departments) {
-					_$_.output_push('<div');
-					_$_.output_push(_$_.attr('class', `dept-${dept.id}`));
-					_$_.output_push('>');
+			for (const dept of departments) {
+				__out += '<div' + _$_.attr('class', `dept-${dept.id}`) + '><h2 class="dept-name">' + _$_.escape(dept.name) + '</h2><!--[-->';
 
-					{
-						_$_.output_push('<h2');
-						_$_.output_push(' class="dept-name"');
-						_$_.output_push('>');
+				for (const team of dept.teams) {
+					__out += '<div' + _$_.attr('class', `team-${team.id}`) + '><h3 class="team-name">' + _$_.escape(team.name) + '</h3><ul><!--[-->';
 
-						{
-							_$_.output_push(_$_.escape(dept.name));
-						}
-
-						_$_.output_push('</h2>');
-						_$_.output_push('<!--[-->');
-
-						for (const team of dept.teams) {
-							_$_.output_push('<div');
-							_$_.output_push(_$_.attr('class', `team-${team.id}`));
-							_$_.output_push('>');
-
-							{
-								_$_.output_push('<h3');
-								_$_.output_push(' class="team-name"');
-								_$_.output_push('>');
-
-								{
-									_$_.output_push(_$_.escape(team.name));
-								}
-
-								_$_.output_push('</h3>');
-								_$_.output_push('<ul');
-								_$_.output_push('>');
-
-								{
-									_$_.output_push('<!--[-->');
-
-									for (const member of team.members) {
-										_$_.output_push('<li');
-										_$_.output_push(' class="member"');
-										_$_.output_push('>');
-
-										{
-											_$_.output_push(_$_.escape(member));
-										}
-
-										_$_.output_push('</li>');
-									}
-
-									_$_.output_push('<!--]-->');
-								}
-
-								_$_.output_push('</ul>');
-							}
-
-							_$_.output_push('</div>');
-						}
-
-						_$_.output_push('<!--]-->');
+					for (const member of team.members) {
+						__out += '<li class="member">' + _$_.escape(member) + '</li>';
 					}
 
-					_$_.output_push('</div>');
+					__out += '<!--]--></ul></div>';
 				}
 
-				_$_.output_push('<!--]-->');
+				__out += '<!--]--></div>';
 			}
 
-			_$_.output_push('</div>');
+			__out += '<!--]--></div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -825,42 +445,25 @@ export function ForLoopIndexUpdate() {
 		let lazy_11 = _$_.track(['First', 'Second', 'Third'], 'f61e31e6');
 
 		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<button class="prepend">Prepend</button><ul>';
+
 			{
-				_$_.output_push('<button');
-				_$_.output_push(' class="prepend"');
-				_$_.output_push('>');
+				__out += '<!--[-->';
 
-				{
-					_$_.output_push('Prepend');
+				var i = 0;
+
+				for (const item of lazy_11.value) {
+					__out += '<li' + _$_.attr('class', `item-${i}`) + '>' + _$_.escape(`[${i}] ${item}`) + '</li>';
+					i++;
 				}
 
-				_$_.output_push('</button>');
-				_$_.output_push('<ul');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('<!--[-->');
-
-					var i = 0;
-
-					for (const item of lazy_11.value) {
-						_$_.output_push('<li');
-						_$_.output_push(_$_.attr('class', `item-${i}`));
-						_$_.output_push('>');
-
-						{
-							_$_.output_push(_$_.escape(`[${i}] ${item}`));
-						}
-
-						_$_.output_push('</li>');
-						i++;
-					}
-
-					_$_.output_push('<!--]-->');
-				}
-
-				_$_.output_push('</ul>');
+				__out += '<!--]-->';
 			}
+
+			__out += '</ul>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -877,43 +480,25 @@ export function KeyedForLoopWithIndex() {
 		);
 
 		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<button class="reorder">Rotate</button><ul>';
+
 			{
-				_$_.output_push('<button');
-				_$_.output_push(' class="reorder"');
-				_$_.output_push('>');
+				__out += '<!--[-->';
 
-				{
-					_$_.output_push('Rotate');
+				var i = 0;
+
+				for (const item of lazy_12.value) {
+					__out += '<li' + _$_.attr('data-index', i, false) + _$_.attr('class', `item-${item.id}`) + '>' + _$_.escape(`[${i}] ${item.id}: ${item.value}`) + '</li>';
+					i++;
 				}
 
-				_$_.output_push('</button>');
-				_$_.output_push('<ul');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('<!--[-->');
-
-					var i = 0;
-
-					for (const item of lazy_12.value) {
-						_$_.output_push('<li');
-						_$_.output_push(_$_.attr('data-index', i, false));
-						_$_.output_push(_$_.attr('class', `item-${item.id}`));
-						_$_.output_push('>');
-
-						{
-							_$_.output_push(_$_.escape(`[${i}] ${item.id}: ${item.value}`));
-						}
-
-						_$_.output_push('</li>');
-						i++;
-					}
-
-					_$_.output_push('<!--]-->');
-				}
-
-				_$_.output_push('</ul>');
+				__out += '<!--]-->';
 			}
+
+			__out += '</ul>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -923,58 +508,16 @@ export function ForLoopWithSiblings() {
 		let lazy_13 = _$_.track(['A', 'B'], '3c7e8152');
 
 		_$_.regular_block(() => {
-			{
-				_$_.output_push('<div');
-				_$_.output_push(' class="wrapper"');
-				_$_.output_push('>');
+			let __out = '';
 
-				{
-					_$_.output_push('<header');
-					_$_.output_push(' class="before"');
-					_$_.output_push('>');
+			__out += '<div class="wrapper"><header class="before">Before</header><!--[-->';
 
-					{
-						_$_.output_push('Before');
-					}
-
-					_$_.output_push('</header>');
-					_$_.output_push('<!--[-->');
-
-					for (const item of lazy_13.value) {
-						_$_.output_push('<div');
-						_$_.output_push(_$_.attr('class', `item-${item}`));
-						_$_.output_push('>');
-
-						{
-							_$_.output_push(_$_.escape(item));
-						}
-
-						_$_.output_push('</div>');
-					}
-
-					_$_.output_push('<!--]-->');
-					_$_.output_push('<footer');
-					_$_.output_push(' class="after"');
-					_$_.output_push('>');
-
-					{
-						_$_.output_push('After');
-					}
-
-					_$_.output_push('</footer>');
-				}
-
-				_$_.output_push('</div>');
-				_$_.output_push('<button');
-				_$_.output_push(' class="add"');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('Add');
-				}
-
-				_$_.output_push('</button>');
+			for (const item of lazy_13.value) {
+				__out += '<div' + _$_.attr('class', `item-${item}`) + '>' + _$_.escape(item) + '</div>';
 			}
+
+			__out += '<!--]--><footer class="after">After</footer></div><button class="add">Add</button>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -988,25 +531,23 @@ export function ForLoopItemState() {
 		];
 
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push('<!--[-->');
+			__out += '<div><!--[-->';
 
-				for (const item of initialItems) {
-					{
-						const comp = TodoItem;
-						const args = [{ id: item.id, text: item.text }];
+			for (const item of initialItems) {
+				{
+					const comp = TodoItem;
+					const args = [{ id: item.id, text: item.text }];
 
-						_$_.render_component(comp, ...args);
-					}
+					_$_.output_push(__out);
+					__out = '';
+					_$_.render_component(comp, ...args);
 				}
-
-				_$_.output_push('<!--]-->');
 			}
 
-			_$_.output_push('</div>');
+			__out += '<!--]--></div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -1016,28 +557,10 @@ function TodoItem(props) {
 		let lazy_14 = _$_.track(false, '4f2402a4');
 
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push(_$_.attr('class', `todo-${props.id}`));
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push('<input');
-				_$_.output_push(' type="checkbox"');
-				_$_.output_push(_$_.attr('checked', lazy_14.value, true));
-				_$_.output_push(' class="checkbox"');
-				_$_.output_push(' />');
-				_$_.output_push('<span');
-				_$_.output_push(_$_.attr('class', lazy_14.value ? 'completed' : 'pending'));
-				_$_.output_push('>');
-
-				{
-					_$_.output_push(_$_.escape(props.text));
-				}
-
-				_$_.output_push('</span>');
-			}
-
-			_$_.output_push('</div>');
+			__out += '<div' + _$_.attr('class', `todo-${props.id}`) + '><input type="checkbox"' + _$_.attr('checked', lazy_14.value, true) + ' class="checkbox" /><span' + _$_.attr('class', lazy_14.value ? 'completed' : 'pending') + '>' + _$_.escape(props.text) + '</span></div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -1047,28 +570,16 @@ export function ForLoopSingleItem() {
 		const items = ['Only'];
 
 		_$_.regular_block(() => {
-			_$_.output_push('<ul');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push('<!--[-->');
+			__out += '<ul><!--[-->';
 
-				for (const item of items) {
-					_$_.output_push('<li');
-					_$_.output_push(' class="single"');
-					_$_.output_push('>');
-
-					{
-						_$_.output_push(_$_.escape(item));
-					}
-
-					_$_.output_push('</li>');
-				}
-
-				_$_.output_push('<!--]-->');
+			for (const item of items) {
+				__out += '<li class="single">' + _$_.escape(item) + '</li>';
 			}
 
-			_$_.output_push('</ul>');
+			__out += '<!--]--></ul>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -1078,39 +589,16 @@ export function ForLoopAddAtBeginning() {
 		let lazy_15 = _$_.track(['B', 'C'], '1561403a');
 
 		_$_.regular_block(() => {
-			{
-				_$_.output_push('<button');
-				_$_.output_push(' class="prepend"');
-				_$_.output_push('>');
+			let __out = '';
 
-				{
-					_$_.output_push('Prepend A');
-				}
+			__out += '<button class="prepend">Prepend A</button><ul><!--[-->';
 
-				_$_.output_push('</button>');
-				_$_.output_push('<ul');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('<!--[-->');
-
-					for (const item of lazy_15.value) {
-						_$_.output_push('<li');
-						_$_.output_push(_$_.attr('class', `item-${item}`));
-						_$_.output_push('>');
-
-						{
-							_$_.output_push(_$_.escape(item));
-						}
-
-						_$_.output_push('</li>');
-					}
-
-					_$_.output_push('<!--]-->');
-				}
-
-				_$_.output_push('</ul>');
+			for (const item of lazy_15.value) {
+				__out += '<li' + _$_.attr('class', `item-${item}`) + '>' + _$_.escape(item) + '</li>';
 			}
+
+			__out += '<!--]--></ul>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -1120,39 +608,16 @@ export function ForLoopAddInMiddle() {
 		let lazy_16 = _$_.track(['A', 'C'], '1bc60b46');
 
 		_$_.regular_block(() => {
-			{
-				_$_.output_push('<button');
-				_$_.output_push(' class="insert"');
-				_$_.output_push('>');
+			let __out = '';
 
-				{
-					_$_.output_push('Insert B');
-				}
+			__out += '<button class="insert">Insert B</button><ul><!--[-->';
 
-				_$_.output_push('</button>');
-				_$_.output_push('<ul');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('<!--[-->');
-
-					for (const item of lazy_16.value) {
-						_$_.output_push('<li');
-						_$_.output_push(_$_.attr('class', `item-${item}`));
-						_$_.output_push('>');
-
-						{
-							_$_.output_push(_$_.escape(item));
-						}
-
-						_$_.output_push('</li>');
-					}
-
-					_$_.output_push('<!--]-->');
-				}
-
-				_$_.output_push('</ul>');
+			for (const item of lazy_16.value) {
+				__out += '<li' + _$_.attr('class', `item-${item}`) + '>' + _$_.escape(item) + '</li>';
 			}
+
+			__out += '<!--]--></ul>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -1162,39 +627,16 @@ export function ForLoopRemoveFromMiddle() {
 		let lazy_17 = _$_.track(['A', 'B', 'C'], '1c87f95f');
 
 		_$_.regular_block(() => {
-			{
-				_$_.output_push('<button');
-				_$_.output_push(' class="remove-middle"');
-				_$_.output_push('>');
+			let __out = '';
 
-				{
-					_$_.output_push('Remove B');
-				}
+			__out += '<button class="remove-middle">Remove B</button><ul><!--[-->';
 
-				_$_.output_push('</button>');
-				_$_.output_push('<ul');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('<!--[-->');
-
-					for (const item of lazy_17.value) {
-						_$_.output_push('<li');
-						_$_.output_push(_$_.attr('class', `item-${item}`));
-						_$_.output_push('>');
-
-						{
-							_$_.output_push(_$_.escape(item));
-						}
-
-						_$_.output_push('</li>');
-					}
-
-					_$_.output_push('<!--]-->');
-				}
-
-				_$_.output_push('</ul>');
+			for (const item of lazy_17.value) {
+				__out += '<li' + _$_.attr('class', `item-${item}`) + '>' + _$_.escape(item) + '</li>';
 			}
+
+			__out += '<!--]--></ul>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -1204,32 +646,25 @@ export function ForLoopLargeList() {
 		const items = Array.from({ length: 50 }, (_, i) => `Item ${i + 1}`);
 
 		_$_.regular_block(() => {
-			_$_.output_push('<ul');
-			_$_.output_push(' class="large-list"');
-			_$_.output_push('>');
+			let __out = '';
+
+			__out += '<ul class="large-list">';
 
 			{
-				_$_.output_push('<!--[-->');
+				__out += '<!--[-->';
 
 				var i = 0;
 
 				for (const item of items) {
-					_$_.output_push('<li');
-					_$_.output_push(_$_.attr('class', `item-${i}`));
-					_$_.output_push('>');
-
-					{
-						_$_.output_push(_$_.escape(item));
-					}
-
-					_$_.output_push('</li>');
+					__out += '<li' + _$_.attr('class', `item-${i}`) + '>' + _$_.escape(item) + '</li>';
 					i++;
 				}
 
-				_$_.output_push('<!--]-->');
+				__out += '<!--]-->';
 			}
 
-			_$_.output_push('</ul>');
+			__out += '</ul>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -1239,39 +674,16 @@ export function ForLoopSwap() {
 		let lazy_18 = _$_.track(['A', 'B', 'C', 'D'], '5f8d152f');
 
 		_$_.regular_block(() => {
-			{
-				_$_.output_push('<button');
-				_$_.output_push(' class="swap"');
-				_$_.output_push('>');
+			let __out = '';
 
-				{
-					_$_.output_push('Swap First and Last');
-				}
+			__out += '<button class="swap">Swap First and Last</button><ul><!--[-->';
 
-				_$_.output_push('</button>');
-				_$_.output_push('<ul');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('<!--[-->');
-
-					for (const item of lazy_18.value) {
-						_$_.output_push('<li');
-						_$_.output_push(_$_.attr('class', `item-${item}`));
-						_$_.output_push('>');
-
-						{
-							_$_.output_push(_$_.escape(item));
-						}
-
-						_$_.output_push('</li>');
-					}
-
-					_$_.output_push('<!--]-->');
-				}
-
-				_$_.output_push('</ul>');
+			for (const item of lazy_18.value) {
+				__out += '<li' + _$_.attr('class', `item-${item}`) + '>' + _$_.escape(item) + '</li>';
 			}
+
+			__out += '<!--]--></ul>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -1281,39 +693,16 @@ export function ForLoopReverse() {
 		let lazy_19 = _$_.track(['A', 'B', 'C', 'D'], '24602e64');
 
 		_$_.regular_block(() => {
-			{
-				_$_.output_push('<button');
-				_$_.output_push(' class="reverse"');
-				_$_.output_push('>');
+			let __out = '';
 
-				{
-					_$_.output_push('Reverse');
-				}
+			__out += '<button class="reverse">Reverse</button><ul><!--[-->';
 
-				_$_.output_push('</button>');
-				_$_.output_push('<ul');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('<!--[-->');
-
-					for (const item of lazy_19.value) {
-						_$_.output_push('<li');
-						_$_.output_push(_$_.attr('class', `item-${item}`));
-						_$_.output_push('>');
-
-						{
-							_$_.output_push(_$_.escape(item));
-						}
-
-						_$_.output_push('</li>');
-					}
-
-					_$_.output_push('<!--]-->');
-				}
-
-				_$_.output_push('</ul>');
+			for (const item of lazy_19.value) {
+				__out += '<li' + _$_.attr('class', `item-${item}`) + '>' + _$_.escape(item) + '</li>';
 			}
+
+			__out += '<!--]--></ul>';
+			_$_.output_push(__out);
 		});
 	});
 }

--- a/packages/ripple/tests/hydration/compiled/server/head.js
+++ b/packages/ripple/tests/hydration/compiled/server/head.js
@@ -6,27 +6,17 @@ import { track } from 'ripple/server';
 export function StaticTitle() {
 	return _$_.tsrx_element(() => {
 		_$_.regular_block(() => {
-			{
-				_$_.output_push('<div');
-				_$_.output_push('>');
+			let __out = '';
 
-				{
-					_$_.output_push('Content');
-				}
-
-				_$_.output_push('</div>');
-				_$_.set_output_target('head');
-				_$_.output_push('<!--6e1f1b90-->');
-				_$_.output_push('<title');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('Static Test Title');
-				}
-
-				_$_.output_push('</title>');
-				_$_.set_output_target(null);
-			}
+			__out += '<div>Content</div>';
+			_$_.output_push(__out);
+			__out = '';
+			_$_.set_output_target('head');
+			__out += '<!--6e1f1b90--><title>Static Test Title</title>';
+			_$_.output_push(__out);
+			__out = '';
+			_$_.set_output_target(null);
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -36,34 +26,17 @@ export function ReactiveTitle() {
 		let lazy = _$_.track('Initial Title', 'cbca63e3');
 
 		_$_.regular_block(() => {
-			{
-				_$_.output_push('<div');
-				_$_.output_push('>');
+			let __out = '';
 
-				{
-					_$_.output_push('<span');
-					_$_.output_push('>');
-
-					{
-						_$_.output_push(_$_.escape(lazy.value));
-					}
-
-					_$_.output_push('</span>');
-				}
-
-				_$_.output_push('</div>');
-				_$_.set_output_target('head');
-				_$_.output_push('<!--91435bee-->');
-				_$_.output_push('<title');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push(_$_.escape(lazy.value));
-				}
-
-				_$_.output_push('</title>');
-				_$_.set_output_target(null);
-			}
+			__out += '<div><span>' + _$_.escape(lazy.value) + '</span></div>';
+			_$_.output_push(__out);
+			__out = '';
+			_$_.set_output_target('head');
+			__out += '<!--91435bee--><title>' + _$_.escape(lazy.value) + '</title>';
+			_$_.output_push(__out);
+			__out = '';
+			_$_.set_output_target(null);
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -71,35 +44,17 @@ export function ReactiveTitle() {
 export function MultipleHeadElements() {
 	return _$_.tsrx_element(() => {
 		_$_.regular_block(() => {
-			{
-				_$_.output_push('<div');
-				_$_.output_push('>');
+			let __out = '';
 
-				{
-					_$_.output_push('Page content');
-				}
-
-				_$_.output_push('</div>');
-				_$_.set_output_target('head');
-				_$_.output_push('<!--07a54928-->');
-				_$_.output_push('<title');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('Page Title');
-				}
-
-				_$_.output_push('</title>');
-				_$_.output_push('<meta');
-				_$_.output_push(' name="description"');
-				_$_.output_push(' content="Page description"');
-				_$_.output_push(' />');
-				_$_.output_push('<link');
-				_$_.output_push(' rel="stylesheet"');
-				_$_.output_push(' href="/styles.css"');
-				_$_.output_push(' />');
-				_$_.set_output_target(null);
-			}
+			__out += '<div>Page content</div>';
+			_$_.output_push(__out);
+			__out = '';
+			_$_.set_output_target('head');
+			__out += '<!--07a54928--><title>Page Title</title><meta name="description" content="Page description" /><link rel="stylesheet" href="/styles.css" />';
+			_$_.output_push(__out);
+			__out = '';
+			_$_.set_output_target(null);
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -109,31 +64,17 @@ export function ReactiveMetaTags() {
 		let lazy_1 = _$_.track('Initial description', '38bfa3b2');
 
 		_$_.regular_block(() => {
-			{
-				_$_.output_push('<div');
-				_$_.output_push('>');
+			let __out = '';
 
-				{
-					_$_.output_push(_$_.escape(lazy_1.value));
-				}
-
-				_$_.output_push('</div>');
-				_$_.set_output_target('head');
-				_$_.output_push('<!--4ca6a546-->');
-				_$_.output_push('<title');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('My Page');
-				}
-
-				_$_.output_push('</title>');
-				_$_.output_push('<meta');
-				_$_.output_push(' name="description"');
-				_$_.output_push(_$_.attr('content', lazy_1.value, false));
-				_$_.output_push(' />');
-				_$_.set_output_target(null);
-			}
+			__out += '<div>' + _$_.escape(lazy_1.value) + '</div>';
+			_$_.output_push(__out);
+			__out = '';
+			_$_.set_output_target('head');
+			__out += '<!--4ca6a546--><title>My Page</title><meta name="description"' + _$_.attr('content', lazy_1.value, false) + ' />';
+			_$_.output_push(__out);
+			__out = '';
+			_$_.set_output_target(null);
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -143,27 +84,17 @@ export function TitleWithTemplate() {
 		let lazy_2 = _$_.track('World', 'f3925cd5');
 
 		_$_.regular_block(() => {
-			{
-				_$_.output_push('<div');
-				_$_.output_push('>');
+			let __out = '';
 
-				{
-					_$_.output_push(_$_.escape(lazy_2.value));
-				}
-
-				_$_.output_push('</div>');
-				_$_.set_output_target('head');
-				_$_.output_push('<!--10dc944d-->');
-				_$_.output_push('<title');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push(_$_.escape(`Hello ${lazy_2.value}!`));
-				}
-
-				_$_.output_push('</title>');
-				_$_.set_output_target(null);
-			}
+			__out += '<div>' + _$_.escape(lazy_2.value) + '</div>';
+			_$_.output_push(__out);
+			__out = '';
+			_$_.set_output_target('head');
+			__out += '<!--10dc944d--><title>' + _$_.escape(`Hello ${lazy_2.value}!`) + '</title>';
+			_$_.output_push(__out);
+			__out = '';
+			_$_.set_output_target(null);
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -171,27 +102,17 @@ export function TitleWithTemplate() {
 export function EmptyTitle() {
 	return _$_.tsrx_element(() => {
 		_$_.regular_block(() => {
-			{
-				_$_.output_push('<div');
-				_$_.output_push('>');
+			let __out = '';
 
-				{
-					_$_.output_push('Empty title test');
-				}
-
-				_$_.output_push('</div>');
-				_$_.set_output_target('head');
-				_$_.output_push('<!--13ba9873-->');
-				_$_.output_push('<title');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('');
-				}
-
-				_$_.output_push('</title>');
-				_$_.set_output_target(null);
-			}
+			__out += '<div>Empty title test</div>';
+			_$_.output_push(__out);
+			__out = '';
+			_$_.set_output_target('head');
+			__out += '<!--13ba9873--><title></title>';
+			_$_.output_push(__out);
+			__out = '';
+			_$_.set_output_target(null);
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -202,27 +123,17 @@ export function ConditionalTitle() {
 		let lazy_4 = _$_.track('Main Page', '7cd7d671');
 
 		_$_.regular_block(() => {
-			{
-				_$_.output_push('<div');
-				_$_.output_push('>');
+			let __out = '';
 
-				{
-					_$_.output_push(_$_.escape(lazy_4.value));
-				}
-
-				_$_.output_push('</div>');
-				_$_.set_output_target('head');
-				_$_.output_push('<!--4b39c36b-->');
-				_$_.output_push('<title');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push(_$_.escape(lazy_3.value ? 'App - ' + lazy_4.value : lazy_4.value));
-				}
-
-				_$_.output_push('</title>');
-				_$_.set_output_target(null);
-			}
+			__out += '<div>' + _$_.escape(lazy_4.value) + '</div>';
+			_$_.output_push(__out);
+			__out = '';
+			_$_.set_output_target('head');
+			__out += '<!--4b39c36b--><title>' + _$_.escape(lazy_3.value ? 'App - ' + lazy_4.value : lazy_4.value) + '</title>';
+			_$_.output_push(__out);
+			__out = '';
+			_$_.set_output_target(null);
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -233,34 +144,17 @@ export function ComputedTitle() {
 		let prefix = 'Count: ';
 
 		_$_.regular_block(() => {
-			{
-				_$_.output_push('<div');
-				_$_.output_push('>');
+			let __out = '';
 
-				{
-					_$_.output_push('<span');
-					_$_.output_push('>');
-
-					{
-						_$_.output_push(_$_.escape(lazy_5.value));
-					}
-
-					_$_.output_push('</span>');
-				}
-
-				_$_.output_push('</div>');
-				_$_.set_output_target('head');
-				_$_.output_push('<!--92c79d98-->');
-				_$_.output_push('<title');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push(_$_.escape(prefix + lazy_5.value));
-				}
-
-				_$_.output_push('</title>');
-				_$_.set_output_target(null);
-			}
+			__out += '<div><span>' + _$_.escape(lazy_5.value) + '</span></div>';
+			_$_.output_push(__out);
+			__out = '';
+			_$_.set_output_target('head');
+			__out += '<!--92c79d98--><title>' + _$_.escape(prefix + lazy_5.value) + '</title>';
+			_$_.output_push(__out);
+			__out = '';
+			_$_.set_output_target(null);
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -268,32 +162,17 @@ export function ComputedTitle() {
 export function MultipleHeadBlocks() {
 	return _$_.tsrx_element(() => {
 		_$_.regular_block(() => {
-			{
-				_$_.output_push('<div');
-				_$_.output_push('>');
+			let __out = '';
 
-				{
-					_$_.output_push('Content');
-				}
-
-				_$_.output_push('</div>');
-				_$_.set_output_target('head');
-				_$_.output_push('<!--9a44f25d-->');
-				_$_.output_push('<title');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('First Head');
-				}
-
-				_$_.output_push('</title>');
-				_$_.output_push('<!--0873e476-->');
-				_$_.output_push('<meta');
-				_$_.output_push(' name="author"');
-				_$_.output_push(' content="Test Author"');
-				_$_.output_push(' />');
-				_$_.set_output_target(null);
-			}
+			__out += '<div>Content</div>';
+			_$_.output_push(__out);
+			__out = '';
+			_$_.set_output_target('head');
+			__out += '<!--9a44f25d--><title>First Head</title><!--0873e476--><meta name="author" content="Test Author" />';
+			_$_.output_push(__out);
+			__out = '';
+			_$_.set_output_target(null);
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -301,27 +180,17 @@ export function MultipleHeadBlocks() {
 export function HeadWithStyle() {
 	return _$_.tsrx_element(() => {
 		_$_.regular_block(() => {
-			{
-				_$_.output_push('<div');
-				_$_.output_push('>');
+			let __out = '';
 
-				{
-					_$_.output_push('Styled content');
-				}
-
-				_$_.output_push('</div>');
-				_$_.set_output_target('head');
-				_$_.output_push('<!--d75c5358-->');
-				_$_.output_push('<title');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('Styled Page');
-				}
-
-				_$_.output_push('</title>');
-				_$_.set_output_target(null);
-			}
+			__out += '<div>Styled content</div>';
+			_$_.output_push(__out);
+			__out = '';
+			_$_.set_output_target('head');
+			__out += '<!--d75c5358--><title>Styled Page</title>';
+			_$_.output_push(__out);
+			__out = '';
+			_$_.set_output_target(null);
+			_$_.output_push(__out);
 		});
 	});
 }

--- a/packages/ripple/tests/hydration/compiled/server/hmr.js
+++ b/packages/ripple/tests/hydration/compiled/server/hmr.js
@@ -6,32 +6,18 @@ import { track } from 'ripple/server';
 export function Layout({ children }) {
 	return _$_.tsrx_element(() => {
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push(' class="layout"');
-			_$_.output_push('>');
+			let __out = '';
+
+			__out += '<div class="layout"><nav class="nav">Navigation</nav><main class="main">';
 
 			{
-				_$_.output_push('<nav');
-				_$_.output_push(' class="nav"');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('Navigation');
-				}
-
-				_$_.output_push('</nav>');
-				_$_.output_push('<main');
-				_$_.output_push(' class="main"');
-				_$_.output_push('>');
-
-				{
-					_$_.render_expression(children);
-				}
-
-				_$_.output_push('</main>');
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_expression(children);
 			}
 
-			_$_.output_push('</div>');
+			__out += '</main></div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -41,29 +27,16 @@ export function Content() {
 		let lazy = _$_.track(true, '0bdb1500');
 
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push(' class="content"');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push('<!--[-->');
+			__out += '<div class="content"><!--[-->';
 
-				if (lazy.value) {
-					_$_.output_push('<p');
-					_$_.output_push(' class="text"');
-					_$_.output_push('>');
-
-					{
-						_$_.output_push('Hello world');
-					}
-
-					_$_.output_push('</p>');
-				}
-
-				_$_.output_push('<!--]-->');
+			if (lazy.value) {
+				__out += '<p class="text">Hello world</p>';
 			}
 
-			_$_.output_push('</div>');
+			__out += '<!--]--></div>';
+			_$_.output_push(__out);
 		});
 	});
 }

--- a/packages/ripple/tests/hydration/compiled/server/html-in-template.js
+++ b/packages/ripple/tests/hydration/compiled/server/html-in-template.js
@@ -6,11 +6,10 @@ export function SimpleTemplateHtml() {
 		const data = 'test data';
 
 		_$_.regular_block(() => {
-			_$_.output_push('<template');
-			_$_.output_push(' id="data1"');
-			_$_.output_push('>');
-			_$_.output_push(String(data ?? ''));
-			_$_.output_push('</template>');
+			let __out = '';
+
+			__out += '<template id="data1">' + String(data ?? '') + '</template>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -20,11 +19,10 @@ export function TemplateWithJSON() {
 		const jsonData = JSON.stringify({ message: 'hello', count: 42 });
 
 		_$_.regular_block(() => {
-			_$_.output_push('<template');
-			_$_.output_push(' id="data2"');
-			_$_.output_push('>');
-			_$_.output_push(String(jsonData ?? ''));
-			_$_.output_push('</template>');
+			let __out = '';
+
+			__out += '<template id="data2">' + String(jsonData ?? '') + '</template>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -34,38 +32,16 @@ export function TemplateAroundIfBlock() {
 		const show = true;
 
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push('<template');
-				_$_.output_push(' id="before"');
-				_$_.output_push('>');
-				_$_.output_push('before');
-				_$_.output_push('</template>');
-				_$_.output_push('<!--[-->');
+			__out += '<div><template id="before">before</template><!--[-->';
 
-				if (show) {
-					_$_.output_push('<span');
-					_$_.output_push(' class="inside"');
-					_$_.output_push('>');
-
-					{
-						_$_.output_push('inside');
-					}
-
-					_$_.output_push('</span>');
-				}
-
-				_$_.output_push('<!--]-->');
-				_$_.output_push('<template');
-				_$_.output_push(' id="after"');
-				_$_.output_push('>');
-				_$_.output_push('after');
-				_$_.output_push('</template>');
+			if (show) {
+				__out += '<span class="inside">inside</span>';
 			}
 
-			_$_.output_push('</div>');
+			__out += '<!--]--><template id="after">after</template></div>';
+			_$_.output_push(__out);
 		});
 	});
 }

--- a/packages/ripple/tests/hydration/compiled/server/html.js
+++ b/packages/ripple/tests/hydration/compiled/server/html.js
@@ -8,10 +8,10 @@ export function StaticHtml() {
 		const html = '<p><strong>Bold</strong> text</p>';
 
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push('>');
-			_$_.output_push(String(html ?? ''));
-			_$_.output_push('</div>');
+			let __out = '';
+
+			__out += '<div>' + String(html ?? '') + '</div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -21,10 +21,10 @@ export function DynamicHtml() {
 		const content = '<p>Dynamic <span>HTML</span> content</p>';
 
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push('>');
-			_$_.output_push(String(content ?? ''));
-			_$_.output_push('</div>');
+			let __out = '';
+
+			__out += '<div>' + String(content ?? '') + '</div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -34,10 +34,10 @@ export function EmptyHtml() {
 		const html = '';
 
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push('>');
-			_$_.output_push(String(html ?? ''));
-			_$_.output_push('</div>');
+			let __out = '';
+
+			__out += '<div>' + String(html ?? '') + '</div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -47,10 +47,10 @@ export function ComplexHtml() {
 		const html = '<div class="nested"><span>Nested <em>content</em></span></div>';
 
 		_$_.regular_block(() => {
-			_$_.output_push('<section');
-			_$_.output_push('>');
-			_$_.output_push(String(html ?? ''));
-			_$_.output_push('</section>');
+			let __out = '';
+
+			__out += '<section>' + String(html ?? '') + '</section>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -61,24 +61,22 @@ export function MultipleHtml() {
 		const html2 = '<p>Second paragraph</p>';
 
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push('>');
+			let __out = '';
+
+			__out += '<div>';
 
 			{
 				const html_value = String(html1 ?? '');
 
-				_$_.output_push('<!--' + _$_.simple_hash(html_value) + '-->');
-				_$_.output_push(html_value);
-				_$_.output_push('<!---->');
+				__out += '<!--' + _$_.simple_hash(html_value) + '-->' + html_value + '<!---->';
 
 				const html_value_1 = String(html2 ?? '');
 
-				_$_.output_push('<!--' + _$_.simple_hash(html_value_1) + '-->');
-				_$_.output_push(html_value_1);
-				_$_.output_push('<!---->');
+				__out += '<!--' + _$_.simple_hash(html_value_1) + '-->' + html_value_1 + '<!---->';
 			}
 
-			_$_.output_push('</div>');
+			__out += '</div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -86,24 +84,10 @@ export function MultipleHtml() {
 export function HtmlWithReactivity() {
 	return _$_.tsrx_element(() => {
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push('<!--1tb17hh-->');
-				_$_.output_push('<p>Count: 0</p>');
-				_$_.output_push('<!---->');
-				_$_.output_push('<button');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('Increment');
-				}
-
-				_$_.output_push('</button>');
-			}
-
-			_$_.output_push('</div>');
+			__out += '<div><!--1tb17hh--><p>Count: 0</p><!----><button>Increment</button></div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -111,23 +95,18 @@ export function HtmlWithReactivity() {
 export function HtmlWrapper({ children }) {
 	return _$_.tsrx_element(() => {
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push(' class="wrapper"');
-			_$_.output_push('>');
+			let __out = '';
+
+			__out += '<div class="wrapper"><div class="inner">';
 
 			{
-				_$_.output_push('<div');
-				_$_.output_push(' class="inner"');
-				_$_.output_push('>');
-
-				{
-					_$_.render_expression(children);
-				}
-
-				_$_.output_push('</div>');
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_expression(children);
 			}
 
-			_$_.output_push('</div>');
+			__out += '</div></div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -144,11 +123,10 @@ export function HtmlInChildren() {
 					{
 						children: _$_.tsrx_element(() => {
 							return _$_.tsrx_element(() => {
-								_$_.output_push('<div');
-								_$_.output_push(' class="vp-doc"');
-								_$_.output_push('>');
-								_$_.output_push(String(content ?? ''));
-								_$_.output_push('</div>');
+								let __out = '';
+
+								__out += '<div class="vp-doc">' + String(content ?? '') + '</div>';
+								_$_.output_push(__out);
 							});
 						})
 					}
@@ -172,19 +150,10 @@ export function HtmlInChildrenWithSiblings() {
 					{
 						children: _$_.tsrx_element(() => {
 							return _$_.tsrx_element(() => {
-								_$_.output_push('<h1');
-								_$_.output_push('>');
+								let __out = '';
 
-								{
-									_$_.output_push('Title');
-								}
-
-								_$_.output_push('</h1>');
-								_$_.output_push('<div');
-								_$_.output_push(' class="content"');
-								_$_.output_push('>');
-								_$_.output_push(String(content ?? ''));
-								_$_.output_push('</div>');
+								__out += '<h1>Title</h1><div class="content">' + String(content ?? '') + '</div>';
+								_$_.output_push(__out);
 							});
 						})
 					}
@@ -209,25 +178,22 @@ export function MultipleHtmlInChildren() {
 					{
 						children: _$_.tsrx_element(() => {
 							return _$_.tsrx_element(() => {
-								_$_.output_push('<div');
-								_$_.output_push(' class="doc"');
-								_$_.output_push('>');
+								let __out = '';
+
+								__out += '<div class="doc">';
 
 								{
 									const html_value_2 = String(html1 ?? '');
 
-									_$_.output_push('<!--' + _$_.simple_hash(html_value_2) + '-->');
-									_$_.output_push(html_value_2);
-									_$_.output_push('<!---->');
+									__out += '<!--' + _$_.simple_hash(html_value_2) + '-->' + html_value_2 + '<!---->';
 
 									const html_value_3 = String(html2 ?? '');
 
-									_$_.output_push('<!--' + _$_.simple_hash(html_value_3) + '-->');
-									_$_.output_push(html_value_3);
-									_$_.output_push('<!---->');
+									__out += '<!--' + _$_.simple_hash(html_value_3) + '-->' + html_value_3 + '<!---->';
 								}
 
-								_$_.output_push('</div>');
+								__out += '</div>';
+								_$_.output_push(__out);
 							});
 						})
 					}
@@ -244,10 +210,10 @@ export function HtmlWithComments() {
 		const content = '<p>Before comment</p><!-- TODO: Elaborate --><p>After comment</p>';
 
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push('>');
-			_$_.output_push(String(content ?? ''));
-			_$_.output_push('</div>');
+			let __out = '';
+
+			__out += '<div>' + String(content ?? '') + '</div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -257,10 +223,10 @@ export function HtmlWithEmptyComment() {
 		const content = '<p>Before</p><!----><p>After</p>';
 
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push('>');
-			_$_.output_push(String(content ?? ''));
-			_$_.output_push('</div>');
+			let __out = '';
+
+			__out += '<div>' + String(content ?? '') + '</div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -277,11 +243,10 @@ export function HtmlWithCommentsInChildren() {
 					{
 						children: _$_.tsrx_element(() => {
 							return _$_.tsrx_element(() => {
-								_$_.output_push('<div');
-								_$_.output_push(' class="vp-doc"');
-								_$_.output_push('>');
-								_$_.output_push(String(content ?? ''));
-								_$_.output_push('</div>');
+								let __out = '';
+
+								__out += '<div class="vp-doc">' + String(content ?? '') + '</div>';
+								_$_.output_push(__out);
 							});
 						})
 					}
@@ -296,15 +261,10 @@ export function HtmlWithCommentsInChildren() {
 function DocFooter() {
 	return _$_.tsrx_element(() => {
 		_$_.regular_block(() => {
-			_$_.output_push('<footer');
-			_$_.output_push(' class="doc-footer"');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push('Footer content');
-			}
-
-			_$_.output_push('</footer>');
+			__out += '<footer class="doc-footer">Footer content</footer>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -312,140 +272,121 @@ function DocFooter() {
 export function DocLayout(__props) {
 	return _$_.tsrx_element(() => {
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push(' class="layout"');
-			_$_.output_push('>');
+			let __out = '';
+
+			__out += '<div class="layout"><div class="content-container"><article><div>';
 
 			{
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_expression(__props.children);
+			}
+
+			__out += '</div></article><!--[-->';
+			_$_.output_push(__out);
+			__out = '';
+
+			if (_$_.fallback(__props.editPath, '')) {
 				_$_.output_push('<div');
-				_$_.output_push(' class="content-container"');
+				_$_.output_push(' class="edit-link"');
 				_$_.output_push('>');
 
 				{
-					_$_.output_push('<article');
+					_$_.output_push('<a');
+					_$_.output_push(_$_.attr('href', `https://github.com/edit/${_$_.fallback(__props.editPath, '')}`, false));
 					_$_.output_push('>');
 
 					{
-						_$_.output_push('<div');
-						_$_.output_push('>');
-
-						{
-							_$_.render_expression(__props.children);
-						}
-
-						_$_.output_push('</div>');
+						_$_.output_push('Edit');
 					}
 
-					_$_.output_push('</article>');
-					_$_.output_push('<!--[-->');
-
-					if (_$_.fallback(__props.editPath, '')) {
-						_$_.output_push('<div');
-						_$_.output_push(' class="edit-link"');
-						_$_.output_push('>');
-
-						{
-							_$_.output_push('<a');
-							_$_.output_push(_$_.attr('href', `https://github.com/edit/${_$_.fallback(__props.editPath, '')}`, false));
-							_$_.output_push('>');
-
-							{
-								_$_.output_push('Edit');
-							}
-
-							_$_.output_push('</a>');
-						}
-
-						_$_.output_push('</div>');
-					}
-
-					_$_.output_push('<!--]-->');
-					_$_.output_push('<!--[-->');
-
-					if (_$_.fallback(__props.nextLink, null)) {
-						_$_.output_push('<nav');
-						_$_.output_push(' class="prev-next"');
-						_$_.output_push('>');
-
-						{
-							_$_.output_push('<a');
-							_$_.output_push(_$_.attr('href', _$_.fallback(__props.nextLink, null).href, false));
-							_$_.output_push('>');
-
-							{
-								_$_.output_push(_$_.escape(_$_.fallback(__props.nextLink, null).text));
-							}
-
-							_$_.output_push('</a>');
-						}
-
-						_$_.output_push('</nav>');
-					}
-
-					_$_.output_push('<!--]-->');
-
-					{
-						const comp = DocFooter;
-						const args = [{}];
-
-						_$_.render_component(comp, ...args);
-					}
+					_$_.output_push('</a>');
 				}
 
 				_$_.output_push('</div>');
-				_$_.output_push('<aside');
+			}
+
+			__out += '<!--]--><!--[-->';
+			_$_.output_push(__out);
+			__out = '';
+
+			if (_$_.fallback(__props.nextLink, null)) {
+				_$_.output_push('<nav');
+				_$_.output_push(' class="prev-next"');
 				_$_.output_push('>');
 
 				{
-					_$_.output_push('<!--[-->');
+					_$_.output_push('<a');
+					_$_.output_push(_$_.attr('href', _$_.fallback(__props.nextLink, null).href, false));
+					_$_.output_push('>');
 
-					if (_$_.fallback(__props.toc, []).length > 0) {
-						_$_.output_push('<div');
-						_$_.output_push(' class="toc"');
-						_$_.output_push('>');
+					{
+						_$_.output_push(_$_.escape(_$_.fallback(__props.nextLink, null).text));
+					}
 
-						{
-							_$_.output_push('<ul');
+					_$_.output_push('</a>');
+				}
+
+				_$_.output_push('</nav>');
+			}
+
+			__out += '<!--]-->';
+
+			{
+				const comp = DocFooter;
+				const args = [{}];
+
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_component(comp, ...args);
+			}
+
+			__out += '</div><aside><!--[-->';
+			_$_.output_push(__out);
+			__out = '';
+
+			if (_$_.fallback(__props.toc, []).length > 0) {
+				_$_.output_push('<div');
+				_$_.output_push(' class="toc"');
+				_$_.output_push('>');
+
+				{
+					_$_.output_push('<ul');
+					_$_.output_push('>');
+
+					{
+						_$_.output_push('<!--[-->');
+
+						for (const item of _$_.fallback(__props.toc, [])) {
+							_$_.output_push('<li');
 							_$_.output_push('>');
 
 							{
-								_$_.output_push('<!--[-->');
+								_$_.output_push('<a');
+								_$_.output_push(_$_.attr('href', item.href, false));
+								_$_.output_push('>');
 
-								for (const item of _$_.fallback(__props.toc, [])) {
-									_$_.output_push('<li');
-									_$_.output_push('>');
-
-									{
-										_$_.output_push('<a');
-										_$_.output_push(_$_.attr('href', item.href, false));
-										_$_.output_push('>');
-
-										{
-											_$_.output_push(_$_.escape(item.text));
-										}
-
-										_$_.output_push('</a>');
-									}
-
-									_$_.output_push('</li>');
+								{
+									_$_.output_push(_$_.escape(item.text));
 								}
 
-								_$_.output_push('<!--]-->');
+								_$_.output_push('</a>');
 							}
 
-							_$_.output_push('</ul>');
+							_$_.output_push('</li>');
 						}
 
-						_$_.output_push('</div>');
+						_$_.output_push('<!--]-->');
 					}
 
-					_$_.output_push('<!--]-->');
+					_$_.output_push('</ul>');
 				}
 
-				_$_.output_push('</aside>');
+				_$_.output_push('</div>');
 			}
 
-			_$_.output_push('</div>');
+			__out += '<!--]--></aside></div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -469,11 +410,10 @@ export function HtmlWithServerData() {
 
 						children: _$_.tsrx_element(() => {
 							return _$_.tsrx_element(() => {
-								_$_.output_push('<div');
-								_$_.output_push(' class="vp-doc"');
-								_$_.output_push('>');
-								_$_.output_push(String(content ?? ''));
-								_$_.output_push('</div>');
+								let __out = '';
+
+								__out += '<div class="vp-doc">' + String(content ?? '') + '</div>';
+								_$_.output_push(__out);
 							});
 						})
 					}
@@ -497,11 +437,10 @@ export function HtmlWithClientDefaults() {
 					{
 						children: _$_.tsrx_element(() => {
 							return _$_.tsrx_element(() => {
-								_$_.output_push('<div');
-								_$_.output_push(' class="vp-doc"');
-								_$_.output_push('>');
-								_$_.output_push(String(content ?? ''));
-								_$_.output_push('</div>');
+								let __out = '';
+
+								__out += '<div class="vp-doc">' + String(content ?? '') + '</div>';
+								_$_.output_push(__out);
 							});
 						})
 					}
@@ -525,11 +464,10 @@ export function HtmlWithUndefinedContent() {
 					{
 						children: _$_.tsrx_element(() => {
 							return _$_.tsrx_element(() => {
-								_$_.output_push('<div');
-								_$_.output_push(' class="vp-doc"');
-								_$_.output_push('>');
-								_$_.output_push(String(content ?? ''));
-								_$_.output_push('</div>');
+								let __out = '';
+
+								__out += '<div class="vp-doc">' + String(content ?? '') + '</div>';
+								_$_.output_push(__out);
 							});
 						})
 					}
@@ -544,31 +482,34 @@ export function HtmlWithUndefinedContent() {
 function DynamicHeading({ level, children }) {
 	return _$_.tsrx_element(() => {
 		_$_.regular_block(() => {
-			_$_.output_push('<!--[-->');
+			let __out = '';
+
+			__out += '<!--[-->';
 
 			switch (level) {
 				case 1:
-					_$_.output_push('<h1');
-					_$_.output_push(' class="heading"');
-					_$_.output_push('>');
+					__out += '<h1 class="heading">';
 					{
+						_$_.output_push(__out);
+						__out = '';
 						_$_.render_expression(children);
 					}
-					_$_.output_push('</h1>');
+					__out += '</h1>';
 					break;
 
 				case 2:
-					_$_.output_push('<h2');
-					_$_.output_push(' class="heading"');
-					_$_.output_push('>');
+					__out += '<h2 class="heading">';
 					{
+						_$_.output_push(__out);
+						__out = '';
 						_$_.render_expression(children);
 					}
-					_$_.output_push('</h2>');
+					__out += '</h2>';
 					break;
 			}
 
-			_$_.output_push('<!--]-->');
+			__out += '<!--]-->';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -578,44 +519,10 @@ function CodeBlock({ code }) {
 		const highlighted = `<pre class="shiki"><code>${code}</code></pre>`;
 
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push(' class="code-block"');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push('<div');
-				_$_.output_push(' class="header"');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('<button');
-					_$_.output_push('>');
-
-					{
-						_$_.output_push('Copy');
-					}
-
-					_$_.output_push('</button>');
-					_$_.output_push('<span');
-					_$_.output_push(' class="lang"');
-					_$_.output_push('>');
-
-					{
-						_$_.output_push('js');
-					}
-
-					_$_.output_push('</span>');
-				}
-
-				_$_.output_push('</div>');
-				_$_.output_push('<div');
-				_$_.output_push(' class="content"');
-				_$_.output_push('>');
-				_$_.output_push(String(highlighted ?? ''));
-				_$_.output_push('</div>');
-			}
-
-			_$_.output_push('</div>');
+			__out += '<div class="code-block"><div class="header"><button>Copy</button><span class="lang">js</span></div><div class="content">' + String(highlighted ?? '') + '</div></div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -623,23 +530,18 @@ function CodeBlock({ code }) {
 function ContentWrapper({ children }) {
 	return _$_.tsrx_element(() => {
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push(' class="wrapper"');
-			_$_.output_push('>');
+			let __out = '';
+
+			__out += '<div class="wrapper"><div class="inner">';
 
 			{
-				_$_.output_push('<div');
-				_$_.output_push(' class="inner"');
-				_$_.output_push('>');
-
-				{
-					_$_.render_expression(children);
-				}
-
-				_$_.output_push('</div>');
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_expression(children);
 			}
 
-			_$_.output_push('</div>');
+			__out += '</div></div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -654,55 +556,46 @@ export function HtmlAfterSwitchInChildren() {
 					{
 						children: _$_.tsrx_element(() => {
 							return _$_.tsrx_element(() => {
+								let __out = '';
+
 								{
 									const comp = DynamicHeading;
+
+									_$_.output_push(__out);
+									__out = '';
 
 									const args = [
 										{
 											level: 1,
 											children: _$_.tsrx_element(() => {
 												return _$_.tsrx_element(() => {
-													_$_.output_push('Title');
+													let __out = '';
+
+													__out += 'Title';
+													_$_.output_push(__out);
 												});
 											})
 										}
 									];
 
+									_$_.output_push(__out);
+									__out = '';
 									_$_.render_component(comp, ...args);
 								}
 
-								_$_.output_push('<p');
-								_$_.output_push('>');
-
-								{
-									_$_.output_push('First paragraph');
-								}
-
-								_$_.output_push('</p>');
-								_$_.output_push('<p');
-								_$_.output_push('>');
-
-								{
-									_$_.output_push('Second paragraph');
-								}
-
-								_$_.output_push('</p>');
+								__out += '<p>First paragraph</p><p>Second paragraph</p>';
 
 								{
 									const comp = CodeBlock;
 									const args = [{ code: "const x = 1;" }];
 
+									_$_.output_push(__out);
+									__out = '';
 									_$_.render_component(comp, ...args);
 								}
 
-								_$_.output_push('<p');
-								_$_.output_push('>');
-
-								{
-									_$_.output_push('After code');
-								}
-
-								_$_.output_push('</p>');
+								__out += '<p>After code</p>';
+								_$_.output_push(__out);
 							});
 						})
 					}
@@ -717,40 +610,21 @@ export function HtmlAfterSwitchInChildren() {
 function NavItem(__props) {
 	return _$_.tsrx_element(() => {
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push(_$_.attr('class', `nav-item${_$_.fallback(__props.active, false) ? ' active' : ''}`));
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push('<!--[-->');
+			__out += '<div' + _$_.attr('class', `nav-item${_$_.fallback(__props.active, false) ? ' active' : ''}`) + '><!--[-->';
+			_$_.output_push(__out);
+			__out = '';
 
-				if (_$_.fallback(__props.active, false)) {
-					_$_.output_push('<div');
-					_$_.output_push(' class="indicator"');
-					_$_.output_push('>');
-					_$_.output_push('</div>');
-				}
-
-				_$_.output_push('<!--]-->');
-				_$_.output_push('<a');
-				_$_.output_push(_$_.attr('href', __props.href, false));
+			if (_$_.fallback(__props.active, false)) {
+				_$_.output_push('<div');
+				_$_.output_push(' class="indicator"');
 				_$_.output_push('>');
-
-				{
-					_$_.output_push('<span');
-					_$_.output_push('>');
-
-					{
-						_$_.output_push(_$_.escape(__props.text));
-					}
-
-					_$_.output_push('</span>');
-				}
-
-				_$_.output_push('</a>');
+				_$_.output_push('</div>');
 			}
 
-			_$_.output_push('</div>');
+			__out += '<!--]--><a' + _$_.attr('href', __props.href, false) + '><span>' + _$_.escape(__props.text) + '</span></a></div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -760,53 +634,24 @@ function SidebarSection({ title, children }) {
 		let lazy = _$_.track(true, '6ac6906f');
 
 		_$_.regular_block(() => {
-			_$_.output_push('<section');
-			_$_.output_push(' class="sidebar-section"');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push('<div');
-				_$_.output_push(' class="section-header"');
-				_$_.output_push('>');
+			__out += '<section class="sidebar-section"><div class="section-header"><h2>' + _$_.escape(title) + '</h2><button>Toggle</button></div><!--[-->';
+
+			if (lazy.value) {
+				__out += '<div class="section-items">';
 
 				{
-					_$_.output_push('<h2');
-					_$_.output_push('>');
-
-					{
-						_$_.output_push(_$_.escape(title));
-					}
-
-					_$_.output_push('</h2>');
-					_$_.output_push('<button');
-					_$_.output_push('>');
-
-					{
-						_$_.output_push('Toggle');
-					}
-
-					_$_.output_push('</button>');
+					_$_.output_push(__out);
+					__out = '';
+					_$_.render_expression(children);
 				}
 
-				_$_.output_push('</div>');
-				_$_.output_push('<!--[-->');
-
-				if (lazy.value) {
-					_$_.output_push('<div');
-					_$_.output_push(' class="section-items"');
-					_$_.output_push('>');
-
-					{
-						_$_.render_expression(children);
-					}
-
-					_$_.output_push('</div>');
-				}
-
-				_$_.output_push('<!--]-->');
+				__out += '</div>';
 			}
 
-			_$_.output_push('</section>');
+			__out += '<!--]--></section>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -814,121 +659,114 @@ function SidebarSection({ title, children }) {
 function SideNav({ currentPath }) {
 	return _$_.tsrx_element(() => {
 		_$_.regular_block(() => {
-			_$_.output_push('<aside');
-			_$_.output_push(' class="sidebar"');
-			_$_.output_push('>');
+			let __out = '';
+
+			__out += '<aside class="sidebar"><nav><div class="group">';
 
 			{
-				_$_.output_push('<nav');
-				_$_.output_push('>');
-
 				{
-					_$_.output_push('<div');
-					_$_.output_push(' class="group"');
-					_$_.output_push('>');
+					const comp = SidebarSection;
 
-					{
+					_$_.output_push(__out);
+					__out = '';
+
+					const args = [
 						{
-							const comp = SidebarSection;
+							title: "Getting Started",
+							children: _$_.tsrx_element(() => {
+								return _$_.tsrx_element(() => {
+									{
+										const comp = NavItem;
 
-							const args = [
-								{
-									title: "Getting Started",
-									children: _$_.tsrx_element(() => {
-										return _$_.tsrx_element(() => {
+										const args = [
 											{
-												const comp = NavItem;
-
-												const args = [
-													{
-														href: "/intro",
-														text: "Introduction",
-														active: currentPath === '/intro'
-													}
-												];
-
-												_$_.render_component(comp, ...args);
+												href: "/intro",
+												text: "Introduction",
+												active: currentPath === '/intro'
 											}
+										];
 
+										_$_.render_component(comp, ...args);
+									}
+
+									{
+										const comp = NavItem;
+
+										const args = [
 											{
-												const comp = NavItem;
-
-												const args = [
-													{
-														href: "/start",
-														text: "Quick Start",
-														active: currentPath === '/start'
-													}
-												];
-
-												_$_.render_component(comp, ...args);
+												href: "/start",
+												text: "Quick Start",
+												active: currentPath === '/start'
 											}
-										});
-									})
-								}
-							];
+										];
 
-							_$_.render_component(comp, ...args);
+										_$_.render_component(comp, ...args);
+									}
+								});
+							})
 						}
-					}
+					];
 
-					_$_.output_push('</div>');
-					_$_.output_push('<div');
-					_$_.output_push(' class="group"');
-					_$_.output_push('>');
-
-					{
-						{
-							const comp = SidebarSection;
-
-							const args = [
-								{
-									title: "Guide",
-									children: _$_.tsrx_element(() => {
-										return _$_.tsrx_element(() => {
-											{
-												const comp = NavItem;
-
-												const args = [
-													{
-														href: "/guide/app",
-														text: "Application",
-														active: currentPath === '/guide/app'
-													}
-												];
-
-												_$_.render_component(comp, ...args);
-											}
-
-											{
-												const comp = NavItem;
-
-												const args = [
-													{
-														href: "/guide/syntax",
-														text: "Syntax",
-														active: currentPath === '/guide/syntax'
-													}
-												];
-
-												_$_.render_component(comp, ...args);
-											}
-										});
-									})
-								}
-							];
-
-							_$_.render_component(comp, ...args);
-						}
-					}
-
-					_$_.output_push('</div>');
+					_$_.output_push(__out);
+					__out = '';
+					_$_.render_component(comp, ...args);
 				}
-
-				_$_.output_push('</nav>');
 			}
 
-			_$_.output_push('</aside>');
+			__out += '</div><div class="group">';
+
+			{
+				{
+					const comp = SidebarSection;
+
+					_$_.output_push(__out);
+					__out = '';
+
+					const args = [
+						{
+							title: "Guide",
+							children: _$_.tsrx_element(() => {
+								return _$_.tsrx_element(() => {
+									{
+										const comp = NavItem;
+
+										const args = [
+											{
+												href: "/guide/app",
+												text: "Application",
+												active: currentPath === '/guide/app'
+											}
+										];
+
+										_$_.render_component(comp, ...args);
+									}
+
+									{
+										const comp = NavItem;
+
+										const args = [
+											{
+												href: "/guide/syntax",
+												text: "Syntax",
+												active: currentPath === '/guide/syntax'
+											}
+										];
+
+										_$_.render_component(comp, ...args);
+									}
+								});
+							})
+						}
+					];
+
+					_$_.output_push(__out);
+					__out = '';
+					_$_.render_component(comp, ...args);
+				}
+			}
+
+			__out += '</div></nav></aside>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -936,23 +774,10 @@ function SideNav({ currentPath }) {
 function PageHeader() {
 	return _$_.tsrx_element(() => {
 		_$_.regular_block(() => {
-			_$_.output_push('<header');
-			_$_.output_push(' class="page-header"');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push('<div');
-				_$_.output_push(' class="logo"');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('MyApp');
-				}
-
-				_$_.output_push('</div>');
-			}
-
-			_$_.output_push('</header>');
+			__out += '<header class="page-header"><div class="logo">MyApp</div></header>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -960,105 +785,49 @@ function PageHeader() {
 export function LayoutWithSidebarAndMain() {
 	return _$_.tsrx_element(() => {
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push(' class="layout"');
-			_$_.output_push('>');
+			let __out = '';
+
+			__out += '<div class="layout">';
 
 			{
-				{
-					const comp = PageHeader;
-					const args = [{}];
+				const comp = PageHeader;
+				const args = [{}];
 
-					_$_.render_component(comp, ...args);
-				}
-
-				_$_.output_push('<div');
-				_$_.output_push(' class="content-wrapper"');
-				_$_.output_push('>');
-
-				{
-					{
-						const comp = SideNav;
-						const args = [{ currentPath: "/intro" }];
-
-						_$_.render_component(comp, ...args);
-					}
-
-					_$_.output_push('<main');
-					_$_.output_push(' class="main-content"');
-					_$_.output_push('>');
-
-					{
-						_$_.output_push('<div');
-						_$_.output_push(' class="article"');
-						_$_.output_push('>');
-
-						{
-							_$_.output_push('<div');
-							_$_.output_push('>');
-
-							{
-								_$_.output_push('<h1');
-								_$_.output_push('>');
-
-								{
-									_$_.output_push('Introduction');
-								}
-
-								_$_.output_push('</h1>');
-								_$_.output_push('<p');
-								_$_.output_push('>');
-
-								{
-									_$_.output_push('Welcome to the docs.');
-								}
-
-								_$_.output_push('</p>');
-							}
-
-							_$_.output_push('</div>');
-						}
-
-						_$_.output_push('</div>');
-						_$_.output_push('<!--[-->');
-
-						if (true) {
-							_$_.output_push('<div');
-							_$_.output_push(' class="edit-link"');
-							_$_.output_push('>');
-
-							{
-								_$_.output_push('<a');
-								_$_.output_push(' href="/edit"');
-								_$_.output_push('>');
-
-								{
-									_$_.output_push('Edit');
-								}
-
-								_$_.output_push('</a>');
-							}
-
-							_$_.output_push('</div>');
-						}
-
-						_$_.output_push('<!--]-->');
-
-						{
-							const comp = PageHeader;
-							const args = [{}];
-
-							_$_.render_component(comp, ...args);
-						}
-					}
-
-					_$_.output_push('</main>');
-				}
-
-				_$_.output_push('</div>');
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_component(comp, ...args);
 			}
 
-			_$_.output_push('</div>');
+			__out += '<div class="content-wrapper">';
+
+			{
+				const comp = SideNav;
+				const args = [{ currentPath: "/intro" }];
+
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_component(comp, ...args);
+			}
+
+			__out += '<main class="main-content"><div class="article"><div><h1>Introduction</h1><p>Welcome to the docs.</p></div></div><!--[-->';
+
+			if (true) {
+				__out += '<div class="edit-link"><a href="/edit">Edit</a></div>';
+			}
+
+			__out += '<!--]-->';
+
+			{
+				const comp = PageHeader;
+				const args = [{}];
+
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_component(comp, ...args);
+			}
+
+			__out += '</main></div></div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -1066,22 +835,18 @@ export function LayoutWithSidebarAndMain() {
 function ArticleWrapper({ children }) {
 	return _$_.tsrx_element(() => {
 		_$_.regular_block(() => {
-			_$_.output_push('<article');
-			_$_.output_push(' class="doc-content"');
-			_$_.output_push('>');
+			let __out = '';
+
+			__out += '<article class="doc-content"><div>';
 
 			{
-				_$_.output_push('<div');
-				_$_.output_push('>');
-
-				{
-					_$_.render_expression(children);
-				}
-
-				_$_.output_push('</div>');
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_expression(children);
 			}
 
-			_$_.output_push('</article>');
+			__out += '</div></article>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -1089,15 +854,10 @@ function ArticleWrapper({ children }) {
 function SimpleFooter() {
 	return _$_.tsrx_element(() => {
 		_$_.regular_block(() => {
-			_$_.output_push('<footer');
-			_$_.output_push(' class="doc-footer"');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push('Footer');
-			}
-
-			_$_.output_push('</footer>');
+			__out += '<footer class="doc-footer">Footer</footer>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -1105,98 +865,59 @@ function SimpleFooter() {
 export function ArticleWithChildrenThenSibling() {
 	return _$_.tsrx_element(() => {
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push(' class="content-container"');
-			_$_.output_push('>');
+			let __out = '';
+
+			__out += '<div class="content-container">';
 
 			{
-				{
-					const comp = ArticleWrapper;
+				const comp = ArticleWrapper;
 
-					const args = [
-						{
-							children: _$_.tsrx_element(() => {
-								return _$_.tsrx_element(() => {
-									_$_.output_push('<h1');
-									_$_.output_push('>');
+				_$_.output_push(__out);
+				__out = '';
 
-									{
-										_$_.output_push('Title');
-									}
-
-									_$_.output_push('</h1>');
-									_$_.output_push('<p');
-									_$_.output_push('>');
-
-									{
-										_$_.output_push('Content goes here.');
-									}
-
-									_$_.output_push('</p>');
-								});
-							})
-						}
-					];
-
-					_$_.render_component(comp, ...args);
-				}
-
-				_$_.output_push('<!--[-->');
-
-				if (true) {
-					_$_.output_push('<div');
-					_$_.output_push(' class="edit-link"');
-					_$_.output_push('>');
-
+				const args = [
 					{
-						_$_.output_push('<a');
-						_$_.output_push(' href="/edit"');
-						_$_.output_push('>');
+						children: _$_.tsrx_element(() => {
+							return _$_.tsrx_element(() => {
+								let __out = '';
 
-						{
-							_$_.output_push('Edit');
-						}
-
-						_$_.output_push('</a>');
+								__out += '<h1>Title</h1><p>Content goes here.</p>';
+								_$_.output_push(__out);
+							});
+						})
 					}
+				];
 
-					_$_.output_push('</div>');
-				}
-
-				_$_.output_push('<!--]-->');
-				_$_.output_push('<!--[-->');
-
-				if (true) {
-					_$_.output_push('<nav');
-					_$_.output_push(' class="prev-next"');
-					_$_.output_push('>');
-
-					{
-						_$_.output_push('<a');
-						_$_.output_push(' href="/prev"');
-						_$_.output_push('>');
-
-						{
-							_$_.output_push('Previous');
-						}
-
-						_$_.output_push('</a>');
-					}
-
-					_$_.output_push('</nav>');
-				}
-
-				_$_.output_push('<!--]-->');
-
-				{
-					const comp = SimpleFooter;
-					const args = [{}];
-
-					_$_.render_component(comp, ...args);
-				}
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_component(comp, ...args);
 			}
 
-			_$_.output_push('</div>');
+			__out += '<!--[-->';
+
+			if (true) {
+				__out += '<div class="edit-link"><a href="/edit">Edit</a></div>';
+			}
+
+			__out += '<!--]--><!--[-->';
+
+			if (true) {
+				__out += '<nav class="prev-next"><a href="/prev">Previous</a></nav>';
+			}
+
+			__out += '<!--]-->';
+
+			{
+				const comp = SimpleFooter;
+				const args = [{}];
+
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_component(comp, ...args);
+			}
+
+			__out += '</div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -1206,64 +927,53 @@ export function ArticleWithHtmlChildThenSibling() {
 		const htmlContent = '<pre><code>const x = 1;</code></pre>';
 
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push(' class="content-container"');
-			_$_.output_push('>');
+			let __out = '';
+
+			__out += '<div class="content-container">';
 
 			{
-				{
-					const comp = ArticleWrapper;
+				const comp = ArticleWrapper;
 
-					const args = [
-						{
-							children: _$_.tsrx_element(() => {
-								return _$_.tsrx_element(() => {
-									_$_.output_push('<div');
-									_$_.output_push(' class="doc-content"');
-									_$_.output_push('>');
-									_$_.output_push(String(htmlContent ?? ''));
-									_$_.output_push('</div>');
-								});
-							})
-						}
-					];
+				_$_.output_push(__out);
+				__out = '';
 
-					_$_.render_component(comp, ...args);
-				}
-
-				_$_.output_push('<!--[-->');
-
-				if (true) {
-					_$_.output_push('<div');
-					_$_.output_push(' class="edit-link"');
-					_$_.output_push('>');
-
+				const args = [
 					{
-						_$_.output_push('<a');
-						_$_.output_push(' href="/edit"');
-						_$_.output_push('>');
+						children: _$_.tsrx_element(() => {
+							return _$_.tsrx_element(() => {
+								let __out = '';
 
-						{
-							_$_.output_push('Edit');
-						}
-
-						_$_.output_push('</a>');
+								__out += '<div class="doc-content">' + String(htmlContent ?? '') + '</div>';
+								_$_.output_push(__out);
+							});
+						})
 					}
+				];
 
-					_$_.output_push('</div>');
-				}
-
-				_$_.output_push('<!--]-->');
-
-				{
-					const comp = SimpleFooter;
-					const args = [{}];
-
-					_$_.render_component(comp, ...args);
-				}
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_component(comp, ...args);
 			}
 
-			_$_.output_push('</div>');
+			__out += '<!--[-->';
+
+			if (true) {
+				__out += '<div class="edit-link"><a href="/edit">Edit</a></div>';
+			}
+
+			__out += '<!--]-->';
+
+			{
+				const comp = SimpleFooter;
+				const args = [{}];
+
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_component(comp, ...args);
+			}
+
+			__out += '</div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -1271,60 +981,35 @@ export function ArticleWithHtmlChildThenSibling() {
 function InlineArticleLayout({ children }) {
 	return _$_.tsrx_element(() => {
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push(' class="content-container"');
-			_$_.output_push('>');
+			let __out = '';
+
+			__out += '<div class="content-container"><article class="doc-content"><div>';
 
 			{
-				_$_.output_push('<article');
-				_$_.output_push(' class="doc-content"');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('<div');
-					_$_.output_push('>');
-
-					{
-						_$_.render_expression(children);
-					}
-
-					_$_.output_push('</div>');
-				}
-
-				_$_.output_push('</article>');
-				_$_.output_push('<!--[-->');
-
-				if (true) {
-					_$_.output_push('<div');
-					_$_.output_push(' class="edit-link"');
-					_$_.output_push('>');
-
-					{
-						_$_.output_push('<a');
-						_$_.output_push(' href="/edit"');
-						_$_.output_push('>');
-
-						{
-							_$_.output_push('Edit');
-						}
-
-						_$_.output_push('</a>');
-					}
-
-					_$_.output_push('</div>');
-				}
-
-				_$_.output_push('<!--]-->');
-
-				{
-					const comp = SimpleFooter;
-					const args = [{}];
-
-					_$_.render_component(comp, ...args);
-				}
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_expression(children);
 			}
 
-			_$_.output_push('</div>');
+			__out += '</div></article><!--[-->';
+
+			if (true) {
+				__out += '<div class="edit-link"><a href="/edit">Edit</a></div>';
+			}
+
+			__out += '<!--]-->';
+
+			{
+				const comp = SimpleFooter;
+				const args = [{}];
+
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_component(comp, ...args);
+			}
+
+			__out += '</div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -1341,11 +1026,10 @@ export function InlineArticleWithHtmlChild() {
 					{
 						children: _$_.tsrx_element(() => {
 							return _$_.tsrx_element(() => {
-								_$_.output_push('<div');
-								_$_.output_push(' class="doc-content"');
-								_$_.output_push('>');
-								_$_.output_push(String(htmlContent ?? ''));
-								_$_.output_push('</div>');
+								let __out = '';
+
+								__out += '<div class="doc-content">' + String(htmlContent ?? '') + '</div>';
+								_$_.output_push(__out);
 							});
 						})
 					}
@@ -1360,15 +1044,10 @@ export function InlineArticleWithHtmlChild() {
 function HeaderStub() {
 	return _$_.tsrx_element(() => {
 		_$_.regular_block(() => {
-			_$_.output_push('<header');
-			_$_.output_push(' class="header"');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push('Header');
-			}
-
-			_$_.output_push('</header>');
+			__out += '<header class="header">Header</header>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -1376,15 +1055,10 @@ function HeaderStub() {
 function SidebarStub() {
 	return _$_.tsrx_element(() => {
 		_$_.regular_block(() => {
-			_$_.output_push('<aside');
-			_$_.output_push(' class="sidebar"');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push('Sidebar');
-			}
-
-			_$_.output_push('</aside>');
+			__out += '<aside class="sidebar">Sidebar</aside>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -1392,15 +1066,10 @@ function SidebarStub() {
 function FooterStub() {
 	return _$_.tsrx_element(() => {
 		_$_.regular_block(() => {
-			_$_.output_push('<footer');
-			_$_.output_push(' class="footer"');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push('Footer');
-			}
-
-			_$_.output_push('</footer>');
+			__out += '<footer class="footer">Footer</footer>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -1408,137 +1077,99 @@ function FooterStub() {
 function DocsLayoutInner(__props) {
 	return _$_.tsrx_element(() => {
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push(' class="layout"');
-			_$_.output_push('>');
+			let __out = '';
+
+			__out += '<div class="layout">';
 
 			{
-				{
-					const comp = HeaderStub;
-					const args = [{}];
+				const comp = HeaderStub;
+				const args = [{}];
 
-					_$_.render_component(comp, ...args);
-				}
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_component(comp, ...args);
+			}
 
+			__out += '<div class="docs-wrapper">';
+
+			{
+				const comp = SidebarStub;
+				const args = [{}];
+
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_component(comp, ...args);
+			}
+
+			__out += '<main class="docs-main"><div class="docs-container"><div class="content"><div class="content-container"><article class="doc-content"><div>';
+
+			{
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_expression(__props.children);
+			}
+
+			__out += '</div></article><!--[-->';
+			_$_.output_push(__out);
+			__out = '';
+
+			if (_$_.fallback(__props.editPath, '')) {
 				_$_.output_push('<div');
-				_$_.output_push(' class="docs-wrapper"');
+				_$_.output_push(' class="edit-link"');
 				_$_.output_push('>');
 
 				{
-					{
-						const comp = SidebarStub;
-						const args = [{}];
-
-						_$_.render_component(comp, ...args);
-					}
-
-					_$_.output_push('<main');
-					_$_.output_push(' class="docs-main"');
+					_$_.output_push('<a');
+					_$_.output_push(' href="/edit"');
 					_$_.output_push('>');
 
 					{
-						_$_.output_push('<div');
-						_$_.output_push(' class="docs-container"');
-						_$_.output_push('>');
-
-						{
-							_$_.output_push('<div');
-							_$_.output_push(' class="content"');
-							_$_.output_push('>');
-
-							{
-								_$_.output_push('<div');
-								_$_.output_push(' class="content-container"');
-								_$_.output_push('>');
-
-								{
-									_$_.output_push('<article');
-									_$_.output_push(' class="doc-content"');
-									_$_.output_push('>');
-
-									{
-										_$_.output_push('<div');
-										_$_.output_push('>');
-
-										{
-											_$_.render_expression(__props.children);
-										}
-
-										_$_.output_push('</div>');
-									}
-
-									_$_.output_push('</article>');
-									_$_.output_push('<!--[-->');
-
-									if (_$_.fallback(__props.editPath, '')) {
-										_$_.output_push('<div');
-										_$_.output_push(' class="edit-link"');
-										_$_.output_push('>');
-
-										{
-											_$_.output_push('<a');
-											_$_.output_push(' href="/edit"');
-											_$_.output_push('>');
-
-											{
-												_$_.output_push('Edit on GitHub');
-											}
-
-											_$_.output_push('</a>');
-										}
-
-										_$_.output_push('</div>');
-									}
-
-									_$_.output_push('<!--]-->');
-									_$_.output_push('<!--[-->');
-
-									if (_$_.fallback(__props.nextLink, null)) {
-										_$_.output_push('<nav');
-										_$_.output_push(' class="prev-next"');
-										_$_.output_push('>');
-
-										{
-											_$_.output_push('<a');
-											_$_.output_push(_$_.attr('href', _$_.fallback(__props.nextLink, null).href, false));
-											_$_.output_push('>');
-
-											{
-												_$_.output_push(_$_.escape(_$_.fallback(__props.nextLink, null).text));
-											}
-
-											_$_.output_push('</a>');
-										}
-
-										_$_.output_push('</nav>');
-									}
-
-									_$_.output_push('<!--]-->');
-
-									{
-										const comp = FooterStub;
-										const args = [{}];
-
-										_$_.render_component(comp, ...args);
-									}
-								}
-
-								_$_.output_push('</div>');
-							}
-
-							_$_.output_push('</div>');
-						}
-
-						_$_.output_push('</div>');
+						_$_.output_push('Edit on GitHub');
 					}
 
-					_$_.output_push('</main>');
+					_$_.output_push('</a>');
 				}
 
 				_$_.output_push('</div>');
 			}
 
-			_$_.output_push('</div>');
+			__out += '<!--]--><!--[-->';
+			_$_.output_push(__out);
+			__out = '';
+
+			if (_$_.fallback(__props.nextLink, null)) {
+				_$_.output_push('<nav');
+				_$_.output_push(' class="prev-next"');
+				_$_.output_push('>');
+
+				{
+					_$_.output_push('<a');
+					_$_.output_push(_$_.attr('href', _$_.fallback(__props.nextLink, null).href, false));
+					_$_.output_push('>');
+
+					{
+						_$_.output_push(_$_.escape(_$_.fallback(__props.nextLink, null).text));
+					}
+
+					_$_.output_push('</a>');
+				}
+
+				_$_.output_push('</nav>');
+			}
+
+			__out += '<!--]-->';
+
+			{
+				const comp = FooterStub;
+				const args = [{}];
+
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_component(comp, ...args);
+			}
+
+			__out += '</div></div></div></main></div></div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -1557,11 +1188,10 @@ export function DocsLayoutWithData() {
 						nextLink: { href: '/next', text: 'Next' },
 						children: _$_.tsrx_element(() => {
 							return _$_.tsrx_element(() => {
-								_$_.output_push('<div');
-								_$_.output_push(' class="doc-content"');
-								_$_.output_push('>');
-								_$_.output_push(String(htmlContent ?? ''));
-								_$_.output_push('</div>');
+								let __out = '';
+
+								__out += '<div class="doc-content">' + String(htmlContent ?? '') + '</div>';
+								_$_.output_push(__out);
 							});
 						})
 					}
@@ -1585,11 +1215,10 @@ export function DocsLayoutWithoutData() {
 					{
 						children: _$_.tsrx_element(() => {
 							return _$_.tsrx_element(() => {
-								_$_.output_push('<div');
-								_$_.output_push(' class="doc-content"');
-								_$_.output_push('>');
-								_$_.output_push(String(htmlContent ?? ''));
-								_$_.output_push('</div>');
+								let __out = '';
+
+								__out += '<div class="doc-content">' + String(htmlContent ?? '') + '</div>';
+								_$_.output_push(__out);
 							});
 						})
 					}
@@ -1604,225 +1233,180 @@ export function DocsLayoutWithoutData() {
 function DocsLayoutExact(__props) {
 	return _$_.tsrx_element(() => {
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push(' class="layout"');
-			_$_.output_push('>');
+			let __out = '';
+
+			__out += '<div class="layout">';
 
 			{
-				{
-					const comp = HeaderStub;
-					const args = [{}];
+				const comp = HeaderStub;
+				const args = [{}];
 
-					_$_.render_component(comp, ...args);
-				}
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_component(comp, ...args);
+			}
 
+			__out += '<div class="docs-wrapper">';
+
+			{
+				const comp = SidebarStub;
+				const args = [{}];
+
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_component(comp, ...args);
+			}
+
+			__out += '<main class="docs-main"><div class="docs-container"><div class="content"><div class="content-container"><article class="doc-content"><div>';
+
+			{
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_expression(__props.children);
+			}
+
+			__out += '</div></article><!--[-->';
+			_$_.output_push(__out);
+			__out = '';
+
+			if (_$_.fallback(__props.editPath, '')) {
 				_$_.output_push('<div');
-				_$_.output_push(' class="docs-wrapper"');
+				_$_.output_push(' class="edit-link"');
 				_$_.output_push('>');
 
 				{
-					{
-						const comp = SidebarStub;
-						const args = [{}];
-
-						_$_.render_component(comp, ...args);
-					}
-
-					_$_.output_push('<main');
-					_$_.output_push(' class="docs-main"');
+					_$_.output_push('<a');
+					_$_.output_push(_$_.attr('href', `/edit/${_$_.fallback(__props.editPath, '')}`, false));
 					_$_.output_push('>');
 
 					{
-						_$_.output_push('<div');
-						_$_.output_push(' class="docs-container"');
-						_$_.output_push('>');
-
-						{
-							_$_.output_push('<div');
-							_$_.output_push(' class="content"');
-							_$_.output_push('>');
-
-							{
-								_$_.output_push('<div');
-								_$_.output_push(' class="content-container"');
-								_$_.output_push('>');
-
-								{
-									_$_.output_push('<article');
-									_$_.output_push(' class="doc-content"');
-									_$_.output_push('>');
-
-									{
-										_$_.output_push('<div');
-										_$_.output_push('>');
-
-										{
-											_$_.render_expression(__props.children);
-										}
-
-										_$_.output_push('</div>');
-									}
-
-									_$_.output_push('</article>');
-									_$_.output_push('<!--[-->');
-
-									if (_$_.fallback(__props.editPath, '')) {
-										_$_.output_push('<div');
-										_$_.output_push(' class="edit-link"');
-										_$_.output_push('>');
-
-										{
-											_$_.output_push('<a');
-											_$_.output_push(_$_.attr('href', `/edit/${_$_.fallback(__props.editPath, '')}`, false));
-											_$_.output_push('>');
-
-											{
-												_$_.output_push('Edit on GitHub');
-											}
-
-											_$_.output_push('</a>');
-										}
-
-										_$_.output_push('</div>');
-									}
-
-									_$_.output_push('<!--]-->');
-									_$_.output_push('<!--[-->');
-
-									if (_$_.fallback(__props.prevLink, null) || _$_.fallback(__props.nextLink, null)) {
-										_$_.output_push('<nav');
-										_$_.output_push(' class="prev-next"');
-										_$_.output_push('>');
-
-										{
-											_$_.output_push('<!--[-->');
-
-											if (_$_.fallback(__props.prevLink, null)) {
-												_$_.output_push('<a');
-												_$_.output_push(_$_.attr('href', _$_.fallback(__props.prevLink, null).href, false));
-												_$_.output_push(' class="pager prev"');
-												_$_.output_push('>');
-
-												{
-													_$_.output_push('<span');
-													_$_.output_push(' class="title"');
-													_$_.output_push('>');
-
-													{
-														_$_.output_push(_$_.escape(_$_.fallback(__props.prevLink, null).text));
-													}
-
-													_$_.output_push('</span>');
-												}
-
-												_$_.output_push('</a>');
-											} else {
-												_$_.output_push('<span');
-												_$_.output_push('>');
-												_$_.output_push('</span>');
-											}
-
-											_$_.output_push('<!--]-->');
-											_$_.output_push('<!--[-->');
-
-											if (_$_.fallback(__props.nextLink, null)) {
-												_$_.output_push('<a');
-												_$_.output_push(_$_.attr('href', _$_.fallback(__props.nextLink, null).href, false));
-												_$_.output_push(' class="pager next"');
-												_$_.output_push('>');
-
-												{
-													_$_.output_push('<span');
-													_$_.output_push(' class="title"');
-													_$_.output_push('>');
-
-													{
-														_$_.output_push(_$_.escape(_$_.fallback(__props.nextLink, null).text));
-													}
-
-													_$_.output_push('</span>');
-												}
-
-												_$_.output_push('</a>');
-											}
-
-											_$_.output_push('<!--]-->');
-										}
-
-										_$_.output_push('</nav>');
-									}
-
-									_$_.output_push('<!--]-->');
-
-									{
-										const comp = FooterStub;
-										const args = [{}];
-
-										_$_.render_component(comp, ...args);
-									}
-								}
-
-								_$_.output_push('</div>');
-							}
-
-							_$_.output_push('</div>');
-							_$_.output_push('<aside');
-							_$_.output_push(' class="aside"');
-							_$_.output_push('>');
-
-							{
-								_$_.output_push('<!--[-->');
-
-								if (_$_.fallback(__props.toc, []).length > 0) {
-									_$_.output_push('<div');
-									_$_.output_push(' class="aside-content"');
-									_$_.output_push('>');
-
-									{
-										_$_.output_push('<nav');
-										_$_.output_push(' class="outline"');
-										_$_.output_push('>');
-
-										{
-											_$_.output_push('<!--[-->');
-
-											for (const item of _$_.fallback(__props.toc, [])) {
-												_$_.output_push('<a');
-												_$_.output_push(_$_.attr('href', item.href, false));
-												_$_.output_push('>');
-
-												{
-													_$_.output_push(_$_.escape(item.text));
-												}
-
-												_$_.output_push('</a>');
-											}
-
-											_$_.output_push('<!--]-->');
-										}
-
-										_$_.output_push('</nav>');
-									}
-
-									_$_.output_push('</div>');
-								}
-
-								_$_.output_push('<!--]-->');
-							}
-
-							_$_.output_push('</aside>');
-						}
-
-						_$_.output_push('</div>');
+						_$_.output_push('Edit on GitHub');
 					}
 
-					_$_.output_push('</main>');
+					_$_.output_push('</a>');
 				}
 
 				_$_.output_push('</div>');
 			}
 
-			_$_.output_push('</div>');
+			__out += '<!--]--><!--[-->';
+			_$_.output_push(__out);
+			__out = '';
+
+			if (_$_.fallback(__props.prevLink, null) || _$_.fallback(__props.nextLink, null)) {
+				_$_.output_push('<nav');
+				_$_.output_push(' class="prev-next"');
+				_$_.output_push('>');
+
+				{
+					_$_.output_push('<!--[-->');
+
+					if (_$_.fallback(__props.prevLink, null)) {
+						_$_.output_push('<a');
+						_$_.output_push(_$_.attr('href', _$_.fallback(__props.prevLink, null).href, false));
+						_$_.output_push(' class="pager prev"');
+						_$_.output_push('>');
+
+						{
+							_$_.output_push('<span');
+							_$_.output_push(' class="title"');
+							_$_.output_push('>');
+
+							{
+								_$_.output_push(_$_.escape(_$_.fallback(__props.prevLink, null).text));
+							}
+
+							_$_.output_push('</span>');
+						}
+
+						_$_.output_push('</a>');
+					} else {
+						_$_.output_push('<span');
+						_$_.output_push('>');
+						_$_.output_push('</span>');
+					}
+
+					_$_.output_push('<!--]-->');
+					_$_.output_push('<!--[-->');
+
+					if (_$_.fallback(__props.nextLink, null)) {
+						_$_.output_push('<a');
+						_$_.output_push(_$_.attr('href', _$_.fallback(__props.nextLink, null).href, false));
+						_$_.output_push(' class="pager next"');
+						_$_.output_push('>');
+
+						{
+							_$_.output_push('<span');
+							_$_.output_push(' class="title"');
+							_$_.output_push('>');
+
+							{
+								_$_.output_push(_$_.escape(_$_.fallback(__props.nextLink, null).text));
+							}
+
+							_$_.output_push('</span>');
+						}
+
+						_$_.output_push('</a>');
+					}
+
+					_$_.output_push('<!--]-->');
+				}
+
+				_$_.output_push('</nav>');
+			}
+
+			__out += '<!--]-->';
+
+			{
+				const comp = FooterStub;
+				const args = [{}];
+
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_component(comp, ...args);
+			}
+
+			__out += '</div></div><aside class="aside"><!--[-->';
+			_$_.output_push(__out);
+			__out = '';
+
+			if (_$_.fallback(__props.toc, []).length > 0) {
+				_$_.output_push('<div');
+				_$_.output_push(' class="aside-content"');
+				_$_.output_push('>');
+
+				{
+					_$_.output_push('<nav');
+					_$_.output_push(' class="outline"');
+					_$_.output_push('>');
+
+					{
+						_$_.output_push('<!--[-->');
+
+						for (const item of _$_.fallback(__props.toc, [])) {
+							_$_.output_push('<a');
+							_$_.output_push(_$_.attr('href', item.href, false));
+							_$_.output_push('>');
+
+							{
+								_$_.output_push(_$_.escape(item.text));
+							}
+
+							_$_.output_push('</a>');
+						}
+
+						_$_.output_push('<!--]-->');
+					}
+
+					_$_.output_push('</nav>');
+				}
+
+				_$_.output_push('</div>');
+			}
+
+			__out += '<!--]--></aside></div></main></div></div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -1847,11 +1431,10 @@ export function DocsLayoutExactWithData() {
 
 						children: _$_.tsrx_element(() => {
 							return _$_.tsrx_element(() => {
-								_$_.output_push('<div');
-								_$_.output_push(' class="doc-content"');
-								_$_.output_push('>');
-								_$_.output_push(String(htmlContent ?? ''));
-								_$_.output_push('</div>');
+								let __out = '';
+
+								__out += '<div class="doc-content">' + String(htmlContent ?? '') + '</div>';
+								_$_.output_push(__out);
 							});
 						})
 					}
@@ -1883,11 +1466,10 @@ export function DocsLayoutExactWithoutData() {
 						toc,
 						children: _$_.tsrx_element(() => {
 							return _$_.tsrx_element(() => {
-								_$_.output_push('<div');
-								_$_.output_push(' class="doc-content"');
-								_$_.output_push('>');
-								_$_.output_push(String(htmlContent ?? ''));
-								_$_.output_push('</div>');
+								let __out = '';
+
+								__out += '<div class="doc-content">' + String(htmlContent ?? '') + '</div>';
+								_$_.output_push(__out);
 							});
 						})
 					}
@@ -1904,27 +1486,10 @@ export function TemplateWithHtmlContent() {
 		const data = { title: 'Test', value: 42 };
 
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push('<template');
-				_$_.output_push(' id="t1"');
-				_$_.output_push('>');
-				_$_.output_push(String(JSON.stringify(data) ?? ''));
-				_$_.output_push('</template>');
-				_$_.output_push('<p');
-				_$_.output_push(' class="content"');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('Main content');
-				}
-
-				_$_.output_push('</p>');
-			}
-
-			_$_.output_push('</div>');
+			__out += '<div><template id="t1">' + String(JSON.stringify(data) ?? '') + '</template><p class="content">Main content</p></div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -1934,36 +1499,10 @@ export function TemplateWithHtmlAndSiblings() {
 		const data = { name: 'Ripple', version: '1.0' };
 
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push(' class="wrapper"');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push('<h1');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('Title');
-				}
-
-				_$_.output_push('</h1>');
-				_$_.output_push('<template');
-				_$_.output_push(' id="data-template"');
-				_$_.output_push('>');
-				_$_.output_push(String(JSON.stringify(data) ?? ''));
-				_$_.output_push('</template>');
-				_$_.output_push('<p');
-				_$_.output_push(' class="after-template"');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('Content after template');
-				}
-
-				_$_.output_push('</p>');
-			}
-
-			_$_.output_push('</div>');
+			__out += '<div class="wrapper"><h1>Title</h1><template id="data-template">' + String(JSON.stringify(data) ?? '') + '</template><p class="after-template">Content after template</p></div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -1971,27 +1510,18 @@ export function TemplateWithHtmlAndSiblings() {
 function LayoutWithTemplate({ children, data }) {
 	return _$_.tsrx_element(() => {
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push(' class="layout"');
-			_$_.output_push('>');
+			let __out = '';
+
+			__out += '<div class="layout"><template id="page-data">' + String(JSON.stringify(data) ?? '') + '</template><main>';
 
 			{
-				_$_.output_push('<template');
-				_$_.output_push(' id="page-data"');
-				_$_.output_push('>');
-				_$_.output_push(String(JSON.stringify(data) ?? ''));
-				_$_.output_push('</template>');
-				_$_.output_push('<main');
-				_$_.output_push('>');
-
-				{
-					_$_.render_expression(children);
-				}
-
-				_$_.output_push('</main>');
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_expression(children);
 			}
 
-			_$_.output_push('</div>');
+			__out += '</main></div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -2009,11 +1539,10 @@ export function NestedTemplateInLayout() {
 						data: doc,
 						children: _$_.tsrx_element(() => {
 							return _$_.tsrx_element(() => {
-								_$_.output_push('<div');
-								_$_.output_push(' class="doc-content"');
-								_$_.output_push('>');
-								_$_.output_push(String(doc.html ?? ''));
-								_$_.output_push('</div>');
+								let __out = '';
+
+								__out += '<div class="doc-content">' + String(doc.html ?? '') + '</div>';
+								_$_.output_push(__out);
 							});
 						})
 					}
@@ -2032,98 +1561,10 @@ export function HtmlCodeBlocksWithSiblingChain() {
 		const html3 = '<span class="kw">const</span> <span class="id">c</span> = 3;';
 
 		_$_.regular_block(() => {
-			_$_.output_push('<section');
-			_$_.output_push(' class="readable-section"');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push('<p');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('Ergonomics');
-				}
-
-				_$_.output_push('</p>');
-				_$_.output_push('<h2');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('Sibling traversal pattern');
-				}
-
-				_$_.output_push('</h2>');
-				_$_.output_push('<p');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('Before first block');
-				}
-
-				_$_.output_push('</p>');
-				_$_.output_push('<p');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('Before second block');
-				}
-
-				_$_.output_push('</p>');
-				_$_.output_push('<pre');
-				_$_.output_push(' class="code-block"');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('<code');
-					_$_.output_push('>');
-					_$_.output_push(String(html1 ?? ''));
-					_$_.output_push('</code>');
-				}
-
-				_$_.output_push('</pre>');
-				_$_.output_push('<p');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('Between one and two');
-				}
-
-				_$_.output_push('</p>');
-				_$_.output_push('<pre');
-				_$_.output_push(' class="code-block"');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('<code');
-					_$_.output_push('>');
-					_$_.output_push(String(html2 ?? ''));
-					_$_.output_push('</code>');
-				}
-
-				_$_.output_push('</pre>');
-				_$_.output_push('<p');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('Between two and three');
-				}
-
-				_$_.output_push('</p>');
-				_$_.output_push('<pre');
-				_$_.output_push(' class="code-block"');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('<code');
-					_$_.output_push('>');
-					_$_.output_push(String(html3 ?? ''));
-					_$_.output_push('</code>');
-				}
-
-				_$_.output_push('</pre>');
-			}
-
-			_$_.output_push('</section>');
+			__out += '<section class="readable-section"><p>Ergonomics</p><h2>Sibling traversal pattern</h2><p>Before first block</p><p>Before second block</p><pre class="code-block"><code>' + String(html1 ?? '') + '</code></pre><p>Between one and two</p><pre class="code-block"><code>' + String(html2 ?? '') + '</code></pre><p>Between two and three</p><pre class="code-block"><code>' + String(html3 ?? '') + '</code></pre></section>';
+			_$_.output_push(__out);
 		});
 	});
 }

--- a/packages/ripple/tests/hydration/compiled/server/if-children.js
+++ b/packages/ripple/tests/hydration/compiled/server/if-children.js
@@ -8,39 +8,24 @@ export function IfWithChildren({ children }) {
 		let lazy = _$_.track(true, 'c64714b1');
 
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push(' class="container"');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push('<div');
-				_$_.output_push(' role="button"');
-				_$_.output_push(' class="header"');
-				_$_.output_push('>');
+			__out += '<div class="container"><div role="button" class="header">Toggle</div><!--[-->';
+
+			if (lazy.value) {
+				__out += '<div class="content">';
 
 				{
-					_$_.output_push('Toggle');
+					_$_.output_push(__out);
+					__out = '';
+					_$_.render_expression(children);
 				}
 
-				_$_.output_push('</div>');
-				_$_.output_push('<!--[-->');
-
-				if (lazy.value) {
-					_$_.output_push('<div');
-					_$_.output_push(' class="content"');
-					_$_.output_push('>');
-
-					{
-						_$_.render_expression(children);
-					}
-
-					_$_.output_push('</div>');
-				}
-
-				_$_.output_push('<!--]-->');
+				__out += '</div>';
 			}
 
-			_$_.output_push('</div>');
+			__out += '<!--]--></div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -48,15 +33,10 @@ export function IfWithChildren({ children }) {
 export function ChildItem({ text: label }) {
 	return _$_.tsrx_element(() => {
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push(' class="item"');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push(_$_.escape(label));
-			}
-
-			_$_.output_push('</div>');
+			__out += '<div class="item">' + _$_.escape(label) + '</div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -100,54 +80,16 @@ export function IfWithStaticChildren() {
 		let lazy_1 = _$_.track(true, '3bba8f77');
 
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push(' class="container"');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push('<div');
-				_$_.output_push(' role="button"');
-				_$_.output_push(' class="header"');
-				_$_.output_push('>');
+			__out += '<div class="container"><div role="button" class="header">Toggle</div><!--[-->';
 
-				{
-					_$_.output_push('Toggle');
-				}
-
-				_$_.output_push('</div>');
-				_$_.output_push('<!--[-->');
-
-				if (lazy_1.value) {
-					_$_.output_push('<div');
-					_$_.output_push(' class="content"');
-					_$_.output_push('>');
-
-					{
-						_$_.output_push('<span');
-						_$_.output_push('>');
-
-						{
-							_$_.output_push('Static child 1');
-						}
-
-						_$_.output_push('</span>');
-						_$_.output_push('<span');
-						_$_.output_push('>');
-
-						{
-							_$_.output_push('Static child 2');
-						}
-
-						_$_.output_push('</span>');
-					}
-
-					_$_.output_push('</div>');
-				}
-
-				_$_.output_push('<!--]-->');
+			if (lazy_1.value) {
+				__out += '<div class="content"><span>Static child 1</span><span>Static child 2</span></div>';
 			}
 
-			_$_.output_push('</div>');
+			__out += '<!--]--></div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -157,74 +99,24 @@ export function IfWithSiblingsAndChildren({ children }) {
 		let lazy_2 = _$_.track(true, 'a1b8fb4c');
 
 		_$_.regular_block(() => {
-			_$_.output_push('<section');
-			_$_.output_push(' class="group"');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push('<div');
-				_$_.output_push(' role="button"');
-				_$_.output_push(' class="item"');
-				_$_.output_push('>');
+			__out += '<section class="group"><div role="button" class="item"><div class="indicator"></div><h2 class="text">Title</h2><div class="caret"><svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24"><path d="m9 18 6-6-6-6"></path></svg></div></div><!--[-->';
+
+			if (lazy_2.value) {
+				__out += '<div class="items">';
 
 				{
-					_$_.output_push('<div');
-					_$_.output_push(' class="indicator"');
-					_$_.output_push('>');
-					_$_.output_push('</div>');
-					_$_.output_push('<h2');
-					_$_.output_push(' class="text"');
-					_$_.output_push('>');
-
-					{
-						_$_.output_push('Title');
-					}
-
-					_$_.output_push('</h2>');
-					_$_.output_push('<div');
-					_$_.output_push(' class="caret"');
-					_$_.output_push('>');
-
-					{
-						_$_.output_push('<svg');
-						_$_.output_push(' xmlns="http://www.w3.org/2000/svg"');
-						_$_.output_push(' width="18"');
-						_$_.output_push(' height="18"');
-						_$_.output_push(' viewBox="0 0 24 24"');
-						_$_.output_push('>');
-
-						{
-							_$_.output_push('<path');
-							_$_.output_push(' d="m9 18 6-6-6-6"');
-							_$_.output_push('>');
-							_$_.output_push('</path>');
-						}
-
-						_$_.output_push('</svg>');
-					}
-
-					_$_.output_push('</div>');
+					_$_.output_push(__out);
+					__out = '';
+					_$_.render_expression(children);
 				}
 
-				_$_.output_push('</div>');
-				_$_.output_push('<!--[-->');
-
-				if (lazy_2.value) {
-					_$_.output_push('<div');
-					_$_.output_push(' class="items"');
-					_$_.output_push('>');
-
-					{
-						_$_.render_expression(children);
-					}
-
-					_$_.output_push('</div>');
-				}
-
-				_$_.output_push('<!--]-->');
+				__out += '</div>';
 			}
 
-			_$_.output_push('</section>');
+			__out += '<!--]--></section>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -268,65 +160,16 @@ export function ElementWithChildrenThenIf() {
 		let lazy_3 = _$_.track(true, '7cd4817b');
 
 		_$_.regular_block(() => {
-			{
-				_$_.output_push('<div');
-				_$_.output_push(' class="wrapper"');
-				_$_.output_push('>');
+			let __out = '';
 
-				{
-					_$_.output_push('<div');
-					_$_.output_push(' class="nested-parent"');
-					_$_.output_push('>');
+			__out += '<div class="wrapper"><div class="nested-parent"><div class="nested-child"><span class="deep">Deep content</span></div></div><!--[-->';
 
-					{
-						_$_.output_push('<div');
-						_$_.output_push(' class="nested-child"');
-						_$_.output_push('>');
-
-						{
-							_$_.output_push('<span');
-							_$_.output_push(' class="deep"');
-							_$_.output_push('>');
-
-							{
-								_$_.output_push('Deep content');
-							}
-
-							_$_.output_push('</span>');
-						}
-
-						_$_.output_push('</div>');
-					}
-
-					_$_.output_push('</div>');
-					_$_.output_push('<!--[-->');
-
-					if (lazy_3.value) {
-						_$_.output_push('<div');
-						_$_.output_push(' class="conditional"');
-						_$_.output_push('>');
-
-						{
-							_$_.output_push('Conditional content');
-						}
-
-						_$_.output_push('</div>');
-					}
-
-					_$_.output_push('<!--]-->');
-				}
-
-				_$_.output_push('</div>');
-				_$_.output_push('<button');
-				_$_.output_push(' class="toggle"');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('Toggle');
-				}
-
-				_$_.output_push('</button>');
+			if (lazy_3.value) {
+				__out += '<div class="conditional">Conditional content</div>';
 			}
+
+			__out += '<!--]--></div><button class="toggle">Toggle</button>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -336,80 +179,16 @@ export function DeepNestingThenIf() {
 		let lazy_4 = _$_.track(true, '923116be');
 
 		_$_.regular_block(() => {
-			{
-				_$_.output_push('<section');
-				_$_.output_push(' class="outer"');
-				_$_.output_push('>');
+			let __out = '';
 
-				{
-					_$_.output_push('<article');
-					_$_.output_push(' class="middle"');
-					_$_.output_push('>');
+			__out += '<section class="outer"><article class="middle"><div class="inner"><p class="leaf"><strong>Bold</strong><em>Italic</em></p></div></article><!--[-->';
 
-					{
-						_$_.output_push('<div');
-						_$_.output_push(' class="inner"');
-						_$_.output_push('>');
-
-						{
-							_$_.output_push('<p');
-							_$_.output_push(' class="leaf"');
-							_$_.output_push('>');
-
-							{
-								_$_.output_push('<strong');
-								_$_.output_push('>');
-
-								{
-									_$_.output_push('Bold');
-								}
-
-								_$_.output_push('</strong>');
-								_$_.output_push('<em');
-								_$_.output_push('>');
-
-								{
-									_$_.output_push('Italic');
-								}
-
-								_$_.output_push('</em>');
-							}
-
-							_$_.output_push('</p>');
-						}
-
-						_$_.output_push('</div>');
-					}
-
-					_$_.output_push('</article>');
-					_$_.output_push('<!--[-->');
-
-					if (lazy_4.value) {
-						_$_.output_push('<footer');
-						_$_.output_push(' class="footer"');
-						_$_.output_push('>');
-
-						{
-							_$_.output_push('Footer');
-						}
-
-						_$_.output_push('</footer>');
-					}
-
-					_$_.output_push('<!--]-->');
-				}
-
-				_$_.output_push('</section>');
-				_$_.output_push('<button');
-				_$_.output_push(' class="btn"');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('Toggle');
-				}
-
-				_$_.output_push('</button>');
+			if (lazy_4.value) {
+				__out += '<footer class="footer">Footer</footer>';
 			}
+
+			__out += '<!--]--></section><button class="btn">Toggle</button>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -419,75 +198,18 @@ export function DomElementChildrenThenSibling() {
 		let lazy_5 = _$_.track('code', '33a1e97f');
 
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push(' class="tabs"');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push('<div');
-				_$_.output_push(' class="tab-list"');
-				_$_.output_push('>');
+			__out += '<div class="tabs"><div class="tab-list"><button' + _$_.attr('aria-selected', lazy_5.value === 'code' ? 'true' : 'false', false) + ' class="tab">Code</button><button' + _$_.attr('aria-selected', lazy_5.value === 'preview' ? 'true' : 'false', false) + ' class="tab">Preview</button></div><div class="panel"><!--[-->';
 
-				{
-					_$_.output_push('<button');
-					_$_.output_push(_$_.attr('aria-selected', lazy_5.value === 'code' ? 'true' : 'false', false));
-					_$_.output_push(' class="tab"');
-					_$_.output_push('>');
-
-					{
-						_$_.output_push('Code');
-					}
-
-					_$_.output_push('</button>');
-					_$_.output_push('<button');
-					_$_.output_push(_$_.attr('aria-selected', lazy_5.value === 'preview' ? 'true' : 'false', false));
-					_$_.output_push(' class="tab"');
-					_$_.output_push('>');
-
-					{
-						_$_.output_push('Preview');
-					}
-
-					_$_.output_push('</button>');
-				}
-
-				_$_.output_push('</div>');
-				_$_.output_push('<div');
-				_$_.output_push(' class="panel"');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('<!--[-->');
-
-					if (lazy_5.value === 'code') {
-						_$_.output_push('<pre');
-						_$_.output_push(' class="code"');
-						_$_.output_push('>');
-
-						{
-							_$_.output_push('const x = 1;');
-						}
-
-						_$_.output_push('</pre>');
-					} else {
-						_$_.output_push('<div');
-						_$_.output_push(' class="preview"');
-						_$_.output_push('>');
-
-						{
-							_$_.output_push('Preview content');
-						}
-
-						_$_.output_push('</div>');
-					}
-
-					_$_.output_push('<!--]-->');
-				}
-
-				_$_.output_push('</div>');
+			if (lazy_5.value === 'code') {
+				__out += '<pre class="code">const x = 1;</pre>';
+			} else {
+				__out += '<div class="preview">Preview content</div>';
 			}
 
-			_$_.output_push('</div>');
+			__out += '<!--]--></div></div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -497,69 +219,10 @@ export function DomChildrenThenStaticSiblings() {
 		let lazy_6 = _$_.track(0, '0ea64305');
 
 		_$_.regular_block(() => {
-			{
-				_$_.output_push('<div');
-				_$_.output_push(' class="container"');
-				_$_.output_push('>');
+			let __out = '';
 
-				{
-					_$_.output_push('<ul');
-					_$_.output_push(' class="list"');
-					_$_.output_push('>');
-
-					{
-						_$_.output_push('<li');
-						_$_.output_push(' class="item"');
-						_$_.output_push('>');
-
-						{
-							_$_.output_push(_$_.escape('Item count: ' + String(lazy_6.value ?? '')));
-						}
-
-						_$_.output_push('</li>');
-						_$_.output_push('<li');
-						_$_.output_push(' class="item"');
-						_$_.output_push('>');
-
-						{
-							_$_.output_push('Another item');
-						}
-
-						_$_.output_push('</li>');
-					}
-
-					_$_.output_push('</ul>');
-					_$_.output_push('<h2');
-					_$_.output_push(' class="heading"');
-					_$_.output_push('>');
-
-					{
-						_$_.output_push('Static Heading');
-					}
-
-					_$_.output_push('</h2>');
-					_$_.output_push('<p');
-					_$_.output_push(' class="para"');
-					_$_.output_push('>');
-
-					{
-						_$_.output_push('Static paragraph');
-					}
-
-					_$_.output_push('</p>');
-				}
-
-				_$_.output_push('</div>');
-				_$_.output_push('<button');
-				_$_.output_push(' class="inc"');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('Increment');
-				}
-
-				_$_.output_push('</button>');
-			}
+			__out += '<div class="container"><ul class="list"><li class="item">' + _$_.escape('Item count: ' + String(lazy_6.value ?? '')) + '</li><li class="item">Another item</li></ul><h2 class="heading">Static Heading</h2><p class="para">Static paragraph</p></div><button class="inc">Increment</button>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -567,107 +230,10 @@ export function DomChildrenThenStaticSiblings() {
 export function StaticListThenStaticSiblings() {
 	return _$_.tsrx_element(() => {
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push(' class="wrapper"');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push('<ul');
-				_$_.output_push(' class="features"');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('<li');
-					_$_.output_push('>');
-
-					{
-						_$_.output_push('<strong');
-						_$_.output_push('>');
-
-						{
-							_$_.output_push('Feature One');
-						}
-
-						_$_.output_push('</strong>');
-						_$_.output_push(': Description of feature one with ');
-						_$_.output_push('<code');
-						_$_.output_push('>');
-
-						{
-							_$_.output_push('code');
-						}
-
-						_$_.output_push('</code>');
-						_$_.output_push(' reference');
-					}
-
-					_$_.output_push('</li>');
-					_$_.output_push('<li');
-					_$_.output_push('>');
-
-					{
-						_$_.output_push('<strong');
-						_$_.output_push('>');
-
-						{
-							_$_.output_push('Feature Two');
-						}
-
-						_$_.output_push('</strong>');
-						_$_.output_push(': Another feature description');
-					}
-
-					_$_.output_push('</li>');
-					_$_.output_push('<li');
-					_$_.output_push('>');
-
-					{
-						_$_.output_push('<strong');
-						_$_.output_push('>');
-
-						{
-							_$_.output_push('Feature Three');
-						}
-
-						_$_.output_push('</strong>');
-						_$_.output_push(': Third feature');
-					}
-
-					_$_.output_push('</li>');
-				}
-
-				_$_.output_push('</ul>');
-				_$_.output_push('<h2');
-				_$_.output_push(' class="section-heading"');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('Section Heading');
-				}
-
-				_$_.output_push('</h2>');
-				_$_.output_push('<p');
-				_$_.output_push(' class="section-content"');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('Static paragraph with ');
-					_$_.output_push('<a');
-					_$_.output_push(' href="/link"');
-					_$_.output_push('>');
-
-					{
-						_$_.output_push('a link');
-					}
-
-					_$_.output_push('</a>');
-					_$_.output_push(' and more text.');
-				}
-
-				_$_.output_push('</p>');
-			}
-
-			_$_.output_push('</div>');
+			__out += '<div class="wrapper"><ul class="features"><li><strong>Feature One</strong>: Description of feature one with <code>code</code> reference</li><li><strong>Feature Two</strong>: Another feature description</li><li><strong>Feature Three</strong>: Third feature</li></ul><h2 class="section-heading">Section Heading</h2><p class="section-content">Static paragraph with <a href="/link">a link</a> and more text.</p></div>';
+			_$_.output_push(__out);
 		});
 	});
 }

--- a/packages/ripple/tests/hydration/compiled/server/if.js
+++ b/packages/ripple/tests/hydration/compiled/server/if.js
@@ -8,21 +8,16 @@ export function IfTruthy() {
 		const show = true;
 
 		_$_.regular_block(() => {
-			_$_.output_push('<!--[-->');
+			let __out = '';
+
+			__out += '<!--[-->';
 
 			if (show) {
-				_$_.output_push('<div');
-				_$_.output_push(' class="shown"');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('Visible');
-				}
-
-				_$_.output_push('</div>');
+				__out += '<div class="shown">Visible</div>';
 			}
 
-			_$_.output_push('<!--]-->');
+			__out += '<!--]-->';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -32,21 +27,16 @@ export function IfFalsy() {
 		const show = false;
 
 		_$_.regular_block(() => {
-			_$_.output_push('<!--[-->');
+			let __out = '';
+
+			__out += '<!--[-->';
 
 			if (show) {
-				_$_.output_push('<div');
-				_$_.output_push(' class="shown"');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('Visible');
-				}
-
-				_$_.output_push('</div>');
+				__out += '<div class="shown">Visible</div>';
 			}
 
-			_$_.output_push('<!--]-->');
+			__out += '<!--]-->';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -56,31 +46,18 @@ export function IfElse() {
 		const isLoggedIn = true;
 
 		_$_.regular_block(() => {
-			_$_.output_push('<!--[-->');
+			let __out = '';
+
+			__out += '<!--[-->';
 
 			if (isLoggedIn) {
-				_$_.output_push('<div');
-				_$_.output_push(' class="logged-in"');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('Welcome back!');
-				}
-
-				_$_.output_push('</div>');
+				__out += '<div class="logged-in">Welcome back!</div>';
 			} else {
-				_$_.output_push('<div');
-				_$_.output_push(' class="logged-out"');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('Please log in');
-				}
-
-				_$_.output_push('</div>');
+				__out += '<div class="logged-out">Please log in</div>';
 			}
 
-			_$_.output_push('<!--]-->');
+			__out += '<!--]-->';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -90,32 +67,16 @@ export function ReactiveIf() {
 		let lazy = _$_.track(true, '19a16ff0');
 
 		_$_.regular_block(() => {
-			{
-				_$_.output_push('<button');
-				_$_.output_push(' class="toggle"');
-				_$_.output_push('>');
+			let __out = '';
 
-				{
-					_$_.output_push('Toggle');
-				}
+			__out += '<button class="toggle">Toggle</button><!--[-->';
 
-				_$_.output_push('</button>');
-				_$_.output_push('<!--[-->');
-
-				if (lazy.value) {
-					_$_.output_push('<div');
-					_$_.output_push(' class="content"');
-					_$_.output_push('>');
-
-					{
-						_$_.output_push('Content visible');
-					}
-
-					_$_.output_push('</div>');
-				}
-
-				_$_.output_push('<!--]-->');
+			if (lazy.value) {
+				__out += '<div class="content">Content visible</div>';
 			}
+
+			__out += '<!--]-->';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -125,42 +86,18 @@ export function ReactiveIfElse() {
 		let lazy_1 = _$_.track(false, '41177f39');
 
 		_$_.regular_block(() => {
-			{
-				_$_.output_push('<button');
-				_$_.output_push(' class="toggle"');
-				_$_.output_push('>');
+			let __out = '';
 
-				{
-					_$_.output_push('Toggle');
-				}
+			__out += '<button class="toggle">Toggle</button><!--[-->';
 
-				_$_.output_push('</button>');
-				_$_.output_push('<!--[-->');
-
-				if (lazy_1.value) {
-					_$_.output_push('<div');
-					_$_.output_push(' class="on"');
-					_$_.output_push('>');
-
-					{
-						_$_.output_push('ON');
-					}
-
-					_$_.output_push('</div>');
-				} else {
-					_$_.output_push('<div');
-					_$_.output_push(' class="off"');
-					_$_.output_push('>');
-
-					{
-						_$_.output_push('OFF');
-					}
-
-					_$_.output_push('</div>');
-				}
-
-				_$_.output_push('<!--]-->');
+			if (lazy_1.value) {
+				__out += '<div class="on">ON</div>';
+			} else {
+				__out += '<div class="off">OFF</div>';
 			}
+
+			__out += '<!--]-->';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -171,56 +108,22 @@ export function NestedIf() {
 		let lazy_3 = _$_.track(true, 'f21b8c26');
 
 		_$_.regular_block(() => {
-			{
-				_$_.output_push('<button');
-				_$_.output_push(' class="outer-toggle"');
-				_$_.output_push('>');
+			let __out = '';
 
-				{
-					_$_.output_push('Outer');
+			__out += '<button class="outer-toggle">Outer</button><button class="inner-toggle">Inner</button><!--[-->';
+
+			if (lazy_2.value) {
+				__out += '<div class="outer-content">Outer<!--[-->';
+
+				if (lazy_3.value) {
+					__out += '<span class="inner-content">Inner</span>';
 				}
 
-				_$_.output_push('</button>');
-				_$_.output_push('<button');
-				_$_.output_push(' class="inner-toggle"');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('Inner');
-				}
-
-				_$_.output_push('</button>');
-				_$_.output_push('<!--[-->');
-
-				if (lazy_2.value) {
-					_$_.output_push('<div');
-					_$_.output_push(' class="outer-content"');
-					_$_.output_push('>');
-
-					{
-						_$_.output_push('Outer');
-						_$_.output_push('<!--[-->');
-
-						if (lazy_3.value) {
-							_$_.output_push('<span');
-							_$_.output_push(' class="inner-content"');
-							_$_.output_push('>');
-
-							{
-								_$_.output_push('Inner');
-							}
-
-							_$_.output_push('</span>');
-						}
-
-						_$_.output_push('<!--]-->');
-					}
-
-					_$_.output_push('</div>');
-				}
-
-				_$_.output_push('<!--]-->');
+				__out += '<!--]--></div>';
 			}
+
+			__out += '<!--]-->';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -230,81 +133,26 @@ export function IfElseIfChain() {
 		let lazy_4 = _$_.track('loading', '4c69c94a');
 
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push('<button');
-				_$_.output_push(' class="success"');
-				_$_.output_push('>');
+			__out += '<div><button class="success">Success</button><button class="error">Error</button><button class="loading">Loading</button><!--[-->';
 
-				{
-					_$_.output_push('Success');
-				}
+			if (lazy_4.value === 'loading') {
+				__out += '<div class="state">Loading...</div>';
+			} else {
+				__out += '<!--[-->';
 
-				_$_.output_push('</button>');
-				_$_.output_push('<button');
-				_$_.output_push(' class="error"');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('Error');
-				}
-
-				_$_.output_push('</button>');
-				_$_.output_push('<button');
-				_$_.output_push(' class="loading"');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('Loading');
-				}
-
-				_$_.output_push('</button>');
-				_$_.output_push('<!--[-->');
-
-				if (lazy_4.value === 'loading') {
-					_$_.output_push('<div');
-					_$_.output_push(' class="state"');
-					_$_.output_push('>');
-
-					{
-						_$_.output_push('Loading...');
-					}
-
-					_$_.output_push('</div>');
+				if (lazy_4.value === 'success') {
+					__out += '<div class="state">Success!</div>';
 				} else {
-					_$_.output_push('<!--[-->');
-
-					if (lazy_4.value === 'success') {
-						_$_.output_push('<div');
-						_$_.output_push(' class="state"');
-						_$_.output_push('>');
-
-						{
-							_$_.output_push('Success!');
-						}
-
-						_$_.output_push('</div>');
-					} else {
-						_$_.output_push('<div');
-						_$_.output_push(' class="state"');
-						_$_.output_push('>');
-
-						{
-							_$_.output_push('Error occurred');
-						}
-
-						_$_.output_push('</div>');
-					}
-
-					_$_.output_push('<!--]-->');
+					__out += '<div class="state">Error occurred</div>';
 				}
 
-				_$_.output_push('<!--]-->');
+				__out += '<!--]-->';
 			}
 
-			_$_.output_push('</div>');
+			__out += '<!--]--></div>';
+			_$_.output_push(__out);
 		});
 	});
 }

--- a/packages/ripple/tests/hydration/compiled/server/mixed-control-flow.js
+++ b/packages/ripple/tests/hydration/compiled/server/mixed-control-flow.js
@@ -12,95 +12,66 @@ export function MixedControlFlowStatic() {
 		];
 
 		_$_.regular_block(() => {
-			_$_.output_push('<section');
-			_$_.output_push(' class="mixed-static"');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push('<!--[-->');
+			__out += '<section class="mixed-static"><!--[-->';
 
-				for (const row of rows) {
-					_$_.output_push('<!--[-->');
+			for (const row of rows) {
+				__out += '<!--[-->';
 
-					if (row.enabled) {
-						_$_.output_push('<!--[-->');
+				if (row.enabled) {
+					__out += '<!--[-->';
 
-						switch (row.kind) {
-							case 'a':
-								_$_.try_block(
-									() => {
-										_$_.output_push('<!--[-->');
-										_$_.output_push('<div');
-										_$_.output_push(_$_.attr('class', `row row-${row.id} kind-a`));
-										_$_.output_push('>');
+					switch (row.kind) {
+						case 'a':
+							_$_.output_push(__out);
+							__out = '';
+							_$_.try_block(
+								() => {
+									let __out = '';
 
-										{
-											_$_.output_push(_$_.escape(`A-${row.id}`));
-										}
+									__out += '<!--[--><div' + _$_.attr('class', `row row-${row.id} kind-a`) + '>' + _$_.escape(`A-${row.id}`) + '</div><!--]-->';
+									_$_.output_push(__out);
+								},
+								null,
+								() => {
+									let __out = '';
 
-										_$_.output_push('</div>');
-										_$_.output_push('<!--]-->');
-									},
-									null,
-									() => {
-										_$_.output_push('<!--[-->');
-										_$_.output_push('<div');
-										_$_.output_push(_$_.attr('class', `pending pending-${row.id}`));
-										_$_.output_push('>');
+									__out += '<!--[--><div' + _$_.attr('class', `pending pending-${row.id}`) + '>pending a</div><!--]-->';
+									_$_.output_push(__out);
+								}
+							);
+							break;
 
-										{
-											_$_.output_push('pending a');
-										}
+						default:
+							_$_.output_push(__out);
+							__out = '';
+							_$_.try_block(
+								() => {
+									let __out = '';
 
-										_$_.output_push('</div>');
-										_$_.output_push('<!--]-->');
-									}
-								);
-								break;
+									__out += '<!--[--><div' + _$_.attr('class', `row row-${row.id} kind-b`) + '>' + _$_.escape(`B-${row.id}`) + '</div><!--]-->';
+									_$_.output_push(__out);
+								},
+								null,
+								() => {
+									let __out = '';
 
-							default:
-								_$_.try_block(
-									() => {
-										_$_.output_push('<!--[-->');
-										_$_.output_push('<div');
-										_$_.output_push(_$_.attr('class', `row row-${row.id} kind-b`));
-										_$_.output_push('>');
-
-										{
-											_$_.output_push(_$_.escape(`B-${row.id}`));
-										}
-
-										_$_.output_push('</div>');
-										_$_.output_push('<!--]-->');
-									},
-									null,
-									() => {
-										_$_.output_push('<!--[-->');
-										_$_.output_push('<div');
-										_$_.output_push(_$_.attr('class', `pending pending-${row.id}`));
-										_$_.output_push('>');
-
-										{
-											_$_.output_push('pending b');
-										}
-
-										_$_.output_push('</div>');
-										_$_.output_push('<!--]-->');
-									}
-								);
-								break;
-						}
-
-						_$_.output_push('<!--]-->');
+									__out += '<!--[--><div' + _$_.attr('class', `pending pending-${row.id}`) + '>pending b</div><!--]-->';
+									_$_.output_push(__out);
+								}
+							);
+							break;
 					}
 
-					_$_.output_push('<!--]-->');
+					__out += '<!--]-->';
 				}
 
-				_$_.output_push('<!--]-->');
+				__out += '<!--]-->';
 			}
 
-			_$_.output_push('</section>');
+			__out += '<!--]--></section>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -112,124 +83,66 @@ export function MixedControlFlowReactive() {
 		let lazy_2 = _$_.track([{ id: 1, label: 'One' }, { id: 2, label: 'Two' }], '7890dad6');
 
 		_$_.regular_block(() => {
-			{
-				_$_.output_push('<button');
-				_$_.output_push(' class="toggle-show"');
-				_$_.output_push('>');
+			let __out = '';
 
-				{
-					_$_.output_push('Toggle Show');
-				}
+			__out += '<button class="toggle-show">Toggle Show</button><button class="toggle-mode">Toggle Mode</button><button class="add-item">Add Item</button><!--[-->';
 
-				_$_.output_push('</button>');
-				_$_.output_push('<button');
-				_$_.output_push(' class="toggle-mode"');
-				_$_.output_push('>');
+			if (lazy.value) {
+				__out += '<div class="mixed-reactive-list"><!--[-->';
 
-				{
-					_$_.output_push('Toggle Mode');
-				}
+				for (const item of lazy_2.value) {
+					__out += '<!--[-->';
 
-				_$_.output_push('</button>');
-				_$_.output_push('<button');
-				_$_.output_push(' class="add-item"');
-				_$_.output_push('>');
+					switch (lazy_1.value) {
+						case 'a':
+							_$_.output_push(__out);
+							__out = '';
+							_$_.try_block(
+								() => {
+									let __out = '';
 
-				{
-					_$_.output_push('Add Item');
-				}
+									__out += '<!--[--><p' + _$_.attr('class', `item item-${item.id}`) + '>' + _$_.escape(`A:${item.label}`) + '</p><!--]-->';
+									_$_.output_push(__out);
+								},
+								null,
+								() => {
+									let __out = '';
 
-				_$_.output_push('</button>');
-				_$_.output_push('<!--[-->');
+									__out += '<!--[--><p class="pending">pending a</p><!--]-->';
+									_$_.output_push(__out);
+								}
+							);
+							break;
 
-				if (lazy.value) {
-					_$_.output_push('<div');
-					_$_.output_push(' class="mixed-reactive-list"');
-					_$_.output_push('>');
+						default:
+							_$_.output_push(__out);
+							__out = '';
+							_$_.try_block(
+								() => {
+									let __out = '';
 
-					{
-						_$_.output_push('<!--[-->');
+									__out += '<!--[--><p' + _$_.attr('class', `item item-${item.id}`) + '>' + _$_.escape(`B:${item.label}`) + '</p><!--]-->';
+									_$_.output_push(__out);
+								},
+								null,
+								() => {
+									let __out = '';
 
-						for (const item of lazy_2.value) {
-							_$_.output_push('<!--[-->');
-
-							switch (lazy_1.value) {
-								case 'a':
-									_$_.try_block(
-										() => {
-											_$_.output_push('<!--[-->');
-											_$_.output_push('<p');
-											_$_.output_push(_$_.attr('class', `item item-${item.id}`));
-											_$_.output_push('>');
-
-											{
-												_$_.output_push(_$_.escape(`A:${item.label}`));
-											}
-
-											_$_.output_push('</p>');
-											_$_.output_push('<!--]-->');
-										},
-										null,
-										() => {
-											_$_.output_push('<!--[-->');
-											_$_.output_push('<p');
-											_$_.output_push(' class="pending"');
-											_$_.output_push('>');
-
-											{
-												_$_.output_push('pending a');
-											}
-
-											_$_.output_push('</p>');
-											_$_.output_push('<!--]-->');
-										}
-									);
-									break;
-
-								default:
-									_$_.try_block(
-										() => {
-											_$_.output_push('<!--[-->');
-											_$_.output_push('<p');
-											_$_.output_push(_$_.attr('class', `item item-${item.id}`));
-											_$_.output_push('>');
-
-											{
-												_$_.output_push(_$_.escape(`B:${item.label}`));
-											}
-
-											_$_.output_push('</p>');
-											_$_.output_push('<!--]-->');
-										},
-										null,
-										() => {
-											_$_.output_push('<!--[-->');
-											_$_.output_push('<p');
-											_$_.output_push(' class="pending"');
-											_$_.output_push('>');
-
-											{
-												_$_.output_push('pending b');
-											}
-
-											_$_.output_push('</p>');
-											_$_.output_push('<!--]-->');
-										}
-									);
-									break;
-							}
-
-							_$_.output_push('<!--]-->');
-						}
-
-						_$_.output_push('<!--]-->');
+									__out += '<!--[--><p class="pending">pending b</p><!--]-->';
+									_$_.output_push(__out);
+								}
+							);
+							break;
 					}
 
-					_$_.output_push('</div>');
+					__out += '<!--]-->';
 				}
 
-				_$_.output_push('<!--]-->');
+				__out += '<!--]--></div>';
 			}
+
+			__out += '<!--]-->';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -240,75 +153,61 @@ export function MixedControlFlowAsyncPending() {
 		const state = 'slow';
 
 		_$_.regular_block(() => {
-			{
-				_$_.output_push('<div');
-				_$_.output_push(' class="before"');
-				_$_.output_push('>');
+			let __out = '';
 
-				{
-					_$_.output_push('before');
-				}
+			__out += '<div class="before">before</div><!--[-->';
 
-				_$_.output_push('</div>');
-				_$_.output_push('<!--[-->');
+			for (const row of rows) {
+				__out += '<!--[-->';
 
-				for (const row of rows) {
-					_$_.output_push('<!--[-->');
+				if (row === 1) {
+					__out += '<!--[-->';
 
-					if (row === 1) {
-						_$_.output_push('<!--[-->');
+					switch (state) {
+						case 'slow':
+							_$_.output_push(__out);
+							__out = '';
+							_$_.try_block(
+								() => {
+									let __out = '';
 
-						switch (state) {
-							case 'slow':
-								_$_.try_block(
-									() => {
-										_$_.output_push('<!--[-->');
+									__out += '<!--[-->';
 
-										{
-											const comp = AsyncRow;
-											const args = [{ label: `row-${row}` }];
+									{
+										const comp = AsyncRow;
+										const args = [{ label: `row-${row}` }];
 
-											_$_.render_component(comp, ...args);
-										}
-
-										_$_.output_push('<!--]-->');
-									},
-									null,
-									() => {
-										_$_.output_push('<!--[-->');
-										_$_.output_push('<div');
-										_$_.output_push(_$_.attr('class', `pending-row pending-row-${row}`));
-										_$_.output_push('>');
-
-										{
-											_$_.output_push(_$_.escape(`pending ${row}`));
-										}
-
-										_$_.output_push('</div>');
-										_$_.output_push('<!--]-->');
+										_$_.output_push(__out);
+										__out = '';
+										_$_.render_component(comp, ...args);
 									}
-								);
-								break;
 
-							default:
-								_$_.output_push('<div');
-								_$_.output_push(' class="unexpected"');
-								_$_.output_push('>');
-								{
-									_$_.output_push('unexpected');
+									__out += '<!--]-->';
+									_$_.output_push(__out);
+								},
+								null,
+								() => {
+									let __out = '';
+
+									__out += '<!--[--><div' + _$_.attr('class', `pending-row pending-row-${row}`) + '>' + _$_.escape(`pending ${row}`) + '</div><!--]-->';
+									_$_.output_push(__out);
 								}
-								_$_.output_push('</div>');
-								break;
-						}
+							);
+							break;
 
-						_$_.output_push('<!--]-->');
+						default:
+							__out += '<div class="unexpected">unexpected</div>';
+							break;
 					}
 
-					_$_.output_push('<!--]-->');
+					__out += '<!--]-->';
 				}
 
-				_$_.output_push('<!--]-->');
+				__out += '<!--]-->';
 			}
+
+			__out += '<!--]-->';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -318,15 +217,10 @@ function AsyncRow({ label }) {
 		let lazy_3 = _$_.track_async(() => Promise.resolve(label), '10cc79a0');
 
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push(' class="resolved-row"');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push(_$_.escape(lazy_3.value));
-			}
-
-			_$_.output_push('</div>');
+			__out += '<div class="resolved-row">' + _$_.escape(lazy_3.value) + '</div>';
+			_$_.output_push(__out);
 		});
 	});
 }

--- a/packages/ripple/tests/hydration/compiled/server/nested-control-flow.js
+++ b/packages/ripple/tests/hydration/compiled/server/nested-control-flow.js
@@ -10,35 +10,22 @@ export function ForIf() {
 		];
 
 		_$_.regular_block(() => {
-			_$_.output_push('<ul');
-			_$_.output_push(' class="for-if"');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push('<!--[-->');
+			__out += '<ul class="for-if"><!--[-->';
 
-				for (const item of items) {
-					_$_.output_push('<!--[-->');
+			for (const item of items) {
+				__out += '<!--[-->';
 
-					if (item.show) {
-						_$_.output_push('<li');
-						_$_.output_push(_$_.attr('class', `item item-${item.id}`));
-						_$_.output_push('>');
-
-						{
-							_$_.output_push(_$_.escape(item.label));
-						}
-
-						_$_.output_push('</li>');
-					}
-
-					_$_.output_push('<!--]-->');
+				if (item.show) {
+					__out += '<li' + _$_.attr('class', `item item-${item.id}`) + '>' + _$_.escape(item.label) + '</li>';
 				}
 
-				_$_.output_push('<!--]-->');
+				__out += '<!--]-->';
 			}
 
-			_$_.output_push('</ul>');
+			__out += '<!--]--></ul>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -52,45 +39,28 @@ export function ForSwitch() {
 		];
 
 		_$_.regular_block(() => {
-			_$_.output_push('<ul');
-			_$_.output_push(' class="for-switch"');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push('<!--[-->');
+			__out += '<ul class="for-switch"><!--[-->';
 
-				for (const item of items) {
-					_$_.output_push('<!--[-->');
+			for (const item of items) {
+				__out += '<!--[-->';
 
-					switch (item.kind) {
-						case 'a':
-							_$_.output_push('<li');
-							_$_.output_push(_$_.attr('class', `item item-${item.id} kind-a`));
-							_$_.output_push('>');
-							{
-								_$_.output_push(_$_.escape(`A-${item.id}`));
-							}
-							_$_.output_push('</li>');
-							break;
+				switch (item.kind) {
+					case 'a':
+						__out += '<li' + _$_.attr('class', `item item-${item.id} kind-a`) + '>' + _$_.escape(`A-${item.id}`) + '</li>';
+						break;
 
-						default:
-							_$_.output_push('<li');
-							_$_.output_push(_$_.attr('class', `item item-${item.id} kind-b`));
-							_$_.output_push('>');
-							{
-								_$_.output_push(_$_.escape(`B-${item.id}`));
-							}
-							_$_.output_push('</li>');
-							break;
-					}
-
-					_$_.output_push('<!--]-->');
+					default:
+						__out += '<li' + _$_.attr('class', `item item-${item.id} kind-b`) + '>' + _$_.escape(`B-${item.id}`) + '</li>';
+						break;
 				}
 
-				_$_.output_push('<!--]-->');
+				__out += '<!--]-->';
 			}
 
-			_$_.output_push('</ul>');
+			__out += '<!--]--></ul>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -101,45 +71,28 @@ export function IfSwitch() {
 		const kind = 'a';
 
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push(' class="if-switch"');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push('<!--[-->');
+			__out += '<div class="if-switch"><!--[-->';
 
-				if (show) {
-					_$_.output_push('<!--[-->');
+			if (show) {
+				__out += '<!--[-->';
 
-					switch (kind) {
-						case 'a':
-							_$_.output_push('<p');
-							_$_.output_push(' class="case-a"');
-							_$_.output_push('>');
-							{
-								_$_.output_push('Case A');
-							}
-							_$_.output_push('</p>');
-							break;
+				switch (kind) {
+					case 'a':
+						__out += '<p class="case-a">Case A</p>';
+						break;
 
-						default:
-							_$_.output_push('<p');
-							_$_.output_push(' class="case-default"');
-							_$_.output_push('>');
-							{
-								_$_.output_push('Default');
-							}
-							_$_.output_push('</p>');
-							break;
-					}
-
-					_$_.output_push('<!--]-->');
+					default:
+						__out += '<p class="case-default">Default</p>';
+						break;
 				}
 
-				_$_.output_push('<!--]-->');
+				__out += '<!--]-->';
 			}
 
-			_$_.output_push('</div>');
+			__out += '<!--]--></div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -150,54 +103,28 @@ export function IfSwitchHidden() {
 		const kind = 'a';
 
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push(' class="if-switch-hidden"');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push('<!--[-->');
+			__out += '<div class="if-switch-hidden"><!--[-->';
 
-				if (show) {
-					_$_.output_push('<!--[-->');
+			if (show) {
+				__out += '<!--[-->';
 
-					switch (kind) {
-						case 'a':
-							_$_.output_push('<p');
-							_$_.output_push(' class="case-a"');
-							_$_.output_push('>');
-							{
-								_$_.output_push('Case A');
-							}
-							_$_.output_push('</p>');
-							break;
+				switch (kind) {
+					case 'a':
+						__out += '<p class="case-a">Case A</p>';
+						break;
 
-						default:
-							_$_.output_push('<p');
-							_$_.output_push(' class="case-default"');
-							_$_.output_push('>');
-							{
-								_$_.output_push('Default');
-							}
-							_$_.output_push('</p>');
-							break;
-					}
-
-					_$_.output_push('<!--]-->');
+					default:
+						__out += '<p class="case-default">Default</p>';
+						break;
 				}
 
-				_$_.output_push('<!--]-->');
-				_$_.output_push('<p');
-				_$_.output_push(' class="after"');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('after');
-				}
-
-				_$_.output_push('</p>');
+				__out += '<!--]-->';
 			}
 
-			_$_.output_push('</div>');
+			__out += '<!--]--><p class="after">after</p></div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -207,51 +134,34 @@ export function ForIfSwitchSingle() {
 		const items = [{ id: 1, kind: 'a', show: true }];
 
 		_$_.regular_block(() => {
-			_$_.output_push('<ul');
-			_$_.output_push(' class="for-if-switch-single"');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push('<!--[-->');
+			__out += '<ul class="for-if-switch-single"><!--[-->';
 
-				for (const item of items) {
-					_$_.output_push('<!--[-->');
+			for (const item of items) {
+				__out += '<!--[-->';
 
-					if (item.show) {
-						_$_.output_push('<!--[-->');
+				if (item.show) {
+					__out += '<!--[-->';
 
-						switch (item.kind) {
-							case 'a':
-								_$_.output_push('<li');
-								_$_.output_push(_$_.attr('class', `item item-${item.id} kind-a`));
-								_$_.output_push('>');
-								{
-									_$_.output_push(_$_.escape(`A-${item.id}`));
-								}
-								_$_.output_push('</li>');
-								break;
+					switch (item.kind) {
+						case 'a':
+							__out += '<li' + _$_.attr('class', `item item-${item.id} kind-a`) + '>' + _$_.escape(`A-${item.id}`) + '</li>';
+							break;
 
-							default:
-								_$_.output_push('<li');
-								_$_.output_push(_$_.attr('class', `item item-${item.id} kind-default`));
-								_$_.output_push('>');
-								{
-									_$_.output_push(_$_.escape(`D-${item.id}`));
-								}
-								_$_.output_push('</li>');
-								break;
-						}
-
-						_$_.output_push('<!--]-->');
+						default:
+							__out += '<li' + _$_.attr('class', `item item-${item.id} kind-default`) + '>' + _$_.escape(`D-${item.id}`) + '</li>';
+							break;
 					}
 
-					_$_.output_push('<!--]-->');
+					__out += '<!--]-->';
 				}
 
-				_$_.output_push('<!--]-->');
+				__out += '<!--]-->';
 			}
 
-			_$_.output_push('</ul>');
+			__out += '<!--]--></ul>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -264,51 +174,34 @@ export function ForIfSwitchMulti() {
 		];
 
 		_$_.regular_block(() => {
-			_$_.output_push('<ul');
-			_$_.output_push(' class="for-if-switch-multi"');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push('<!--[-->');
+			__out += '<ul class="for-if-switch-multi"><!--[-->';
 
-				for (const item of items) {
-					_$_.output_push('<!--[-->');
+			for (const item of items) {
+				__out += '<!--[-->';
 
-					if (item.show) {
-						_$_.output_push('<!--[-->');
+				if (item.show) {
+					__out += '<!--[-->';
 
-						switch (item.kind) {
-							case 'a':
-								_$_.output_push('<li');
-								_$_.output_push(_$_.attr('class', `item item-${item.id} kind-a`));
-								_$_.output_push('>');
-								{
-									_$_.output_push(_$_.escape(`A-${item.id}`));
-								}
-								_$_.output_push('</li>');
-								break;
+					switch (item.kind) {
+						case 'a':
+							__out += '<li' + _$_.attr('class', `item item-${item.id} kind-a`) + '>' + _$_.escape(`A-${item.id}`) + '</li>';
+							break;
 
-							default:
-								_$_.output_push('<li');
-								_$_.output_push(_$_.attr('class', `item item-${item.id} kind-b`));
-								_$_.output_push('>');
-								{
-									_$_.output_push(_$_.escape(`B-${item.id}`));
-								}
-								_$_.output_push('</li>');
-								break;
-						}
-
-						_$_.output_push('<!--]-->');
+						default:
+							__out += '<li' + _$_.attr('class', `item item-${item.id} kind-b`) + '>' + _$_.escape(`B-${item.id}`) + '</li>';
+							break;
 					}
 
-					_$_.output_push('<!--]-->');
+					__out += '<!--]-->';
 				}
 
-				_$_.output_push('<!--]-->');
+				__out += '<!--]-->';
 			}
 
-			_$_.output_push('</ul>');
+			__out += '<!--]--></ul>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -322,51 +215,34 @@ export function ForIfSwitchWithDisabled() {
 		];
 
 		_$_.regular_block(() => {
-			_$_.output_push('<ul');
-			_$_.output_push(' class="for-if-switch-disabled"');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push('<!--[-->');
+			__out += '<ul class="for-if-switch-disabled"><!--[-->';
 
-				for (const item of items) {
-					_$_.output_push('<!--[-->');
+			for (const item of items) {
+				__out += '<!--[-->';
 
-					if (item.show) {
-						_$_.output_push('<!--[-->');
+				if (item.show) {
+					__out += '<!--[-->';
 
-						switch (item.kind) {
-							case 'a':
-								_$_.output_push('<li');
-								_$_.output_push(_$_.attr('class', `item item-${item.id} kind-a`));
-								_$_.output_push('>');
-								{
-									_$_.output_push(_$_.escape(`A-${item.id}`));
-								}
-								_$_.output_push('</li>');
-								break;
+					switch (item.kind) {
+						case 'a':
+							__out += '<li' + _$_.attr('class', `item item-${item.id} kind-a`) + '>' + _$_.escape(`A-${item.id}`) + '</li>';
+							break;
 
-							default:
-								_$_.output_push('<li');
-								_$_.output_push(_$_.attr('class', `item item-${item.id} kind-b`));
-								_$_.output_push('>');
-								{
-									_$_.output_push(_$_.escape(`B-${item.id}`));
-								}
-								_$_.output_push('</li>');
-								break;
-						}
-
-						_$_.output_push('<!--]-->');
+						default:
+							__out += '<li' + _$_.attr('class', `item item-${item.id} kind-b`) + '>' + _$_.escape(`B-${item.id}`) + '</li>';
+							break;
 					}
 
-					_$_.output_push('<!--]-->');
+					__out += '<!--]-->';
 				}
 
-				_$_.output_push('<!--]-->');
+				__out += '<!--]-->';
 			}
 
-			_$_.output_push('</ul>');
+			__out += '<!--]--></ul>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -376,61 +252,38 @@ export function SwitchTry() {
 		const kind = 'a';
 
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push(' class="switch-try"');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push('<!--[-->');
+			__out += '<div class="switch-try"><!--[-->';
 
-				switch (kind) {
-					case 'a':
-						_$_.try_block(
-							() => {
-								_$_.output_push('<!--[-->');
-								_$_.output_push('<p');
-								_$_.output_push(' class="resolved-a"');
-								_$_.output_push('>');
+			switch (kind) {
+				case 'a':
+					_$_.output_push(__out);
+					__out = '';
+					_$_.try_block(
+						() => {
+							let __out = '';
 
-								{
-									_$_.output_push('A resolved');
-								}
+							__out += '<!--[--><p class="resolved-a">A resolved</p><!--]-->';
+							_$_.output_push(__out);
+						},
+						null,
+						() => {
+							let __out = '';
 
-								_$_.output_push('</p>');
-								_$_.output_push('<!--]-->');
-							},
-							null,
-							() => {
-								_$_.output_push('<!--[-->');
-								_$_.output_push('<p');
-								_$_.output_push(' class="pending-a"');
-								_$_.output_push('>');
-
-								{
-									_$_.output_push('A pending');
-								}
-
-								_$_.output_push('</p>');
-								_$_.output_push('<!--]-->');
-							}
-						);
-						break;
-
-					default:
-						_$_.output_push('<p');
-						_$_.output_push(' class="default"');
-						_$_.output_push('>');
-						{
-							_$_.output_push('Default');
+							__out += '<!--[--><p class="pending-a">A pending</p><!--]-->';
+							_$_.output_push(__out);
 						}
-						_$_.output_push('</p>');
-						break;
-				}
+					);
+					break;
 
-				_$_.output_push('<!--]-->');
+				default:
+					__out += '<p class="default">Default</p>';
+					break;
 			}
 
-			_$_.output_push('</div>');
+			__out += '<!--]--></div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -440,89 +293,60 @@ export function ForSwitchTry() {
 		const items = [{ id: 1, kind: 'a' }, { id: 2, kind: 'b' }];
 
 		_$_.regular_block(() => {
-			_$_.output_push('<ul');
-			_$_.output_push(' class="for-switch-try"');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push('<!--[-->');
+			__out += '<ul class="for-switch-try"><!--[-->';
 
-				for (const item of items) {
-					_$_.output_push('<!--[-->');
+			for (const item of items) {
+				__out += '<!--[-->';
 
-					switch (item.kind) {
-						case 'a':
-							_$_.try_block(
-								() => {
-									_$_.output_push('<!--[-->');
-									_$_.output_push('<li');
-									_$_.output_push(_$_.attr('class', `item item-${item.id} kind-a`));
-									_$_.output_push('>');
+				switch (item.kind) {
+					case 'a':
+						_$_.output_push(__out);
+						__out = '';
+						_$_.try_block(
+							() => {
+								let __out = '';
 
-									{
-										_$_.output_push(_$_.escape(`A-${item.id}`));
-									}
+								__out += '<!--[--><li' + _$_.attr('class', `item item-${item.id} kind-a`) + '>' + _$_.escape(`A-${item.id}`) + '</li><!--]-->';
+								_$_.output_push(__out);
+							},
+							null,
+							() => {
+								let __out = '';
 
-									_$_.output_push('</li>');
-									_$_.output_push('<!--]-->');
-								},
-								null,
-								() => {
-									_$_.output_push('<!--[-->');
-									_$_.output_push('<li');
-									_$_.output_push(_$_.attr('class', `pending pending-${item.id}`));
-									_$_.output_push('>');
+								__out += '<!--[--><li' + _$_.attr('class', `pending pending-${item.id}`) + '>' + _$_.escape(`pending ${item.id}`) + '</li><!--]-->';
+								_$_.output_push(__out);
+							}
+						);
+						break;
 
-									{
-										_$_.output_push(_$_.escape(`pending ${item.id}`));
-									}
+					default:
+						_$_.output_push(__out);
+						__out = '';
+						_$_.try_block(
+							() => {
+								let __out = '';
 
-									_$_.output_push('</li>');
-									_$_.output_push('<!--]-->');
-								}
-							);
-							break;
+								__out += '<!--[--><li' + _$_.attr('class', `item item-${item.id} kind-b`) + '>' + _$_.escape(`B-${item.id}`) + '</li><!--]-->';
+								_$_.output_push(__out);
+							},
+							null,
+							() => {
+								let __out = '';
 
-						default:
-							_$_.try_block(
-								() => {
-									_$_.output_push('<!--[-->');
-									_$_.output_push('<li');
-									_$_.output_push(_$_.attr('class', `item item-${item.id} kind-b`));
-									_$_.output_push('>');
-
-									{
-										_$_.output_push(_$_.escape(`B-${item.id}`));
-									}
-
-									_$_.output_push('</li>');
-									_$_.output_push('<!--]-->');
-								},
-								null,
-								() => {
-									_$_.output_push('<!--[-->');
-									_$_.output_push('<li');
-									_$_.output_push(_$_.attr('class', `pending pending-${item.id}`));
-									_$_.output_push('>');
-
-									{
-										_$_.output_push(_$_.escape(`pending ${item.id}`));
-									}
-
-									_$_.output_push('</li>');
-									_$_.output_push('<!--]-->');
-								}
-							);
-							break;
-					}
-
-					_$_.output_push('<!--]-->');
+								__out += '<!--[--><li' + _$_.attr('class', `pending pending-${item.id}`) + '>' + _$_.escape(`pending ${item.id}`) + '</li><!--]-->';
+								_$_.output_push(__out);
+							}
+						);
+						break;
 				}
 
-				_$_.output_push('<!--]-->');
+				__out += '<!--]-->';
 			}
 
-			_$_.output_push('</ul>');
+			__out += '<!--]--></ul>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -532,55 +356,39 @@ export function ForIfTry() {
 		const items = [{ id: 1, show: true }, { id: 2, show: true }];
 
 		_$_.regular_block(() => {
-			_$_.output_push('<ul');
-			_$_.output_push(' class="for-if-try"');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push('<!--[-->');
+			__out += '<ul class="for-if-try"><!--[-->';
 
-				for (const item of items) {
-					_$_.output_push('<!--[-->');
+			for (const item of items) {
+				__out += '<!--[-->';
 
-					if (item.show) {
-						_$_.try_block(
-							() => {
-								_$_.output_push('<!--[-->');
-								_$_.output_push('<li');
-								_$_.output_push(_$_.attr('class', `item item-${item.id}`));
-								_$_.output_push('>');
+				if (item.show) {
+					_$_.output_push(__out);
+					__out = '';
 
-								{
-									_$_.output_push(_$_.escape(`item-${item.id}`));
-								}
+					_$_.try_block(
+						() => {
+							let __out = '';
 
-								_$_.output_push('</li>');
-								_$_.output_push('<!--]-->');
-							},
-							null,
-							() => {
-								_$_.output_push('<!--[-->');
-								_$_.output_push('<li');
-								_$_.output_push(_$_.attr('class', `pending pending-${item.id}`));
-								_$_.output_push('>');
+							__out += '<!--[--><li' + _$_.attr('class', `item item-${item.id}`) + '>' + _$_.escape(`item-${item.id}`) + '</li><!--]-->';
+							_$_.output_push(__out);
+						},
+						null,
+						() => {
+							let __out = '';
 
-								{
-									_$_.output_push(_$_.escape(`pending ${item.id}`));
-								}
-
-								_$_.output_push('</li>');
-								_$_.output_push('<!--]-->');
-							}
-						);
-					}
-
-					_$_.output_push('<!--]-->');
+							__out += '<!--[--><li' + _$_.attr('class', `pending pending-${item.id}`) + '>' + _$_.escape(`pending ${item.id}`) + '</li><!--]-->';
+							_$_.output_push(__out);
+						}
+					);
 				}
 
-				_$_.output_push('<!--]-->');
+				__out += '<!--]-->';
 			}
 
-			_$_.output_push('</ul>');
+			__out += '<!--]--></ul>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -590,95 +398,66 @@ export function ForIfSwitchTrySingle() {
 		const items = [{ id: 1, kind: 'a', show: true }];
 
 		_$_.regular_block(() => {
-			_$_.output_push('<ul');
-			_$_.output_push(' class="for-if-switch-try-single"');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push('<!--[-->');
+			__out += '<ul class="for-if-switch-try-single"><!--[-->';
 
-				for (const item of items) {
-					_$_.output_push('<!--[-->');
+			for (const item of items) {
+				__out += '<!--[-->';
 
-					if (item.show) {
-						_$_.output_push('<!--[-->');
+				if (item.show) {
+					__out += '<!--[-->';
 
-						switch (item.kind) {
-							case 'a':
-								_$_.try_block(
-									() => {
-										_$_.output_push('<!--[-->');
-										_$_.output_push('<li');
-										_$_.output_push(_$_.attr('class', `item item-${item.id} kind-a`));
-										_$_.output_push('>');
+					switch (item.kind) {
+						case 'a':
+							_$_.output_push(__out);
+							__out = '';
+							_$_.try_block(
+								() => {
+									let __out = '';
 
-										{
-											_$_.output_push(_$_.escape(`A-${item.id}`));
-										}
+									__out += '<!--[--><li' + _$_.attr('class', `item item-${item.id} kind-a`) + '>' + _$_.escape(`A-${item.id}`) + '</li><!--]-->';
+									_$_.output_push(__out);
+								},
+								null,
+								() => {
+									let __out = '';
 
-										_$_.output_push('</li>');
-										_$_.output_push('<!--]-->');
-									},
-									null,
-									() => {
-										_$_.output_push('<!--[-->');
-										_$_.output_push('<li');
-										_$_.output_push(_$_.attr('class', `pending pending-${item.id}`));
-										_$_.output_push('>');
+									__out += '<!--[--><li' + _$_.attr('class', `pending pending-${item.id}`) + '>' + _$_.escape(`pending ${item.id}`) + '</li><!--]-->';
+									_$_.output_push(__out);
+								}
+							);
+							break;
 
-										{
-											_$_.output_push(_$_.escape(`pending ${item.id}`));
-										}
+						default:
+							_$_.output_push(__out);
+							__out = '';
+							_$_.try_block(
+								() => {
+									let __out = '';
 
-										_$_.output_push('</li>');
-										_$_.output_push('<!--]-->');
-									}
-								);
-								break;
+									__out += '<!--[--><li' + _$_.attr('class', `item item-${item.id} kind-default`) + '>' + _$_.escape(`D-${item.id}`) + '</li><!--]-->';
+									_$_.output_push(__out);
+								},
+								null,
+								() => {
+									let __out = '';
 
-							default:
-								_$_.try_block(
-									() => {
-										_$_.output_push('<!--[-->');
-										_$_.output_push('<li');
-										_$_.output_push(_$_.attr('class', `item item-${item.id} kind-default`));
-										_$_.output_push('>');
-
-										{
-											_$_.output_push(_$_.escape(`D-${item.id}`));
-										}
-
-										_$_.output_push('</li>');
-										_$_.output_push('<!--]-->');
-									},
-									null,
-									() => {
-										_$_.output_push('<!--[-->');
-										_$_.output_push('<li');
-										_$_.output_push(_$_.attr('class', `pending pending-${item.id}`));
-										_$_.output_push('>');
-
-										{
-											_$_.output_push(_$_.escape(`pending ${item.id}`));
-										}
-
-										_$_.output_push('</li>');
-										_$_.output_push('<!--]-->');
-									}
-								);
-								break;
-						}
-
-						_$_.output_push('<!--]-->');
+									__out += '<!--[--><li' + _$_.attr('class', `pending pending-${item.id}`) + '>' + _$_.escape(`pending ${item.id}`) + '</li><!--]-->';
+									_$_.output_push(__out);
+								}
+							);
+							break;
 					}
 
-					_$_.output_push('<!--]-->');
+					__out += '<!--]-->';
 				}
 
-				_$_.output_push('<!--]-->');
+				__out += '<!--]-->';
 			}
 
-			_$_.output_push('</ul>');
+			__out += '<!--]--></ul>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -691,95 +470,66 @@ export function ForIfSwitchTryMulti() {
 		];
 
 		_$_.regular_block(() => {
-			_$_.output_push('<ul');
-			_$_.output_push(' class="for-if-switch-try-multi"');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push('<!--[-->');
+			__out += '<ul class="for-if-switch-try-multi"><!--[-->';
 
-				for (const item of items) {
-					_$_.output_push('<!--[-->');
+			for (const item of items) {
+				__out += '<!--[-->';
 
-					if (item.show) {
-						_$_.output_push('<!--[-->');
+				if (item.show) {
+					__out += '<!--[-->';
 
-						switch (item.kind) {
-							case 'a':
-								_$_.try_block(
-									() => {
-										_$_.output_push('<!--[-->');
-										_$_.output_push('<li');
-										_$_.output_push(_$_.attr('class', `item item-${item.id} kind-a`));
-										_$_.output_push('>');
+					switch (item.kind) {
+						case 'a':
+							_$_.output_push(__out);
+							__out = '';
+							_$_.try_block(
+								() => {
+									let __out = '';
 
-										{
-											_$_.output_push(_$_.escape(`A-${item.id}`));
-										}
+									__out += '<!--[--><li' + _$_.attr('class', `item item-${item.id} kind-a`) + '>' + _$_.escape(`A-${item.id}`) + '</li><!--]-->';
+									_$_.output_push(__out);
+								},
+								null,
+								() => {
+									let __out = '';
 
-										_$_.output_push('</li>');
-										_$_.output_push('<!--]-->');
-									},
-									null,
-									() => {
-										_$_.output_push('<!--[-->');
-										_$_.output_push('<li');
-										_$_.output_push(_$_.attr('class', `pending pending-${item.id}`));
-										_$_.output_push('>');
+									__out += '<!--[--><li' + _$_.attr('class', `pending pending-${item.id}`) + '>' + _$_.escape(`pending ${item.id}`) + '</li><!--]-->';
+									_$_.output_push(__out);
+								}
+							);
+							break;
 
-										{
-											_$_.output_push(_$_.escape(`pending ${item.id}`));
-										}
+						default:
+							_$_.output_push(__out);
+							__out = '';
+							_$_.try_block(
+								() => {
+									let __out = '';
 
-										_$_.output_push('</li>');
-										_$_.output_push('<!--]-->');
-									}
-								);
-								break;
+									__out += '<!--[--><li' + _$_.attr('class', `item item-${item.id} kind-b`) + '>' + _$_.escape(`B-${item.id}`) + '</li><!--]-->';
+									_$_.output_push(__out);
+								},
+								null,
+								() => {
+									let __out = '';
 
-							default:
-								_$_.try_block(
-									() => {
-										_$_.output_push('<!--[-->');
-										_$_.output_push('<li');
-										_$_.output_push(_$_.attr('class', `item item-${item.id} kind-b`));
-										_$_.output_push('>');
-
-										{
-											_$_.output_push(_$_.escape(`B-${item.id}`));
-										}
-
-										_$_.output_push('</li>');
-										_$_.output_push('<!--]-->');
-									},
-									null,
-									() => {
-										_$_.output_push('<!--[-->');
-										_$_.output_push('<li');
-										_$_.output_push(_$_.attr('class', `pending pending-${item.id}`));
-										_$_.output_push('>');
-
-										{
-											_$_.output_push(_$_.escape(`pending ${item.id}`));
-										}
-
-										_$_.output_push('</li>');
-										_$_.output_push('<!--]-->');
-									}
-								);
-								break;
-						}
-
-						_$_.output_push('<!--]-->');
+									__out += '<!--[--><li' + _$_.attr('class', `pending pending-${item.id}`) + '>' + _$_.escape(`pending ${item.id}`) + '</li><!--]-->';
+									_$_.output_push(__out);
+								}
+							);
+							break;
 					}
 
-					_$_.output_push('<!--]-->');
+					__out += '<!--]-->';
 				}
 
-				_$_.output_push('<!--]-->');
+				__out += '<!--]-->';
 			}
 
-			_$_.output_push('</ul>');
+			__out += '<!--]--></ul>';
+			_$_.output_push(__out);
 		});
 	});
 }

--- a/packages/ripple/tests/hydration/compiled/server/portal.js
+++ b/packages/ripple/tests/hydration/compiled/server/portal.js
@@ -6,49 +6,39 @@ import { Portal, track } from 'ripple/server';
 export function SimplePortal() {
 	return _$_.tsrx_element(() => {
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push(' class="container"');
-			_$_.output_push('>');
+			let __out = '';
+
+			__out += '<div class="container"><h1>Main Content</h1>';
 
 			{
-				_$_.output_push('<h1');
-				_$_.output_push('>');
+				const comp = Portal;
 
-				{
-					_$_.output_push('Main Content');
-				}
+				_$_.output_push(__out);
+				__out = '';
 
-				_$_.output_push('</h1>');
+				const args = [
+					{
+						target: typeof document !== 'undefined' ? document.body : null,
+						children: _$_.tsrx_element(() => {
+							return _$_.tsrx_element(() => {
+								let __out = '';
 
-				{
-					const comp = Portal;
-
-					const args = [
-						{
-							target: typeof document !== 'undefined' ? document.body : null,
-							children: _$_.tsrx_element(() => {
-								return _$_.tsrx_element(() => {
-									_$_.output_push('<div');
-									_$_.output_push(' class="portal-content"');
-									_$_.output_push('>');
-
-									{
-										_$_.output_push('Portal content');
-									}
-
-									_$_.output_push('</div>');
-								});
-							})
-						}
-					];
-
-					if (comp) {
-						_$_.render_component(comp, ...args);
+								__out += '<div class="portal-content">Portal content</div>';
+								_$_.output_push(__out);
+							});
+						})
 					}
+				];
+
+				if (comp) {
+					_$_.output_push(__out);
+					__out = '';
+					_$_.render_component(comp, ...args);
 				}
 			}
 
-			_$_.output_push('</div>');
+			__out += '</div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -58,55 +48,41 @@ export function ConditionalPortal() {
 		let lazy = _$_.track(true, '4f6df174');
 
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push(' class="container"');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push('<button');
-				_$_.output_push(' class="toggle"');
-				_$_.output_push('>');
+			__out += '<div class="container"><button class="toggle">Toggle</button><!--[-->';
 
+			if (lazy.value) {
 				{
-					_$_.output_push('Toggle');
-				}
+					const comp = Portal;
 
-				_$_.output_push('</button>');
-				_$_.output_push('<!--[-->');
+					_$_.output_push(__out);
+					__out = '';
 
-				if (lazy.value) {
-					{
-						const comp = Portal;
+					const args = [
+						{
+							target: typeof document !== 'undefined' ? document.body : null,
+							children: _$_.tsrx_element(() => {
+								return _$_.tsrx_element(() => {
+									let __out = '';
 
-						const args = [
-							{
-								target: typeof document !== 'undefined' ? document.body : null,
-								children: _$_.tsrx_element(() => {
-									return _$_.tsrx_element(() => {
-										_$_.output_push('<div');
-										_$_.output_push(' class="portal-content"');
-										_$_.output_push('>');
-
-										{
-											_$_.output_push('Portal is visible');
-										}
-
-										_$_.output_push('</div>');
-									});
-								})
-							}
-						];
-
-						if (comp) {
-							_$_.render_component(comp, ...args);
+									__out += '<div class="portal-content">Portal is visible</div>';
+									_$_.output_push(__out);
+								});
+							})
 						}
+					];
+
+					if (comp) {
+						_$_.output_push(__out);
+						__out = '';
+						_$_.render_component(comp, ...args);
 					}
 				}
-
-				_$_.output_push('<!--]-->');
 			}
 
-			_$_.output_push('</div>');
+			__out += '<!--]--></div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -114,59 +90,39 @@ export function ConditionalPortal() {
 export function PortalWithMainContent() {
 	return _$_.tsrx_element(() => {
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push('>');
+			let __out = '';
+
+			__out += '<div><div class="main-content">Main page content</div>';
 
 			{
-				_$_.output_push('<div');
-				_$_.output_push(' class="main-content"');
-				_$_.output_push('>');
+				const comp = Portal;
 
-				{
-					_$_.output_push('Main page content');
-				}
+				_$_.output_push(__out);
+				__out = '';
 
-				_$_.output_push('</div>');
+				const args = [
+					{
+						target: typeof document !== 'undefined' ? document.body : null,
+						children: _$_.tsrx_element(() => {
+							return _$_.tsrx_element(() => {
+								let __out = '';
 
-				{
-					const comp = Portal;
-
-					const args = [
-						{
-							target: typeof document !== 'undefined' ? document.body : null,
-							children: _$_.tsrx_element(() => {
-								return _$_.tsrx_element(() => {
-									_$_.output_push('<div');
-									_$_.output_push(' class="portal-content"');
-									_$_.output_push('>');
-
-									{
-										_$_.output_push('Modal content');
-									}
-
-									_$_.output_push('</div>');
-								});
-							})
-						}
-					];
-
-					if (comp) {
-						_$_.render_component(comp, ...args);
+								__out += '<div class="portal-content">Modal content</div>';
+								_$_.output_push(__out);
+							});
+						})
 					}
+				];
+
+				if (comp) {
+					_$_.output_push(__out);
+					__out = '';
+					_$_.render_component(comp, ...args);
 				}
-
-				_$_.output_push('<div');
-				_$_.output_push(' class="footer"');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('Footer');
-				}
-
-				_$_.output_push('</div>');
 			}
 
-			_$_.output_push('</div>');
+			__out += '<div class="footer">Footer</div></div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -174,57 +130,39 @@ export function PortalWithMainContent() {
 export function NestedContentWithPortal() {
 	return _$_.tsrx_element(() => {
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push(' class="outer"');
-			_$_.output_push('>');
+			let __out = '';
+
+			__out += '<div class="outer"><div class="inner"><span>Nested content</span></div>';
 
 			{
-				_$_.output_push('<div');
-				_$_.output_push(' class="inner"');
-				_$_.output_push('>');
+				const comp = Portal;
 
-				{
-					_$_.output_push('<span');
-					_$_.output_push('>');
+				_$_.output_push(__out);
+				__out = '';
 
+				const args = [
 					{
-						_$_.output_push('Nested content');
+						target: typeof document !== 'undefined' ? document.body : null,
+						children: _$_.tsrx_element(() => {
+							return _$_.tsrx_element(() => {
+								let __out = '';
+
+								__out += '<div class="portal-content">Portal content</div>';
+								_$_.output_push(__out);
+							});
+						})
 					}
+				];
 
-					_$_.output_push('</span>');
-				}
-
-				_$_.output_push('</div>');
-
-				{
-					const comp = Portal;
-
-					const args = [
-						{
-							target: typeof document !== 'undefined' ? document.body : null,
-							children: _$_.tsrx_element(() => {
-								return _$_.tsrx_element(() => {
-									_$_.output_push('<div');
-									_$_.output_push(' class="portal-content"');
-									_$_.output_push('>');
-
-									{
-										_$_.output_push('Portal content');
-									}
-
-									_$_.output_push('</div>');
-								});
-							})
-						}
-					];
-
-					if (comp) {
-						_$_.render_component(comp, ...args);
-					}
+				if (comp) {
+					_$_.output_push(__out);
+					__out = '';
+					_$_.render_component(comp, ...args);
 				}
 			}
 
-			_$_.output_push('</div>');
+			__out += '</div>';
+			_$_.output_push(__out);
 		});
 	});
 }

--- a/packages/ripple/tests/hydration/compiled/server/reactivity.js
+++ b/packages/ripple/tests/hydration/compiled/server/reactivity.js
@@ -8,15 +8,10 @@ export function TrackedState() {
 		let lazy = _$_.track(0, 'c1818584');
 
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push(' class="count"');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push(_$_.escape(lazy.value));
-			}
-
-			_$_.output_push('</div>');
+			__out += '<div class="count">' + _$_.escape(lazy.value) + '</div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -26,22 +21,10 @@ export function CounterWithInitial(props) {
 		let lazy_1 = _$_.track(props.initial, '03ea4348');
 
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push('<span');
-				_$_.output_push(' class="count"');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push(_$_.escape(lazy_1.value));
-				}
-
-				_$_.output_push('</span>');
-			}
-
-			_$_.output_push('</div>');
+			__out += '<div><span class="count">' + _$_.escape(lazy_1.value) + '</span></div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -66,15 +49,18 @@ export function ComputedValues() {
 		const sum = () => lazy_2.value + lazy_3.value;
 
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push(' class="sum"');
-			_$_.output_push('>');
+			let __out = '';
+
+			__out += '<div class="sum">';
 
 			{
+				_$_.output_push(__out);
+				__out = '';
 				_$_.render_expression(sum());
 			}
 
-			_$_.output_push('</div>');
+			__out += '</div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -86,41 +72,10 @@ export function MultipleTracked() {
 		let lazy_6 = _$_.track(30, '048c3fd0');
 
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push(' class="multiple-tracked"');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push('<div');
-				_$_.output_push(' class="x"');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push(_$_.escape(lazy_4.value));
-				}
-
-				_$_.output_push('</div>');
-				_$_.output_push('<div');
-				_$_.output_push(' class="y"');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push(_$_.escape(lazy_5.value));
-				}
-
-				_$_.output_push('</div>');
-				_$_.output_push('<div');
-				_$_.output_push(' class="z"');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push(_$_.escape(lazy_6.value));
-				}
-
-				_$_.output_push('</div>');
-			}
-
-			_$_.output_push('</div>');
+			__out += '<div class="multiple-tracked"><div class="x">' + _$_.escape(lazy_4.value) + '</div><div class="y">' + _$_.escape(lazy_5.value) + '</div><div class="z">' + _$_.escape(lazy_6.value) + '</div></div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -132,15 +87,18 @@ export function DerivedState() {
 		const fullName = () => `${lazy_7.value} ${lazy_8.value}`;
 
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push(' class="name"');
-			_$_.output_push('>');
+			let __out = '';
+
+			__out += '<div class="name">';
 
 			{
+				_$_.output_push(__out);
+				__out = '';
 				_$_.render_expression(fullName());
 			}
 
-			_$_.output_push('</div>');
+			__out += '</div>';
+			_$_.output_push(__out);
 		});
 	});
 }

--- a/packages/ripple/tests/hydration/compiled/server/return.js
+++ b/packages/ripple/tests/hydration/compiled/server/return.js
@@ -10,15 +10,10 @@ export function GuardReturnRenders() {
 		}
 
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push(' class="ready"');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push('ready');
-			}
-
-			_$_.output_push('</div>');
+			__out += '<div class="ready">ready</div>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -32,15 +27,10 @@ export function GuardReturnNull() {
 		}
 
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push(' class="ready"');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push('ready');
-			}
-
-			_$_.output_push('</div>');
+			__out += '<div class="ready">ready</div>';
+			_$_.output_push(__out);
 		});
 	});
 }

--- a/packages/ripple/tests/hydration/compiled/server/switch.js
+++ b/packages/ripple/tests/hydration/compiled/server/switch.js
@@ -8,41 +8,26 @@ export function SwitchStatic() {
 		const status = 'success';
 
 		_$_.regular_block(() => {
-			_$_.output_push('<!--[-->');
+			let __out = '';
+
+			__out += '<!--[-->';
 
 			switch (status) {
 				case 'success':
-					_$_.output_push('<div');
-					_$_.output_push(' class="status-success"');
-					_$_.output_push('>');
-					{
-						_$_.output_push('Success');
-					}
-					_$_.output_push('</div>');
+					__out += '<div class="status-success">Success</div>';
 					break;
 
 				case 'error':
-					_$_.output_push('<div');
-					_$_.output_push(' class="status-error"');
-					_$_.output_push('>');
-					{
-						_$_.output_push('Error');
-					}
-					_$_.output_push('</div>');
+					__out += '<div class="status-error">Error</div>';
 					break;
 
 				default:
-					_$_.output_push('<div');
-					_$_.output_push(' class="status-unknown"');
-					_$_.output_push('>');
-					{
-						_$_.output_push('Unknown');
-					}
-					_$_.output_push('</div>');
+					__out += '<div class="status-unknown">Unknown</div>';
 					break;
 			}
 
-			_$_.output_push('<!--]-->');
+			__out += '<!--]-->';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -52,52 +37,26 @@ export function SwitchReactive() {
 		let lazy = _$_.track('a', '9b34d955');
 
 		_$_.regular_block(() => {
-			{
-				_$_.output_push('<button');
-				_$_.output_push(' class="toggle"');
-				_$_.output_push('>');
+			let __out = '';
 
-				{
-					_$_.output_push('Toggle');
-				}
+			__out += '<button class="toggle">Toggle</button><!--[-->';
 
-				_$_.output_push('</button>');
-				_$_.output_push('<!--[-->');
+			switch (lazy.value) {
+				case 'a':
+					__out += '<div class="case-a">Case A</div>';
+					break;
 
-				switch (lazy.value) {
-					case 'a':
-						_$_.output_push('<div');
-						_$_.output_push(' class="case-a"');
-						_$_.output_push('>');
-						{
-							_$_.output_push('Case A');
-						}
-						_$_.output_push('</div>');
-						break;
+				case 'b':
+					__out += '<div class="case-b">Case B</div>';
+					break;
 
-					case 'b':
-						_$_.output_push('<div');
-						_$_.output_push(' class="case-b"');
-						_$_.output_push('>');
-						{
-							_$_.output_push('Case B');
-						}
-						_$_.output_push('</div>');
-						break;
-
-					default:
-						_$_.output_push('<div');
-						_$_.output_push(' class="case-c"');
-						_$_.output_push('>');
-						{
-							_$_.output_push('Case C');
-						}
-						_$_.output_push('</div>');
-						break;
-				}
-
-				_$_.output_push('<!--]-->');
+				default:
+					__out += '<div class="case-c">Case C</div>';
+					break;
 			}
+
+			__out += '<!--]-->';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -107,34 +66,25 @@ export function SwitchFallthrough() {
 		const val = 1;
 
 		_$_.regular_block(() => {
-			_$_.output_push('<!--[-->');
+			let __out = '';
+
+			__out += '<!--[-->';
 
 			switch (val) {
 				case 1:
 					break;
 
 				case 2:
-					_$_.output_push('<div');
-					_$_.output_push(' class="case-1-2"');
-					_$_.output_push('>');
-					{
-						_$_.output_push('1 or 2');
-					}
-					_$_.output_push('</div>');
+					__out += '<div class="case-1-2">1 or 2</div>';
 					break;
 
 				default:
-					_$_.output_push('<div');
-					_$_.output_push(' class="case-other"');
-					_$_.output_push('>');
-					{
-						_$_.output_push('Other');
-					}
-					_$_.output_push('</div>');
+					__out += '<div class="case-other">Other</div>';
 					break;
 			}
 
-			_$_.output_push('<!--]-->');
+			__out += '<!--]-->';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -144,52 +94,26 @@ export function SwitchNumericLevels() {
 		let lazy_1 = _$_.track(1, '7581a7ab');
 
 		_$_.regular_block(() => {
-			{
-				_$_.output_push('<button');
-				_$_.output_push(' class="level-toggle"');
-				_$_.output_push('>');
+			let __out = '';
 
-				{
-					_$_.output_push('Toggle Level');
-				}
+			__out += '<button class="level-toggle">Toggle Level</button><!--[-->';
 
-				_$_.output_push('</button>');
-				_$_.output_push('<!--[-->');
+			switch (lazy_1.value) {
+				case 1:
+					__out += '<div class="level-1">Level 1</div>';
+					break;
 
-				switch (lazy_1.value) {
-					case 1:
-						_$_.output_push('<div');
-						_$_.output_push(' class="level-1"');
-						_$_.output_push('>');
-						{
-							_$_.output_push('Level 1');
-						}
-						_$_.output_push('</div>');
-						break;
+				case 2:
+					__out += '<div class="level-2">Level 2</div>';
+					break;
 
-					case 2:
-						_$_.output_push('<div');
-						_$_.output_push(' class="level-2"');
-						_$_.output_push('>');
-						{
-							_$_.output_push('Level 2');
-						}
-						_$_.output_push('</div>');
-						break;
-
-					case 3:
-						_$_.output_push('<div');
-						_$_.output_push(' class="level-3"');
-						_$_.output_push('>');
-						{
-							_$_.output_push('Level 3');
-						}
-						_$_.output_push('</div>');
-						break;
-				}
-
-				_$_.output_push('<!--]-->');
+				case 3:
+					__out += '<div class="level-3">Level 3</div>';
+					break;
 			}
+
+			__out += '<!--]-->';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -199,52 +123,26 @@ export function SwitchBlockScoped() {
 		let lazy_2 = _$_.track(1, 'ca9f9852');
 
 		_$_.regular_block(() => {
-			{
-				_$_.output_push('<button');
-				_$_.output_push(' class="block-toggle"');
-				_$_.output_push('>');
+			let __out = '';
 
-				{
-					_$_.output_push('Toggle');
-				}
+			__out += '<button class="block-toggle">Toggle</button><!--[-->';
 
-				_$_.output_push('</button>');
-				_$_.output_push('<!--[-->');
+			switch (lazy_2.value) {
+				case 1:
+					__out += '<div class="block-1">Block 1</div>';
+					break;
 
-				switch (lazy_2.value) {
-					case 1:
-						_$_.output_push('<div');
-						_$_.output_push(' class="block-1"');
-						_$_.output_push('>');
-						{
-							_$_.output_push('Block 1');
-						}
-						_$_.output_push('</div>');
-						break;
+				case 2:
+					__out += '<div class="block-2">Block 2</div>';
+					break;
 
-					case 2:
-						_$_.output_push('<div');
-						_$_.output_push(' class="block-2"');
-						_$_.output_push('>');
-						{
-							_$_.output_push('Block 2');
-						}
-						_$_.output_push('</div>');
-						break;
-
-					case 3:
-						_$_.output_push('<div');
-						_$_.output_push(' class="block-3"');
-						_$_.output_push('>');
-						{
-							_$_.output_push('Block 3');
-						}
-						_$_.output_push('</div>');
-						break;
-				}
-
-				_$_.output_push('<!--]-->');
+				case 3:
+					__out += '<div class="block-3">Block 3</div>';
+					break;
 			}
+
+			__out += '<!--]-->';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -254,52 +152,26 @@ export function SwitchNoBreak() {
 		let lazy_3 = _$_.track(1, '6b7cb0ea');
 
 		_$_.regular_block(() => {
-			{
-				_$_.output_push('<button');
-				_$_.output_push(' class="nobreak-toggle"');
-				_$_.output_push('>');
+			let __out = '';
 
-				{
-					_$_.output_push('Toggle');
-				}
+			__out += '<button class="nobreak-toggle">Toggle</button><!--[-->';
 
-				_$_.output_push('</button>');
-				_$_.output_push('<!--[-->');
+			switch (lazy_3.value) {
+				case 1:
+					__out += '<div class="nobreak-1">NoBreak 1</div>';
+					break;
 
-				switch (lazy_3.value) {
-					case 1:
-						_$_.output_push('<div');
-						_$_.output_push(' class="nobreak-1"');
-						_$_.output_push('>');
-						{
-							_$_.output_push('NoBreak 1');
-						}
-						_$_.output_push('</div>');
-						break;
+				case 2:
+					__out += '<div class="nobreak-2">NoBreak 2</div>';
+					break;
 
-					case 2:
-						_$_.output_push('<div');
-						_$_.output_push(' class="nobreak-2"');
-						_$_.output_push('>');
-						{
-							_$_.output_push('NoBreak 2');
-						}
-						_$_.output_push('</div>');
-						break;
-
-					case 3:
-						_$_.output_push('<div');
-						_$_.output_push(' class="nobreak-3"');
-						_$_.output_push('>');
-						{
-							_$_.output_push('NoBreak 3');
-						}
-						_$_.output_push('</div>');
-						break;
-				}
-
-				_$_.output_push('<!--]-->');
+				case 3:
+					__out += '<div class="nobreak-3">NoBreak 3</div>';
+					break;
 			}
+
+			__out += '<!--]-->';
+			_$_.output_push(__out);
 		});
 	});
 }

--- a/packages/ripple/tests/hydration/compiled/server/track-async-serialization.js
+++ b/packages/ripple/tests/hydration/compiled/server/track-async-serialization.js
@@ -22,15 +22,10 @@ function ServerCallResult({ count }) {
 		let lazy = _$_.track_async(() => formatValue(count.value), '2e21cbe9');
 
 		_$_.regular_block(() => {
-			_$_.output_push('<p');
-			_$_.output_push(' class="result"');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push(_$_.escape(lazy.value));
-			}
-
-			_$_.output_push('</p>');
+			__out += '<p class="result">' + _$_.escape(lazy.value) + '</p>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -40,46 +35,40 @@ export function AsyncWithServerCall() {
 		let lazy_1 = _$_.track(0, 'f0c2b41e');
 
 		_$_.regular_block(() => {
-			{
-				_$_.output_push('<button');
-				_$_.output_push(' class="increment"');
-				_$_.output_push('>');
+			let __out = '';
 
-				{
-					_$_.output_push('increment');
-				}
+			__out += '<button class="increment">increment</button>';
+			_$_.output_push(__out);
+			__out = '';
 
-				_$_.output_push('</button>');
+			_$_.try_block(
+				() => {
+					let __out = '';
 
-				_$_.try_block(
-					() => {
-						_$_.output_push('<!--[-->');
+					__out += '<!--[-->';
 
-						{
-							const comp = ServerCallResult;
-							const args = [{ count: lazy_1 }];
+					{
+						const comp = ServerCallResult;
+						const args = [{ count: lazy_1 }];
 
-							_$_.render_component(comp, ...args);
-						}
-
-						_$_.output_push('<!--]-->');
-					},
-					null,
-					() => {
-						_$_.output_push('<!--[-->');
-						_$_.output_push('<p');
-						_$_.output_push(' class="loading"');
-						_$_.output_push('>');
-
-						{
-							_$_.output_push('loading...');
-						}
-
-						_$_.output_push('</p>');
-						_$_.output_push('<!--]-->');
+						_$_.output_push(__out);
+						__out = '';
+						_$_.render_component(comp, ...args);
 					}
-				);
-			}
+
+					__out += '<!--]-->';
+					_$_.output_push(__out);
+				},
+				null,
+				() => {
+					let __out = '';
+
+					__out += '<!--[--><p class="loading">loading...</p><!--]-->';
+					_$_.output_push(__out);
+				}
+			);
+
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -88,41 +77,42 @@ export function AsyncSimpleValue() {
 	return _$_.tsrx_element(() => {
 		_$_.try_block(
 			() => {
-				_$_.output_push('<!--[-->');
+				let __out = '';
+
+				__out += '<!--[-->';
 
 				let lazy_2 = _$_.track_async(() => Promise.resolve('hydrated value'), '4e502c38');
 
+				_$_.output_push(__out);
+				__out = '';
+
 				_$_.regular_block(() => {
-					_$_.output_push('<p');
-					_$_.output_push(' class="result"');
-					_$_.output_push('>');
+					let __out = '';
 
-					{
-						_$_.output_push(_$_.escape(lazy_2.value));
-					}
-
-					_$_.output_push('</p>');
+					__out += '<p class="result">' + _$_.escape(lazy_2.value) + '</p>';
+					_$_.output_push(__out);
 				});
 
-				_$_.output_push('<!--]-->');
+				__out += '<!--]-->';
+				_$_.output_push(__out);
 			},
 			null,
 			() => {
-				_$_.output_push('<!--[-->');
+				let __out = '';
+
+				__out += '<!--[-->';
+				_$_.output_push(__out);
+				__out = '';
 
 				_$_.regular_block(() => {
-					_$_.output_push('<p');
-					_$_.output_push(' class="loading"');
-					_$_.output_push('>');
+					let __out = '';
 
-					{
-						_$_.output_push('loading...');
-					}
-
-					_$_.output_push('</p>');
+					__out += '<p class="loading">loading...</p>';
+					_$_.output_push(__out);
 				});
 
-				_$_.output_push('<!--]-->');
+				__out += '<!--]-->';
+				_$_.output_push(__out);
 			}
 		);
 	});
@@ -132,41 +122,42 @@ export function AsyncNumericValue() {
 	return _$_.tsrx_element(() => {
 		_$_.try_block(
 			() => {
-				_$_.output_push('<!--[-->');
+				let __out = '';
+
+				__out += '<!--[-->';
 
 				let lazy_3 = _$_.track_async(() => Promise.resolve(42), '14891754');
 
+				_$_.output_push(__out);
+				__out = '';
+
 				_$_.regular_block(() => {
-					_$_.output_push('<span');
-					_$_.output_push(' class="count"');
-					_$_.output_push('>');
+					let __out = '';
 
-					{
-						_$_.output_push(_$_.escape(lazy_3.value));
-					}
-
-					_$_.output_push('</span>');
+					__out += '<span class="count">' + _$_.escape(lazy_3.value) + '</span>';
+					_$_.output_push(__out);
 				});
 
-				_$_.output_push('<!--]-->');
+				__out += '<!--]-->';
+				_$_.output_push(__out);
 			},
 			null,
 			() => {
-				_$_.output_push('<!--[-->');
+				let __out = '';
+
+				__out += '<!--[-->';
+				_$_.output_push(__out);
+				__out = '';
 
 				_$_.regular_block(() => {
-					_$_.output_push('<span');
-					_$_.output_push(' class="pending"');
-					_$_.output_push('>');
+					let __out = '';
 
-					{
-						_$_.output_push('...');
-					}
-
-					_$_.output_push('</span>');
+					__out += '<span class="pending">...</span>';
+					_$_.output_push(__out);
 				});
 
-				_$_.output_push('<!--]-->');
+				__out += '<!--]-->';
+				_$_.output_push(__out);
 			}
 		);
 	});
@@ -176,58 +167,42 @@ export function AsyncObjectValue() {
 	return _$_.tsrx_element(() => {
 		_$_.try_block(
 			() => {
-				_$_.output_push('<!--[-->');
+				let __out = '';
+
+				__out += '<!--[-->';
 
 				let lazy_4 = _$_.track_async(() => Promise.resolve({ name: 'Alice', age: 30 }), 'f325448a');
 
+				_$_.output_push(__out);
+				__out = '';
+
 				_$_.regular_block(() => {
-					_$_.output_push('<div');
-					_$_.output_push(' class="user"');
-					_$_.output_push('>');
+					let __out = '';
 
-					{
-						_$_.output_push('<span');
-						_$_.output_push(' class="name"');
-						_$_.output_push('>');
-
-						{
-							_$_.output_push(_$_.escape(lazy_4.value.name));
-						}
-
-						_$_.output_push('</span>');
-						_$_.output_push('<span');
-						_$_.output_push(' class="age"');
-						_$_.output_push('>');
-
-						{
-							_$_.output_push(_$_.escape(lazy_4.value.age));
-						}
-
-						_$_.output_push('</span>');
-					}
-
-					_$_.output_push('</div>');
+					__out += '<div class="user"><span class="name">' + _$_.escape(lazy_4.value.name) + '</span><span class="age">' + _$_.escape(lazy_4.value.age) + '</span></div>';
+					_$_.output_push(__out);
 				});
 
-				_$_.output_push('<!--]-->');
+				__out += '<!--]-->';
+				_$_.output_push(__out);
 			},
 			null,
 			() => {
-				_$_.output_push('<!--[-->');
+				let __out = '';
+
+				__out += '<!--[-->';
+				_$_.output_push(__out);
+				__out = '';
 
 				_$_.regular_block(() => {
-					_$_.output_push('<div');
-					_$_.output_push(' class="loading"');
-					_$_.output_push('>');
+					let __out = '';
 
-					{
-						_$_.output_push('loading user...');
-					}
-
-					_$_.output_push('</div>');
+					__out += '<div class="loading">loading user...</div>';
+					_$_.output_push(__out);
 				});
 
-				_$_.output_push('<!--]-->');
+				__out += '<!--]-->';
+				_$_.output_push(__out);
 			}
 		);
 	});
@@ -237,59 +212,43 @@ export function AsyncMultipleValues() {
 	return _$_.tsrx_element(() => {
 		_$_.try_block(
 			() => {
-				_$_.output_push('<!--[-->');
+				let __out = '';
+
+				__out += '<!--[-->';
 
 				let lazy_5 = _$_.track_async(() => Promise.resolve('alpha'), 'ab8199a0');
 				let lazy_6 = _$_.track_async(() => Promise.resolve('beta'), 'fb7ad40b');
 
+				_$_.output_push(__out);
+				__out = '';
+
 				_$_.regular_block(() => {
-					_$_.output_push('<div');
-					_$_.output_push(' class="multi"');
-					_$_.output_push('>');
+					let __out = '';
 
-					{
-						_$_.output_push('<span');
-						_$_.output_push(' class="first"');
-						_$_.output_push('>');
-
-						{
-							_$_.output_push(_$_.escape(lazy_5.value));
-						}
-
-						_$_.output_push('</span>');
-						_$_.output_push('<span');
-						_$_.output_push(' class="second"');
-						_$_.output_push('>');
-
-						{
-							_$_.output_push(_$_.escape(lazy_6.value));
-						}
-
-						_$_.output_push('</span>');
-					}
-
-					_$_.output_push('</div>');
+					__out += '<div class="multi"><span class="first">' + _$_.escape(lazy_5.value) + '</span><span class="second">' + _$_.escape(lazy_6.value) + '</span></div>';
+					_$_.output_push(__out);
 				});
 
-				_$_.output_push('<!--]-->');
+				__out += '<!--]-->';
+				_$_.output_push(__out);
 			},
 			null,
 			() => {
-				_$_.output_push('<!--[-->');
+				let __out = '';
+
+				__out += '<!--[-->';
+				_$_.output_push(__out);
+				__out = '';
 
 				_$_.regular_block(() => {
-					_$_.output_push('<div');
-					_$_.output_push(' class="loading"');
-					_$_.output_push('>');
+					let __out = '';
 
-					{
-						_$_.output_push('loading...');
-					}
-
-					_$_.output_push('</div>');
+					__out += '<div class="loading">loading...</div>';
+					_$_.output_push(__out);
 				});
 
-				_$_.output_push('<!--]-->');
+				__out += '<!--]-->';
+				_$_.output_push(__out);
 			}
 		);
 	});
@@ -299,57 +258,58 @@ export function AsyncWithCatch() {
 	return _$_.tsrx_element(() => {
 		_$_.try_block(
 			() => {
-				_$_.output_push('<!--[-->');
+				let __out = '';
+
+				__out += '<!--[-->';
 
 				let lazy_7 = _$_.track_async(() => Promise.reject(new Error('fetch failed')), '99982de5');
 
+				_$_.output_push(__out);
+				__out = '';
+
 				_$_.regular_block(() => {
-					_$_.output_push('<p');
-					_$_.output_push(' class="result"');
-					_$_.output_push('>');
+					let __out = '';
 
-					{
-						_$_.output_push(_$_.escape(lazy_7.value));
-					}
-
-					_$_.output_push('</p>');
+					__out += '<p class="result">' + _$_.escape(lazy_7.value) + '</p>';
+					_$_.output_push(__out);
 				});
 
-				_$_.output_push('<!--]-->');
+				__out += '<!--]-->';
+				_$_.output_push(__out);
 			},
 			(e) => {
-				_$_.output_push('<!--[-->');
+				let __out = '';
+
+				__out += '<!--[-->';
+				_$_.output_push(__out);
+				__out = '';
 
 				_$_.regular_block(() => {
-					_$_.output_push('<p');
-					_$_.output_push(' class="error"');
-					_$_.output_push('>');
+					let __out = '';
 
-					{
-						_$_.output_push(_$_.escape(e.message));
-					}
-
-					_$_.output_push('</p>');
+					__out += '<p class="error">' + _$_.escape(e.message) + '</p>';
+					_$_.output_push(__out);
 				});
 
-				_$_.output_push('<!--]-->');
+				__out += '<!--]-->';
+				_$_.output_push(__out);
 			},
 			() => {
-				_$_.output_push('<!--[-->');
+				let __out = '';
+
+				__out += '<!--[-->';
+				_$_.output_push(__out);
+				__out = '';
 
 				_$_.regular_block(() => {
-					_$_.output_push('<p');
-					_$_.output_push(' class="loading"');
-					_$_.output_push('>');
+					let __out = '';
 
-					{
-						_$_.output_push('loading...');
-					}
-
-					_$_.output_push('</p>');
+					__out += '<p class="loading">loading...</p>';
+					_$_.output_push(__out);
 				});
 
-				_$_.output_push('<!--]-->');
+				__out += '<!--]-->';
+				_$_.output_push(__out);
 			}
 		);
 	});
@@ -359,41 +319,42 @@ export function ChildWithError() {
 	return _$_.tsrx_element(() => {
 		_$_.try_block(
 			() => {
-				_$_.output_push('<!--[-->');
+				let __out = '';
+
+				__out += '<!--[-->';
 
 				let lazy_8 = _$_.track_async(() => Promise.reject(new Error('child error')), '1dea4c85');
 
+				_$_.output_push(__out);
+				__out = '';
+
 				_$_.regular_block(() => {
-					_$_.output_push('<p');
-					_$_.output_push(' class="result"');
-					_$_.output_push('>');
+					let __out = '';
 
-					{
-						_$_.output_push(_$_.escape(lazy_8.value));
-					}
-
-					_$_.output_push('</p>');
+					__out += '<p class="result">' + _$_.escape(lazy_8.value) + '</p>';
+					_$_.output_push(__out);
 				});
 
-				_$_.output_push('<!--]-->');
+				__out += '<!--]-->';
+				_$_.output_push(__out);
 			},
 			null,
 			() => {
-				_$_.output_push('<!--[-->');
+				let __out = '';
+
+				__out += '<!--[-->';
+				_$_.output_push(__out);
+				__out = '';
 
 				_$_.regular_block(() => {
-					_$_.output_push('<p');
-					_$_.output_push(' class="pending"');
-					_$_.output_push('>');
+					let __out = '';
 
-					{
-						_$_.output_push('loading...');
-					}
-
-					_$_.output_push('</p>');
+					__out += '<p class="pending">loading...</p>';
+					_$_.output_push(__out);
 				});
 
-				_$_.output_push('<!--]-->');
+				__out += '<!--]-->';
+				_$_.output_push(__out);
 			}
 		);
 	});
@@ -403,7 +364,11 @@ export function ParentWithCatch() {
 	return _$_.tsrx_element(() => {
 		_$_.try_block(
 			() => {
-				_$_.output_push('<!--[-->');
+				let __out = '';
+
+				__out += '<!--[-->';
+				_$_.output_push(__out);
+				__out = '';
 
 				_$_.regular_block(() => {
 					{
@@ -414,24 +379,25 @@ export function ParentWithCatch() {
 					}
 				});
 
-				_$_.output_push('<!--]-->');
+				__out += '<!--]-->';
+				_$_.output_push(__out);
 			},
 			(e) => {
-				_$_.output_push('<!--[-->');
+				let __out = '';
+
+				__out += '<!--[-->';
+				_$_.output_push(__out);
+				__out = '';
 
 				_$_.regular_block(() => {
-					_$_.output_push('<p');
-					_$_.output_push(' class="parent-error"');
-					_$_.output_push('>');
+					let __out = '';
 
-					{
-						_$_.output_push(_$_.escape(e.message));
-					}
-
-					_$_.output_push('</p>');
+					__out += '<p class="parent-error">' + _$_.escape(e.message) + '</p>';
+					_$_.output_push(__out);
 				});
 
-				_$_.output_push('<!--]-->');
+				__out += '<!--]-->';
+				_$_.output_push(__out);
 			},
 			null
 		);
@@ -443,15 +409,10 @@ function ReactiveDependencyResult({ count }) {
 		let lazy_9 = _$_.track_async(() => Promise.resolve(`count-${count.value}`), 'c9d12acf');
 
 		_$_.regular_block(() => {
-			_$_.output_push('<p');
-			_$_.output_push(' class="result"');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push(_$_.escape(lazy_9.value));
-			}
-
-			_$_.output_push('</p>');
+			__out += '<p class="result">' + _$_.escape(lazy_9.value) + '</p>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -461,46 +422,40 @@ export function AsyncWithReactiveDependency() {
 		let lazy_10 = _$_.track(0, 'cdd1adb8');
 
 		_$_.regular_block(() => {
-			{
-				_$_.output_push('<button');
-				_$_.output_push(' class="increment"');
-				_$_.output_push('>');
+			let __out = '';
 
-				{
-					_$_.output_push('increment');
-				}
+			__out += '<button class="increment">increment</button>';
+			_$_.output_push(__out);
+			__out = '';
 
-				_$_.output_push('</button>');
+			_$_.try_block(
+				() => {
+					let __out = '';
 
-				_$_.try_block(
-					() => {
-						_$_.output_push('<!--[-->');
+					__out += '<!--[-->';
 
-						{
-							const comp = ReactiveDependencyResult;
-							const args = [{ count: lazy_10 }];
+					{
+						const comp = ReactiveDependencyResult;
+						const args = [{ count: lazy_10 }];
 
-							_$_.render_component(comp, ...args);
-						}
-
-						_$_.output_push('<!--]-->');
-					},
-					null,
-					() => {
-						_$_.output_push('<!--[-->');
-						_$_.output_push('<p');
-						_$_.output_push(' class="loading"');
-						_$_.output_push('>');
-
-						{
-							_$_.output_push('loading...');
-						}
-
-						_$_.output_push('</p>');
-						_$_.output_push('<!--]-->');
+						_$_.output_push(__out);
+						__out = '';
+						_$_.render_component(comp, ...args);
 					}
-				);
-			}
+
+					__out += '<!--]-->';
+					_$_.output_push(__out);
+				},
+				null,
+				() => {
+					let __out = '';
+
+					__out += '<!--[--><p class="loading">loading...</p><!--]-->';
+					_$_.output_push(__out);
+				}
+			);
+
+			_$_.output_push(__out);
 		});
 	});
 }

--- a/packages/ripple/tests/hydration/compiled/server/try.js
+++ b/packages/ripple/tests/hydration/compiled/server/try.js
@@ -6,15 +6,10 @@ import { trackAsync } from 'ripple/server';
 export function RootPending() {
 	return _$_.tsrx_element(() => {
 		_$_.regular_block(() => {
-			_$_.output_push('<p');
-			_$_.output_push(' class="root-pending"');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push('root loading...');
-			}
-
-			_$_.output_push('</p>');
+			__out += '<p class="root-pending">root loading...</p>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -22,32 +17,10 @@ export function RootPending() {
 export function RootCatch({ error, reset }) {
 	return _$_.tsrx_element(() => {
 		_$_.regular_block(() => {
-			_$_.output_push('<section');
-			_$_.output_push(' class="root-catch"');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push('<p');
-				_$_.output_push(' class="root-error"');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push(_$_.escape(error.message));
-				}
-
-				_$_.output_push('</p>');
-				_$_.output_push('<button');
-				_$_.output_push(' class="root-reset"');
-				_$_.output_push('>');
-
-				{
-					_$_.output_push('retry');
-				}
-
-				_$_.output_push('</button>');
-			}
-
-			_$_.output_push('</section>');
+			__out += '<section class="root-catch"><p class="root-error">' + _$_.escape(error.message) + '</p><button class="root-reset">retry</button></section>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -57,14 +30,10 @@ export function RootThrows() {
 		throw new Error('root exploded');
 
 		_$_.regular_block(() => {
-			_$_.output_push('<p');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push('should not render');
-			}
-
-			_$_.output_push('</p>');
+			__out += '<p>should not render</p>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -74,15 +43,10 @@ export function RootAsyncDirect() {
 		let lazy = _$_.track_async(() => Promise.resolve('root async value'), 'd6bf9e33');
 
 		_$_.regular_block(() => {
-			_$_.output_push('<p');
-			_$_.output_push(' class="root-async-value"');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push(_$_.escape(lazy.value));
-			}
-
-			_$_.output_push('</p>');
+			__out += '<p class="root-async-value">' + _$_.escape(lazy.value) + '</p>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -92,15 +56,10 @@ export function RootAsyncRejects() {
 		let lazy_1 = _$_.track_async(() => Promise.reject(new Error('root async failed')), 'd2fe7b64');
 
 		_$_.regular_block(() => {
-			_$_.output_push('<p');
-			_$_.output_push(' class="root-async-value"');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push(_$_.escape(lazy_1.value));
-			}
-
-			_$_.output_push('</p>');
+			__out += '<p class="root-async-value">' + _$_.escape(lazy_1.value) + '</p>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -109,7 +68,11 @@ export function AsyncListInTryPending() {
 	return _$_.tsrx_element(() => {
 		_$_.try_block(
 			() => {
-				_$_.output_push('<!--[-->');
+				let __out = '';
+
+				__out += '<!--[-->';
+				_$_.output_push(__out);
+				__out = '';
 
 				_$_.regular_block(() => {
 					{
@@ -120,25 +83,26 @@ export function AsyncListInTryPending() {
 					}
 				});
 
-				_$_.output_push('<!--]-->');
+				__out += '<!--]-->';
+				_$_.output_push(__out);
 			},
 			null,
 			() => {
-				_$_.output_push('<!--[-->');
+				let __out = '';
+
+				__out += '<!--[-->';
+				_$_.output_push(__out);
+				__out = '';
 
 				_$_.regular_block(() => {
-					_$_.output_push('<p');
-					_$_.output_push(' class="loading"');
-					_$_.output_push('>');
+					let __out = '';
 
-					{
-						_$_.output_push('loading...');
-					}
-
-					_$_.output_push('</p>');
+					__out += '<p class="loading">loading...</p>';
+					_$_.output_push(__out);
 				});
 
-				_$_.output_push('<!--]-->');
+				__out += '<!--]-->';
+				_$_.output_push(__out);
 			}
 		);
 	});
@@ -149,28 +113,16 @@ function AsyncList() {
 		let lazy_2 = _$_.track_async(() => Promise.resolve(['alpha', 'beta', 'gamma']), 'b3d31627');
 
 		_$_.regular_block(() => {
-			_$_.output_push('<ul');
-			_$_.output_push(' class="items"');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push('<!--[-->');
+			__out += '<ul class="items"><!--[-->';
 
-				for (let item of lazy_2.value) {
-					_$_.output_push('<li');
-					_$_.output_push('>');
-
-					{
-						_$_.output_push(_$_.escape(item));
-					}
-
-					_$_.output_push('</li>');
-				}
-
-				_$_.output_push('<!--]-->');
+			for (let item of lazy_2.value) {
+				__out += '<li>' + _$_.escape(item) + '</li>';
 			}
 
-			_$_.output_push('</ul>');
+			__out += '<!--]--></ul>';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -178,46 +130,40 @@ function AsyncList() {
 export function AsyncTryWithLeadingSibling() {
 	return _$_.tsrx_element(() => {
 		_$_.regular_block(() => {
-			{
-				_$_.output_push('<div');
-				_$_.output_push(' class="before"');
-				_$_.output_push('>');
+			let __out = '';
 
-				{
-					_$_.output_push('before');
-				}
+			__out += '<div class="before">before</div>';
+			_$_.output_push(__out);
+			__out = '';
 
-				_$_.output_push('</div>');
+			_$_.try_block(
+				() => {
+					let __out = '';
 
-				_$_.try_block(
-					() => {
-						_$_.output_push('<!--[-->');
+					__out += '<!--[-->';
 
-						{
-							const comp = AsyncContent;
-							const args = [{}];
+					{
+						const comp = AsyncContent;
+						const args = [{}];
 
-							_$_.render_component(comp, ...args);
-						}
-
-						_$_.output_push('<!--]-->');
-					},
-					null,
-					() => {
-						_$_.output_push('<!--[-->');
-						_$_.output_push('<div');
-						_$_.output_push(' class="loading"');
-						_$_.output_push('>');
-
-						{
-							_$_.output_push('loading async content');
-						}
-
-						_$_.output_push('</div>');
-						_$_.output_push('<!--]-->');
+						_$_.output_push(__out);
+						__out = '';
+						_$_.render_component(comp, ...args);
 					}
-				);
-			}
+
+					__out += '<!--]-->';
+					_$_.output_push(__out);
+				},
+				null,
+				() => {
+					let __out = '';
+
+					__out += '<!--[--><div class="loading">loading async content</div><!--]-->';
+					_$_.output_push(__out);
+				}
+			);
+
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -227,15 +173,10 @@ function AsyncContent() {
 		let lazy_3 = _$_.track_async(() => Promise.resolve('ready'), '15ea8758');
 
 		_$_.regular_block(() => {
-			_$_.output_push('<div');
-			_$_.output_push(' class="resolved"');
-			_$_.output_push('>');
+			let __out = '';
 
-			{
-				_$_.output_push(_$_.escape(lazy_3.value));
-			}
-
-			_$_.output_push('</div>');
+			__out += '<div class="resolved">' + _$_.escape(lazy_3.value) + '</div>';
+			_$_.output_push(__out);
 		});
 	});
 }

--- a/packages/ripple/tests/server/compiler.test.tsrx
+++ b/packages/ripple/tests/server/compiler.test.tsrx
@@ -192,7 +192,9 @@ export default function A() @{
 
 		const result = compile(source, 'test.tsrx', { mode: 'server' }).code;
 
-		expect(result).toContain(`_$_.output_push('Hello')`);
+		// Indented text is trimmed to `Hello` and emitted as output (not a dangling
+		// `"Hello";`); the server accumulator merges it into the parent element.
+		expect(result).toContain(`__out += '<div>Hello</div>'`);
 		expect(result).not.toContain(`"Hello";`);
 	});
 
@@ -275,7 +277,9 @@ export function App() @{
 			{ mode: 'server' },
 		);
 
-		expect(result.code).toContain(`_$_.output_push('Rock &amp; "Roll"')`);
+		// Entities decode then re-escape for text (`&amp;`→`&`→`&amp;`, `&quot;`→`"`);
+		// the server accumulator merges the result into the parent element.
+		expect(result.code).toContain(`__out += '<div>Rock &amp; "Roll"</div>'`);
 	});
 
 	it('emits anonymous component expressions as arrows in SSR output', () => {

--- a/packages/tsrx-ripple/src/transform/server/index.js
+++ b/packages/tsrx-ripple/src/transform/server/index.js
@@ -78,6 +78,20 @@ import {
 } from '../../utils.js';
 
 /**
+ * @param {unknown} value
+ * @returns {value is AST.TraversableAstNode}
+ */
+function is_traversable_ast_node(value) {
+	return (
+		value != null &&
+		typeof value === 'object' &&
+		!Array.isArray(value) &&
+		'type' in value &&
+		typeof value.type === 'string'
+	);
+}
+
+/**
  * Re-run CSS pruning on JSX converted into Ripple template nodes so server
  * output applies the same scoped metadata as regular Ripple template elements.
  *
@@ -2950,14 +2964,18 @@ const PURE_RUNTIME_CALLS = new Set(['_$_.escape', '_$_.attr', '_$_.clsx']);
  */
 function contains_branching_call(node) {
 	let found = false;
-	/** @param {any} n */
+	/** @param {unknown} n */
 	const visit = (n) => {
-		if (found || !n || typeof n !== 'object') return;
+		if (found || !n || typeof n !== 'object') {
+			return;
+		}
 		if (Array.isArray(n)) {
 			for (const child of n) visit(child);
 			return;
 		}
-		if (typeof n.type !== 'string' || isFunctionNode(n)) return;
+		if (!is_traversable_ast_node(n) || isFunctionNode(n)) {
+			return;
+		}
 		if (
 			n.type === 'CallExpression' &&
 			n.callee.type === 'Identifier' &&
@@ -3019,7 +3037,7 @@ const CONTAINER_TYPES = new Set([
  * True if any of a container's non-body header expressions (a loop init/test, an
  * `if`/`switch` discriminant, …) contains a branching call — in which case we
  * cannot safely thread the accumulator through it.
- * @param {any} stmt
+ * @param {AST.Statement} stmt
  * @returns {boolean}
  */
 function container_header_branches(stmt) {
@@ -3031,13 +3049,13 @@ function container_header_branches(stmt) {
 		case 'SwitchStatement':
 			return (
 				contains_branching_call(stmt.discriminant) ||
-				stmt.cases.some((/** @type {any} */ c) => c.test && contains_branching_call(c.test))
+				stmt.cases.some((c) => c.test && contains_branching_call(c.test))
 			);
 		case 'ForStatement':
 			return (
-				(stmt.init && contains_branching_call(stmt.init)) ||
-				(stmt.test && contains_branching_call(stmt.test)) ||
-				(stmt.update && contains_branching_call(stmt.update))
+				(!!stmt.init && contains_branching_call(stmt.init)) ||
+				(!!stmt.test && contains_branching_call(stmt.test)) ||
+				(!!stmt.update && contains_branching_call(stmt.update))
 			);
 		case 'ForInStatement':
 		case 'ForOfStatement':
@@ -3098,7 +3116,7 @@ function thread_statement_list(list, out_id) {
 
 /**
  * Threads the accumulator into a container's body slot(s), in place.
- * @param {any} stmt
+ * @param {AST.Statement} stmt
  * @param {string} out_id
  * @returns {void}
  */
@@ -3149,14 +3167,14 @@ function thread_container(stmt, out_id) {
  */
 function has_direct_output_push(body) {
 	let found = false;
-	/** @param {any} n */
+	/** @param {unknown} n */
 	const visit = (n) => {
 		if (found || !n || typeof n !== 'object') return;
 		if (Array.isArray(n)) {
 			for (const child of n) visit(child);
 			return;
 		}
-		if (typeof n.type !== 'string' || isFunctionNode(n)) return;
+		if (!is_traversable_ast_node(n) || isFunctionNode(n)) return;
 		if (output_push_arg(n) !== null) {
 			found = true;
 			return;
@@ -3178,13 +3196,14 @@ function has_direct_output_push(body) {
 function fresh_accumulator_name(body) {
 	/** @type {Set<string>} */
 	const names = new Set();
-	/** @param {any} n */
+	/** @param {unknown} n */
 	const visit = (n) => {
 		if (!n || typeof n !== 'object') return;
 		if (Array.isArray(n)) {
 			for (const child of n) visit(child);
 			return;
 		}
+		if (!is_traversable_ast_node(n)) return;
 		if (n.type === 'Identifier' && typeof n.name === 'string') names.add(n.name);
 		for (const key in n) {
 			if (key === 'metadata' || key === 'loc' || key === 'leadingComments') continue;
@@ -3217,32 +3236,38 @@ function fresh_accumulator_name(body) {
  */
 function accumulate_output_pushes(program) {
 	const seen = new WeakSet();
-	/** @param {any} node */
+	/** @param {unknown} node */
 	const recurse = (node) => {
 		if (Array.isArray(node)) {
 			for (const child of node) recurse(child);
 			return;
 		}
-		if (!node || typeof node !== 'object' || typeof node.type !== 'string') return;
+		if (!is_traversable_ast_node(node)) return;
 		if (seen.has(node)) return;
 		seen.add(node);
 
-		if (
-			isFunctionNode(node) &&
-			node.body &&
-			node.body.type === 'BlockStatement' &&
-			has_direct_output_push(node.body.body)
-		) {
-			const out_id = fresh_accumulator_name(node.body.body);
-			node.body.body = [
-				b.let(b.id(out_id), b.literal('')),
-				...thread_statement_list(node.body.body, out_id),
-				b.stmt(b.call(b.id('_$_.output_push'), b.id(out_id))),
-			];
+		if (isFunctionNode(node)) {
+			const body = /** @type {AST.Function} */ (node).body;
+			if (body && body.type === 'BlockStatement' && has_direct_output_push(body.body)) {
+				const out_id = fresh_accumulator_name(body.body);
+				body.body = [
+					b.let(b.id(out_id), b.literal('')),
+					...thread_statement_list(body.body, out_id),
+					b.stmt(b.call(b.id('_$_.output_push'), b.id(out_id))),
+				];
+			}
 		}
 
 		for (const key in node) {
-			if (key === 'metadata' || key === 'loc' || key === 'leadingComments') continue;
+			if (
+				key === 'metadata' ||
+				key === 'loc' ||
+				key === 'start' ||
+				key === 'end' ||
+				key === 'leadingComments'
+			) {
+				continue;
+			}
 			recurse(node[key]);
 		}
 	};

--- a/packages/tsrx-ripple/src/transform/server/index.js
+++ b/packages/tsrx-ripple/src/transform/server/index.js
@@ -2847,6 +2847,409 @@ const visitors = {
 };
 
 /**
+ * Returns the single argument expression of a `_$_.output_push(x)` statement, or
+ * `null` for anything else. Every `output_push` argument is a pure string
+ * expression (a literal, or `escape(…)` / `attr(…)` / a value id) computed before
+ * the push, so any run of these folds into one `output_push(a + b + c)` without
+ * changing evaluation order or the emitted bytes.
+ * @param {AST.Node} stmt
+ * @returns {AST.Expression | null}
+ */
+function output_push_arg(stmt) {
+	if (stmt.type !== 'ExpressionStatement') return null;
+	const expr = stmt.expression;
+	if (
+		expr.type === 'CallExpression' &&
+		expr.callee.type === 'Identifier' &&
+		expr.callee.name === '_$_.output_push' &&
+		expr.arguments.length === 1 &&
+		expr.arguments[0].type !== 'SpreadElement'
+	) {
+		return /** @type {AST.Expression} */ (expr.arguments[0]);
+	}
+	return null;
+}
+
+/**
+ * True if a block body declares any block-scoped binding, in which case the
+ * `{ … }` is a meaningful lexical scope and must not be unwrapped. Conservative:
+ * treats every declaration form (incl. hoisting `var`) as a binding.
+ * @param {AST.Statement[]} body
+ * @returns {boolean}
+ */
+function declares_binding(body) {
+	return body.some(
+		(stmt) =>
+			stmt.type === 'VariableDeclaration' ||
+			stmt.type === 'FunctionDeclaration' ||
+			stmt.type === 'ClassDeclaration',
+	);
+}
+
+/**
+ * @param {AST.Expression} arg
+ * @returns {boolean}
+ */
+function is_string_literal(arg) {
+	return arg.type === 'Literal' && typeof arg.value === 'string';
+}
+
+/**
+ * True if a block directly contains an `output_push` — i.e. unwrapping it would
+ * enable a fold. Keeps the unwrap scoped to the SSR template path instead of
+ * stripping every binding-free block (e.g. server-module export wrappers).
+ * @param {AST.Statement[]} body
+ * @returns {boolean}
+ */
+function contains_output_push(body) {
+	return body.some((stmt) => output_push_arg(stmt) !== null);
+}
+
+/**
+ * Builds one `+`-concatenated expression from a run of `output_push` argument
+ * expressions, merging consecutive string literals into single literals.
+ * @param {AST.Expression[]} args
+ * @returns {AST.Expression}
+ */
+function build_concat(args) {
+	/** @type {(string | AST.Expression)[]} */
+	const parts = [];
+	for (const arg of args) {
+		const last = parts[parts.length - 1];
+		if (is_string_literal(arg)) {
+			const value = /** @type {string} */ (/** @type {AST.Literal} */ (arg).value);
+			if (typeof last === 'string') {
+				parts[parts.length - 1] = last + value;
+			} else {
+				parts.push(value);
+			}
+		} else {
+			parts.push(arg);
+		}
+	}
+	const exprs = parts.map((p) => (typeof p === 'string' ? b.literal(p) : p));
+	let concat = exprs[0];
+	for (let i = 1; i < exprs.length; i++) {
+		concat = b.binary('+', concat, exprs[i]);
+	}
+	return concat;
+}
+
+// Runtime helpers whose calls return a string and never touch the output buffer
+// — safe to leave inside an accumulated run. Anything else under the `_$_.`
+// namespace (render_component, regular_block, try_block, set_output_target, the
+// serialized-push helpers, …) may branch/emit and forces a flush before it.
+const PURE_RUNTIME_CALLS = new Set(['_$_.escape', '_$_.attr', '_$_.clsx']);
+
+/**
+ * True if `node` contains a runtime call that may create a child block or emit
+ * out of band (i.e. anything `_$_.*` that isn't in {@link PURE_RUNTIME_CALLS}),
+ * not crossing into nested functions (those are separate blocks).
+ * @param {AST.Node} node
+ * @returns {boolean}
+ */
+function contains_branching_call(node) {
+	let found = false;
+	/** @param {any} n */
+	const visit = (n) => {
+		if (found || !n || typeof n !== 'object') return;
+		if (Array.isArray(n)) {
+			for (const child of n) visit(child);
+			return;
+		}
+		if (typeof n.type !== 'string' || isFunctionNode(n)) return;
+		if (
+			n.type === 'CallExpression' &&
+			n.callee.type === 'Identifier' &&
+			n.callee.name.startsWith('_$_.') &&
+			n.callee.name !== '_$_.output_push' &&
+			!PURE_RUNTIME_CALLS.has(n.callee.name)
+		) {
+			found = true;
+			return;
+		}
+		for (const key in n) {
+			if (key === 'metadata' || key === 'loc' || key === 'leadingComments') continue;
+			visit(n[key]);
+		}
+	};
+	visit(node);
+	return found;
+}
+
+/**
+ * Inlines binding-free `{ … }` blocks that directly contain a push (the
+ * `{ escape(x) }` holes) so their pushes become siblings and can coalesce.
+ * Recurses only through such blocks — control flow and bindful blocks are left
+ * for the threader to descend into.
+ * @param {AST.Statement[]} list
+ * @returns {AST.Statement[]}
+ */
+function flatten_push_blocks(list) {
+	/** @type {AST.Statement[]} */
+	const out = [];
+	for (const stmt of list) {
+		if (
+			stmt.type === 'BlockStatement' &&
+			!declares_binding(stmt.body) &&
+			contains_output_push(stmt.body)
+		) {
+			out.push(...flatten_push_blocks(/** @type {AST.Statement[]} */ (stmt.body)));
+		} else {
+			out.push(stmt);
+		}
+	}
+	return out;
+}
+
+const CONTAINER_TYPES = new Set([
+	'BlockStatement',
+	'IfStatement',
+	'ForStatement',
+	'ForInStatement',
+	'ForOfStatement',
+	'WhileStatement',
+	'DoWhileStatement',
+	'SwitchStatement',
+	'TryStatement',
+	'LabeledStatement',
+]);
+
+/**
+ * True if any of a container's non-body header expressions (a loop init/test, an
+ * `if`/`switch` discriminant, …) contains a branching call — in which case we
+ * cannot safely thread the accumulator through it.
+ * @param {any} stmt
+ * @returns {boolean}
+ */
+function container_header_branches(stmt) {
+	switch (stmt.type) {
+		case 'IfStatement':
+		case 'WhileStatement':
+		case 'DoWhileStatement':
+			return contains_branching_call(stmt.test);
+		case 'SwitchStatement':
+			return (
+				contains_branching_call(stmt.discriminant) ||
+				stmt.cases.some((/** @type {any} */ c) => c.test && contains_branching_call(c.test))
+			);
+		case 'ForStatement':
+			return (
+				(stmt.init && contains_branching_call(stmt.init)) ||
+				(stmt.test && contains_branching_call(stmt.test)) ||
+				(stmt.update && contains_branching_call(stmt.update))
+			);
+		case 'ForInStatement':
+		case 'ForOfStatement':
+			return contains_branching_call(stmt.right);
+		default:
+			return false;
+	}
+}
+
+/**
+ * Accumulator threading for one runtime block body and everything inside it
+ * except nested functions (separate blocks). Coalesces adjacent pushes into
+ * `__out += a + b + c`, threads the same accumulator through control flow and
+ * binding-free blocks, and flushes (`output_push(__out); __out = ''`) before any
+ * branching statement. See {@link accumulate_output_pushes} for why this stays
+ * within block boundaries.
+ * @param {AST.Statement[]} list
+ * @param {string} out_id
+ * @returns {AST.Statement[]}
+ */
+function thread_statement_list(list, out_id) {
+	const flat = flatten_push_blocks(list);
+	/** @type {AST.Statement[]} */
+	const out = [];
+	/** @type {AST.Expression[]} */
+	let pending = [];
+	const commit = () => {
+		if (pending.length === 0) return;
+		out.push(b.stmt(b.assignment('+=', b.id(out_id), build_concat(pending))));
+		pending = [];
+	};
+	const flush = () => {
+		commit();
+		out.push(b.stmt(b.call(b.id('_$_.output_push'), b.id(out_id))));
+		out.push(b.stmt(b.assignment('=', b.id(out_id), b.literal(''))));
+	};
+	for (const stmt of flat) {
+		const arg = output_push_arg(stmt);
+		if (arg !== null) {
+			pending.push(arg);
+		} else if (CONTAINER_TYPES.has(stmt.type) && !container_header_branches(stmt)) {
+			commit();
+			thread_container(stmt, out_id);
+			out.push(stmt);
+		} else if (stmt.type === 'ReturnStatement' || contains_branching_call(stmt)) {
+			flush();
+			out.push(stmt);
+		} else {
+			// Pure statement (var decl, `i++`, …): keep, no flush, but commit first
+			// so accumulated pushes stay ordered relative to it.
+			commit();
+			out.push(stmt);
+		}
+	}
+	commit();
+	return out;
+}
+
+/**
+ * Threads the accumulator into a container's body slot(s), in place.
+ * @param {any} stmt
+ * @param {string} out_id
+ * @returns {void}
+ */
+function thread_container(stmt, out_id) {
+	/** @param {AST.Statement} node @returns {AST.Statement} */
+	const body_slot = (node) => {
+		if (node.type === 'BlockStatement') {
+			node.body = thread_statement_list(node.body, out_id);
+			return node;
+		}
+		return b.block(thread_statement_list([node], out_id));
+	};
+	switch (stmt.type) {
+		case 'BlockStatement':
+			stmt.body = thread_statement_list(stmt.body, out_id);
+			break;
+		case 'IfStatement':
+			stmt.consequent = body_slot(stmt.consequent);
+			if (stmt.alternate) stmt.alternate = body_slot(stmt.alternate);
+			break;
+		case 'ForStatement':
+		case 'ForInStatement':
+		case 'ForOfStatement':
+		case 'WhileStatement':
+		case 'DoWhileStatement':
+		case 'LabeledStatement':
+			stmt.body = body_slot(stmt.body);
+			break;
+		case 'SwitchStatement':
+			for (const switch_case of stmt.cases) {
+				switch_case.consequent = thread_statement_list(switch_case.consequent, out_id);
+			}
+			break;
+		case 'TryStatement':
+			stmt.block.body = thread_statement_list(stmt.block.body, out_id);
+			if (stmt.handler)
+				stmt.handler.body.body = thread_statement_list(stmt.handler.body.body, out_id);
+			if (stmt.finalizer) stmt.finalizer.body = thread_statement_list(stmt.finalizer.body, out_id);
+			break;
+	}
+}
+
+/**
+ * True if `body` directly contains an `output_push` (not inside a nested
+ * function), i.e. it is a runtime block body the accumulator should rewrite.
+ * @param {AST.Statement[]} body
+ * @returns {boolean}
+ */
+function has_direct_output_push(body) {
+	let found = false;
+	/** @param {any} n */
+	const visit = (n) => {
+		if (found || !n || typeof n !== 'object') return;
+		if (Array.isArray(n)) {
+			for (const child of n) visit(child);
+			return;
+		}
+		if (typeof n.type !== 'string' || isFunctionNode(n)) return;
+		if (output_push_arg(n) !== null) {
+			found = true;
+			return;
+		}
+		for (const key in n) {
+			if (key === 'metadata' || key === 'loc' || key === 'leadingComments') continue;
+			visit(n[key]);
+		}
+	};
+	body.forEach(visit);
+	return found;
+}
+
+/**
+ * Picks an accumulator name not used anywhere in `body` (incl. nested scopes).
+ * @param {AST.Statement[]} body
+ * @returns {string}
+ */
+function fresh_accumulator_name(body) {
+	/** @type {Set<string>} */
+	const names = new Set();
+	/** @param {any} n */
+	const visit = (n) => {
+		if (!n || typeof n !== 'object') return;
+		if (Array.isArray(n)) {
+			for (const child of n) visit(child);
+			return;
+		}
+		if (n.type === 'Identifier' && typeof n.name === 'string') names.add(n.name);
+		for (const key in n) {
+			if (key === 'metadata' || key === 'loc' || key === 'leadingComments') continue;
+			visit(n[key]);
+		}
+	};
+	body.forEach(visit);
+	let name = '__out';
+	for (let i = 2; names.has(name); i++) name = `__out${i}`;
+	return name;
+}
+
+/**
+ * Pass over the generated server program: within each runtime block, accumulate
+ * output into a single `let __out` string and push it once per block instead of
+ * once per element — flushing only before a child block. This beats the per-item
+ * push shape (the whole `@for` feed lands in one push) because accumulation spans
+ * loops and control flow.
+ *
+ * Correctness rests on the block model: every runtime block owns its own output
+ * buffer, and a child block reserves its slot in the parent buffer at the moment
+ * it branches — so everything before it must already be in the buffer. We declare
+ * one accumulator per runtime block body (a function/arrow that directly pushes),
+ * thread it through that body's control flow without crossing nested functions,
+ * and flush before every branching statement and at block end. So a child block's
+ * slot always follows what the parent already flushed: we never accumulate across
+ * a block boundary.
+ * @param {AST.Program} program
+ * @returns {void}
+ */
+function accumulate_output_pushes(program) {
+	const seen = new WeakSet();
+	/** @param {any} node */
+	const recurse = (node) => {
+		if (Array.isArray(node)) {
+			for (const child of node) recurse(child);
+			return;
+		}
+		if (!node || typeof node !== 'object' || typeof node.type !== 'string') return;
+		if (seen.has(node)) return;
+		seen.add(node);
+
+		if (
+			isFunctionNode(node) &&
+			node.body &&
+			node.body.type === 'BlockStatement' &&
+			has_direct_output_push(node.body.body)
+		) {
+			const out_id = fresh_accumulator_name(node.body.body);
+			node.body.body = [
+				b.let(b.id(out_id), b.literal('')),
+				...thread_statement_list(node.body.body, out_id),
+				b.stmt(b.call(b.id('_$_.output_push'), b.id(out_id))),
+			];
+		}
+
+		for (const key in node) {
+			if (key === 'metadata' || key === 'loc' || key === 'leadingComments') continue;
+			recurse(node[key]);
+		}
+	};
+	recurse(program);
+}
+
+/**
  * @param {string} filename
  * @param {string} source
  * @param {AnalysisResult} analysis
@@ -2909,6 +3312,12 @@ export function transform_server(filename, source, analysis, minify_css, dev = f
 	body.push(...program.body);
 
 	program.body = body;
+
+	// Accumulate each runtime block's output into a single `__out` string and
+	// push it once per block (flushing only before a child block) so the whole
+	// `@for` feed lands in one push. Stays within block boundaries by
+	// construction (see accumulate_output_pushes).
+	accumulate_output_pushes(/** @type {AST.Program} */ (program));
 
 	const { code, map } = print(
 		program,

--- a/packages/tsrx-ripple/tests/code-block-children.test.js
+++ b/packages/tsrx-ripple/tests/code-block-children.test.js
@@ -153,7 +153,10 @@ describe('@tsrx/ripple code blocks in template children position', () => {
 		for (const source of [template_only, template_only_nested]) {
 			const { code, errors } = compile(source, 'App.tsrx', { mode: 'server' });
 			expect(errors).toEqual([]);
-			expect(code).toContain(`_$_.output_push(' class="x"')`);
+			// Merged statically (not via render_expression); the server accumulator
+			// collapses the whole template — static + the `'a'`/`'x'` holes — into a
+			// single `__out +=`, mirroring the client output.
+			expect(code).toContain(`__out += '<span class="a">a</span><span class="x">x</span>'`);
 			expect(code).not.toContain('render_expression');
 		}
 	});

--- a/packages/tsrx/types/index.d.ts
+++ b/packages/tsrx/types/index.d.ts
@@ -296,6 +296,8 @@ declare module 'estree' {
 		TSAsExpression: TSAsExpression;
 	}
 
+	type TraversableAstNode = AST.Node & Record<string, unknown>;
+
 	// Ripple-normalized template node shapes. The core parser emits JSX-shaped
 	// TSRX nodes; @tsrx/ripple creates these during its normalization pass.
 	interface Attribute extends AST.BaseNode {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches the core server compile output for all templates; regressions would show as wrong HTML or hydration mismatches, though extensive fixture updates and the byte-identical goal mitigate that.
> 
> **Overview**
> **SSR codegen** no longer emits many per-fragment `output_push` calls. Each `regular_block` (and similar nested scopes) gets a `let __out = ''`, adjacent static markup and dynamic segments are merged into `__out += …`, and the buffer is pushed once at the end of the block.
> 
> Before **child components**, `render_component`, `render_expression`, `try_block`, or head target switches, the transform **flushes** accumulated `__out` via `output_push`, resets `__out`, then runs the nested work—so ordering and hydration boundaries stay the same while loops and `@for` bodies can stringify in one push.
> 
> The changeset states rendered HTML stays **byte-identical**; this is an assembly strategy change aimed at ~2× SSR throughput (fewer pushes / more string concat). The diff is mostly **regenerated** `packages/ripple/tests/hydration/compiled/server/*.js` snapshots reflecting the new shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21560e951542abb0ff67ef7ac6d724ffcf582762. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->