### PR TITLE
fix: remove extra formatter options that did nothing as we use a separate prettier plugin

### DIFF
--- a/packages/language-server/src/server.js
+++ b/packages/language-server/src/server.js
@@ -20,6 +20,32 @@ import { create as createCssService } from 'volar-service-css';
 
 const { log, logError } = createLogging('[Ripple Language Server]');
 
+/**
+ * Strip whole-document formatting capabilities from a Volar service plugin.
+ *
+ * The bundled TypeScript (`typescript-syntactic`) and CSS services advertise a
+ * `documentFormattingProvider`. Because they run against the virtual TS/CSS code
+ * rather than the `.tsrx` source, their edits don't map back and formatting is a
+ * no-op — yet the capability still makes the language client contribute a
+ * "TSRX for VS Code" entry to "Format Document With…" that silently does nothing.
+ * Formatting for `.tsrx` is owned by Prettier + @tsrx/prettier-plugin (configured
+ * as the default `[ripple]` formatter in the VS Code extension), so we drop these
+ * capabilities to keep Prettier as the single, working formatter. On-type
+ * formatting is left intact.
+ *
+ * @template {{ capabilities?: Record<string, unknown> }} T
+ * @param {T} plugin
+ * @returns {T}
+ */
+function stripDocumentFormatting(plugin) {
+	const {
+		documentFormattingProvider: _fmt,
+		documentRangeFormattingProvider: _rangeFmt,
+		...capabilities
+	} = plugin.capabilities ?? {};
+	return { ...plugin, capabilities };
+}
+
 export function createRippleLanguageServer() {
 	const connection = createConnection();
 	const server = createServer(connection);
@@ -98,8 +124,8 @@ export function createRippleLanguageServer() {
 					createCompileErrorDiagnosticPlugin(),
 					createDefinitionPlugin(),
 					createDocumentSymbolPlugin(),
-					createCssService(),
-					...createTypeScriptServices(ts),
+					stripDocumentFormatting(createCssService()),
+					...createTypeScriptServices(ts).map(stripDocumentFormatting),
 					// !IMPORTANT 'createTypeScriptDiagnosticFilterPlugin', 'createHoverPlugin',
 					// and 'createDocumentHighlightPlugin' must come after TypeScript services
 					// to intercept volar's and vscode default providers

--- a/packages/vscode-plugin/src/extension.js
+++ b/packages/vscode-plugin/src/extension.js
@@ -204,12 +204,13 @@ export async function activate(context) {
 		context.subscriptions.push(activateAutoInsertion([{ language: 'ripple' }], client));
 		console.log('[Ripple] Auto-insertion activated');
 
-		// Configure Prettier to handle .tsrx files
+		// Configure Prettier to handle .tsrx files. This sets Prettier as the default
+		// formatter for `[ripple]`, so "Format Document" routes to it directly. We deliberately
+		// do not register our own DocumentFormattingEditProvider: it would show up as a second,
+		// redundant "TSRX for VS Code" entry in "Format Document With…" alongside the one the
+		// language client already contributes (volar-service-typescript / -css), and it broke
+		// whenever the Prettier extension's format command was unavailable.
 		await configurePrettier();
-
-		// Register custom formatter
-		const formatProvider = registerFormatter();
-		context.subscriptions.push(formatProvider);
 
 		// Configure TypeScript command visibility for Ripple files
 		//
@@ -516,31 +517,6 @@ async function configurePrettier() {
 	} catch (error) {
 		console.error('Failed to configure Prettier:', error);
 	}
-}
-
-function registerFormatter() {
-	return vscode.languages.registerDocumentFormattingEditProvider(
-		{ language: 'ripple', scheme: 'file' },
-		{
-			async provideDocumentFormattingEdits(document) {
-				try {
-					console.log('Formatting Ripple document:', document.fileName);
-
-					// Try to use Prettier extension first
-					const edits = await vscode.commands.executeCommand(
-						'editor.action.formatDocument.prettier',
-					);
-					return Array.isArray(edits) ? edits : [];
-				} catch (error) {
-					console.error('Ripple formatting error:', error);
-					vscode.window.showErrorMessage(
-						'Failed to format Ripple file. Ensure Prettier and @tsrx/prettier-plugin are installed.',
-					);
-					return [];
-				}
-			},
-		},
-	);
 }
 
 export async function deactivate() {


### PR DESCRIPTION
as per https://discord.com/channels/1411020393170473002/1411021104780148837/1510881805316915302

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UX-only change around formatter registration and LSP capabilities; formatting behavior should improve with no auth or data impact.
> 
> **Overview**
> Removes **no-op and duplicate formatters** for `.tsrx` so **Prettier** (via `@tsrx/prettier-plugin` and `[ripple]` default formatter settings) is the only working path for "Format Document".
> 
> The language server wraps Volar **CSS** and **TypeScript** service plugins with `stripDocumentFormatting`, dropping `documentFormattingProvider` and `documentRangeFormattingProvider` so the client no longer advertises a **"TSRX for VS Code"** entry in "Format Document With…" that formats virtual TS/CSS and does nothing on the real file. **On-type** formatting capabilities are unchanged.
> 
> The VS Code extension **deletes** the custom `DocumentFormattingEditProvider` (`registerFormatter`) that proxied `editor.action.formatDocument.prettier`, which duplicated that menu entry and failed when the Prettier extension command was unavailable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 989392b09937c00706a8e3be7a3cdbca94f11d28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->