### PR TITLE
Avoid redundant iteration by using a generator function

### DIFF
--- a/website-tsrx/src/pages/features.tsrx
+++ b/website-tsrx/src/pages/features.tsrx
@@ -94,10 +94,16 @@ const IF_HTML = highlight_tsrx(
 
 const FOR_HTML = highlight_tsrx(
 	`function TodoList({ items }: { items: Todo[] }) @{
-  const visibleItems = items.filter((item) => !item.hidden);
+  const visibleItems = function* () {
+		for (const item of items) {
+			if (!item.hidden) {
+				yield item;
+			}
+		}
+	}
 
   <ul>
-    @for (const item of visibleItems; index i; key item.id) {
+    @for (const item of visibleItems(); index i; key item.id) {
       <li>{i + 1}. {item.text}</li>
     } @empty {
       <li>No todos yet</li>


### PR DESCRIPTION
The docs recommend iterating over the array in question twice—which can have huge performance implication if
1. The initial array is huge
2. The filtered array isn't significantly smaller

This might not apply to all arrays of course, but as these are the docs and this _might_ be the case, I would recommend documenting it in a performance-proof way by using a generator function.

Not sure if this is the proper approach or this should be a separate example below—please let me know if you want me to change this

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to an embedded code snippet; no runtime or compiler behavior is affected.
> 
> **Overview**
> Updates the **List rendering** code sample on the Features page so filtering no longer uses `items.filter(...)`.
> 
> The example now defines a **generator function** that yields only non-hidden items, and `@for` iterates with `visibleItems()` instead of a pre-built array. That aligns the docs with a single-pass iteration pattern when large lists are only lightly filtered, avoiding an extra full-array pass before rendering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5f7deb3255c66f101e669de9e1bf1b1ed21cbf1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->