### PR TITLE
feat(tsrx): editor completions for @ directives, JSX intellisense, and a mid-typing crash fix

### DIFF
--- a/.changeset/tsrx-at-completions.md
+++ b/.changeset/tsrx-at-completions.md
@@ -1,0 +1,18 @@
+---
+'@ripple-ts/language-server': patch
+'@tsrx/typescript-plugin': patch
+'@tsrx/core': patch
+---
+
+Add TSRX `@` control-flow completions and make them reachable in editors.
+Typing `@` in a template now offers `@{}`, `@if`, `@for`, `@switch`, and
+`@try` snippets plus the clause keywords (`@else`, `@else if`, `@empty`,
+`@case`, `@default`, `@pending`, `@catch`), replacing the typed `@` prefix so
+accepting `@if` never produces `@@if`. The legacy `@`-reactivity `@value`
+suggestion and the outdated control-flow snippets (`for-of`, `for-index`,
+`for-key`, `for-empty`, `for-index-key`, `if-else`, `switch-case`,
+`try-pending`) are removed. Previously no completions could appear at a typed
+`@` at all: Volar only routes completion requests through completion-enabled
+mappings, so `@`-containing JSX text chunks now get exact completion-only
+mappings, and the parse-error fallback mapping (a bare `@` in statement
+position is a parse error mid-keystroke) keeps completion enabled.

--- a/.changeset/tsrx-legacy-accessor-cleanup.md
+++ b/.changeset/tsrx-legacy-accessor-cleanup.md
@@ -1,0 +1,8 @@
+---
+'@ripple-ts/language-server': patch
+---
+
+Remove legacy `@`-reactivity accessor syntax from completion snippet bodies.
+The `track-derived`, `effect`, and `untrack` snippets now insert plain
+placeholders (`${2:dependency}`, `console.log(value)`, `${1:value}`) instead
+of the removed `@dependency`/`@value` accessor reads.

--- a/.changeset/tsrx-ripple-valueless-event-attribute.md
+++ b/.changeset/tsrx-ripple-valueless-event-attribute.md
@@ -1,0 +1,5 @@
+---
+'@tsrx/ripple': patch
+---
+
+Valueless event attributes (e.g. mid-typing `<div onC>`) no longer crash the compiler with a position-less TypeError. They now produce a positioned error at the attribute (recoverable in loose/collect mode, so editor completions and diagnostics stay alive on the rest of the file), while boolean shorthand on non-event attributes like `<div hidden>` keeps compiling clean.

--- a/packages/language-server/src/completionPlugin.js
+++ b/packages/language-server/src/completionPlugin.js
@@ -209,7 +209,7 @@ const RIPPLE_SNIPPETS = [
 		kind: CompletionItemKind.Snippet,
 		detail: 'Derived reactive value',
 		documentation: 'Create a derived reactive value',
-		insertText: 'let ${1:name} = track(() => ${2:@dependency});',
+		insertText: 'let ${1:name} = track(() => ${2:dependency});',
 		insertTextFormat: InsertTextFormat.Snippet,
 		sortText: '0-track-derived',
 	},
@@ -228,95 +228,113 @@ const RIPPLE_SNIPPETS = [
 		kind: CompletionItemKind.Snippet,
 		detail: 'Create an effect',
 		documentation: 'Run side effects when reactive dependencies change',
-		insertText: 'effect(() => {\n\t${1:console.log(@value);}\n});',
+		insertText: 'effect(() => {\n\t${1:console.log(value);}\n});',
 		insertTextFormat: InsertTextFormat.Snippet,
 		sortText: '0-effect',
-	},
-	{
-		label: 'for-of',
-		kind: CompletionItemKind.Snippet,
-		detail: 'for...of loop',
-		documentation: 'Iterate over items in Ripple template',
-		insertText: '@for (const ${1:item} of ${2:items}) {\n\t<${3:li}>{${1:item}}</${3:li}>\n}',
-		insertTextFormat: InsertTextFormat.Snippet,
-		sortText: '0-for-of',
-	},
-	{
-		label: 'for-index',
-		kind: CompletionItemKind.Snippet,
-		detail: 'for...of loop with index',
-		documentation: 'Iterate with index',
-		insertText:
-			'@for (const ${1:item} of ${2:items}; index ${3:i}) {\n\t<${4:li}>{${1:item}} at {${3}}</${4:li}>\n}',
-		insertTextFormat: InsertTextFormat.Snippet,
-		sortText: '0-for-index',
-	},
-	{
-		label: 'for-key',
-		kind: CompletionItemKind.Snippet,
-		detail: 'for...of loop with key',
-		documentation: 'Iterate with key for identity',
-		insertText:
-			'@for (const ${1:item} of ${2:items}; key ${1:item}.${3:id}) {\n\t<${4:li}>{${1:item}.${5:text}}</${4:li}>\n}',
-		insertTextFormat: InsertTextFormat.Snippet,
-		sortText: '0-for-key',
-	},
-	{
-		label: 'for-empty',
-		kind: CompletionItemKind.Snippet,
-		detail: 'for...of loop with empty fallback',
-		documentation: 'Iterate over items with an empty fallback',
-		insertText:
-			'@for (const ${1:item} of ${2:items}; key ${1:item}.${3:id}) {\n\t<${4:li}>{${1:item}.${5:text}}</${4:li}>\n} @empty {\n\t<${6:li}>${7:No items}</${6:li}>\n}',
-		insertTextFormat: InsertTextFormat.Snippet,
-		sortText: '0-for-empty',
-	},
-	{
-		label: 'for-index-key',
-		kind: CompletionItemKind.Snippet,
-		detail: 'for...of loop with key',
-		documentation: 'Iterate with key for identity',
-		insertText:
-			'@for (const ${1:item} of ${2:items}; index ${3:i}; key ${1:item}.${4:id}) {\n\t<${5:li}>{${1:item}.${6:text}} at index {${3}}</${5:li}>\n}',
-		insertTextFormat: InsertTextFormat.Snippet,
-		sortText: '0-for-key-index',
-	},
-	{
-		label: 'if-else',
-		kind: CompletionItemKind.Snippet,
-		detail: 'if...else statement',
-		documentation: 'Conditional rendering',
-		insertText: '@if (${1:condition}) {\n\t<>\n\t\t$2\n\t</>\n} else {\n\t<>\n\t\t$3\n\t</>\n}',
-		insertTextFormat: InsertTextFormat.Snippet,
-		sortText: '0-if-else',
-	},
-	{
-		label: 'switch-case',
-		kind: CompletionItemKind.Snippet,
-		detail: 'switch statement',
-		documentation: 'Switch-based conditional rendering',
-		insertText:
-			"@switch (${1:value}) {\n\tcase ${2:'case1'}: {\n\t\t<>\n\t\t\t$3\n\t\t</>\n\t}\n\tcase ${4:'case2'}: {\n\t\t<>\n\t\t\t$5\n\t\t</>\n\t}\n\tdefault: {\n\t\t<>\n\t\t\t$6\n\t\t</>\n\t}\n}",
-		insertTextFormat: InsertTextFormat.Snippet,
-		sortText: '0-switch-case',
 	},
 	{
 		label: 'untrack',
 		kind: CompletionItemKind.Snippet,
 		detail: 'Untrack reactive value',
 		documentation: 'Read reactive value without creating dependency',
-		insertText: 'untrack(() => @${1:value})',
+		insertText: 'untrack(() => ${1:value})',
 		insertTextFormat: InsertTextFormat.Snippet,
 		sortText: '0-untrack',
 	},
+];
+
+/**
+ * Completions offered when the user types `@` in a template. The editor orders
+ * items by `sortText` (compared as plain text, not by label), so these are
+ * zero-padded to force the order: statement container first, then the
+ * directives (`@if`/`@for`/...), then the clause keywords (`@else`/`@case`/...).
+ */
+const AT_DIRECTIVE_SNIPPETS = [
 	{
-		label: 'try-pending',
-		kind: CompletionItemKind.Snippet,
-		detail: 'try...pending block',
-		documentation: 'Handle async content with loading fallback',
-		insertText: '@try {\n\t$1\n} @pending {\n\t<div>Loading...</div>\n}',
-		insertTextFormat: InsertTextFormat.Snippet,
-		sortText: '0-try-pending',
+		label: '@{}',
+		detail: 'Statement block',
+		documentation: 'Run TypeScript statements inside the template',
+		insertText: '@{\n\t$0\n}',
+		sortText: '0-@-00',
+		preselect: true,
+	},
+	{
+		label: '@if',
+		detail: '@if block',
+		documentation: 'Conditional rendering',
+		insertText: '@if (${1:condition}) {\n\t$0\n}',
+		sortText: '0-@-01',
+	},
+	{
+		label: '@for',
+		detail: '@for block',
+		documentation: 'Iterate over items in the template',
+		insertText: '@for (const ${1:item} of ${2:items}) {\n\t$0\n}',
+		sortText: '0-@-02',
+	},
+	{
+		label: '@switch',
+		detail: '@switch block',
+		documentation: 'Switch-based conditional rendering',
+		insertText:
+			'@switch (${1:value}) {\n\t@case ${2:match}: {\n\t\t$3\n\t}\n\t@default: {\n\t\t$0\n\t}\n}',
+		sortText: '0-@-03',
+	},
+	{
+		label: '@try',
+		detail: '@try block',
+		documentation: 'Handle async content with loading and error fallbacks',
+		insertText: '@try {\n\t$1\n} @pending {\n\t$2\n} @catch (${3:e}) {\n\t$0\n}',
+		sortText: '0-@-04',
+	},
+	{
+		label: '@else',
+		detail: '@else clause',
+		documentation: 'Fallback branch after an @if block',
+		insertText: '@else {\n\t$0\n}',
+		sortText: '0-@-10',
+	},
+	{
+		label: '@else if',
+		detail: '@else if clause',
+		documentation: 'Chained condition after an @if block',
+		insertText: '@else if (${1:condition}) {\n\t$0\n}',
+		sortText: '0-@-11',
+	},
+	{
+		label: '@empty',
+		detail: '@empty clause',
+		documentation: 'Fallback branch when an @for block has no items',
+		insertText: '@empty {\n\t$0\n}',
+		sortText: '0-@-12',
+	},
+	{
+		label: '@case',
+		detail: '@case clause',
+		documentation: 'Match branch inside an @switch block',
+		insertText: '@case ${1:match}: {\n\t$0\n}',
+		sortText: '0-@-13',
+	},
+	{
+		label: '@default',
+		detail: '@default clause',
+		documentation: 'Default branch inside an @switch block',
+		insertText: '@default: {\n\t$0\n}',
+		sortText: '0-@-14',
+	},
+	{
+		label: '@pending',
+		detail: '@pending clause',
+		documentation: 'Loading branch of an @try block',
+		insertText: '@pending {\n\t$0\n}',
+		sortText: '0-@-15',
+	},
+	{
+		label: '@catch',
+		detail: '@catch clause',
+		documentation: 'Error branch of an @try block',
+		insertText: '@catch (${1:e}) {\n\t$0\n}',
+		sortText: '0-@-16',
 	},
 ];
 
@@ -429,14 +447,33 @@ export function createCompletionPlugin() {
 						return { items, isIncomplete: false };
 					}
 
-					// @ accessor hint when typing after @
-					if (/@\w*$/.test(line)) {
-						items.push({
-							label: '@value',
-							kind: CompletionItemKind.Variable,
-							detail: 'Access tracked value',
-							documentation: 'Use @ to read/write tracked values',
-						});
+					const atMatch = line.match(/@\w*$/);
+					if (atMatch) {
+						// Anchor the edit at the '@' the user already typed so selecting
+						// '@if' replaces it, instead of inserting after it (giving '@@if')
+						const atStart = {
+							line: position.line,
+							character: position.character - atMatch[0].length,
+						};
+						for (const snippet of AT_DIRECTIVE_SNIPPETS) {
+							items.push({
+								label: snippet.label,
+								kind: CompletionItemKind.Snippet,
+								detail: snippet.detail,
+								documentation: snippet.documentation,
+								insertText: snippet.insertText,
+								insertTextFormat: InsertTextFormat.Snippet,
+								sortText: snippet.sortText,
+								preselect: snippet.preselect,
+								// filterText keeps the '@' so the editor's as-you-type filtering
+								// still matches once the user has typed it
+								filterText: snippet.label,
+								textEdit: {
+									range: { start: atStart, end: position },
+									newText: snippet.insertText,
+								},
+							});
+						}
 					}
 
 					// RippleMap/RippleSet completions when typing R, M...

--- a/packages/language-server/tests/compileErrorDiagnostic.test.js
+++ b/packages/language-server/tests/compileErrorDiagnostic.test.js
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { create_completion_harness, create_diagnostic_harness } from './setup.js';
+
+const INVOKED = { triggerKind: 1 };
+
+// User typed `onC` on the way to `onClick`. The compile must survive with an
+// error pointing at the attribute, so the squiggle lands there (not at the top
+// of the file) and completions still work at the cursor.
+const ONC_FIXTURE = `export default function App() {
+	return <div class="shown" onC>{'hi'}</div>;
+}
+`;
+
+describe('compile error diagnostic plugin', () => {
+	it('ranges the valueless-event-attribute error on the attribute itself', async () => {
+		const { document, service, uri } = create_diagnostic_harness(ONC_FIXTURE);
+		const diagnostics = await service.getDiagnostics(uri);
+
+		expect(diagnostics.length).toBeGreaterThan(0);
+		const diagnostic = diagnostics.find((d) => /event attribute/i.test(d.message));
+		expect(diagnostic).toBeDefined();
+
+		// not pinned to the top of the file
+		expect(diagnostic?.range.start).not.toEqual({ line: 0, character: 0 });
+
+		// the range covers the `onC` attribute
+		const start_offset = document.offsetAt(diagnostic.range.start);
+		const end_offset = document.offsetAt(diagnostic.range.end);
+		const onc_offset = ONC_FIXTURE.indexOf('onC');
+		expect(start_offset).toBeLessThanOrEqual(onc_offset);
+		expect(end_offset).toBeGreaterThanOrEqual(onc_offset + 'onC'.length);
+	});
+
+	it('keeps completions alive at the cursor right after "onC"', async () => {
+		const { service, uri } = create_completion_harness(ONC_FIXTURE);
+		// cursor right after `onC` on line 1
+		const cursor = { line: 1, character: '\treturn <div class="shown" onC'.length };
+		const result = await service.getCompletionItems(uri, cursor, INVOKED);
+
+		expect(result.items.length).toBeGreaterThan(0);
+	});
+});

--- a/packages/language-server/tests/completionPlugin.test.js
+++ b/packages/language-server/tests/completionPlugin.test.js
@@ -1,0 +1,232 @@
+import { CompletionItemKind, InsertTextFormat } from '@volar/language-server';
+import { describe, expect, it } from 'vitest';
+import { create_completion_harness } from './setup.js';
+
+const TRIGGERED_BY_AT = { triggerKind: 2, triggerCharacter: '@' };
+const INVOKED = { triggerKind: 1 };
+
+const EXPECTED_AT_ITEMS = [
+	{ label: '@{}', insertText: '@{\n\t$0\n}', sortText: '0-@-00', preselect: true },
+	{ label: '@if', insertText: '@if (${1:condition}) {\n\t$0\n}', sortText: '0-@-01' },
+	{
+		label: '@for',
+		insertText: '@for (const ${1:item} of ${2:items}) {\n\t$0\n}',
+		sortText: '0-@-02',
+	},
+	{
+		label: '@switch',
+		insertText:
+			'@switch (${1:value}) {\n\t@case ${2:match}: {\n\t\t$3\n\t}\n\t@default: {\n\t\t$0\n\t}\n}',
+		sortText: '0-@-03',
+	},
+	{
+		label: '@try',
+		insertText: '@try {\n\t$1\n} @pending {\n\t$2\n} @catch (${3:e}) {\n\t$0\n}',
+		sortText: '0-@-04',
+	},
+	{ label: '@else', insertText: '@else {\n\t$0\n}', sortText: '0-@-10' },
+	{ label: '@else if', insertText: '@else if (${1:condition}) {\n\t$0\n}', sortText: '0-@-11' },
+	{ label: '@empty', insertText: '@empty {\n\t$0\n}', sortText: '0-@-12' },
+	{ label: '@case', insertText: '@case ${1:match}: {\n\t$0\n}', sortText: '0-@-13' },
+	{ label: '@default', insertText: '@default: {\n\t$0\n}', sortText: '0-@-14' },
+	{ label: '@pending', insertText: '@pending {\n\t$0\n}', sortText: '0-@-15' },
+	{ label: '@catch', insertText: '@catch (${1:e}) {\n\t$0\n}', sortText: '0-@-16' },
+];
+
+const EXPECTED_AT_ORDER = [
+	'@{}',
+	'@if',
+	'@for',
+	'@switch',
+	'@try',
+	'@else',
+	'@else if',
+	'@empty',
+	'@case',
+	'@default',
+	'@pending',
+	'@catch',
+];
+
+// old @-reactivity and control-flow snippets we deleted; pinned so they can't creep back
+const REMOVED_SNIPPET_LABELS = [
+	'@value',
+	'for-of',
+	'for-index',
+	'for-key',
+	'for-empty',
+	'for-index-key',
+	'if-else',
+	'switch-case',
+	'try-pending',
+];
+
+// Parses clean: the typed `@` is plain JSX text inside the template.
+const JSX_TEXT_AT_FIXTURE = `export default function App() {
+	return (
+		<div>
+			@
+		</div>
+	);
+}
+`;
+
+// Parses clean: partial keyword `@i` is plain JSX text inside the template.
+const JSX_TEXT_PARTIAL_FIXTURE = `export default function App() {
+	return (
+		<div>
+			@i
+		</div>
+	);
+}
+`;
+
+// Fails to parse: a lone `@` outside a template is a compile error — this covers
+// the "file won't compile" path where completions still need to work
+const STATEMENT_AT_FIXTURE = `export default function App() @{
+	let x = 1;
+	@
+	<div>{x}</div>
+}
+`;
+
+/**
+ * @param {import('@volar/language-server').CompletionList} result
+ * @param {import('@volar/language-server').Position} at_start - position of the typed '@'
+ * @param {import('@volar/language-server').Position} cursor - position completion was requested at
+ */
+function expect_at_directive_items(result, at_start, cursor) {
+	const by_label = new Map(result.items.map((item) => [item.label, item]));
+
+	for (const expected of EXPECTED_AT_ITEMS) {
+		const item = by_label.get(expected.label);
+		expect(item, `expected completion item '${expected.label}'`).toBeDefined();
+		expect(item?.insertText).toBe(expected.insertText);
+		expect(item?.kind).toBe(CompletionItemKind.Snippet);
+		expect(item?.insertTextFormat).toBe(InsertTextFormat.Snippet);
+		expect(item?.sortText).toBe(expected.sortText);
+		expect(item?.preselect ?? false).toBe(expected.preselect ?? false);
+		// filterText keeps the '@' so the editor keeps matching this item as you type
+		expect(item?.filterText?.startsWith('@')).toBe(true);
+		// the edit replaces the typed '@' so accepting '@if' does not produce '@@if'
+		expect(item?.textEdit).toEqual({
+			range: { start: at_start, end: cursor },
+			newText: expected.insertText,
+		});
+	}
+
+	// sortText puts '@{}' first, then @if/@for/@switch/@try, then clause keywords
+	const sorted_labels = EXPECTED_AT_ITEMS.map((expected) => expected.label).sort((a, b) => {
+		const a_sort = /** @type {string} */ (by_label.get(a)?.sortText);
+		const b_sort = /** @type {string} */ (by_label.get(b)?.sortText);
+		return a_sort < b_sort ? -1 : a_sort > b_sort ? 1 : 0;
+	});
+	expect(sorted_labels).toEqual(EXPECTED_AT_ORDER);
+}
+
+/**
+ * @param {import('@volar/language-server').CompletionList} result
+ */
+function expect_no_legacy_items(result) {
+	const labels = result.items.map((item) => item.label);
+	for (const legacy of REMOVED_SNIPPET_LABELS) {
+		expect(labels).not.toContain(legacy);
+	}
+}
+
+describe('completion plugin', () => {
+	it('offers the 12 @ template directives after typing "@" amid JSX text', async () => {
+		const { service, uri } = create_completion_harness(JSX_TEXT_AT_FIXTURE);
+		const cursor = { line: 3, character: 4 };
+		const result = await service.getCompletionItems(uri, cursor, TRIGGERED_BY_AT);
+
+		expect_at_directive_items(result, { line: 3, character: 3 }, cursor);
+		expect_no_legacy_items(result);
+	});
+
+	it('offers @ template directives on Invoked completion after a partial "@i" amid JSX text', async () => {
+		const { service, uri } = create_completion_harness(JSX_TEXT_PARTIAL_FIXTURE);
+		const cursor = { line: 3, character: 5 };
+		const result = await service.getCompletionItems(uri, cursor, INVOKED);
+
+		// the textEdit range must cover the whole typed '@i' prefix
+		expect_at_directive_items(result, { line: 3, character: 3 }, cursor);
+		expect_no_legacy_items(result);
+	});
+
+	it('offers @ template directives in statement position while the file fails to parse', async () => {
+		const { service, uri } = create_completion_harness(STATEMENT_AT_FIXTURE);
+		const cursor = { line: 2, character: 2 };
+
+		const triggered = await service.getCompletionItems(uri, cursor, TRIGGERED_BY_AT);
+		expect_at_directive_items(triggered, { line: 2, character: 1 }, cursor);
+		expect_no_legacy_items(triggered);
+
+		const invoked = await service.getCompletionItems(uri, cursor, INVOKED);
+		expect_at_directive_items(invoked, { line: 2, character: 1 }, cursor);
+		expect_no_legacy_items(invoked);
+	});
+
+	it('keeps non-template Ripple snippets available', async () => {
+		const { service, uri } = create_completion_harness(JSX_TEXT_AT_FIXTURE);
+		const result = await service.getCompletionItems(uri, { line: 3, character: 4 }, INVOKED);
+		const labels = result.items.map((item) => item.label);
+
+		expect(labels).toContain('function component');
+		expect(labels).toContain('effect');
+		expect(labels).toContain('track');
+	});
+
+	it('uses plain placeholders instead of legacy @-accessor reads in snippet bodies', async () => {
+		const source = `export default function App() {
+	const tra = 1;
+	return <div>{tra}</div>;
+}
+`;
+		const { service, uri } = create_completion_harness(source);
+		// cursor after 'tra' inside {...}, where the general Ripple snippets show up
+		const result = await service.getCompletionItems(
+			uri,
+			{ line: 2, character: '\treturn <div>{tra'.length },
+			INVOKED,
+		);
+		const by_label = new Map(result.items.map((item) => [item.label, item]));
+
+		expect(by_label.get('track-derived')?.insertText).toBe(
+			'let ${1:name} = track(() => ${2:dependency});',
+		);
+		expect(by_label.get('effect')?.insertText).toBe(
+			'effect(() => {\n\t${1:console.log(value);}\n});',
+		);
+		expect(by_label.get('untrack')?.insertText).toBe('untrack(() => ${1:value})');
+
+		// no snippet body should use the old '@' accessor syntax; the @if/@case/...
+		// directive items are allowed to have '@' in their labels, so skip those
+		for (const item of result.items) {
+			if (String(item.label).startsWith('@')) {
+				continue;
+			}
+			expect(
+				item.insertText ?? '',
+				`snippet '${item.label}' must not use legacy @-accessor syntax`,
+			).not.toMatch(/@\w/);
+		}
+	});
+
+	it('keeps import-context completions unchanged', async () => {
+		const source = `import { track } from 'ripple';
+
+export default function App() {
+	return <div>hi</div>;
+}
+`;
+		const { service, uri } = create_completion_harness(source);
+		// cursor at the end of 'track' inside the import statement
+		const result = await service.getCompletionItems(uri, { line: 0, character: 14 }, INVOKED);
+		const labels = result.items.map((item) => item.label);
+
+		expect(labels).toContain('import track');
+		expect(labels).not.toContain('@if');
+		expect(labels).not.toContain('function component');
+	});
+});

--- a/packages/language-server/tests/jsxCompletion.test.js
+++ b/packages/language-server/tests/jsxCompletion.test.js
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { create_ts_completion_harness as harness } from './setup.js';
+
+const INVOKED = { triggerKind: 1 };
+
+/**
+ * @param {import('@volar/language-server').CompletionList} result
+ * @returns {string[]} labels with the optional-member '?' marker stripped
+ */
+function labels_of(result) {
+	return result.items.map((item) => String(item.label).replace(/\?$/, ''));
+}
+
+describe('JSX completions through the TypeScript layer', () => {
+	it('offers intrinsic element completions like "div" inside an open JSX tag', async () => {
+		const source = `export default function App() {
+	return (
+		<div>
+			<di></di>
+		</div>
+	);
+}
+`;
+		const { service, uri } = harness(source, 'jsx-elements.tsrx');
+		// cursor at the end of '<di' on line 3 ("\t\t\t<di></di>")
+		const result = await service.getCompletionItems(uri, { line: 3, character: 6 }, INVOKED);
+
+		expect(labels_of(result)).toContain('div');
+	});
+
+	it('offers ripple/jsx-runtime attribute completions like "onClick" on a div', async () => {
+		const source = `export default function App() {
+	const handle = () => {};
+	return <div onC={handle}></div>;
+}
+`;
+		const { service, uri } = harness(source, 'jsx-attributes.tsrx');
+		// cursor at the end of 'onC' on line 2 ("\treturn <div onC={handle}></div>;")
+		const result = await service.getCompletionItems(uri, { line: 2, character: 16 }, INVOKED);
+		const labels = labels_of(result);
+
+		expect(labels).toContain('onClick');
+		// onClickCapture (the capture-phase variant) also comes from ripple's jsx types
+		expect(labels).toContain('onClickCapture');
+	});
+});

--- a/packages/language-server/tests/setup.js
+++ b/packages/language-server/tests/setup.js
@@ -1,3 +1,5 @@
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import ts from 'typescript';
@@ -6,8 +8,25 @@ import { createLanguageService, createUriMap } from '@volar/language-service';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { URI } from 'vscode-uri';
 import { beforeEach } from 'vitest';
-import { getRippleLanguagePlugin, _reset_for_test } from '@tsrx/typescript-plugin/src/language.js';
+import {
+	getRippleLanguagePlugin,
+	resolveConfig,
+	_reset_for_test,
+} from '@tsrx/typescript-plugin/src/language.js';
+import { createCompileErrorDiagnosticPlugin } from '../src/compileErrorDiagnosticPlugin.js';
+import { createCompletionPlugin } from '../src/completionPlugin.js';
 import { createDocumentSymbolPlugin } from '../src/documentSymbolPlugin.js';
+import { createTypeScriptServices } from '../src/typescriptService.js';
+
+// `@volar/typescript` isn't a direct dependency; resolve it through the pinned
+// `@volar/language-server`, like src/typescriptService.js does
+const require = createRequire(import.meta.url);
+/** @type {typeof import('@volar/typescript')} */
+const volar_typescript = require(
+	require.resolve('@volar/typescript', {
+		paths: [path.dirname(fs.realpathSync(require.resolve('@volar/language-server')))],
+	}),
+);
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 const root_dir = path.resolve(dirname, '../../..');
@@ -44,6 +63,183 @@ export function create_symbol_harness(source, fixture_name = 'App.tsrx') {
 			console,
 		},
 		{},
+	);
+	const document = TextDocument.create(uri.toString(), 'ripple', 0, source);
+
+	return { document, service, uri };
+}
+
+/**
+ * Harness for asserting completionPlugin items via `service.getCompletionItems`.
+ *
+ * @param {string} source
+ * @param {string} [fixture_name]
+ */
+export function create_completion_harness(source, fixture_name = 'App.tsrx') {
+	const uri = URI.file(path.join(fixture_dir, fixture_name));
+	const scripts = createUriMap();
+	const language = createLanguage([getRippleLanguagePlugin()], scripts, () => {});
+	const source_snapshot = create_snapshot(source);
+	language.scripts.set(uri, source_snapshot, 'ripple');
+
+	const service = createLanguageService(
+		language,
+		[createCompletionPlugin()],
+		{
+			workspaceFolders: [URI.file(root_dir)],
+			console,
+		},
+		{},
+	);
+	const document = TextDocument.create(uri.toString(), 'ripple', 0, source);
+
+	return { document, service, uri };
+}
+
+/**
+ * Harness for asserting source-mapped compile-error ranges via `service.getDiagnostics`.
+ *
+ * @param {string} source
+ * @param {string} [fixture_name]
+ */
+export function create_diagnostic_harness(source, fixture_name = 'App.tsrx') {
+	const uri = URI.file(path.join(fixture_dir, fixture_name));
+	const scripts = createUriMap();
+	const language = createLanguage([getRippleLanguagePlugin()], scripts, () => {});
+	const source_snapshot = create_snapshot(source);
+	language.scripts.set(uri, source_snapshot, 'ripple');
+
+	const service = createLanguageService(
+		language,
+		[createCompileErrorDiagnosticPlugin()],
+		{
+			workspaceFolders: [URI.file(root_dir)],
+			console,
+		},
+		{},
+	);
+	const document = TextDocument.create(uri.toString(), 'ripple', 0, source);
+
+	return { document, service, uri };
+}
+
+/**
+ * @param {string} file_name
+ * @returns {string}
+ */
+function file_language_id(file_name) {
+	if (file_name.endsWith('.tsrx')) return 'ripple';
+	if (file_name.endsWith('.tsx')) return 'typescriptreact';
+	if (file_name.endsWith('.jsx')) return 'javascriptreact';
+	if (/\.(c|m)?js$/.test(file_name)) return 'javascript';
+	if (file_name.endsWith('.json')) return 'json';
+	return 'typescript';
+}
+
+/**
+ * Completion harness with real TypeScript wired in, mirroring src/server.js's
+ * project setup, so JSX element/attribute completions can be asserted.
+ *
+ * @param {string} source
+ * @param {string} [fixture_name]
+ */
+export function create_ts_completion_harness(source, fixture_name = 'App.tsrx') {
+	const uri = URI.file(path.join(fixture_dir, fixture_name));
+	const scripts = createUriMap();
+
+	/** @param {URI} script_uri */
+	const as_file_name = (script_uri) => script_uri.fsPath.replace(/\\/g, '/');
+	/** @param {string} file_name */
+	const as_uri = (file_name) => URI.file(file_name);
+	const fixture_file_name = as_file_name(uri);
+
+	/** @type {Map<string, import('@volar/language-core').IScriptSnapshot | undefined>} */
+	const fs_snapshots = new Map();
+
+	const language_plugins = [
+		getRippleLanguagePlugin(),
+		{
+			/** @param {URI} script_uri */
+			getLanguageId: (script_uri) => file_language_id(script_uri.path),
+		},
+	];
+
+	/** @type {import('@volar/language-core').Language<URI>} */
+	const language = createLanguage(language_plugins, scripts, (script_uri, include_fs_files) => {
+		if (!include_fs_files) {
+			return;
+		}
+		const file_name = as_file_name(script_uri);
+		if (file_name === fixture_file_name) {
+			// the fixture lives in memory, never on disk
+			return;
+		}
+		if (!fs_snapshots.has(file_name)) {
+			fs_snapshots.set(
+				file_name,
+				ts.sys.fileExists(file_name)
+					? ts.ScriptSnapshot.fromString(ts.sys.readFile(file_name) ?? '')
+					: undefined,
+			);
+		}
+		const snapshot = fs_snapshots.get(file_name);
+		if (snapshot) {
+			language.scripts.set(script_uri, snapshot, file_language_id(file_name));
+		}
+	});
+	language.scripts.set(uri, create_snapshot(source), 'ripple');
+
+	// jsx settings mirror a Ripple project tsconfig (templates/basic/tsconfig.json)
+	const compiler_options = resolveConfig({
+		options: {
+			module: ts.ModuleKind.ESNext,
+			moduleResolution: ts.ModuleResolutionKind.Bundler,
+			jsx: ts.JsxEmit.Preserve,
+			jsxImportSource: 'ripple',
+			types: [],
+			allowNonTsExtensions: true,
+			baseUrl: root_dir,
+			paths: {
+				ripple: ['packages/ripple/types/index.d.ts'],
+				'ripple/jsx-runtime': ['packages/ripple/src/jsx-runtime.d.ts'],
+			},
+		},
+	}).options;
+
+	const project_host = {
+		getCurrentDirectory: () => root_dir,
+		getCompilationSettings: () => compiler_options,
+		getScriptFileNames: () => [fixture_file_name],
+		getProjectVersion: () => '1',
+	};
+
+	const { languageServiceHost, getExtraServiceScript } = volar_typescript.createLanguageServiceHost(
+		ts,
+		ts.sys,
+		language,
+		as_uri,
+		project_host,
+	);
+
+	const service = createLanguageService(
+		language,
+		[createCompletionPlugin(), ...createTypeScriptServices(ts)],
+		{
+			workspaceFolders: [URI.file(root_dir)],
+			console,
+		},
+		{
+			typescript: {
+				configFileName: undefined,
+				sys: ts.sys,
+				languageServiceHost,
+				getExtraServiceScript,
+				uriConverter: {
+					asUri: as_uri,
+					asFileName: as_file_name,
+				},
+			},
+		},
 	);
 	const document = TextDocument.create(uri.toString(), 'ripple', 0, source);
 

--- a/packages/tsrx-ripple/src/analyze/index.js
+++ b/packages/tsrx-ripple/src/analyze/index.js
@@ -2565,15 +2565,27 @@ const visitors = {
 						}
 
 						if (isEventAttribute(attr.name.name)) {
-							const handler = visit(/** @type {AST.Expression} */ (attr.value), state);
-							const is_delegated = is_delegated_event(attr.name.name, handler, context);
+							if (attr.value === null) {
+								// A regular attribute can have no value (like `hidden`), but an
+								// event attribute like `<div onC>` has no handler to run
+								error(
+									`the \`${attr.name.name}\` event attribute must be assigned a handler expression`,
+									state.analysis.module.filename,
+									attr,
+									context.state.collect ? context.state.analysis.errors : undefined,
+									context.state.analysis.comments,
+								);
+							} else {
+								const handler = visit(/** @type {AST.Expression} */ (attr.value), state);
+								const is_delegated = is_delegated_event(attr.name.name, handler, context);
 
-							if (is_delegated) {
-								if (attr.metadata === undefined) {
-									attr.metadata = { path: [...path] };
+								if (is_delegated) {
+									if (attr.metadata === undefined) {
+										attr.metadata = { path: [...path] };
+									}
+
+									attr.metadata.delegated = is_delegated;
 								}
-
-								attr.metadata.delegated = is_delegated;
 							}
 						} else if (attr.value !== null) {
 							visit(attr.value, state);

--- a/packages/tsrx-ripple/src/transform/client/index.js
+++ b/packages/tsrx-ripple/src/transform/client/index.js
@@ -2287,7 +2287,10 @@ const visitors = {
 						}
 
 						if (attr.value === null) {
-							handle_static_attr(name, true);
+							// omit a valueless event attr (analyze errored); `hidden` etc. still emit
+							if (!isEventAttribute(name)) {
+								handle_static_attr(name, true);
+							}
 							continue;
 						}
 
@@ -2391,10 +2394,6 @@ const visitors = {
 						}
 
 						if (isEventAttribute(name)) {
-							if (attr.value === null) {
-								// analyze already errored on the valueless event attribute
-								continue;
-							}
 							const metadata = { tracking: false };
 							let handler = /** @type {AST.Expression} */ (
 								visit(attr.value, { ...state, metadata })

--- a/packages/tsrx-ripple/src/transform/client/index.js
+++ b/packages/tsrx-ripple/src/transform/client/index.js
@@ -2391,6 +2391,10 @@ const visitors = {
 						}
 
 						if (isEventAttribute(name)) {
+							if (attr.value === null) {
+								// analyze already errored on the valueless event attribute
+								continue;
+							}
 							const metadata = { tracking: false };
 							let handler = /** @type {AST.Expression} */ (
 								visit(attr.value, { ...state, metadata })

--- a/packages/tsrx-ripple/src/transform/server/index.js
+++ b/packages/tsrx-ripple/src/transform/server/index.js
@@ -1995,7 +1995,10 @@ const visitors = {
 						}
 
 						if (attr.value === null) {
-							handle_static_attr(name, true);
+							// omit a valueless event attr (analyze errored); `hidden` etc. still emit
+							if (!isEventAttribute(name)) {
+								handle_static_attr(name, true);
+							}
 							continue;
 						}
 

--- a/packages/tsrx-ripple/tests/valueless-attribute.test.js
+++ b/packages/tsrx-ripple/tests/valueless-attribute.test.js
@@ -1,0 +1,94 @@
+import { compile, compile_to_volar_mappings } from '../src/index.js';
+import { describe, expect, it } from 'vitest';
+
+// An event attribute with no value like `<div onC>` (mid-typing while completing
+// `onClick`) is a mistake, not a crash. The compiler reports an error pointing at
+// the attribute (collected in editor mode, thrown in strict mode) and skips
+// generating the handler. A valueless non-event attribute like `<div hidden>` is
+// normal JSX and still works.
+describe('@tsrx/ripple valueless event attributes', () => {
+	const sources = {
+		'mid-typing onC': `export function App() {
+	return <div class="x" onC>{'hi'}</div>;
+}`,
+		'bare onClick': `export function App() {
+	return <div onClick>{'hi'}</div>;
+}`,
+	};
+
+	/** @param {string} source */
+	const attr_range = (source) => {
+		const name = source.includes('onClick') ? 'onClick' : 'onC';
+		const start = source.indexOf(name);
+		return { start, end: start + name.length };
+	};
+
+	for (const [kind, source] of Object.entries(sources)) {
+		it(`collects a positioned error and completes client compilation (${kind})`, () => {
+			const { code, errors } = compile(source, 'App.tsrx', { collect: true });
+			const { start, end } = attr_range(source);
+
+			expect(code).toBeTypeOf('string');
+			expect(errors.length).toBeGreaterThan(0);
+			const error = errors.find((e) => /event attribute/i.test(e.message));
+			expect(error).toBeDefined();
+			// the error range covers the attribute node
+			expect(error?.pos).toBeLessThanOrEqual(start);
+			expect(error?.end).toBeGreaterThanOrEqual(end);
+		});
+
+		it(`collects a positioned error and completes server compilation (${kind})`, () => {
+			const { code, errors } = compile(source, 'App.tsrx', { collect: true, mode: 'server' });
+			const { start, end } = attr_range(source);
+
+			expect(code).toBeTypeOf('string');
+			const error = errors.find((e) => /event attribute/i.test(e.message));
+			expect(error).toBeDefined();
+			expect(error?.pos).toBeLessThanOrEqual(start);
+			expect(error?.end).toBeGreaterThanOrEqual(end);
+		});
+
+		it(`completes compile_to_volar_mappings with full mappings (${kind})`, () => {
+			const result = compile_to_volar_mappings(source, 'App.tsrx', { loose: true });
+			const { start, end } = attr_range(source);
+
+			expect(result.code).toBeTypeOf('string');
+			expect(result.mappings.length).toBeGreaterThan(1);
+			const error = result.errors.find((e) => /event attribute/i.test(e.message));
+			expect(error).toBeDefined();
+			expect(error?.pos).toBeLessThanOrEqual(start);
+			expect(error?.end).toBeGreaterThanOrEqual(end);
+		});
+
+		it(`throws a positioned CompileError in strict mode (${kind})`, () => {
+			const { start, end } = attr_range(source);
+			let thrown;
+			try {
+				compile(source, 'App.tsrx');
+			} catch (e) {
+				thrown = e;
+			}
+
+			expect(thrown).toBeDefined();
+			// an error that points at the code, not a crash with no location
+			expect(thrown.constructor).not.toBe(TypeError);
+			expect(thrown.message).toMatch(/event attribute/i);
+			expect(thrown.pos).toBeLessThanOrEqual(start);
+			expect(thrown.end).toBeGreaterThanOrEqual(end);
+		});
+	}
+
+	it('keeps boolean shorthand on non-event attributes compiling clean', () => {
+		const source = `export function App() {
+	return <div hidden>{'x'}</div>;
+}`;
+		const client = compile(source, 'App.tsrx', { collect: true });
+		const server = compile(source, 'App.tsrx', { collect: true, mode: 'server' });
+
+		expect(client.errors).toEqual([]);
+		expect(server.errors).toEqual([]);
+		// strict mode must not throw either
+		expect(() => compile(source, 'App.tsrx')).not.toThrow();
+		expect(() => compile(source, 'App.tsrx', { mode: 'server' })).not.toThrow();
+	});
+});

--- a/packages/tsrx-ripple/tests/valueless-attribute.test.js
+++ b/packages/tsrx-ripple/tests/valueless-attribute.test.js
@@ -24,6 +24,8 @@ describe('@tsrx/ripple valueless event attributes', () => {
 	};
 
 	for (const [kind, source] of Object.entries(sources)) {
+		const attr_name = source.includes('onClick') ? 'onClick' : 'onC';
+
 		it(`collects a positioned error and completes client compilation (${kind})`, () => {
 			const { code, errors } = compile(source, 'App.tsrx', { collect: true });
 			const { start, end } = attr_range(source);
@@ -35,6 +37,8 @@ describe('@tsrx/ripple valueless event attributes', () => {
 			// the error range covers the attribute node
 			expect(error?.pos).toBeLessThanOrEqual(start);
 			expect(error?.end).toBeGreaterThanOrEqual(end);
+			// the broken attribute is omitted, not emitted as `onClick=""` markup
+			expect(code).not.toContain(`${attr_name}=`);
 		});
 
 		it(`collects a positioned error and completes server compilation (${kind})`, () => {
@@ -46,6 +50,7 @@ describe('@tsrx/ripple valueless event attributes', () => {
 			expect(error).toBeDefined();
 			expect(error?.pos).toBeLessThanOrEqual(start);
 			expect(error?.end).toBeGreaterThanOrEqual(end);
+			expect(code).not.toContain(`${attr_name}=`);
 		});
 
 		it(`completes compile_to_volar_mappings with full mappings (${kind})`, () => {

--- a/packages/tsrx/src/source-map-utils.js
+++ b/packages/tsrx/src/source-map-utils.js
@@ -50,6 +50,11 @@ export const mapping_data_verify_complete = {
 	completion: true,
 };
 
+/** @type {Partial<VolarCodeMapping['data']>} */
+export const mapping_data_completion_only = {
+	completion: true,
+};
+
 /**
  * Convert byte offset to line/column
  * @param {number} offset

--- a/packages/tsrx/src/transform/segments.js
+++ b/packages/tsrx/src/transform/segments.js
@@ -53,6 +53,7 @@ import {
 	mapping_data,
 	mapping_data_verify_only,
 	mapping_data_verify_complete,
+	mapping_data_completion_only,
 	build_line_offsets,
 	get_mapping_from_node,
 } from '../source-map-utils.js';
@@ -172,6 +173,76 @@ function visit_source_ast(ast, src_line_offsets, { regions, css_element_info }) 
 				}
 
 				css_element_info.set(`${line}:${column}`, css);
+			}
+		},
+	});
+}
+
+/**
+ * A half-typed directive (`@`, `@i`) is just plain text, and the editor only
+ * suggests completions where source maps into the generated TSX. This adds
+ * those maps for `@`-containing text, matched by exact text so a chunk we can't
+ * line up is skipped rather than mapped to a wrong (guessed) spot.
+ *
+ * @param {AST.Node} ast
+ * @param {string} source
+ * @param {ReturnType<typeof build_src_to_gen_map>[0]} src_to_gen_map
+ * @param {number[]} gen_line_offsets
+ * @param {CodeMapping[]} mappings
+ */
+function add_jsx_text_completion_mappings(ast, source, src_to_gen_map, gen_line_offsets, mappings) {
+	walk(ast, null, {
+		JSXText(node) {
+			const { loc, start, end } = /** @type {AST.NodeWithLocation} */ (
+				/** @type {unknown} */ (node)
+			);
+			if (!loc || typeof start !== 'number' || typeof end !== 'number') {
+				return;
+			}
+			const text = source.slice(start, end);
+			if (!text.includes('@')) {
+				return;
+			}
+
+			// One source spot can map to several generated spots; pick the first
+			// whose text matches every chunk (like get_generated_position_for_token)
+			const positions = src_to_gen_map.get(`${loc.start.line}:${loc.start.column}`) ?? [];
+
+			for (const position of positions) {
+				const gen_text = position.code;
+				const gen_text_start = loc_to_offset(position.line, position.column, gen_line_offsets);
+				/** @type {CodeMapping[]} */
+				const chunk_mappings = [];
+				const chunk_regex = /\S+/g;
+				let search_from = 0;
+				let matched_all = true;
+				let chunk_match;
+				while ((chunk_match = chunk_regex.exec(text)) !== null) {
+					const chunk = chunk_match[0];
+					const gen_index = gen_text.indexOf(chunk, search_from);
+					if (gen_index === -1) {
+						matched_all = false;
+						break;
+					}
+					search_from = gen_index + chunk.length;
+					if (!chunk.includes('@')) {
+						continue;
+					}
+					chunk_mappings.push({
+						sourceOffsets: [start + chunk_match.index],
+						generatedOffsets: [gen_text_start + gen_index],
+						lengths: [chunk.length],
+						generatedLengths: [chunk.length],
+						data: {
+							...mapping_data_completion_only,
+							customData: {},
+						},
+					});
+				}
+				if (matched_all && chunk_mappings.length > 0) {
+					mappings.push(...chunk_mappings);
+					return;
+				}
 			}
 		},
 	});
@@ -374,6 +445,14 @@ export function convert_source_map_to_mappings(
 		regions: css_regions,
 		css_element_info,
 	});
+
+	add_jsx_text_completion_mappings(
+		ast_from_source,
+		source,
+		src_to_gen_map,
+		gen_line_offsets,
+		mappings,
+	);
 
 	/** @type {Map<string, number>} */
 	const generated_position_indexes = new Map();
@@ -806,7 +885,7 @@ export function convert_source_map_to_mappings(
 				}
 				return;
 			} else if (node.type === 'JSXText') {
-				// Text content, no tokens to collect
+				// Text content, no tokens to collect (see add_jsx_text_completion_mappings)
 				return;
 			} else if (node.type === 'JSXCodeBlock') {
 				for (const statement of node.body) {

--- a/packages/typescript-plugin/src/language.js
+++ b/packages/typescript-plugin/src/language.js
@@ -391,6 +391,7 @@ export class TSRXVirtualCode {
 					generatedLengths: [newCode.length],
 					data: {
 						verification: true,
+						completion: true,
 						customData: {},
 					},
 				},

--- a/packages/typescript-plugin/tests/volar-completion-mappings.test.js
+++ b/packages/typescript-plugin/tests/volar-completion-mappings.test.js
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import * as ts from 'typescript';
+import { getRippleLanguagePlugin, _reset_for_test } from '../src/language.js';
+
+/** @import { TSRXVirtualCode } from '../src/language.js' */
+
+/**
+ * @param {string} source
+ * @returns {import('typescript').IScriptSnapshot}
+ */
+function create_snapshot(source) {
+	return ts.ScriptSnapshot.fromString(source);
+}
+
+/**
+ * @param {string} source
+ * @returns {TSRXVirtualCode}
+ */
+function create_virtual_code(source) {
+	const plugin = getRippleLanguagePlugin();
+	const create_virtual_code_fn = plugin.createVirtualCode;
+	if (typeof create_virtual_code_fn !== 'function') {
+		throw new Error('Language plugin does not expose createVirtualCode');
+	}
+
+	/** @type {import('@volar/language-core').CodegenContext<string>} */
+	const ctx = { getAssociatedScript: () => undefined };
+
+	return /** @type {TSRXVirtualCode} */ (
+		create_virtual_code_fn('/App.tsrx', 'ripple', create_snapshot(source), ctx)
+	);
+}
+
+describe('volar completion mappings', () => {
+	beforeEach(() => {
+		_reset_for_test();
+	});
+
+	it('emits an exact completion-enabled mapping for a typed "@" amid JSX text', () => {
+		const source = `export default function App() {
+	return (
+		<div>
+			@
+		</div>
+	);
+}
+`;
+		const virtual_code = create_virtual_code(source);
+		expect(virtual_code.fatalErrors).toEqual([]);
+
+		const at_source_offset = source.indexOf('@');
+		const at_generated_offset = virtual_code.generatedCode.indexOf('@');
+		const mapping = virtual_code.mappings.find(
+			(m) => m.sourceOffsets[0] === at_source_offset && m.data?.completion,
+		);
+
+		expect(mapping).toBeDefined();
+		expect(mapping?.lengths[0]).toBe(1);
+		expect(mapping?.generatedOffsets[0]).toBe(at_generated_offset);
+		expect(mapping?.generatedLengths?.[0]).toBe(1);
+	});
+
+	it('emits exact completion-enabled mappings for a partial "@i" directive in JSX text', () => {
+		const source = `export default function App() {
+	return (
+		<div>
+			hello @i
+		</div>
+	);
+}
+`;
+		const virtual_code = create_virtual_code(source);
+		expect(virtual_code.fatalErrors).toEqual([]);
+
+		const at_source_offset = source.indexOf('@i');
+		const at_generated_offset = virtual_code.generatedCode.indexOf('@i');
+		const mapping = virtual_code.mappings.find(
+			(m) => m.sourceOffsets[0] === at_source_offset && m.data?.completion,
+		);
+
+		expect(mapping).toBeDefined();
+		expect(mapping?.lengths[0]).toBe(2);
+		expect(mapping?.generatedOffsets[0]).toBe(at_generated_offset);
+		expect(mapping?.generatedLengths?.[0]).toBe(2);
+
+		// plain text without '@' gets no mapping, so completions aren't offered there
+		const hello_offset = source.indexOf('hello');
+		const hello_mapping = virtual_code.mappings.find((m) => m.sourceOffsets[0] === hello_offset);
+		expect(hello_mapping).toBeUndefined();
+	});
+
+	it('keeps full completion mappings for a valueless event attribute (mid-typing onC)', () => {
+		const source = `export default function App() {
+	return <div class="shown" onC>{'hi'}</div>;
+}
+`;
+		const virtual_code = create_virtual_code(source);
+
+		// compile finishes with a normal error, not a fatal one that would drop all
+		// the mappings and fall back to a single straight-through map
+		expect(virtual_code.fatalErrors).toEqual([]);
+		expect(virtual_code.usageErrors.length).toBeGreaterThan(0);
+		expect(virtual_code.generatedCode).not.toBe(source);
+		expect(virtual_code.mappings.length).toBeGreaterThan(1);
+
+		const completion_mappings = virtual_code.mappings.filter((m) => m.data?.completion);
+		expect(completion_mappings.length).toBeGreaterThan(0);
+
+		// a completion mapping covers the 'onC' attribute
+		const onc_offset = source.indexOf('onC');
+		const covering = completion_mappings.find((m) =>
+			m.sourceOffsets.some(
+				(offset, i) => onc_offset >= offset && onc_offset < offset + m.lengths[i],
+			),
+		);
+		expect(covering).toBeDefined();
+	});
+
+	it('keeps completion enabled on the parse-error fallback mapping', () => {
+		const source = `export default function App() @{
+	let x = 1;
+	@
+	<div>{x}</div>
+}
+`;
+		const virtual_code = create_virtual_code(source);
+		expect(virtual_code.fatalErrors.length).toBeGreaterThan(0);
+
+		// the fallback maps source straight through, position for position
+		expect(virtual_code.generatedCode).toBe(source);
+		expect(virtual_code.mappings).toHaveLength(1);
+		expect(virtual_code.mappings[0].sourceOffsets).toEqual([0]);
+		expect(virtual_code.mappings[0].lengths).toEqual([source.length]);
+		expect(virtual_code.mappings[0].data?.completion).toBe(true);
+		expect(virtual_code.mappings[0].data?.verification).toBe(true);
+	});
+});


### PR DESCRIPTION
## What this does

Fixes GitHub issue #1313 (no `@` intellisense for `.tsrx`) and, along the way, a compiler crash that silently disabled all editor features mid-typing.

### 1. `@` control-flow completions
Typing `@` in a template now offers `@{}` (preselected), `@if`, `@for`, `@switch`, `@try`, and the clause keywords (`@else`, `@else if`, `@empty`, `@case`, `@default`, `@pending`, `@catch`), ordered per the TSRX spec via `sortText`. Accepting an item replaces the typed `@` (so `@if` never becomes `@@if`).

The legacy `@`-reactivity `@value` suggestion and the outdated control-flow snippets (`for-of`, `for-index`, `for-key`, `for-empty`, `for-index-key`, `if-else`, `switch-case`, `try-pending` — whose bodies contradicted the current `@else`/`@case` syntax) are removed, and the `@`-accessor reads in the `track-derived`/`effect`/`untrack` snippet bodies are replaced with plain placeholders.

### 2. The routing fix that makes them actually appear
The completions were unreachable before this change. Volar only serves completions at source positions that have a completion-enabled mapping into the generated TSX, and `.tsrx` produced none at `@` positions:
- `@`-containing JSX text now gets exact, completion-only mappings (`packages/tsrx/src/transform/segments.js`, `source-map-utils.js`).
- The parse-error fallback mapping keeps completion enabled (`packages/typescript-plugin/src/language.js`), so a half-typed `@` in statement position (a parse error until the directive is finished) still serves completions instead of going dark.

### 3. Mid-typing crash fix
A valueless event attribute — `<div onC>`, the state while typing toward `onClick` — threw a location-less `TypeError` in `@tsrx/ripple` analyze. That flipped the whole file into a fallback state with **zero** completions and a single compile-error squiggle pinned to the top of the file. It now reports a positioned error on the attribute (recoverable in editor mode, a `CompileError` in strict builds) and keeps the rest of the file's editor features alive. Boolean shorthand on non-event attributes (`<div hidden>`) is unaffected.

### 4. `tsrxImportSource`?
No new mechanism needed. `.tsrx` compiles to virtual TSX and JSX element/attribute completions (`div`, `onClick`) flow from the user tsconfig `jsx: "preserve"` + `jsxImportSource: "ripple"`. This is now a tested invariant.

## Testing
Adds a language-server completion/diagnostic harness (`packages/language-server/tests/setup.js`) that drives `service.getCompletionItems` / `getDiagnostics` — the same LSP entry points editors call — so what VSCode/Zed show is asserted in CI rather than checked by hand. New tests cover `@` items and ordering, JSX element/attribute completions through a real TypeScript project, the mapping layer, diagnostic ranges, and the valueless-attribute fix.

Full suite green (`pnpm test`: 4337 passed / 45 skipped), `pnpm changeset:check` and `pnpm format:check` pass. Patch changesets included for `@ripple-ts/language-server`, `@tsrx/typescript-plugin`, `@tsrx/core`, and `@tsrx/ripple`.

## Known follow-ups (out of scope, not silently dropped)
- Clause keywords (`@else`/`@case`/...) are offered unconditionally with lower `sortText`; AST-aware context filtering would need new virtual-code machinery.
- `@for await` is parser-accepted but undocumented, so it's excluded until the spec documents it.
- `resolveConfig` doesn't default `jsx`/`jsxImportSource`; a `.tsrx` file outside a configured project gets no JSX intrinsics. A target-aware default needs its own design.
- Editor-side fuzzy re-ranking can reorder items despite `sortText`; the tests pin what the server sends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches compiler analyze/transform, Volar virtual-code mappings, and LSP completion behavior—editor-facing but well covered by new tests; no auth or data-path changes.
> 
> **Overview**
> Adds **editor support for TSRX `@` template directives** and fixes two issues that previously made `.tsrx` intellisense unreliable mid-edit.
> 
> The language server now offers **12 `@` snippets** (`@{}`, `@if`, `@for`, `@switch`, `@try`, plus clause keywords) when the user types `@`, with **text edits that replace the typed prefix** so accepting `@if` does not yield `@@if`. Legacy **`@value` reactivity** and outdated control-flow snippets are removed; **`track-derived` / `effect` / `untrack`** snippet bodies no longer insert `@`-accessor syntax.
> 
> **Volar routing** is updated so those completions can actually appear: `@`-containing JSX text gets **completion-only source maps** in `@tsrx/core`, and the **parse-error fallback** virtual code enables `completion` on its 1:1 mapping.
> 
> **`@tsrx/ripple`** no longer throws on **valueless event attributes** (e.g. `<div onC>` while typing `onClick`); it emits a **positioned, recoverable error** and skips emitting the bad handler, while **`hidden`-style boolean attrs** still compile. Client/server transforms omit valueless event attrs instead of treating them like static booleans.
> 
> **CI harnesses** exercise `getCompletionItems` / `getDiagnostics` (including JSX `div` / `onClick` through a real TS project), mapping behavior, and the valueless-attribute path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03a98fd2a230ab5853808a44ff024568d68142fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->