### PR TITLE
fix: control flow hydration

### DIFF
--- a/.changeset/hydration-fragment-control-flow.md
+++ b/.changeset/hydration-fragment-control-flow.md
@@ -13,6 +13,8 @@ control-flow's start marker as its own and advanced the hydration cursor past
 that child's content, landing later operations on a comment node. The server
 transform now brackets such fragments with hydration block markers — matching
 every other control-flow block — when the fragment is a control-flow branch body
-(or nested in an element within one) or leads with control flow. Fragments that
-lead with an element/component are unchanged (they reuse their host boundary), so
-no extra comment nodes are emitted for the common cases.
+(or nested in an element within one) or leads with content that emits its own
+start marker: a control-flow directive or a `{ … }`/`@{ … }` expression lowered
+to `render_expression`. Fragments that lead with an element/component/plain text
+are unchanged (they reuse their host boundary), so no extra comment nodes are
+emitted for the common cases.

--- a/.changeset/hydration-fragment-control-flow.md
+++ b/.changeset/hydration-fragment-control-flow.md
@@ -1,0 +1,18 @@
+---
+'@tsrx/ripple': patch
+---
+
+Fix `HierarchyRequestError: Node can't be inserted in a #comment parent` during
+hydration of a `<>…</>` fragment that contains control flow — e.g. an `@if`
+(or `@for`/`@switch`/`@try`/`@else`) body, or a component body, whose fragment
+leads with an `@for`/`@if`. In template position the client lowers such a
+fragment to a `<!>` placeholder + `expression(() => tsrx_element(…))`, whose
+hydration needs a matching `<!--[-->`…`<!--]-->` boundary. The server inlined the
+fragment without one, so the client's `expression()` borrowed the first nested
+control-flow's start marker as its own and advanced the hydration cursor past
+that child's content, landing later operations on a comment node. The server
+transform now brackets such fragments with hydration block markers — matching
+every other control-flow block — when the fragment is a control-flow branch body
+(or nested in an element within one) or leads with control flow. Fragments that
+lead with an element/component are unchanged (they reuse their host boundary), so
+no extra comment nodes are emitted for the common cases.

--- a/packages/ripple/tests/hydration/compiled/client/if-fragment-controlflow.js
+++ b/packages/ripple/tests/hydration/compiled/client/if-fragment-controlflow.js
@@ -17,19 +17,22 @@ var root_10 = _$_.template(`<div class="feed-b"><!></div>`, 0);
 var root_15 = _$_.template(`<p class="muze"> </p>`, 0);
 var root_14 = _$_.template(`<!><span class="after">after</span>`, 1, 2);
 var root_13 = _$_.template(`<!>`, 1, 1);
-var root_18 = _$_.template(`<p class="muze"> </p>`, 0);
-var root_19 = _$_.template(`<!><span class="after">after</span>`, 1, 2);
-var root_17 = _$_.template(`<!>`, 1, 1);
-var root_16 = _$_.template(`<div class="feed-f"><!></div>`, 0);
-var root_21 = _$_.template(`<span class="loading">loading</span>`, 0);
-var root_24 = _$_.template(`<p class="muze"> </p>`, 0);
-var root_23 = _$_.template(`<!><span class="after">after</span>`, 1, 2);
-var root_22 = _$_.template(`<!>`, 1, 1);
-var root_20 = _$_.template(`<div class="feed-d"><!></div>`, 0);
-var root_28 = _$_.template(`<p class="muze"> </p>`, 0);
-var root_27 = _$_.template(`<!><span class="after">after</span>`, 1, 2);
-var root_26 = _$_.template(`<section><!></section>`, 0);
-var root_25 = _$_.template(`<div class="feed-e"><!></div>`, 0);
+var root_17 = _$_.template(`<p class="muze"> </p>`, 0);
+var root_18 = _$_.template(`<!><span class="after">after</span>`, 1, 2);
+var root_16 = _$_.template(`<!>`, 1, 1);
+var root_21 = _$_.template(`<p class="muze"> </p>`, 0);
+var root_22 = _$_.template(`<!><span class="after">after</span>`, 1, 2);
+var root_20 = _$_.template(`<!>`, 1, 1);
+var root_19 = _$_.template(`<div class="feed-f"><!></div>`, 0);
+var root_24 = _$_.template(`<span class="loading">loading</span>`, 0);
+var root_27 = _$_.template(`<p class="muze"> </p>`, 0);
+var root_26 = _$_.template(`<!><span class="after">after</span>`, 1, 2);
+var root_25 = _$_.template(`<!>`, 1, 1);
+var root_23 = _$_.template(`<div class="feed-d"><!></div>`, 0);
+var root_31 = _$_.template(`<p class="muze"> </p>`, 0);
+var root_30 = _$_.template(`<!><span class="after">after</span>`, 1, 2);
+var root_29 = _$_.template(`<section><!></section>`, 0);
+var root_28 = _$_.template(`<div class="feed-e"><!></div>`, 0);
 
 export function IfFragmentForElement() {
 	return _$_.tsrx_element((__anchor, __block) => {
@@ -239,54 +242,94 @@ export function ComponentBodyFragmentControlFlow() {
 	});
 }
 
+export function ComponentBodyCodeBlockControlFlow() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		const muzes = [{ muzeId: 'b' }, { muzeId: 'c' }];
+		var fragment_8 = root_16();
+		var node_12 = _$_.first_child_frag(fragment_8);
+
+		_$_.expression(node_12, () => _$_.tsrx_element((__anchor, __block) => {
+			var fragment_9 = root_18();
+			var expression_4 = _$_.first_child_frag(fragment_9);
+
+			_$_.expression(expression_4, () => _$_.tsrx_element((__anchor, __block) => {
+				const rows = muzes;
+
+				_$_.for_keyed(
+					__anchor,
+					() => rows,
+					(__anchor, pattern_3) => {
+						var p_4 = root_17();
+
+						{
+							var expression_3 = _$_.child(p_4);
+
+							_$_.expression(expression_3, () => _$_.get(pattern_3).muzeId);
+							_$_.pop(p_4);
+						}
+
+						_$_.append(__anchor, p_4);
+					},
+					16,
+					(pattern_3) => _$_.get(pattern_3).muzeId
+				);
+			}));
+
+			_$_.append(__anchor, fragment_9);
+		}));
+
+		_$_.append(__anchor, fragment_8);
+	});
+}
+
 export function IfCodeBlockControlFlow() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		const muzes = [{ muzeId: 'b' }, { muzeId: 'c' }];
 		const hasLoaded = true;
-		var div_4 = root_16();
+		var div_4 = root_19();
 
 		{
-			var node_12 = _$_.child(div_4);
+			var node_13 = _$_.child(div_4);
 
 			{
 				var consequent_5 = (__anchor) => {
-					var fragment_8 = root_17();
-					var node_13 = _$_.first_child_frag(fragment_8);
+					var fragment_10 = root_20();
+					var node_14 = _$_.first_child_frag(fragment_10);
 
-					_$_.expression(node_13, () => _$_.tsrx_element((__anchor, __block) => {
-						var fragment_9 = root_19();
-						var expression_4 = _$_.first_child_frag(fragment_9);
+					_$_.expression(node_14, () => _$_.tsrx_element((__anchor, __block) => {
+						var fragment_11 = root_22();
+						var expression_6 = _$_.first_child_frag(fragment_11);
 
-						_$_.expression(expression_4, () => _$_.tsrx_element((__anchor, __block) => {
+						_$_.expression(expression_6, () => _$_.tsrx_element((__anchor, __block) => {
 							const rows = muzes;
 
 							_$_.for_keyed(
 								__anchor,
 								() => rows,
-								(__anchor, pattern_3) => {
-									var p_4 = root_18();
+								(__anchor, pattern_4) => {
+									var p_5 = root_21();
 
 									{
-										var expression_3 = _$_.child(p_4);
+										var expression_5 = _$_.child(p_5);
 
-										_$_.expression(expression_3, () => _$_.get(pattern_3).muzeId);
-										_$_.pop(p_4);
+										_$_.expression(expression_5, () => _$_.get(pattern_4).muzeId);
+										_$_.pop(p_5);
 									}
 
-									_$_.append(__anchor, p_4);
+									_$_.append(__anchor, p_5);
 								},
 								16,
-								(pattern_3) => _$_.get(pattern_3).muzeId
+								(pattern_4) => _$_.get(pattern_4).muzeId
 							);
 						}));
 
-						_$_.append(__anchor, fragment_9);
+						_$_.append(__anchor, fragment_11);
 					}));
 
-					_$_.append(__anchor, fragment_8);
+					_$_.append(__anchor, fragment_10);
 				};
 
-				_$_.if(node_12, (__render) => {
+				_$_.if(node_13, (__render) => {
 					if (hasLoaded) __render(consequent_5);
 				});
 			}
@@ -302,52 +345,52 @@ export function IfElseFragment() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		const muzes = [{ muzeId: 'b' }, { muzeId: 'c' }];
 		const hasLoaded = false;
-		var div_5 = root_20();
+		var div_5 = root_23();
 
 		{
-			var node_14 = _$_.child(div_5);
+			var node_15 = _$_.child(div_5);
 
 			{
 				var consequent_6 = (__anchor) => {
-					var span_3 = root_21();
+					var span_3 = root_24();
 
 					_$_.append(__anchor, span_3);
 				};
 
 				var alternate = (__anchor) => {
-					var fragment_10 = root_22();
-					var node_16 = _$_.first_child_frag(fragment_10);
+					var fragment_12 = root_25();
+					var node_17 = _$_.first_child_frag(fragment_12);
 
-					_$_.expression(node_16, () => _$_.tsrx_element((__anchor, __block) => {
-						var fragment_11 = root_23();
-						var node_15 = _$_.first_child_frag(fragment_11);
+					_$_.expression(node_17, () => _$_.tsrx_element((__anchor, __block) => {
+						var fragment_13 = root_26();
+						var node_16 = _$_.first_child_frag(fragment_13);
 
 						_$_.for_keyed(
-							node_15,
+							node_16,
 							() => muzes,
-							(__anchor, pattern_4) => {
-								var p_5 = root_24();
+							(__anchor, pattern_5) => {
+								var p_6 = root_27();
 
 								{
-									var expression_5 = _$_.child(p_5);
+									var expression_7 = _$_.child(p_6);
 
-									_$_.expression(expression_5, () => _$_.get(pattern_4).muzeId);
-									_$_.pop(p_5);
+									_$_.expression(expression_7, () => _$_.get(pattern_5).muzeId);
+									_$_.pop(p_6);
 								}
 
-								_$_.append(__anchor, p_5);
+								_$_.append(__anchor, p_6);
 							},
 							0,
-							(pattern_4) => _$_.get(pattern_4).muzeId
+							(pattern_5) => _$_.get(pattern_5).muzeId
 						);
 
-						_$_.append(__anchor, fragment_11);
+						_$_.append(__anchor, fragment_13);
 					}));
 
-					_$_.append(__anchor, fragment_10);
+					_$_.append(__anchor, fragment_12);
 				};
 
-				_$_.if(node_14, (__render) => {
+				_$_.if(node_15, (__render) => {
 					if (hasLoaded) __render(consequent_6); else __render(alternate, false);
 				});
 			}
@@ -363,42 +406,42 @@ export function IfDivFragment() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		const muzes = [{ muzeId: 'b' }, { muzeId: 'c' }];
 		const hasLoaded = true;
-		var div_6 = root_25();
+		var div_6 = root_28();
 
 		{
-			var node_17 = _$_.child(div_6);
+			var node_18 = _$_.child(div_6);
 
 			{
 				var consequent_7 = (__anchor) => {
-					var section_1 = root_26();
+					var section_1 = root_29();
 
 					{
-						var node_19 = _$_.child(section_1);
+						var node_20 = _$_.child(section_1);
 
-						_$_.expression(node_19, () => _$_.tsrx_element((__anchor, __block) => {
-							var fragment_12 = root_27();
-							var node_18 = _$_.first_child_frag(fragment_12);
+						_$_.expression(node_20, () => _$_.tsrx_element((__anchor, __block) => {
+							var fragment_14 = root_30();
+							var node_19 = _$_.first_child_frag(fragment_14);
 
 							_$_.for_keyed(
-								node_18,
+								node_19,
 								() => muzes,
-								(__anchor, pattern_5) => {
-									var p_6 = root_28();
+								(__anchor, pattern_6) => {
+									var p_7 = root_31();
 
 									{
-										var expression_6 = _$_.child(p_6);
+										var expression_8 = _$_.child(p_7);
 
-										_$_.expression(expression_6, () => _$_.get(pattern_5).muzeId);
-										_$_.pop(p_6);
+										_$_.expression(expression_8, () => _$_.get(pattern_6).muzeId);
+										_$_.pop(p_7);
 									}
 
-									_$_.append(__anchor, p_6);
+									_$_.append(__anchor, p_7);
 								},
 								0,
-								(pattern_5) => _$_.get(pattern_5).muzeId
+								(pattern_6) => _$_.get(pattern_6).muzeId
 							);
 
-							_$_.append(__anchor, fragment_12);
+							_$_.append(__anchor, fragment_14);
 						}));
 
 						_$_.pop(section_1);
@@ -407,7 +450,7 @@ export function IfDivFragment() {
 					_$_.append(__anchor, section_1);
 				};
 
-				_$_.if(node_17, (__render) => {
+				_$_.if(node_18, (__render) => {
 					if (hasLoaded) __render(consequent_7);
 				});
 			}

--- a/packages/ripple/tests/hydration/compiled/client/if-fragment-controlflow.js
+++ b/packages/ripple/tests/hydration/compiled/client/if-fragment-controlflow.js
@@ -1,0 +1,420 @@
+// @ts-nocheck
+import * as _$_ from 'ripple/internal/client';
+
+var root_3 = _$_.template(`<p class="muze"> </p>`, 0);
+var root_2 = _$_.template(`<!><span class="after">after</span>`, 1, 2);
+var root_1 = _$_.template(`<!>`, 1, 1);
+var root = _$_.template(`<div class="feed-c"><!></div>`, 0);
+var root_7 = _$_.template(`<p class="muze"> </p>`, 0);
+var root_8 = _$_.template(`<span class="has-items">has items</span>`, 0);
+var root_9 = _$_.template(`<span class="empty">empty</span>`, 0);
+var root_6 = _$_.template(`<!><!><!>`, 1, 3);
+var root_5 = _$_.template(`<!>`, 1, 1);
+var root_4 = _$_.template(`<div class="feed"><!></div>`, 0);
+var root_12 = _$_.template(`<p class="muze">b</p><p class="muze">c</p>`, 1, 2);
+var root_11 = _$_.template(`<!>`, 1, 1);
+var root_10 = _$_.template(`<div class="feed-b"><!></div>`, 0);
+var root_15 = _$_.template(`<p class="muze"> </p>`, 0);
+var root_14 = _$_.template(`<!><span class="after">after</span>`, 1, 2);
+var root_13 = _$_.template(`<!>`, 1, 1);
+var root_18 = _$_.template(`<p class="muze"> </p>`, 0);
+var root_19 = _$_.template(`<!><span class="after">after</span>`, 1, 2);
+var root_17 = _$_.template(`<!>`, 1, 1);
+var root_16 = _$_.template(`<div class="feed-f"><!></div>`, 0);
+var root_21 = _$_.template(`<span class="loading">loading</span>`, 0);
+var root_24 = _$_.template(`<p class="muze"> </p>`, 0);
+var root_23 = _$_.template(`<!><span class="after">after</span>`, 1, 2);
+var root_22 = _$_.template(`<!>`, 1, 1);
+var root_20 = _$_.template(`<div class="feed-d"><!></div>`, 0);
+var root_28 = _$_.template(`<p class="muze"> </p>`, 0);
+var root_27 = _$_.template(`<!><span class="after">after</span>`, 1, 2);
+var root_26 = _$_.template(`<section><!></section>`, 0);
+var root_25 = _$_.template(`<div class="feed-e"><!></div>`, 0);
+
+export function IfFragmentForElement() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		const muzes = [{ muzeId: 'b' }, { muzeId: 'c' }];
+		const hasLoaded = true;
+		var div_1 = root();
+
+		{
+			var node = _$_.child(div_1);
+
+			{
+				var consequent = (__anchor) => {
+					var fragment = root_1();
+					var node_2 = _$_.first_child_frag(fragment);
+
+					_$_.expression(node_2, () => _$_.tsrx_element((__anchor, __block) => {
+						var fragment_1 = root_2();
+						var node_1 = _$_.first_child_frag(fragment_1);
+
+						_$_.for_keyed(
+							node_1,
+							() => muzes,
+							(__anchor, pattern) => {
+								var p_1 = root_3();
+
+								{
+									var expression = _$_.child(p_1);
+
+									_$_.expression(expression, () => _$_.get(pattern).muzeId);
+									_$_.pop(p_1);
+								}
+
+								_$_.append(__anchor, p_1);
+							},
+							0,
+							(pattern) => _$_.get(pattern).muzeId
+						);
+
+						_$_.append(__anchor, fragment_1);
+					}));
+
+					_$_.append(__anchor, fragment);
+				};
+
+				_$_.if(node, (__render) => {
+					if (hasLoaded) __render(consequent);
+				});
+			}
+
+			_$_.pop(div_1);
+		}
+
+		_$_.append(__anchor, div_1);
+	});
+}
+
+export function IfFragmentForIfIf() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		const muzes = [{ muzeId: 'b' }, { muzeId: 'c' }];
+		const hasLoaded = true;
+		var div_2 = root_4();
+
+		{
+			var node_3 = _$_.child(div_2);
+
+			{
+				var consequent_3 = (__anchor) => {
+					var fragment_2 = root_5();
+					var node_7 = _$_.first_child_frag(fragment_2);
+
+					_$_.expression(node_7, () => _$_.tsrx_element((__anchor, __block) => {
+						var fragment_3 = root_6();
+						var node_4 = _$_.first_child_frag(fragment_3);
+
+						_$_.for_keyed(
+							node_4,
+							() => muzes,
+							(__anchor, pattern_1) => {
+								var p_2 = root_7();
+
+								{
+									var expression_1 = _$_.child(p_2);
+
+									_$_.expression(expression_1, () => _$_.get(pattern_1).muzeId);
+									_$_.pop(p_2);
+								}
+
+								_$_.append(__anchor, p_2);
+							},
+							0,
+							(pattern_1) => _$_.get(pattern_1).muzeId
+						);
+
+						var node_5 = _$_.sibling(node_4);
+
+						{
+							var consequent_1 = (__anchor) => {
+								var span_1 = root_8();
+
+								_$_.append(__anchor, span_1);
+							};
+
+							_$_.if(node_5, (__render) => {
+								if (muzes.length > 0) __render(consequent_1);
+							});
+						}
+
+						var node_6 = _$_.sibling(node_5);
+
+						{
+							var consequent_2 = (__anchor) => {
+								var span_2 = root_9();
+
+								_$_.append(__anchor, span_2);
+							};
+
+							_$_.if(node_6, (__render) => {
+								if (muzes.length === 0) __render(consequent_2);
+							});
+						}
+
+						_$_.append(__anchor, fragment_3);
+					}));
+
+					_$_.append(__anchor, fragment_2);
+				};
+
+				_$_.if(node_3, (__render) => {
+					if (hasLoaded) __render(consequent_3);
+				});
+			}
+
+			_$_.pop(div_2);
+		}
+
+		_$_.append(__anchor, div_2);
+	});
+}
+
+export function IfFragmentElements() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		const hasLoaded = true;
+		var div_3 = root_10();
+
+		{
+			var node_8 = _$_.child(div_3);
+
+			{
+				var consequent_4 = (__anchor) => {
+					var fragment_4 = root_11();
+					var node_9 = _$_.first_child_frag(fragment_4);
+
+					_$_.expression(node_9, () => _$_.tsrx_element((__anchor, __block) => {
+						var fragment_5 = root_12();
+
+						_$_.append(__anchor, fragment_5);
+					}));
+
+					_$_.append(__anchor, fragment_4);
+				};
+
+				_$_.if(node_8, (__render) => {
+					if (hasLoaded) __render(consequent_4);
+				});
+			}
+
+			_$_.pop(div_3);
+		}
+
+		_$_.append(__anchor, div_3);
+	});
+}
+
+export function ComponentBodyFragmentControlFlow() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		const muzes = [{ muzeId: 'b' }, { muzeId: 'c' }];
+		var fragment_6 = root_13();
+		var node_11 = _$_.first_child_frag(fragment_6);
+
+		_$_.expression(node_11, () => _$_.tsrx_element((__anchor, __block) => {
+			var fragment_7 = root_14();
+			var node_10 = _$_.first_child_frag(fragment_7);
+
+			_$_.for_keyed(
+				node_10,
+				() => muzes,
+				(__anchor, pattern_2) => {
+					var p_3 = root_15();
+
+					{
+						var expression_2 = _$_.child(p_3);
+
+						_$_.expression(expression_2, () => _$_.get(pattern_2).muzeId);
+						_$_.pop(p_3);
+					}
+
+					_$_.append(__anchor, p_3);
+				},
+				0,
+				(pattern_2) => _$_.get(pattern_2).muzeId
+			);
+
+			_$_.append(__anchor, fragment_7);
+		}));
+
+		_$_.append(__anchor, fragment_6);
+	});
+}
+
+export function IfCodeBlockControlFlow() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		const muzes = [{ muzeId: 'b' }, { muzeId: 'c' }];
+		const hasLoaded = true;
+		var div_4 = root_16();
+
+		{
+			var node_12 = _$_.child(div_4);
+
+			{
+				var consequent_5 = (__anchor) => {
+					var fragment_8 = root_17();
+					var node_13 = _$_.first_child_frag(fragment_8);
+
+					_$_.expression(node_13, () => _$_.tsrx_element((__anchor, __block) => {
+						var fragment_9 = root_19();
+						var expression_4 = _$_.first_child_frag(fragment_9);
+
+						_$_.expression(expression_4, () => _$_.tsrx_element((__anchor, __block) => {
+							const rows = muzes;
+
+							_$_.for_keyed(
+								__anchor,
+								() => rows,
+								(__anchor, pattern_3) => {
+									var p_4 = root_18();
+
+									{
+										var expression_3 = _$_.child(p_4);
+
+										_$_.expression(expression_3, () => _$_.get(pattern_3).muzeId);
+										_$_.pop(p_4);
+									}
+
+									_$_.append(__anchor, p_4);
+								},
+								16,
+								(pattern_3) => _$_.get(pattern_3).muzeId
+							);
+						}));
+
+						_$_.append(__anchor, fragment_9);
+					}));
+
+					_$_.append(__anchor, fragment_8);
+				};
+
+				_$_.if(node_12, (__render) => {
+					if (hasLoaded) __render(consequent_5);
+				});
+			}
+
+			_$_.pop(div_4);
+		}
+
+		_$_.append(__anchor, div_4);
+	});
+}
+
+export function IfElseFragment() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		const muzes = [{ muzeId: 'b' }, { muzeId: 'c' }];
+		const hasLoaded = false;
+		var div_5 = root_20();
+
+		{
+			var node_14 = _$_.child(div_5);
+
+			{
+				var consequent_6 = (__anchor) => {
+					var span_3 = root_21();
+
+					_$_.append(__anchor, span_3);
+				};
+
+				var alternate = (__anchor) => {
+					var fragment_10 = root_22();
+					var node_16 = _$_.first_child_frag(fragment_10);
+
+					_$_.expression(node_16, () => _$_.tsrx_element((__anchor, __block) => {
+						var fragment_11 = root_23();
+						var node_15 = _$_.first_child_frag(fragment_11);
+
+						_$_.for_keyed(
+							node_15,
+							() => muzes,
+							(__anchor, pattern_4) => {
+								var p_5 = root_24();
+
+								{
+									var expression_5 = _$_.child(p_5);
+
+									_$_.expression(expression_5, () => _$_.get(pattern_4).muzeId);
+									_$_.pop(p_5);
+								}
+
+								_$_.append(__anchor, p_5);
+							},
+							0,
+							(pattern_4) => _$_.get(pattern_4).muzeId
+						);
+
+						_$_.append(__anchor, fragment_11);
+					}));
+
+					_$_.append(__anchor, fragment_10);
+				};
+
+				_$_.if(node_14, (__render) => {
+					if (hasLoaded) __render(consequent_6); else __render(alternate, false);
+				});
+			}
+
+			_$_.pop(div_5);
+		}
+
+		_$_.append(__anchor, div_5);
+	});
+}
+
+export function IfDivFragment() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		const muzes = [{ muzeId: 'b' }, { muzeId: 'c' }];
+		const hasLoaded = true;
+		var div_6 = root_25();
+
+		{
+			var node_17 = _$_.child(div_6);
+
+			{
+				var consequent_7 = (__anchor) => {
+					var section_1 = root_26();
+
+					{
+						var node_19 = _$_.child(section_1);
+
+						_$_.expression(node_19, () => _$_.tsrx_element((__anchor, __block) => {
+							var fragment_12 = root_27();
+							var node_18 = _$_.first_child_frag(fragment_12);
+
+							_$_.for_keyed(
+								node_18,
+								() => muzes,
+								(__anchor, pattern_5) => {
+									var p_6 = root_28();
+
+									{
+										var expression_6 = _$_.child(p_6);
+
+										_$_.expression(expression_6, () => _$_.get(pattern_5).muzeId);
+										_$_.pop(p_6);
+									}
+
+									_$_.append(__anchor, p_6);
+								},
+								0,
+								(pattern_5) => _$_.get(pattern_5).muzeId
+							);
+
+							_$_.append(__anchor, fragment_12);
+						}));
+
+						_$_.pop(section_1);
+					}
+
+					_$_.append(__anchor, section_1);
+				};
+
+				_$_.if(node_17, (__render) => {
+					if (hasLoaded) __render(consequent_7);
+				});
+			}
+
+			_$_.pop(div_6);
+		}
+
+		_$_.append(__anchor, div_6);
+	});
+}

--- a/packages/ripple/tests/hydration/compiled/server/basic.js
+++ b/packages/ripple/tests/hydration/compiled/server/basic.js
@@ -544,9 +544,18 @@ export function NestedTsrxInsideTopLevelTsxExpression() {
 		});
 
 		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<!--[-->';
+
 			{
+				_$_.output_push(__out);
+				__out = '';
 				_$_.render_expression(content);
 			}
+
+			__out += '<!--]-->';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -563,9 +572,18 @@ export function NestedTsrxElementsInsideTopLevelTsxValue() {
 		});
 
 		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<!--[-->';
+
 			{
+				_$_.output_push(__out);
+				__out = '';
 				_$_.render_expression(content);
 			}
+
+			__out += '<!--]-->';
+			_$_.output_push(__out);
 		});
 	});
 }
@@ -599,9 +617,18 @@ export function TsxDeclaredBeforeTopLevelTsx() {
 		});
 
 		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<!--[-->';
+
 			{
+				_$_.output_push(__out);
+				__out = '';
 				_$_.render_expression(content);
 			}
+
+			__out += '<!--]-->';
+			_$_.output_push(__out);
 		});
 	});
 }

--- a/packages/ripple/tests/hydration/compiled/server/if-fragment-controlflow.js
+++ b/packages/ripple/tests/hydration/compiled/server/if-fragment-controlflow.js
@@ -103,6 +103,37 @@ export function ComponentBodyFragmentControlFlow() {
 	});
 }
 
+export function ComponentBodyCodeBlockControlFlow() {
+	return _$_.tsrx_element(() => {
+		const muzes = [{ muzeId: 'b' }, { muzeId: 'c' }];
+
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<!--[-->';
+			_$_.output_push(__out);
+			__out = '';
+
+			_$_.render_expression(_$_.tsrx_element(() => {
+				let __out = '';
+				const rows = muzes;
+
+				__out += '<!--[-->';
+
+				for (const muze of rows) {
+					__out += '<p class="muze">' + _$_.escape(muze.muzeId) + '</p>';
+				}
+
+				__out += '<!--]-->';
+				_$_.output_push(__out);
+			}));
+
+			__out += '<span class="after">after</span><!--]-->';
+			_$_.output_push(__out);
+		});
+	});
+}
+
 export function IfCodeBlockControlFlow() {
 	return _$_.tsrx_element(() => {
 		const muzes = [{ muzeId: 'b' }, { muzeId: 'c' }];

--- a/packages/ripple/tests/hydration/compiled/server/if-fragment-controlflow.js
+++ b/packages/ripple/tests/hydration/compiled/server/if-fragment-controlflow.js
@@ -1,0 +1,196 @@
+// @ts-nocheck
+import * as _$_ from 'ripple/internal/server';
+
+export function IfFragmentForElement() {
+	return _$_.tsrx_element(() => {
+		const muzes = [{ muzeId: 'b' }, { muzeId: 'c' }];
+		const hasLoaded = true;
+
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<div class="feed-c"><!--[-->';
+
+			if (hasLoaded) {
+				__out += '<!--[--><!--[-->';
+
+				for (const muze of muzes) {
+					__out += '<p class="muze">' + _$_.escape(muze.muzeId) + '</p>';
+				}
+
+				__out += '<!--]--><span class="after">after</span><!--]-->';
+			}
+
+			__out += '<!--]--></div>';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function IfFragmentForIfIf() {
+	return _$_.tsrx_element(() => {
+		const muzes = [{ muzeId: 'b' }, { muzeId: 'c' }];
+		const hasLoaded = true;
+
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<div class="feed"><!--[-->';
+
+			if (hasLoaded) {
+				__out += '<!--[--><!--[-->';
+
+				for (const muze of muzes) {
+					__out += '<p class="muze">' + _$_.escape(muze.muzeId) + '</p>';
+				}
+
+				__out += '<!--]--><!--[-->';
+
+				if (muzes.length > 0) {
+					__out += '<span class="has-items">has items</span>';
+				}
+
+				__out += '<!--]--><!--[-->';
+
+				if (muzes.length === 0) {
+					__out += '<span class="empty">empty</span>';
+				}
+
+				__out += '<!--]--><!--]-->';
+			}
+
+			__out += '<!--]--></div>';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function IfFragmentElements() {
+	return _$_.tsrx_element(() => {
+		const hasLoaded = true;
+
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<div class="feed-b"><!--[-->';
+
+			if (hasLoaded) {
+				__out += '<!--[--><p class="muze">b</p><p class="muze">c</p><!--]-->';
+			}
+
+			__out += '<!--]--></div>';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function ComponentBodyFragmentControlFlow() {
+	return _$_.tsrx_element(() => {
+		const muzes = [{ muzeId: 'b' }, { muzeId: 'c' }];
+
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<!--[--><!--[-->';
+
+			for (const muze of muzes) {
+				__out += '<p class="muze">' + _$_.escape(muze.muzeId) + '</p>';
+			}
+
+			__out += '<!--]--><span class="after">after</span><!--]-->';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function IfCodeBlockControlFlow() {
+	return _$_.tsrx_element(() => {
+		const muzes = [{ muzeId: 'b' }, { muzeId: 'c' }];
+		const hasLoaded = true;
+
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<div class="feed-f"><!--[-->';
+
+			if (hasLoaded) {
+				__out += '<!--[-->';
+				_$_.output_push(__out);
+				__out = '';
+
+				_$_.render_expression(_$_.tsrx_element(() => {
+					let __out = '';
+					const rows = muzes;
+
+					__out += '<!--[-->';
+
+					for (const muze of rows) {
+						__out += '<p class="muze">' + _$_.escape(muze.muzeId) + '</p>';
+					}
+
+					__out += '<!--]-->';
+					_$_.output_push(__out);
+				}));
+
+				__out += '<span class="after">after</span><!--]-->';
+			}
+
+			__out += '<!--]--></div>';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function IfElseFragment() {
+	return _$_.tsrx_element(() => {
+		const muzes = [{ muzeId: 'b' }, { muzeId: 'c' }];
+		const hasLoaded = false;
+
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<div class="feed-d"><!--[-->';
+
+			if (hasLoaded) {
+				__out += '<span class="loading">loading</span>';
+			} else {
+				__out += '<!--[--><!--[-->';
+
+				for (const muze of muzes) {
+					__out += '<p class="muze">' + _$_.escape(muze.muzeId) + '</p>';
+				}
+
+				__out += '<!--]--><span class="after">after</span><!--]-->';
+			}
+
+			__out += '<!--]--></div>';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function IfDivFragment() {
+	return _$_.tsrx_element(() => {
+		const muzes = [{ muzeId: 'b' }, { muzeId: 'c' }];
+		const hasLoaded = true;
+
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<div class="feed-e"><!--[-->';
+
+			if (hasLoaded) {
+				__out += '<section><!--[--><!--[-->';
+
+				for (const muze of muzes) {
+					__out += '<p class="muze">' + _$_.escape(muze.muzeId) + '</p>';
+				}
+
+				__out += '<!--]--><span class="after">after</span><!--]--></section>';
+			}
+
+			__out += '<!--]--></div>';
+			_$_.output_push(__out);
+		});
+	});
+}

--- a/packages/ripple/tests/hydration/components/if-fragment-controlflow.tsrx
+++ b/packages/ripple/tests/hydration/components/if-fragment-controlflow.tsrx
@@ -1,0 +1,128 @@
+// Hydration repro: an @if body whose only child is a fragment containing
+// control-flow siblings (@for / @if). The fragment is lowered to a nested
+// tsrx_element rendered via an expression container, which introduces client
+// placeholder `<!>` nodes that the SSR markup has no dedicated marker for — so
+// the hydration cursor must still line up with the server's control-flow
+// boundary comments.
+
+// @for + trailing element sibling inside the fragment.
+export function IfFragmentForElement() @{
+	const muzes = [{ muzeId: 'b' }, { muzeId: 'c' }];
+	const hasLoaded = true;
+	<div class="feed-c">
+		@if (hasLoaded) {
+			<>
+				@for (const muze of muzes; key muze.muzeId) {
+					<p class="muze">{muze.muzeId}</p>
+				}
+				<span class="after">{'after'}</span>
+			</>
+		}
+	</div>
+}
+
+// @for + @if + @if siblings inside the fragment (the originally reported shape).
+export function IfFragmentForIfIf() @{
+	const muzes = [{ muzeId: 'b' }, { muzeId: 'c' }];
+	const hasLoaded = true;
+	<div class="feed">
+		@if (hasLoaded) {
+			<>
+				@for (const muze of muzes; key muze.muzeId) {
+					<p class="muze">{muze.muzeId}</p>
+				}
+				@if (muzes.length > 0) {
+					<span class="has-items">{'has items'}</span>
+				}
+				@if (muzes.length === 0) {
+					<span class="empty">{'empty'}</span>
+				}
+			</>
+		}
+	</div>
+}
+
+// Control variant that already worked: fragment of plain elements (no control
+// flow). Guards against a regression in the simple case.
+export function IfFragmentElements() @{
+	const hasLoaded = true;
+	<div class="feed-b">
+		@if (hasLoaded) {
+			<>
+				<p class="muze">{'b'}</p>
+				<p class="muze">{'c'}</p>
+			</>
+		}
+	</div>
+}
+
+// Regression guard: a COMPONENT-body fragment containing control flow must keep
+// working WITHOUT an extra block marker — it reuses the component's own
+// boundary, so the control_flow_branch_body marker must NOT be emitted here.
+export function ComponentBodyFragmentControlFlow() @{
+	const muzes = [{ muzeId: 'b' }, { muzeId: 'c' }];
+	<>
+		@for (const muze of muzes; key muze.muzeId) {
+			<p class="muze">{muze.muzeId}</p>
+		}
+		<span class="after">{'after'}</span>
+	</>
+}
+
+// @if branch fragment whose first child is a `@{}` code block that renders
+// control flow. The fragment is a control-flow branch body, so it is bracketed
+// via the control_flow_branch_body flag.
+export function IfCodeBlockControlFlow() @{
+	const muzes = [{ muzeId: 'b' }, { muzeId: 'c' }];
+	const hasLoaded = true;
+	<div class="feed-f">
+		@if (hasLoaded) {
+			<>
+				@{
+					const rows = muzes;
+					@for (const muze of rows; key muze.muzeId) {
+						<p class="muze">{muze.muzeId}</p>
+					}
+				}
+				<span class="after">{'after'}</span>
+			</>
+		}
+	</div>
+}
+
+// @else branch whose body is a fragment of control-flow siblings.
+export function IfElseFragment() @{
+	const muzes = [{ muzeId: 'b' }, { muzeId: 'c' }];
+	const hasLoaded = false;
+	<div class="feed-d">
+		@if (hasLoaded) {
+			<span class="loading">{'loading'}</span>
+		} @else {
+			<>
+				@for (const muze of muzes; key muze.muzeId) {
+					<p class="muze">{muze.muzeId}</p>
+				}
+				<span class="after">{'after'}</span>
+			</>
+		}
+	</div>
+}
+
+// Fragment-in-element nested inside a control-flow branch: the inner `<>` is a
+// child of <section>, not the direct branch body.
+export function IfDivFragment() @{
+	const muzes = [{ muzeId: 'b' }, { muzeId: 'c' }];
+	const hasLoaded = true;
+	<div class="feed-e">
+		@if (hasLoaded) {
+			<section>
+				<>
+					@for (const muze of muzes; key muze.muzeId) {
+						<p class="muze">{muze.muzeId}</p>
+					}
+					<span class="after">{'after'}</span>
+				</>
+			</section>
+		}
+	</div>
+}

--- a/packages/ripple/tests/hydration/components/if-fragment-controlflow.tsrx
+++ b/packages/ripple/tests/hydration/components/if-fragment-controlflow.tsrx
@@ -69,6 +69,23 @@ export function ComponentBodyFragmentControlFlow() @{
 	</>
 }
 
+// Component-body fragment whose first child is a `@{}` code block that renders
+// control flow. The code block lowers to a render_expression(tsrx_element) on
+// the client and emits its own SSR marker; hydration must keep the code block's
+// boundary aligned.
+export function ComponentBodyCodeBlockControlFlow() @{
+	const muzes = [{ muzeId: 'b' }, { muzeId: 'c' }];
+	<>
+		@{
+			const rows = muzes;
+			@for (const muze of rows; key muze.muzeId) {
+				<p class="muze">{muze.muzeId}</p>
+			}
+		}
+		<span class="after">{'after'}</span>
+	</>
+}
+
 // @if branch fragment whose first child is a `@{}` code block that renders
 // control flow. The fragment is a control-flow branch body, so it is bracketed
 // via the control_flow_branch_body flag.

--- a/packages/ripple/tests/hydration/if-fragment-controlflow.test.js
+++ b/packages/ripple/tests/hydration/if-fragment-controlflow.test.js
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { hydrateComponent, container } from '../setup-hydration.js';
+
+import * as ServerComponents from './compiled/server/if-fragment-controlflow.js';
+import * as ClientComponents from './compiled/client/if-fragment-controlflow.js';
+
+describe('hydration > @if body is a fragment of control-flow siblings', () => {
+	it('hydrates @for + element sibling', async () => {
+		await hydrateComponent(
+			ServerComponents.IfFragmentForElement,
+			ClientComponents.IfFragmentForElement,
+		);
+		expect(Array.from(container.querySelectorAll('.muze')).map((n) => n.textContent)).toEqual([
+			'b',
+			'c',
+		]);
+		expect(container.querySelector('.after')).not.toBeNull();
+	});
+
+	it('hydrates @for + @if + @if siblings', async () => {
+		await hydrateComponent(ServerComponents.IfFragmentForIfIf, ClientComponents.IfFragmentForIfIf);
+		expect(Array.from(container.querySelectorAll('.muze')).map((n) => n.textContent)).toEqual([
+			'b',
+			'c',
+		]);
+		expect(container.querySelector('.has-items')).not.toBeNull();
+		expect(container.querySelector('.empty')).toBeNull();
+	});
+
+	it('hydrates a fragment of plain elements (control)', async () => {
+		await hydrateComponent(
+			ServerComponents.IfFragmentElements,
+			ClientComponents.IfFragmentElements,
+		);
+		expect(Array.from(container.querySelectorAll('.muze')).map((n) => n.textContent)).toEqual([
+			'b',
+			'c',
+		]);
+	});
+
+	it('hydrates a component-body fragment with control flow (no extra marker)', async () => {
+		await hydrateComponent(
+			ServerComponents.ComponentBodyFragmentControlFlow,
+			ClientComponents.ComponentBodyFragmentControlFlow,
+		);
+		expect(Array.from(container.querySelectorAll('.muze')).map((n) => n.textContent)).toEqual([
+			'b',
+			'c',
+		]);
+		expect(container.querySelector('.after')).not.toBeNull();
+	});
+
+	it('hydrates an @if branch fragment leading with a @{} code block of control flow', async () => {
+		await hydrateComponent(
+			ServerComponents.IfCodeBlockControlFlow,
+			ClientComponents.IfCodeBlockControlFlow,
+		);
+		expect(Array.from(container.querySelectorAll('.muze')).map((n) => n.textContent)).toEqual([
+			'b',
+			'c',
+		]);
+		expect(container.querySelector('.after')).not.toBeNull();
+	});
+
+	it('hydrates an @else branch fragment of control-flow siblings', async () => {
+		await hydrateComponent(ServerComponents.IfElseFragment, ClientComponents.IfElseFragment);
+		expect(Array.from(container.querySelectorAll('.muze')).map((n) => n.textContent)).toEqual([
+			'b',
+			'c',
+		]);
+		expect(container.querySelector('.after')).not.toBeNull();
+		expect(container.querySelector('.loading')).toBeNull();
+	});
+
+	it('hydrates a fragment-in-element nested in a control-flow branch', async () => {
+		await hydrateComponent(ServerComponents.IfDivFragment, ClientComponents.IfDivFragment);
+		expect(Array.from(container.querySelectorAll('.muze')).map((n) => n.textContent)).toEqual([
+			'b',
+			'c',
+		]);
+		expect(container.querySelector('.after')).not.toBeNull();
+	});
+});

--- a/packages/ripple/tests/hydration/if-fragment-controlflow.test.js
+++ b/packages/ripple/tests/hydration/if-fragment-controlflow.test.js
@@ -50,6 +50,18 @@ describe('hydration > @if body is a fragment of control-flow siblings', () => {
 		expect(container.querySelector('.after')).not.toBeNull();
 	});
 
+	it('hydrates a component-body fragment leading with a @{} code block of control flow', async () => {
+		await hydrateComponent(
+			ServerComponents.ComponentBodyCodeBlockControlFlow,
+			ClientComponents.ComponentBodyCodeBlockControlFlow,
+		);
+		expect(Array.from(container.querySelectorAll('.muze')).map((n) => n.textContent)).toEqual([
+			'b',
+			'c',
+		]);
+		expect(container.querySelector('.after')).not.toBeNull();
+	});
+
 	it('hydrates an @if branch fragment leading with a @{} code block of control flow', async () => {
 		await hydrateComponent(
 			ServerComponents.IfCodeBlockControlFlow,

--- a/packages/tsrx-ripple/src/transform/server/index.js
+++ b/packages/tsrx-ripple/src/transform/server/index.js
@@ -750,6 +750,65 @@ function is_template_or_control_flow(node) {
 }
 
 /**
+ * Classify a single node for {@link fragment_leads_with_control_flow}:
+ *   - `true`  — it renders leading with a TSRX control-flow directive
+ *               (`@if`/`@for`/`@switch`/`@try`), which emits its own `<!--[-->`
+ *               start marker during SSR;
+ *   - `false` — it renders leading with an element/component/text (real DOM that
+ *               the fragment reuses / adopts, no borrowable marker);
+ *   - `null`  — it produces no leading DOM (plain JS setup, a code-only `@{}`
+ *               block, an empty fragment) — keep scanning subsequent siblings.
+ * Only TSRX directives count; a regular JS `if`/`for`/`switch`/`try` (marked
+ * `metadata.regular_js`) is setup, renders nothing, and is skipped.
+ * @param {AST.Node} node
+ * @returns {boolean | null}
+ */
+function node_leads_with_control_flow(node) {
+	switch (node.type) {
+		case 'IfStatement':
+		case 'ForOfStatement':
+		case 'SwitchStatement':
+		case 'TryStatement':
+			return node.metadata?.regular_js ? null : true;
+		case 'Element':
+		case 'Text':
+		case 'TSRXExpression':
+			return false;
+		case 'TsrxFragment':
+			return fragment_leads_with_control_flow(
+				node.children.filter((c) => c != null && c.type !== 'EmptyStatement'),
+			);
+		case 'JSXCodeBlock':
+			// A `@{ … }` block renders only its `render` output (the body is setup);
+			// a code-only block (no render) contributes no DOM.
+			return node.render != null ? node_leads_with_control_flow(node.render) : null;
+		default:
+			// Non-renderable setup statement — keep scanning for the first node.
+			return null;
+	}
+}
+
+/**
+ * Whether a template fragment's first renderable child is a TSRX control-flow
+ * directive. Such a child emits its own `<!--[-->` start marker during SSR,
+ * which the client's fragment `expression()` would otherwise mistake for the
+ * fragment's own boundary — so the fragment must be bracketed with its own
+ * hydration markers. A fragment leading with an element/component/text reuses its
+ * host boundary (or adopts real nodes) and must not be bracketed.
+ * @param {AST.Node[]} children
+ * @returns {boolean}
+ */
+function fragment_leads_with_control_flow(children) {
+	for (const child of children) {
+		const result = node_leads_with_control_flow(child);
+		if (result !== null) {
+			return result;
+		}
+	}
+	return false;
+}
+
+/**
  * @param {AST.Node[]} path
  * @returns {boolean}
  */
@@ -2255,7 +2314,11 @@ const visitors = {
 				const consequent = b.block(
 					transform_body(flattened_consequent, {
 						...context,
-						state: { ...context.state, scope: consequent_scope },
+						state: {
+							...context.state,
+							scope: consequent_scope,
+							control_flow_branch_body: true,
+						},
 					}),
 				);
 				case_body.push(...consequent.body);
@@ -2316,7 +2379,11 @@ const visitors = {
 
 		const body = transform_body(/** @type {AST.BlockStatement} */ (node.body).body, {
 			...context,
-			state: { ...context.state, scope: /** @type {ScopeInterface} */ (body_scope) },
+			state: {
+				...context.state,
+				scope: /** @type {ScopeInterface} */ (body_scope),
+				control_flow_branch_body: true,
+			},
 		});
 		const empty_id = node.empty ? b.id(context.state.scope.generate('for_empty')) : null;
 
@@ -2395,6 +2462,7 @@ const visitors = {
 				state: {
 					...context.state,
 					scope: /** @type {ScopeInterface} */ (consequent_scope),
+					control_flow_branch_body: true,
 				},
 			}),
 		);
@@ -2415,7 +2483,11 @@ const visitors = {
 			alternate = b.block(
 				transform_body(alternate_body_nodes, {
 					...context,
-					state: { ...context.state, scope: alternate_scope },
+					state: {
+						...context.state,
+						scope: alternate_scope,
+						control_flow_branch_body: node.alternate.type !== 'IfStatement',
+					},
 				}),
 			);
 		}
@@ -2755,13 +2827,38 @@ const visitors = {
 					init,
 					regular_js: false,
 					jsx_to_tsrx_element: true,
+					// The fragment's own children are no longer the direct body of the
+					// enclosing control-flow branch, so they must not inherit the marker.
+					control_flow_branch_body: false,
 				},
 			}),
 		);
 
 		if (state.template_child) {
-			// Template body: push children statements inline
-			if (init.length > 0) {
+			// In template position the client lowers `<>…</>` to a `<!>` placeholder +
+			// `_$_.expression(() => _$_.tsrx_element(…))`. During hydration that
+			// expression() needs a matching `<!--[-->`…`<!--]-->` boundary whenever it
+			// would otherwise borrow a nested control-flow's start marker as its own and
+			// advance the cursor past that child's content (desyncing hydration). That
+			// happens in two situations:
+			//   - the fragment is the direct body of a control-flow branch (or nested in
+			//     an element within one): the enclosing block already consumed its own
+			//     marker via hydrate_next before the branch body runs, leaving none for
+			//     the fragment — `control_flow_branch_body`;
+			//   - the fragment leads with control flow (e.g. a component body
+			//     `<> @for … </>`): its first child's marker would be mistaken for the
+			//     fragment's own.
+			// A fragment that leads with a component/element instead reuses its host
+			// boundary (or adopts real nodes) and must NOT be bracketed, or the extra
+			// markers desync the static-cursor (`next()` + skip_advance) client path.
+			const needs_boundary =
+				state.control_flow_branch_body || fragment_leads_with_control_flow(children);
+			if (needs_boundary && init.length > 0) {
+				state.init?.push(b.stmt(b.call(b.id('_$_.output_push'), b.literal(BLOCK_OPEN))));
+				state.init?.push(b.block(init));
+				state.init?.push(b.stmt(b.call(b.id('_$_.output_push'), b.literal(BLOCK_CLOSE))));
+			} else if (init.length > 0) {
+				// Template body: push children statements inline
 				state.init?.push(b.block(init));
 			}
 		} else {

--- a/packages/tsrx-ripple/src/transform/server/index.js
+++ b/packages/tsrx-ripple/src/transform/server/index.js
@@ -750,10 +750,40 @@ function is_template_or_control_flow(node) {
 }
 
 /**
+ * Whether a `{ … }` expression child is lowered to `_$_.render_expression(…)`,
+ * which (unlike `render_tsrx_element` or plain text output) brackets its output
+ * in a `<!--[-->`…`<!--]-->` hydration boundary. Mirrors the routing in the
+ * `TSRXExpression` server visitor. A `@{ … }` block in template position reaches
+ * here as a `TSRXExpression` wrapping its IIFE call.
+ * @param {AST.TSRXExpression} node
+ * @param {TransformServerContext} context
+ * @returns {boolean}
+ */
+function tsrx_expression_emits_marker(node, context) {
+	const expression = /** @type {AST.Expression} */ (node.expression);
+	if (expression.type === 'Literal') {
+		return false;
+	}
+	if (is_static_native_tsrx_function_call(expression, context)) {
+		return false;
+	}
+	const scope = context.state.scope;
+	return (
+		is_children_template_expression(expression, scope) ||
+		contains_template_value_node(/** @type {AST.Node} */ (expression)) ||
+		is_template_value_call(expression, scope) ||
+		is_template_value_binding(expression, scope) ||
+		is_collection_value_expression(expression, scope, context) ||
+		expression_contains_call(expression)
+	);
+}
+
+/**
  * Classify a single node for {@link fragment_leads_with_control_flow}:
- *   - `true`  — it renders leading with a TSRX control-flow directive
- *               (`@if`/`@for`/`@switch`/`@try`), which emits its own `<!--[-->`
- *               start marker during SSR;
+ *   - `true`  — it renders leading with content that emits its own `<!--[-->`
+ *               start marker during SSR: a TSRX control-flow directive
+ *               (`@if`/`@for`/`@switch`/`@try`) or a `{ … }`/`@{ … }` expression
+ *               lowered to `render_expression`;
  *   - `false` — it renders leading with an element/component/text (real DOM that
  *               the fragment reuses / adopts, no borrowable marker);
  *   - `null`  — it produces no leading DOM (plain JS setup, a code-only `@{}`
@@ -761,9 +791,10 @@ function is_template_or_control_flow(node) {
  * Only TSRX directives count; a regular JS `if`/`for`/`switch`/`try` (marked
  * `metadata.regular_js`) is setup, renders nothing, and is skipped.
  * @param {AST.Node} node
+ * @param {TransformServerContext} context
  * @returns {boolean | null}
  */
-function node_leads_with_control_flow(node) {
+function node_leads_with_control_flow(node, context) {
 	switch (node.type) {
 		case 'IfStatement':
 		case 'ForOfStatement':
@@ -772,16 +803,18 @@ function node_leads_with_control_flow(node) {
 			return node.metadata?.regular_js ? null : true;
 		case 'Element':
 		case 'Text':
-		case 'TSRXExpression':
 			return false;
+		case 'TSRXExpression':
+			return tsrx_expression_emits_marker(/** @type {AST.TSRXExpression} */ (node), context);
 		case 'TsrxFragment':
 			return fragment_leads_with_control_flow(
 				node.children.filter((c) => c != null && c.type !== 'EmptyStatement'),
+				context,
 			);
 		case 'JSXCodeBlock':
 			// A `@{ … }` block renders only its `render` output (the body is setup);
 			// a code-only block (no render) contributes no DOM.
-			return node.render != null ? node_leads_with_control_flow(node.render) : null;
+			return node.render != null ? node_leads_with_control_flow(node.render, context) : null;
 		default:
 			// Non-renderable setup statement — keep scanning for the first node.
 			return null;
@@ -789,18 +822,20 @@ function node_leads_with_control_flow(node) {
 }
 
 /**
- * Whether a template fragment's first renderable child is a TSRX control-flow
- * directive. Such a child emits its own `<!--[-->` start marker during SSR,
- * which the client's fragment `expression()` would otherwise mistake for the
- * fragment's own boundary — so the fragment must be bracketed with its own
- * hydration markers. A fragment leading with an element/component/text reuses its
- * host boundary (or adopts real nodes) and must not be bracketed.
+ * Whether a template fragment's first renderable child emits its own `<!--[-->`
+ * start marker during SSR (a TSRX control-flow directive or a `render_expression`
+ * child such as a `@{ … }` block). The client's fragment `expression()` would
+ * otherwise mistake that child's marker for the fragment's own boundary — so the
+ * fragment must be bracketed with its own hydration markers. A fragment leading
+ * with an element/component/text reuses its host boundary (or adopts real nodes)
+ * and must not be bracketed.
  * @param {AST.Node[]} children
+ * @param {TransformServerContext} context
  * @returns {boolean}
  */
-function fragment_leads_with_control_flow(children) {
+function fragment_leads_with_control_flow(children, context) {
 	for (const child of children) {
-		const result = node_leads_with_control_flow(child);
+		const result = node_leads_with_control_flow(child, context);
 		if (result !== null) {
 			return result;
 		}
@@ -2810,7 +2845,8 @@ const visitors = {
 		}
 	},
 
-	TsrxFragment(node, { visit, state }) {
+	TsrxFragment(node, context) {
+		const { visit, state } = context;
 		const children = node.children.filter(
 			(child) => child != null && child.type !== 'EmptyStatement',
 		);
@@ -2852,7 +2888,7 @@ const visitors = {
 			// boundary (or adopts real nodes) and must NOT be bracketed, or the extra
 			// markers desync the static-cursor (`next()` + skip_advance) client path.
 			const needs_boundary =
-				state.control_flow_branch_body || fragment_leads_with_control_flow(children);
+				state.control_flow_branch_body || fragment_leads_with_control_flow(children, context);
 			if (needs_boundary && init.length > 0) {
 				state.init?.push(b.stmt(b.call(b.id('_$_.output_push'), b.literal(BLOCK_OPEN))));
 				state.init?.push(b.block(init));

--- a/packages/tsrx/types/index.d.ts
+++ b/packages/tsrx/types/index.d.ts
@@ -1480,6 +1480,13 @@ export interface TransformServerState extends BaseState {
 	dev?: boolean;
 	return_flags?: Map<AST.ReturnStatement, { name: string; tracked: boolean }>;
 	template_child?: boolean;
+	/**
+	 * True while transforming the direct body of a control-flow branch
+	 * (`@if`/`@else`/`@for`/`@switch`/`@try`). A `<>…</>` in this position is
+	 * bracketed with hydration block markers so the client's fragment
+	 * `expression()` finds a matching boundary during hydration.
+	 */
+	control_flow_branch_body?: boolean;
 	skip_regular_blocks?: boolean;
 	in_regular_block?: boolean;
 	is_tsrx_element?: boolean;


### PR DESCRIPTION
another part of #1309 - pre-existing hydration issues.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes server compile output for specific fragment/control-flow shapes; wrong bracketing could break hydration or add spurious markers, though coverage is broad in new tests.
> 
> **Overview**
> Fixes **`HierarchyRequestError`** during hydration when an `@if`/`@else` (or similar) branch body is a **`<>…</>`** fragment whose first renderable content is **`@for`/`@if`** or a **`@{…}`** block that lowers to **`render_expression`**. On the client those fragments become a `<!>` plus **`expression(() => tsrx_element(…))`**, which expects its own **`<!--[-->`…`<!--]-->`** pair; SSR used to inline the fragment without it, so hydration stole a nested control-flow marker and advanced the cursor onto comment nodes.
> 
> The **server transform** now wraps qualifying template fragments in the same hydration block comments as other control-flow output. It tracks **`control_flow_branch_body`** while lowering **`@if`/`@else`/`@for`/`@switch`** branch bodies and only adds the extra boundary when the fragment is a direct branch body (or nested under one) **or** its first meaningful child would emit its own start marker. Fragments that lead with **elements, components, or plain text** stay unchanged.
> 
> Adds **hydration regression tests** (including guards for component-body fragments and plain-element fragments) and a **patch changeset** for `@tsrx/ripple`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10cebefd58a4c53766f271328589d8fe10e9cd86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->