### PR TITLE
fix: valueless event attribute crashing editor

### DIFF
--- a/.changeset/tsrx-ripple-valueless-event-attribute.md
+++ b/.changeset/tsrx-ripple-valueless-event-attribute.md
@@ -1,0 +1,5 @@
+---
+'@tsrx/ripple': patch
+---
+
+Valueless event attributes (e.g. mid-typing `<div onC>`) no longer crash the compiler with a position-less TypeError. They now produce a positioned error at the attribute (recoverable in loose/collect mode, so editor completions and diagnostics stay alive on the rest of the file), while boolean shorthand on non-event attributes like `<div hidden>` keeps compiling clean.

--- a/packages/tsrx-ripple/src/analyze/index.js
+++ b/packages/tsrx-ripple/src/analyze/index.js
@@ -2565,15 +2565,27 @@ const visitors = {
 						}
 
 						if (isEventAttribute(attr.name.name)) {
-							const handler = visit(/** @type {AST.Expression} */ (attr.value), state);
-							const is_delegated = is_delegated_event(attr.name.name, handler, context);
+							if (attr.value === null) {
+								// A regular attribute can have no value (like `hidden`), but an
+								// event attribute like `<div onC>` has no handler to run
+								error(
+									`the \`${attr.name.name}\` event attribute must be assigned a handler expression`,
+									state.analysis.module.filename,
+									attr,
+									context.state.collect ? context.state.analysis.errors : undefined,
+									context.state.analysis.comments,
+								);
+							} else {
+								const handler = visit(/** @type {AST.Expression} */ (attr.value), state);
+								const is_delegated = is_delegated_event(attr.name.name, handler, context);
 
-							if (is_delegated) {
-								if (attr.metadata === undefined) {
-									attr.metadata = { path: [...path] };
+								if (is_delegated) {
+									if (attr.metadata === undefined) {
+										attr.metadata = { path: [...path] };
+									}
+
+									attr.metadata.delegated = is_delegated;
 								}
-
-								attr.metadata.delegated = is_delegated;
 							}
 						} else if (attr.value !== null) {
 							visit(attr.value, state);

--- a/packages/tsrx-ripple/src/transform/client/index.js
+++ b/packages/tsrx-ripple/src/transform/client/index.js
@@ -2287,7 +2287,10 @@ const visitors = {
 						}
 
 						if (attr.value === null) {
-							handle_static_attr(name, true);
+							// omit a valueless event attr (analyze errored); `hidden` etc. still emit
+							if (!isEventAttribute(name)) {
+								handle_static_attr(name, true);
+							}
 							continue;
 						}
 

--- a/packages/tsrx-ripple/src/transform/server/index.js
+++ b/packages/tsrx-ripple/src/transform/server/index.js
@@ -1995,7 +1995,10 @@ const visitors = {
 						}
 
 						if (attr.value === null) {
-							handle_static_attr(name, true);
+							// omit a valueless event attr (analyze errored); `hidden` etc. still emit
+							if (!isEventAttribute(name)) {
+								handle_static_attr(name, true);
+							}
 							continue;
 						}
 

--- a/packages/tsrx-ripple/tests/valueless-attribute.test.js
+++ b/packages/tsrx-ripple/tests/valueless-attribute.test.js
@@ -1,0 +1,99 @@
+import { compile, compile_to_volar_mappings } from '../src/index.js';
+import { describe, expect, it } from 'vitest';
+
+// An event attribute with no value like `<div onC>` (mid-typing while completing
+// `onClick`) is a mistake, not a crash. The compiler reports an error pointing at
+// the attribute (collected in editor mode, thrown in strict mode) and skips
+// generating the handler. A valueless non-event attribute like `<div hidden>` is
+// normal JSX and still works.
+describe('@tsrx/ripple valueless event attributes', () => {
+	const sources = {
+		'mid-typing onC': `export function App() {
+	return <div class="x" onC>{'hi'}</div>;
+}`,
+		'bare onClick': `export function App() {
+	return <div onClick>{'hi'}</div>;
+}`,
+	};
+
+	/** @param {string} source */
+	const attr_range = (source) => {
+		const name = source.includes('onClick') ? 'onClick' : 'onC';
+		const start = source.indexOf(name);
+		return { start, end: start + name.length };
+	};
+
+	for (const [kind, source] of Object.entries(sources)) {
+		const attr_name = source.includes('onClick') ? 'onClick' : 'onC';
+
+		it(`collects a positioned error and completes client compilation (${kind})`, () => {
+			const { code, errors } = compile(source, 'App.tsrx', { collect: true });
+			const { start, end } = attr_range(source);
+
+			expect(code).toBeTypeOf('string');
+			expect(errors.length).toBeGreaterThan(0);
+			const error = errors.find((e) => /event attribute/i.test(e.message));
+			expect(error).toBeDefined();
+			// the error range covers the attribute node
+			expect(error?.pos).toBeLessThanOrEqual(start);
+			expect(error?.end).toBeGreaterThanOrEqual(end);
+			// the broken attribute is omitted, not emitted as `onClick=""` markup
+			expect(code).not.toContain(`${attr_name}=`);
+		});
+
+		it(`collects a positioned error and completes server compilation (${kind})`, () => {
+			const { code, errors } = compile(source, 'App.tsrx', { collect: true, mode: 'server' });
+			const { start, end } = attr_range(source);
+
+			expect(code).toBeTypeOf('string');
+			const error = errors.find((e) => /event attribute/i.test(e.message));
+			expect(error).toBeDefined();
+			expect(error?.pos).toBeLessThanOrEqual(start);
+			expect(error?.end).toBeGreaterThanOrEqual(end);
+			expect(code).not.toContain(`${attr_name}=`);
+		});
+
+		it(`completes compile_to_volar_mappings with full mappings (${kind})`, () => {
+			const result = compile_to_volar_mappings(source, 'App.tsrx', { loose: true });
+			const { start, end } = attr_range(source);
+
+			expect(result.code).toBeTypeOf('string');
+			expect(result.mappings.length).toBeGreaterThan(1);
+			const error = result.errors.find((e) => /event attribute/i.test(e.message));
+			expect(error).toBeDefined();
+			expect(error?.pos).toBeLessThanOrEqual(start);
+			expect(error?.end).toBeGreaterThanOrEqual(end);
+		});
+
+		it(`throws a positioned CompileError in strict mode (${kind})`, () => {
+			const { start, end } = attr_range(source);
+			let thrown;
+			try {
+				compile(source, 'App.tsrx');
+			} catch (e) {
+				thrown = e;
+			}
+
+			expect(thrown).toBeDefined();
+			// an error that points at the code, not a crash with no location
+			expect(thrown.constructor).not.toBe(TypeError);
+			expect(thrown.message).toMatch(/event attribute/i);
+			expect(thrown.pos).toBeLessThanOrEqual(start);
+			expect(thrown.end).toBeGreaterThanOrEqual(end);
+		});
+	}
+
+	it('keeps boolean shorthand on non-event attributes compiling clean', () => {
+		const source = `export function App() {
+	return <div hidden>{'x'}</div>;
+}`;
+		const client = compile(source, 'App.tsrx', { collect: true });
+		const server = compile(source, 'App.tsrx', { collect: true, mode: 'server' });
+
+		expect(client.errors).toEqual([]);
+		expect(server.errors).toEqual([]);
+		// strict mode must not throw either
+		expect(() => compile(source, 'App.tsrx')).not.toThrow();
+		expect(() => compile(source, 'App.tsrx', { mode: 'server' })).not.toThrow();
+	});
+});


### PR DESCRIPTION
extracted from #1314 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted compiler analyze/transform guardrails and diagnostics; valid templates are unchanged and behavior only differs for already-invalid valueless event attributes.
> 
> **Overview**
> Fixes a **compiler crash** when templates contain event attributes with no handler (e.g. mid-autocomplete `<div onC>` or `<div onClick>`). Instead of a position-less `TypeError`, **analysis** now reports a **located** error that the event attribute must have a handler expression; in **collect/loose** mode compilation still finishes so the editor can keep diagnostics and mappings on the rest of the file.
> 
> **Client and server transforms** no longer treat valueless `on*` attributes like boolean DOM shorthand—they skip emitting those attributes after analyze has errored—while **non-event** valueless attrs such as `<div hidden>` still compile as before.
> 
> Adds **Vitest** coverage for collect/strict modes, server output, Volar mappings, and the `hidden` regression.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a69d24f03b2e9e7c0d3ab03f37a543eceb497bb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->