### PR TITLE
fix: single text node should stay faithful to the source

### DIFF
--- a/.changeset/faithful-single-text-output.md
+++ b/.changeset/faithful-single-text-output.md
@@ -1,0 +1,6 @@
+---
+'@tsrx/core': patch
+'@tsrx/ripple': patch
+---
+
+Keep single-text template output faithful to the source instead of promoting it to a string-literal expression. A component or fragment whose only output is a text node (e.g. `<>@</>` or `<>Hello</>`) is now emitted as-is in both the editor (type-only) view and runtime codegen, rather than being rewritten to `{'@'}` / `{'Hello'}`. This fixes valid text characters like `@` being mangled and preserves source fidelity/mappings across all targets. Nullish or whitespace-only single-text output now renders nothing at runtime instead of emitting a stray empty-string expression.

--- a/.changeset/prettier-ignore-respected.md
+++ b/.changeset/prettier-ignore-respected.md
@@ -1,0 +1,8 @@
+---
+'@tsrx/prettier-plugin': patch
+---
+
+Respect `// prettier-ignore` (and `/* prettier-ignore */`) directives. A node
+immediately preceded by a `prettier-ignore` comment is now emitted verbatim from
+the original source instead of being reformatted, matching Prettier core
+behavior. This works for statements, JSX elements, and fragments.

--- a/packages/prettier-plugin/src/index.js
+++ b/packages/prettier-plugin/src/index.js
@@ -224,6 +224,32 @@ function hasComment(node) {
 }
 
 /**
+ * Check whether a comment is a `prettier-ignore` directive.
+ * @param {AST.Comment | undefined} comment - The comment to check
+ * @returns {boolean} - True if the comment reads exactly `prettier-ignore`
+ */
+function isPrettierIgnoreComment(comment) {
+	if (!comment || (comment.type !== 'Line' && comment.type !== 'Block')) {
+		return false;
+	}
+	return comment.value.trim() === 'prettier-ignore';
+}
+
+/**
+ * Check whether a node is immediately preceded by a `prettier-ignore` directive.
+ * Only the last leading comment counts, matching Prettier core.
+ * @param {AST.Node & AST.NodeWithMaybeComments} node - The AST node to check
+ * @returns {boolean} - True if the node should be printed verbatim
+ */
+function hasPrettierIgnore(node) {
+	const comments = node.leadingComments;
+	if (!comments || comments.length === 0) {
+		return false;
+	}
+	return isPrettierIgnoreComment(comments[comments.length - 1]);
+}
+
+/**
  * @param {AST.FunctionDeclaration | AST.FunctionExpression | AST.ArrowFunctionExpression | AST.TSDeclareFunction} node - The function node
  * @returns {Array<AST.Pattern | AST.Parameter>} - Array of parameter patterns
  */
@@ -723,6 +749,70 @@ function printKey(node, path, options, print) {
 }
 
 /**
+ * Combine already-printed leading comment parts, a node's printed body, and its
+ * trailing comments into the final Doc returned by {@link printRippleNode}.
+ * @param {AST.Node} node - The AST node
+ * @param {Doc[]} parts - Leading-comment parts already collected for the node
+ * @param {Doc[] | Doc} nodeContent - The printed body of the node
+ * @returns {Doc[] | Doc}
+ */
+function finishRippleNode(node, parts, nodeContent) {
+	// Handle trailing comments
+	if (node.trailingComments) {
+		const trailingParts = [];
+		let previousComment = null;
+
+		for (let i = 0; i < node.trailingComments.length; i++) {
+			const comment = node.trailingComments[i];
+			const isInlineComment = Boolean(
+				node.loc && comment.loc && node.loc.end.line === comment.loc.start.line,
+			);
+
+			const commentDoc =
+				comment.type === 'Line' ? '//' + comment.value : '/*' + comment.value + '*/';
+
+			if (isInlineComment) {
+				if (comment.type === 'Line') {
+					trailingParts.push(lineSuffix([' ', commentDoc]));
+					trailingParts.push(breakParent);
+				} else {
+					trailingParts.push(' ' + commentDoc);
+				}
+			} else {
+				const refs = [];
+				refs.push(hardline);
+
+				const blankLinesBetween = previousComment
+					? getBlankLinesBetweenNodes(previousComment, comment)
+					: getBlankLinesBetweenNodes(node, comment);
+				if (blankLinesBetween > 0) {
+					refs.push(hardline);
+				}
+
+				refs.push(commentDoc);
+				trailingParts.push(lineSuffix(refs));
+			}
+
+			previousComment = comment;
+		}
+
+		if (trailingParts.length > 0) {
+			parts.push(nodeContent);
+			parts.push(...trailingParts);
+			return parts;
+		}
+	} // Return with or without leading comments
+	if (parts.length > 0) {
+		// Don't add blank line between leading comments and node
+		// because they're meant to be attached together
+		parts.push(nodeContent);
+		return parts;
+	}
+
+	return nodeContent;
+}
+
+/**
  * Main print function for Ripple AST nodes
  * @param {AST.Node | AST.CSS.StyleSheet} node - The AST node to print
  * @param {AstPath} path - The AST path
@@ -810,6 +900,23 @@ function printRippleNode(node, path, options, print, args) {
 				innerCommentParts.push('/*' + comment.value + '*/');
 			}
 		}
+	}
+
+	// A `prettier-ignore` directive keeps the node's original source verbatim.
+	const commentNode = /** @type {AST.Node & AST.NodeWithMaybeComments} */ (node);
+	const ignoreStart = /** @type {AST.NodeWithLocation} */ (node).start;
+	const ignoreEnd = /** @type {AST.NodeWithLocation} */ (node).end;
+	if (
+		hasPrettierIgnore(commentNode) &&
+		typeof options.originalText === 'string' &&
+		typeof ignoreStart === 'number' &&
+		typeof ignoreEnd === 'number'
+	) {
+		return finishRippleNode(
+			commentNode,
+			parts,
+			replaceEndOfLine(options.originalText.slice(ignoreStart, ignoreEnd)),
+		);
 	}
 
 	/** @type {Doc[] | Doc} */
@@ -2338,64 +2445,7 @@ function printRippleNode(node, path, options, print, args) {
 			break;
 	}
 
-	// Handle trailing comments
-	if (node.trailingComments) {
-		const trailingParts = [];
-		let previousComment = null;
-
-		for (let i = 0; i < node.trailingComments.length; i++) {
-			const comment = node.trailingComments[i];
-			const isInlineComment = Boolean(
-				node.loc && comment.loc && node.loc.end.line === comment.loc.start.line,
-			);
-
-			const commentDoc =
-				comment.type === 'Line' ? '//' + comment.value : '/*' + comment.value + '*/';
-
-			if (isInlineComment) {
-				if (comment.type === 'Line') {
-					trailingParts.push(lineSuffix([' ', commentDoc]));
-					trailingParts.push(breakParent);
-				} else {
-					trailingParts.push(' ' + commentDoc);
-				}
-			} else {
-				const refs = [];
-				refs.push(hardline);
-
-				const blankLinesBetween = previousComment
-					? getBlankLinesBetweenNodes(previousComment, comment)
-					: getBlankLinesBetweenNodes(node, comment);
-				if (blankLinesBetween > 0) {
-					refs.push(hardline);
-				}
-
-				if (comment.type === 'Line') {
-					refs.push(commentDoc);
-					trailingParts.push(lineSuffix(refs));
-				} else {
-					refs.push(commentDoc);
-					trailingParts.push(lineSuffix(refs));
-				}
-			}
-
-			previousComment = comment;
-		}
-
-		if (trailingParts.length > 0) {
-			parts.push(nodeContent);
-			parts.push(...trailingParts);
-			return parts;
-		}
-	} // Return with or without leading comments
-	if (parts.length > 0) {
-		// Don't add blank line between leading comments and node
-		// because they're meant to be attached together
-		parts.push(nodeContent);
-		return parts;
-	}
-
-	return nodeContent;
+	return finishRippleNode(/** @type {AST.Node} */ (node), parts, nodeContent);
 }
 
 /**

--- a/packages/prettier-plugin/src/index.test.js
+++ b/packages/prettier-plugin/src/index.test.js
@@ -851,6 +851,89 @@ const items=[1,2,3];
 		expect(result).toBeWithNewline(expected);
 	});
 
+	describe('prettier-ignore', () => {
+		it('preserves a statement verbatim after a line directive', async () => {
+			const input = `export function App() {
+	// prettier-ignore
+	const matrix = [1,0,0,
+		0,1,0,
+		0,0,1];
+	return <div>{matrix.length}</div>;
+}`;
+			const expected = `export function App() {
+  // prettier-ignore
+  const matrix = [1,0,0,
+		0,1,0,
+		0,0,1];
+  return <div>{matrix.length}</div>;
+}`;
+			const result = await format(input);
+			expect(result).toBeWithNewline(expected);
+		});
+
+		it('preserves a statement verbatim after a block directive', async () => {
+			const input = `export function App() {
+	/* prettier-ignore */
+	const obj = {a:1,     b:2};
+	return <div>{obj.a}</div>;
+}`;
+			const expected = `export function App() {
+  /* prettier-ignore */
+  const obj = {a:1,     b:2};
+  return <div>{obj.a}</div>;
+}`;
+			const result = await format(input);
+			expect(result).toBeWithNewline(expected);
+		});
+
+		it('preserves a JSX element verbatim', async () => {
+			const input = `export function App() @{
+	// prettier-ignore
+	<div   class="x"     id="y">
+		hello
+	</div>
+}`;
+			const expected = `export function App() @{
+  // prettier-ignore
+  <div   class="x"     id="y">
+		hello
+	</div>
+}`;
+			const result = await format(input);
+			expect(result).toBeWithNewline(expected);
+		});
+
+		it('preserves a whitespace-only fragment verbatim', async () => {
+			const input = `function WhitespaceOnlyApp() @{
+	// prettier-ignore
+	<>
+	</>
+}`;
+			const expected = `function WhitespaceOnlyApp() @{
+  // prettier-ignore
+  <>
+	</>
+}`;
+			const result = await format(input);
+			expect(result).toBeWithNewline(expected);
+		});
+
+		it('still formats when the comment is not a prettier-ignore directive', async () => {
+			const input = `export function App() {
+	// this is a normal comment
+	const obj = {a:1,     b:2};
+	return <div>{obj.a}</div>;
+}`;
+			const expected = `export function App() {
+  // this is a normal comment
+  const obj = { a: 1, b: 2 };
+  return <div>{obj.a}</div>;
+}`;
+			const result = await format(input);
+			expect(result).toBeWithNewline(expected);
+		});
+	});
+
 	describe('recovered', () => {
 		/**
 		 * @param {string} code

--- a/packages/ripple/tests/client/basic/basic.rendering.test.tsrx
+++ b/packages/ripple/tests/client/basic/basic.rendering.test.tsrx
@@ -13,6 +13,27 @@ describe('basic client > rendering & text', () => {
 		expect(container).toMatchSnapshot();
 	});
 
+	it('renders a bare `@` text child as literal text', () => {
+		function Basic() @{
+			<>@</>
+		}
+
+		render(Basic);
+
+		expect(container.textContent).toBe('@');
+	});
+
+	it('renders nothing for a whitespace-only fragment', () => {
+		function Basic() @{
+			<>
+			</>
+		}
+
+		render(Basic);
+
+		expect(container.textContent).toBe('');
+	});
+
 	it('renders semi-dynamic text', () => {
 		function Basic() @{
 			let message = 'Hello World';

--- a/packages/ripple/tests/client/basic/basic.rendering.test.tsrx
+++ b/packages/ripple/tests/client/basic/basic.rendering.test.tsrx
@@ -25,6 +25,7 @@ describe('basic client > rendering & text', () => {
 
 	it('renders nothing for a whitespace-only fragment', () => {
 		function Basic() @{
+			// prettier-ignore
 			<>
 			</>
 		}

--- a/packages/tsrx-ripple/src/transform/client/index.js
+++ b/packages/tsrx-ripple/src/transform/client/index.js
@@ -3715,9 +3715,10 @@ function build_tsrx_ts_return_expression(children, in_jsx_child, loc_node) {
 	if (children.length === 1) {
 		const only = children[0];
 		if (only.type === 'JSXText') {
-			return in_jsx_child
-				? setLocation(b.jsx_fragment([only]), /** @type {AST.NodeWithLocation} */ (only))
-				: b.literal(only.value);
+			// Stay faithful to the source: keep a single text child as `<>text</>`
+			// rather than promoting it to a `{'text'}` string literal. Promotion mangles
+			// characters like `@` (a valid text char) into `{'@'}` and loses fidelity.
+			return setLocation(b.jsx_fragment([only]), /** @type {AST.NodeWithLocation} */ (only));
 		}
 		if (only.type === 'JSXExpressionContainer' && !in_jsx_child) {
 			return only.expression;

--- a/packages/tsrx-ripple/tests/basic.test.js
+++ b/packages/tsrx-ripple/tests/basic.test.js
@@ -18,6 +18,62 @@ runSharedComponentParamsTests({
 	name: 'ripple',
 });
 
+describe('@tsrx/ripple faithful text output', () => {
+	it('keeps a single `@` text child as `<>@</>` instead of `{\'@\'}` in type-only output', () => {
+		const { code, errors } = compile_to_volar_mappings(
+			`export function App() {
+				<>@</>
+			}`,
+			'App.tsrx',
+			{ loose: true },
+		);
+
+		expect(errors).toEqual([]);
+		expect(code).toContain('<>@</>');
+		expect(code).not.toContain("{'@'}");
+	});
+
+	it('does not promote ordinary single-text output into a string literal', () => {
+		const { code, errors } = compile_to_volar_mappings(
+			`export function App() {
+				<>Hello</>
+			}`,
+			'App.tsrx',
+			{ loose: true },
+		);
+
+		expect(errors).toEqual([]);
+		expect(code).toContain('<>Hello</>');
+		expect(code).not.toContain("{'Hello'}");
+	});
+
+	it('lowers a single `@` text child to a faithful runtime text node', () => {
+		const { code } = compile(
+			`export function App() {
+				<>@</>
+			}`,
+			'App.tsrx',
+			{ loose: true },
+		);
+
+		expect(code).toContain('_$_.text("@")');
+	});
+
+	it('renders nothing for a whitespace-only runtime output', () => {
+		const { code } = compile(
+			`export function App() {
+				<>
+				</>
+			}`,
+			'App.tsrx',
+			{ loose: true },
+		);
+
+		// A nullish/whitespace-only output should emit no text node at all.
+		expect(code).not.toContain('_$_.text');
+	});
+});
+
 describe('@tsrx/ripple style scope hashes', () => {
 	const source = `export function Card() @{
 	<>

--- a/packages/tsrx-ripple/tests/basic.test.js
+++ b/packages/tsrx-ripple/tests/basic.test.js
@@ -19,7 +19,7 @@ runSharedComponentParamsTests({
 });
 
 describe('@tsrx/ripple faithful text output', () => {
-	it('keeps a single `@` text child as `<>@</>` instead of `{\'@\'}` in type-only output', () => {
+	it("keeps a single `@` text child as `<>@</>` instead of `{'@'}` in type-only output", () => {
 		const { code, errors } = compile_to_volar_mappings(
 			`export function App() {
 				<>@</>

--- a/packages/tsrx/src/transform/jsx/index.js
+++ b/packages/tsrx/src/transform/jsx/index.js
@@ -1202,7 +1202,9 @@ function build_render_statements(
 		const child = body_nodes[i];
 
 		if (is_loop_skip_return_statement(child)) {
-			statements.push(create_component_return_statement(render_nodes, child));
+			statements.push(
+				create_component_return_statement(render_nodes, child, true, transform_context.typeOnly),
+			);
 			render_nodes.length = 0;
 			has_terminal_return = true;
 			continue;
@@ -1314,7 +1316,7 @@ function build_render_statements(
 		hoist_static_render_nodes(render_nodes, transform_context);
 	}
 
-	let return_arg = build_return_expression(render_nodes);
+	let return_arg = build_return_expression(render_nodes, false, transform_context.typeOnly);
 	// Keep an authored `<> … </>` render output verbatim instead of collapsing it:
 	// an empty `<></>` stays `<></>` (not `null`), and a single child stays wrapped
 	// (not its bare value). The `!== 'JSXFragment'` guard avoids double-wrapping a
@@ -3142,18 +3144,23 @@ function get_generated_component_metadata_list(node) {
  * @param {any[]} render_nodes
  * @param {any} source_node
  * @param {boolean} [map_render_node_locations]
+ * @param {boolean} [type_only]
  * @returns {any}
  */
 function create_component_return_statement(
 	render_nodes,
 	source_node,
 	map_render_node_locations = true,
+	type_only = false,
 ) {
 	const cloned = render_nodes.map((node) =>
 		map_render_node_locations ? clone_expression_node(node) : clone_expression_node(node, false),
 	);
 
-	return set_loc(b.return(build_return_expression(cloned) || create_null_literal()), source_node);
+	return set_loc(
+		b.return(build_return_expression(cloned, false, type_only) || create_null_literal()),
+		source_node,
+	);
 }
 
 /**
@@ -4412,7 +4419,9 @@ function tsrx_node_to_jsx_expression(node, transform_context, in_jsx_child = fal
 				const render_nodes = wrap_edge_whitespace(
 					children.map((/** @type {any} */ child) => to_jsx_child(child, transform_context)),
 				);
-				expression = build_return_expression(render_nodes, in_jsx_child) || create_null_literal();
+				expression =
+					build_return_expression(render_nodes, in_jsx_child, transform_context.typeOnly) ||
+					create_null_literal();
 			} finally {
 				transform_context.inside_element_child = saved_inside_element_child;
 			}
@@ -5605,7 +5614,12 @@ function build_switch_with_lift(switch_node, transform_context) {
 			if (helper) {
 				return set_loc(
 					b.switch_case(original_case.test, [
-						create_component_return_statement([helper.component_element], original_case),
+						create_component_return_statement(
+							[helper.component_element],
+							original_case,
+							true,
+							transform_context.typeOnly,
+						),
 					]),
 					original_case,
 				);
@@ -5626,7 +5640,14 @@ function build_switch_with_lift(switch_node, transform_context) {
 
 			for (const child of own_body) {
 				if (is_loop_skip_return_statement(child)) {
-					case_body.push(create_component_return_statement(render_nodes, child));
+					case_body.push(
+						create_component_return_statement(
+							render_nodes,
+							child,
+							true,
+							transform_context.typeOnly,
+						),
+					);
 					has_terminal = true;
 					break;
 				}
@@ -5646,7 +5667,14 @@ function build_switch_with_lift(switch_node, transform_context) {
 
 			if (!has_terminal) {
 				if (render_nodes.length > 0) {
-					case_body.push(create_component_return_statement(render_nodes, original_case));
+					case_body.push(
+						create_component_return_statement(
+							render_nodes,
+							original_case,
+							true,
+							transform_context.typeOnly,
+						),
+					);
 				} else if (case_body.length > 0) {
 					case_body.push(create_null_return_statement());
 				} else if (has_terminator) {
@@ -6199,7 +6227,7 @@ function value_has_unmappable_jsx_loc(value) {
  * @param {boolean} [in_jsx_child]
  * @returns {any}
  */
-export function build_return_expression(render_nodes, in_jsx_child = false) {
+export function build_return_expression(render_nodes, in_jsx_child = false, type_only = false) {
 	if (render_nodes.length === 0) return null;
 	if (render_nodes.length === 1) {
 		const only = render_nodes[0];
@@ -6213,11 +6241,15 @@ export function build_return_expression(render_nodes, in_jsx_child = false) {
 			return only.expression;
 		}
 		if (only.type === 'JSXText') {
-			if (in_jsx_child) {
-				return set_loc(b.jsx_fragment([only]), only.loc ? only : undefined);
+			// Keep a single text child faithful to the source (e.g. `<>@</>`) — never
+			// promote it to a `{'text'}` string-literal expression, in either the
+			// type-only editor view or runtime codegen. At runtime we additionally drop a
+			// nullish/whitespace-only child so it renders nothing instead of emitting
+			// empty output.
+			if (!type_only && !in_jsx_child && (only.value ?? '').trim() === '') {
+				return null;
 			}
-			const value = (only.value ?? '').trim();
-			return b.literal(value, JSON.stringify(value), only);
+			return set_loc(b.jsx_fragment([only]), only.loc ? only : undefined);
 		}
 		return only;
 	}

--- a/packages/tsrx/src/transform/jsx/index.js
+++ b/packages/tsrx/src/transform/jsx/index.js
@@ -3203,7 +3203,11 @@ function get_loop_skip_if_consequent_body(node) {
 function create_component_loop_skip_if_statement(node, render_nodes, transform_context) {
 	const consequent_body = /** @type {any[]} */ (get_loop_skip_if_consequent_body(node));
 	const branch_statements = build_render_statements(consequent_body, true, transform_context);
-	prepend_render_nodes_to_return_statements(branch_statements, render_nodes);
+	prepend_render_nodes_to_return_statements(
+		branch_statements,
+		render_nodes,
+		transform_context.typeOnly,
+	);
 
 	const statement = set_loc(
 		b.if(node.test, set_loc(b.block(branch_statements), node.consequent), null),
@@ -3219,15 +3223,16 @@ function create_component_loop_skip_if_statement(node, render_nodes, transform_c
 /**
  * @param {any[]} statements
  * @param {any[]} render_nodes
+ * @param {boolean} [type_only]
  * @returns {void}
  */
-function prepend_render_nodes_to_return_statements(statements, render_nodes) {
+function prepend_render_nodes_to_return_statements(statements, render_nodes, type_only = false) {
 	if (render_nodes.length === 0) {
 		return;
 	}
 
 	for (const statement of statements) {
-		prepend_render_nodes_to_return_statement(statement, render_nodes, false);
+		prepend_render_nodes_to_return_statement(statement, render_nodes, false, type_only);
 	}
 }
 
@@ -3235,9 +3240,15 @@ function prepend_render_nodes_to_return_statements(statements, render_nodes) {
  * @param {any} node
  * @param {any[]} render_nodes
  * @param {boolean} inside_nested_function
+ * @param {boolean} [type_only]
  * @returns {void}
  */
-function prepend_render_nodes_to_return_statement(node, render_nodes, inside_nested_function) {
+function prepend_render_nodes_to_return_statement(
+	node,
+	render_nodes,
+	inside_nested_function,
+	type_only = false,
+) {
 	if (!node || typeof node !== 'object') {
 		return;
 	}
@@ -3251,13 +3262,18 @@ function prepend_render_nodes_to_return_statement(node, render_nodes, inside_nes
 	}
 
 	if (!inside_nested_function && node.type === 'ReturnStatement') {
-		node.argument = combine_render_return_argument(render_nodes, node.argument);
+		node.argument = combine_render_return_argument(render_nodes, node.argument, type_only);
 		return;
 	}
 
 	if (Array.isArray(node)) {
 		for (const child of node) {
-			prepend_render_nodes_to_return_statement(child, render_nodes, inside_nested_function);
+			prepend_render_nodes_to_return_statement(
+				child,
+				render_nodes,
+				inside_nested_function,
+				type_only,
+			);
 		}
 		return;
 	}
@@ -3266,23 +3282,29 @@ function prepend_render_nodes_to_return_statement(node, render_nodes, inside_nes
 		if (key === 'loc' || key === 'start' || key === 'end' || key === 'metadata') {
 			continue;
 		}
-		prepend_render_nodes_to_return_statement(node[key], render_nodes, inside_nested_function);
+		prepend_render_nodes_to_return_statement(
+			node[key],
+			render_nodes,
+			inside_nested_function,
+			type_only,
+		);
 	}
 }
 
 /**
  * @param {any[]} render_nodes
  * @param {any} return_argument
+ * @param {boolean} [type_only]
  * @returns {any}
  */
-function combine_render_return_argument(render_nodes, return_argument) {
+function combine_render_return_argument(render_nodes, return_argument, type_only = false) {
 	const combined = render_nodes.map((node) => clone_expression_node(node, false));
 
 	if (return_argument != null && !is_null_literal(return_argument)) {
 		combined.push(return_argument_to_render_node(return_argument));
 	}
 
-	return build_return_expression(combined) || create_null_literal();
+	return build_return_expression(combined, false, type_only) || create_null_literal();
 }
 
 /**

--- a/packages/tsrx/tests/shared/compile.js
+++ b/packages/tsrx/tests/shared/compile.js
@@ -63,6 +63,35 @@ export function runSharedCompileDiagnosticsTests({ compile_to_volar_mappings, na
 			expect(result.code).not.toContain('<>{a}a</>');
 		});
 
+		it('keeps a single text child faithful instead of promoting it to a string literal', () => {
+			const result = compile_to_volar_mappings(
+				`export function App() {
+					<>@</>
+				}`,
+				'App.tsrx',
+				{ loose: true },
+			);
+
+			expect(result.errors).toEqual([]);
+			// `@` is valid text content and must stay as-is, not be mangled into `{'@'}`.
+			expect(result.code).toContain('<>@</>');
+			expect(result.code).not.toContain("{'@'}");
+		});
+
+		it('does not promote ordinary single-text output into a string literal', () => {
+			const result = compile_to_volar_mappings(
+				`export function App() {
+					<>Hello</>
+				}`,
+				'App.tsrx',
+				{ loose: true },
+			);
+
+			expect(result.errors).toEqual([]);
+			expect(result.code).toContain('<>Hello</>');
+			expect(result.code).not.toContain("{'Hello'}");
+		});
+
 		it('keeps callback returns around JSX values clean in type-only output', () => {
 			const result = compile_to_volar_mappings(
 				`function Test() @{
@@ -2686,6 +2715,24 @@ export function optionalFn(bar: string, baz?: string) {
 			expect(code).not.toContain('return null;');
 		});
 
+		it('keeps a single text child faithful at runtime instead of a string-literal expression', () => {
+			const { code } = compile(`export function App() {\n\t<>@</>\n}`, 'App.tsrx', { loose: true });
+			// `@` is valid text; keep it as-is rather than promoting it to `{'@'}` / `{"@"}`.
+			expect(code).toContain('<>@</>');
+			expect(code).not.toContain("{'@'}");
+			expect(code).not.toContain('{"@"}');
+		});
+
+		it('renders nothing for a whitespace-only render output at runtime', () => {
+			const { code } = compile(`export function App() {\n\t<>\n\t</>\n}`, 'App.tsrx', {
+				loose: true,
+			});
+			// A nullish/whitespace-only output should be nothing, not a stray `{''}` / `{""}`.
+			expect(code).toContain('<></>');
+			expect(code).not.toContain("{''}");
+			expect(code).not.toContain('{""}');
+		});
+
 		it('parses text-only fragment initializers before template expression children', () => {
 			const { code } = compile(
 				`export function Button() @{
@@ -2695,9 +2742,10 @@ export function optionalFn(bar: string, baz?: string) {
 				'App.tsrx',
 			);
 
-			// An authored `<>…</>` is kept verbatim in value position (var-init), so the
-			// text fragment stays a fragment instead of unwrapping to a bare string.
-			expect(code).toContain('const x = <>{"Hello world"}</>;');
+			// An authored `<>…</>` is kept verbatim in value position (var-init): the text
+			// stays faithful to the source rather than being promoted to a `{"Hello world"}`
+			// string-literal expression.
+			expect(code).toContain('const x = <>Hello world</>;');
 			expect(code).toContain('return <>{x}</>;');
 		});
 

--- a/packages/vite-plugin-react/tests/runtime.test.tsrx
+++ b/packages/vite-plugin-react/tests/runtime.test.tsrx
@@ -53,6 +53,7 @@ function AtTextApp() @{
 }
 
 function WhitespaceOnlyApp() @{
+	// prettier-ignore
 	<>
 	</>
 }

--- a/packages/vite-plugin-react/tests/runtime.test.tsrx
+++ b/packages/vite-plugin-react/tests/runtime.test.tsrx
@@ -48,6 +48,15 @@ function BasicApp() @{
 	<div className="greeting">{'Hello world'}</div>
 }
 
+function AtTextApp() @{
+	<>@</>
+}
+
+function WhitespaceOnlyApp() @{
+	<>
+	</>
+}
+
 function JsxTextApp() @{
 	<>
 		<div className="jsx-text-entities">Rock &amp; &quot;Roll&quot;</div>
@@ -1041,6 +1050,16 @@ describe('tsrx-react runtime', () => {
 		expect(text('.jsx-text-entities')).toBe('Rock & "Roll"');
 		expect(text('.jsx-text-backslash')).toBe('line\\nbreak');
 		expect(text('.jsx-text-multiline')).toBe('first second');
+	});
+
+	it('renders a bare `@` root text child as literal text', async () => {
+		await render(AtTextApp);
+		expect(container.textContent).toBe('@');
+	});
+
+	it('renders nothing for a whitespace-only root fragment', async () => {
+		await render(WhitespaceOnlyApp);
+		expect(container.textContent).toBe('');
 	});
 
 	it('renders bare JSX text in if-else branches', async () => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core JSX return lowering and codegen paths used across compile and runtime targets, though behavior is narrowly scoped and covered by new tests.
> 
> **Overview**
> **Single-text template output** no longer gets rewritten into `{'…'}` string-literal expressions. A lone text child (e.g. `<>@</>`, `<>Hello</>`) stays as JSX text in the **type-only** editor view and in **runtime** codegen, which fixes mangling of characters like `@` and keeps source/mappings aligned. **Whitespace-only** sole text at runtime is dropped so nothing is emitted instead of an empty-string expression.
> 
> The JSX transform threads **`type_only`** through `build_return_expression` and related return/combine paths so editor vs runtime behavior stays consistent; **@tsrx/ripple** mirrors the same rule in its TS return lowering.
> 
> **@tsrx/prettier-plugin** now honors **`// prettier-ignore`** and **`/* prettier-ignore */`** on the immediately following node (last leading comment only), slicing **`originalText`** verbatim via a refactored **`finishRippleNode`** helper—statements, JSX elements, and fragments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb93e1c9b50f5d319b629a3a1ae1d20eef4dbcf7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->