### PR TITLE
Fix TSRX parser crash on parenthesized JSX branch with nested element children

### DIFF
--- a/.changeset/fix-tsrx-conditional-jsx-parse.md
+++ b/.changeset/fix-tsrx-conditional-jsx-parse.md
@@ -1,0 +1,5 @@
+---
+'@tsrx/core': patch
+---
+
+Fix a TSRX parser crash on a conditional/logical JSX branch that Prettier wraps in parentheses across multiple lines when it contains a nested non-self-closing child element on its own line (e.g. `{cond ? (\n  <Outer>\n    <Inner/>\n  </Outer>\n) : null}`). A JSX tokenizer context leaked by the nested child sat above the enclosing `(`, so after the closing `)` the tokenizer stayed in JSX-text mode and mis-tokenized the following `:`.

--- a/packages/tsrx/src/plugin.js
+++ b/packages/tsrx/src/plugin.js
@@ -2358,6 +2358,32 @@ export function TSRXPlugin(config) {
 					ctx.length = ci - 1;
 					return;
 				}
+				// A JSX tokenizer context (`tc_expr`/`tc_oTag`/`tc_cTag`) leaked by a nested
+				// element child laid out on its own line can sit directly above the enclosing
+				// `(`/`[` delimiter. Left in place it keeps the tokenizer in JSX-text mode for
+				// whatever follows the delimiter's close, so a ternary `:` after a parenthesized
+				// JSX consequent (`{c ? (<a><b/></a>) : d}`) tokenizes as JSX text and the parse
+				// derails. Strip the leaked context(s) down to the delimiter and pop it,
+				// restoring JS-expression mode. (A non-JSX context such as a template-literal
+				// `${` already shields the shallow case, so only the leaked-JSX top needs this.)
+				if (
+					(this.type === tt.parenR || this.type === tt.bracketR) &&
+					(top === tstc.tc_expr || top === tstc.tc_oTag || top === tstc.tc_cTag)
+				) {
+					let i = ci;
+					while (
+						i >= 0 &&
+						(ctx[i] === tstc.tc_expr || ctx[i] === tstc.tc_oTag || ctx[i] === tstc.tc_cTag)
+					) {
+						i--;
+					}
+					const delimiter = this.type === tt.parenR ? '(' : '[';
+					if (i >= 0 && ctx[i]?.token === delimiter) {
+						ctx.length = i;
+						this.exprAllowed = false;
+						return;
+					}
+				}
 				// Closing token after the template at expression position. For `}`
 				// only pop if it actually closes this `b_expr` — otherwise the
 				// brace targets an inner callback/object body that should pop it

--- a/packages/tsrx/tests/utils/parser.test.js
+++ b/packages/tsrx/tests/utils/parser.test.js
@@ -2900,4 +2900,62 @@ foo();`;
 		expect(block.body).toEqual([]);
 		expect(block.render.type).toBe('JSXFragment');
 	});
+
+	it('parses a conditional whose parenthesized branch has nested element children on their own lines', () => {
+		// Regression: Prettier wraps a conditional JSX branch in parentheses across
+		// multiple lines. A nested non-self-closing child on its own line left a JSX
+		// tokenizer context above the enclosing `(`, so after the `)` the tokenizer
+		// stayed in JSX-text mode and mis-tokenized the ternary `:` (an `&&` branch,
+		// whose next token is `}`, happened to survive). See
+		// #popTokenContextsAfterTemplateExpressionElement.
+		const source = [
+			'export function C() {',
+			'  return (',
+			'    <div>',
+			'      {cond ? (',
+			'        <Outer>',
+			'          <Inner>hi</Inner>',
+			'        </Outer>',
+			'      ) : null}',
+			'    </div>',
+			'  );',
+			'}',
+		].join('\n');
+		const conditional = findNode(source, 'ConditionalExpression');
+		expect(conditional.consequent.type).toBe('JSXElement');
+		expect(conditional.consequent.openingElement.name.name).toBe('Outer');
+		expect(conditional.alternate.type).toBe('Literal');
+	});
+
+	it('parses the same nested-JSX shape in `&&` and array-literal holes', () => {
+		const and = [
+			'export function C() {',
+			'  return (',
+			'    <div>',
+			'      {cond && (',
+			'        <Outer>',
+			'          <Inner>hi</Inner>',
+			'        </Outer>',
+			'      )}',
+			'    </div>',
+			'  );',
+			'}',
+		].join('\n');
+		expect(findElement(and, 'Outer')).toBeTruthy();
+
+		const list = [
+			'export function C() {',
+			'  return (',
+			'    <div>',
+			'      {[',
+			'        <Outer>',
+			'          <Inner>hi</Inner>',
+			'        </Outer>,',
+			'      ]}',
+			'    </div>',
+			'  );',
+			'}',
+		].join('\n');
+		expect(findElement(list, 'Outer')).toBeTruthy();
+	});
 });


### PR DESCRIPTION
## What

Fixes a TSRX parser crash (`Unexpected token`) on a conditional/logical JSX branch that Prettier wraps in parentheses across multiple lines, when the branch contains a **nested non-self-closing child element on its own line** — i.e. the extremely common shape Prettier emits:

```tsx
{cond ? (
  <Outer>
    <Inner>…</Inner>
  </Outer>
) : null}
```

Single-line branches, self-closing/text children, `&&` branches, and depth-1 branches all parsed fine — only this specific (and Prettier-default) combination threw.

## Root cause

`#popTokenContextsAfterTemplateExpressionElement` restores the tokenizer context after a JSX element parsed in expression position. When the element has a nested non-self-closing child laid out on its own line, a JSX tokenizer context (`tc_expr`) is left **above** the enclosing `(`. The paren-pop only fires when `top?.token === '('`, so it never strips the leaked context. Left in place, the tokenizer stays in JSX-text mode after the `)`, and the ternary `:` is mis-tokenized as JSX text → the parse derails (reported back at the `?`).

An `&&` branch survives only by luck — its next token after `)` is `}`, which `tc_expr` closes correctly. A depth-1 branch survives because a non-JSX context (`${`) shields the top. Only *leaked-JSX-on-top* + *`:`-next* breaks.

## Fix

When the following token is a closing `)`/`]` and a run of leaked JSX contexts (`tc_expr`/`tc_oTag`/`tc_cTag`) sits directly above the matching `(`/`[`, strip them down to the delimiter and pop it — restoring JS-expression mode. 26 lines, guarded so it fires only in exactly this leaked-context case.

## Testing

- New regression tests in `parser.test.js` (ternary + `&&`/array-literal variants). The ternary test **fails without the fix, passes with it**.
- Full `@tsrx/core` suite stays green (**314 tests**).
- AST verified correct: `ConditionalExpression` → `JSXElement` consequent → nested child, `Literal null` alternate.
- `prettier --check` clean; `patch` changeset included.

## Motivation

Found while building a deterministic (non-AI) React→Octane source bridger — Octane consumes `@tsrx/core`'s `parseModule` via its compiler, and a bridged React component using this Prettier-standard formatting failed to compile. Companion Octane PR that consumes this fix: **octanejs/octane#23** (its `react-compat` bridger hit this on the Prettier-formatted branch of one example).
