### PR TITLE
fix(parser): parenthesized JSX with nested children inside a ternary branch of an expression container

### DIFF
--- a/.changeset/parenthesized-jsx-ternary-branch.md
+++ b/.changeset/parenthesized-jsx-ternary-branch.md
@@ -1,0 +1,5 @@
+---
+'@tsrx/core': patch
+---
+
+Parenthesized multiline JSX with nested children inside a ternary branch of an expression container (e.g. `{cond ? (<Outer><Inner>hi</Inner></Outer>) : null}` spread across lines) no longer fails to parse. After the closing `)`, the tokenizer treated the following `: null` as template raw text of the enclosing element and swallowed it; raw text inside an expression container is now only read when the innermost template element was opened inside that container.

--- a/packages/tsrx/src/plugin.js
+++ b/packages/tsrx/src/plugin.js
@@ -259,6 +259,13 @@ export function TSRXPlugin(config) {
 			// `#filterTemplateScriptContexts`.
 			/** @type {number[]} */
 			#expressionContainerContextBaselines = [];
+			// `#path` length at the start of each open `{ … }` expression container.
+			// Raw template text inside a container belongs only to an element opened
+			// inside it (`{<div>   a</div>}`); at the container's own expression level
+			// (`{cond ? (<Outer>…</Outer>) : null}` after the `)`) the next characters
+			// are JS, and reading them as raw text would swallow tokens like `: null`.
+			/** @type {number[]} */
+			#expressionContainerPathBaselines = [];
 			#consumeContainerBraceAfterScope = false;
 			#scriptJSXElementDepth = 0;
 			#forceScriptJSXElementDepth = 0;
@@ -935,6 +942,26 @@ export function TSRXPlugin(config) {
 				const current_template_node = this.#currentNativeTemplateNode();
 				if (!current_template_node || this.#isJSXControlFlowDirectiveAt(this.pos)) {
 					return false;
+				}
+				// Inside an expression container (only reachable with
+				// `allow_inside_expression_container`), raw text belongs to an element
+				// opened inside the container. When the innermost native template element
+				// sits below the container's path baseline we are at the container's own
+				// expression level — e.g. after `(<Outer>…</Outer>)` in
+				// `{cond ? (<Outer>…</Outer>) : null}` — and the following characters are
+				// JS tokens, not template text.
+				if (this.#jsxExpressionContainerDepth > 0 && !this.#openingNativeTemplateNode) {
+					const path_baseline = this.#expressionContainerPathBaselines.at(-1) ?? 0;
+					let inside_container = false;
+					for (let i = this.#path.length - 1; i >= path_baseline; i--) {
+						if (this.#isNativeTemplateNode(this.#path[i])) {
+							inside_container = true;
+							break;
+						}
+					}
+					if (!inside_container) {
+						return false;
+					}
 				}
 				if (this.#isTemplateLineCommentStart(this.pos)) {
 					return false;
@@ -3377,6 +3404,7 @@ export function TSRXPlugin(config) {
 					// container must not strip anything below this floor (see
 					// `#filterTemplateScriptContexts`).
 					this.#expressionContainerContextBaselines.push(this.context.length);
+					this.#expressionContainerPathBaselines.push(this.#path.length);
 					pushed_context_baseline = true;
 
 					node.expression =
@@ -3398,6 +3426,7 @@ export function TSRXPlugin(config) {
 					this.#jsxExpressionContainerDepth--;
 					if (pushed_context_baseline) {
 						this.#expressionContainerContextBaselines.pop();
+						this.#expressionContainerPathBaselines.pop();
 					}
 				}
 

--- a/packages/tsrx/tests/utils/parser.test.js
+++ b/packages/tsrx/tests/utils/parser.test.js
@@ -541,6 +541,32 @@ abc
 		expect(outer.alternate.alternate.type).toBe('JSXElement');
 	});
 
+	it('parses a parenthesized multiline element with nested children in a ternary branch', () => {
+		const returned = getReturned(
+			`function App({ cond }) {
+				return <div>
+					{cond
+						? (<Outer>
+								<Inner>hi</Inner>
+							</Outer>)
+						: null}
+				</div>;
+			}`,
+		);
+
+		const expression = returned.children.find(
+			(child) => child.type === 'JSXExpressionContainer',
+		).expression;
+		expect(expression.type).toBe('ConditionalExpression');
+		expect(expression.consequent.type).toBe('JSXElement');
+		expect(expression.consequent.openingElement.name.name).toBe('Outer');
+		const inner = expression.consequent.children.find((child) => child.type === 'JSXElement');
+		expect(inner.openingElement.name.name).toBe('Inner');
+		expect(inner.children[0].value).toBe('hi');
+		expect(expression.alternate.type).toBe('Literal');
+		expect(expression.alternate.value).toBeNull();
+	});
+
 	it('preserves element-text whitespace in ternary branches inside an expression container', () => {
 		const span = findElement(
 			`function App() {


### PR DESCRIPTION
supersedes #1321 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core JSX/expression-container tokenization in the TSRX Acorn plugin; scope is narrow and covered by a new test, but tokenizer bugs can have subtle regressions elsewhere in template syntax.
> 
> **Overview**
> Fixes a **TSRX parser** failure when a **multiline, parenthesized JSX element with nested children** appears as the consequent of a ternary inside `{…}` (e.g. `{cond ? (<Outer><Inner>hi</Inner></Outer>) : null}`).
> 
> After the closing `)` of that JSX group, the tokenizer was still treating following characters as **template raw text** on the enclosing element, which **swallowed** the `: null` branch and broke parsing. The plugin now records a **path baseline** when each expression container opens and only reads raw template text inside a container when a **native template element was opened within that container’s path**; otherwise it tokenizes as **JavaScript** again.
> 
> A **regression test** asserts the conditional AST (Outer/Inner/`null` alternate). Patch-level **changeset** for `@tsrx/core`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b04c9d2763b115b7cd2b87fdc442702ec9389cc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->