### PR TITLE
chore: migrate Ripple to the parser ast and stop extra transforms

### DIFF
--- a/.changeset/deep-mugs-obey.md
+++ b/.changeset/deep-mugs-obey.md
@@ -1,0 +1,7 @@
+---
+'@tsrx/prettier-plugin': patch
+'@tsrx/solid': patch
+'ripple': patch
+---
+
+Minor adjustments from @tsrx/ripple moving to the parser ast vs its own version

--- a/.changeset/eighty-jobs-brake.md
+++ b/.changeset/eighty-jobs-brake.md
@@ -1,0 +1,9 @@
+---
+'@tsrx/core': patch
+---
+
+Remove the Ripple-normalized AST node types (`Element`, `TsrxFragment`,
+`Text`, `TSRXExpression`, `Attribute`, `SpreadAttribute`) and their builders
+(`builders.text`, `builders.tsrx_fragment`, `builders.tsrx_expression`).
+`@tsrx/ripple` now consumes the parser's JSX AST directly, so these shapes are
+no longer produced anywhere.

--- a/.changeset/olive-poets-refuse.md
+++ b/.changeset/olive-poets-refuse.md
@@ -1,0 +1,11 @@
+---
+'@tsrx/ripple': patch
+---
+
+`parse()` now returns the parser's raw AST instead of the Ripple-normalized
+one: template nodes keep their JSX shapes (`JSXElement`, `JSXFragment`,
+`JSXText`, `JSXExpressionContainer`, `JSXAttribute`, `JSXStyleElement`) and
+control-flow directives keep their `JSX…Expression` forms. The Ripple-specific
+`Element`/`TsrxFragment`/`Text`/`TSRXExpression`/`Attribute`/`SpreadAttribute`
+node types are no longer produced; the analyzer and client/server transforms
+consume the parser AST directly.

--- a/.changeset/olive-poets-refuse.md
+++ b/.changeset/olive-poets-refuse.md
@@ -9,3 +9,8 @@ control-flow directives keep their `JSX…Expression` forms. The Ripple-specific
 `Element`/`TsrxFragment`/`Text`/`TSRXExpression`/`Attribute`/`SpreadAttribute`
 node types are no longer produced; the analyzer and client/server transforms
 consume the parser AST directly.
+
+The analyzer and transforms are also copy-on-write now — they never mutate the
+parsed AST — so `compile_to_volar_mappings` no longer clones the tree, and the
+Volar source walk sees the analyzer's scoped-CSS metadata: class attributes on
+scoped elements get their CSS hover and go-to-definition mappings back.

--- a/packages/prettier-plugin/src/index.js
+++ b/packages/prettier-plugin/src/index.js
@@ -2603,7 +2603,9 @@ function printVariableDeclaration(node, path, options, print) {
 		(parentNode && parentNode.type === 'ForInStatement' && parentNode.left === node) ||
 		(parentNode &&
 			parentNode.type === 'JSXForExpression' &&
-			(parentNode.left === node || parentNode.init === node));
+			(parentNode.statementType === 'ForStatement'
+				? parentNode.init === node
+				: parentNode.left === node));
 
 	const declarations = path.map(print, 'declarations');
 	const declarationParts = join(', ', declarations);

--- a/packages/prettier-plugin/src/index.js
+++ b/packages/prettier-plugin/src/index.js
@@ -1576,10 +1576,6 @@ function printRippleNode(node, path, options, print, args) {
 			if (node.typeArguments) {
 				parts.push(path.call(print, 'typeArguments'));
 			}
-			// @ts-expect-error account for future changes as our acorn-typescript is buggy
-			else if (node.typeParameters) {
-				parts.push(path.call(print, 'typeParameters'));
-			}
 
 			const argsDoc = printCallArguments(path, options, print);
 			parts.push(argsDoc);
@@ -4162,11 +4158,6 @@ function printNewExpression(node, path, options, print) {
 
 	if (node.typeArguments) {
 		parts.push(path.call(print, 'typeArguments'));
-	}
-	// @ts-expect-error account for future changes as our acorn-typescript is buggy
-	else if (node.typeParameters) {
-		// @ts-expect-error
-		parts.push(path.call(print, 'typeParameters'));
 	}
 
 	if (node.arguments && node.arguments.length > 0) {

--- a/packages/ripple/tests/client/compiler/compiler.basic.test.tsrx
+++ b/packages/ripple/tests/client/compiler/compiler.basic.test.tsrx
@@ -196,7 +196,7 @@ export function App() @{
 		const declaration = (ast.body[0] as AST.VariableDeclaration).declarations[0];
 		const fragment = get_returned_tsrx(declaration) as any;
 
-		expect(fragment.type).toBe('TsrxFragment');
+		expect(fragment.type).toBe('JSXFragment');
 		expect(fragment.children[0].type).toBe('JSXExpressionContainer');
 		expect(fragment.children[0].expression.type).toBe('TemplateLiteral');
 		expect(fragment.children[0].expression.quasis[0].value.raw).toBe('333');
@@ -215,7 +215,7 @@ export function App() @{
 		const declaration = (ast.body[0] as AST.VariableDeclaration).declarations[0];
 		const fragment = get_returned_tsrx(declaration) as any;
 
-		expect(fragment.type).toBe('TsrxFragment');
+		expect(fragment.type).toBe('JSXFragment');
 		expect(fragment.children.map((child: any) => child.type)).toEqual([
 			'JSXExpressionContainer',
 		]);

--- a/packages/ripple/tests/client/compiler/compiler.basic.test.tsrx
+++ b/packages/ripple/tests/client/compiler/compiler.basic.test.tsrx
@@ -1231,7 +1231,9 @@ export function App() @{
 			const ul =
 				returned.type === 'JSXElement'
 					? returned
-					: (returned.children.find((n: AST.Node) => n.type === 'JSXElement') as ESTreeJSX.JSXElement);
+					: returned.children.find(
+							(n: AST.Node) => n.type === 'JSXElement',
+						) as ESTreeJSX.JSXElement;
 			expect((ul.openingElement.name as ESTreeJSX.JSXIdentifier).name).toBe('ul');
 			expect(ul.children).toHaveLength(1);
 			const text = ul.children[0] as unknown as { type: string; value: string };

--- a/packages/ripple/tests/client/compiler/compiler.basic.test.tsrx
+++ b/packages/ripple/tests/client/compiler/compiler.basic.test.tsrx
@@ -75,9 +75,9 @@ describe('compiler > basics', () => {
 		const text_expression = elements[1].children[0] as AST.Node & { expression: AST.Expression };
 
 		expect(elements).toHaveLength(2);
-		expect(expression.type).toBe('TSRXExpression');
+		expect(expression.type).toBe('JSXExpressionContainer');
 		expect((expression.expression as AST.Identifier).name).toBe('markup');
-		expect(text_expression.type).toBe('TSRXExpression');
+		expect(text_expression.type).toBe('JSXExpressionContainer');
 		expect((text_expression.expression as AST.Identifier).name).toBe('text');
 
 		const { code } = compile(source, 'text-directive.tsrx', { mode: 'client' });
@@ -197,7 +197,7 @@ export function App() @{
 		const fragment = get_returned_tsrx(declaration) as any;
 
 		expect(fragment.type).toBe('TsrxFragment');
-		expect(fragment.children[0].type).toBe('TSRXExpression');
+		expect(fragment.children[0].type).toBe('JSXExpressionContainer');
 		expect(fragment.children[0].expression.type).toBe('TemplateLiteral');
 		expect(fragment.children[0].expression.quasis[0].value.raw).toBe('333');
 	});
@@ -217,7 +217,7 @@ export function App() @{
 
 		expect(fragment.type).toBe('TsrxFragment');
 		expect(fragment.children.map((child: any) => child.type)).toEqual([
-			'TSRXExpression',
+			'JSXExpressionContainer',
 		]);
 		expect(fragment.children[0].expression.type).toBe('TemplateLiteral');
 		expect(fragment.children[0].expression.quasis[0].value.raw).toContain('<b></b>');
@@ -1234,9 +1234,9 @@ export function App() @{
 					: returned.children.find((n: AST.Node) => n.type === 'Element') as AST.Element;
 			expect((ul.id as AST.Identifier).name).toBe('ul');
 			expect(ul.children).toHaveLength(1);
-			const text = ul.children[0] as unknown as { type: string; expression: AST.Literal };
-			expect(text.type).toBe('Text');
-			expect(text.expression.value).toBe('var a = "123"');
+			const text = ul.children[0] as unknown as { type: string; value: string };
+			expect(text.type).toBe('JSXText');
+			expect(text.value).toBe('var a = "123"');
 			expect((ul.closingElement?.name as ESTreeJSX.JSXIdentifier)?.name).toBe('ul');
 		},
 	);

--- a/packages/ripple/tests/client/compiler/compiler.basic.test.tsrx
+++ b/packages/ripple/tests/client/compiler/compiler.basic.test.tsrx
@@ -69,8 +69,8 @@ describe('compiler > basics', () => {
 
 		const ast = parse(source, 'App.tsrx');
 		const elements = get_returned_tsrx(ast.body[0]).children.filter(
-			(node: AST.Node) => node.type === 'Element',
-		) as AST.Element[];
+			(node: AST.Node) => node.type === 'JSXElement',
+		) as ESTreeJSX.JSXElement[];
 		const expression = elements[0].children[0] as AST.Node & { expression: AST.Expression };
 		const text_expression = elements[1].children[0] as AST.Node & { expression: AST.Expression };
 
@@ -1229,10 +1229,10 @@ export function App() @{
 			const ast = parse(source, 'App.tsrx');
 			const returned = get_returned_tsrx(ast.body[0]);
 			const ul =
-				returned.type === 'Element'
+				returned.type === 'JSXElement'
 					? returned
-					: returned.children.find((n: AST.Node) => n.type === 'Element') as AST.Element;
-			expect((ul.id as AST.Identifier).name).toBe('ul');
+					: (returned.children.find((n: AST.Node) => n.type === 'JSXElement') as ESTreeJSX.JSXElement);
+			expect((ul.openingElement.name as ESTreeJSX.JSXIdentifier).name).toBe('ul');
 			expect(ul.children).toHaveLength(1);
 			const text = ul.children[0] as unknown as { type: string; value: string };
 			expect(text.type).toBe('JSXText');

--- a/packages/ripple/tests/hydration/compiled/client/basic.js
+++ b/packages/ripple/tests/hydration/compiled/client/basic.js
@@ -76,9 +76,9 @@ import { track } from 'ripple';
 
 export function StaticText() {
 	return _$_.tsrx_element((__anchor, __block) => {
-		var div_1 = root();
+		var div = root();
 
-		_$_.append(__anchor, div_1);
+		_$_.append(__anchor, div);
 	});
 }
 
@@ -100,9 +100,9 @@ export function MultipleElements() {
 
 export function NestedElements() {
 	return _$_.tsrx_element((__anchor, __block) => {
-		var div_2 = root_3();
+		var div_1 = root_3();
 
-		_$_.append(__anchor, div_2);
+		_$_.append(__anchor, div_1);
 	});
 }
 
@@ -124,40 +124,40 @@ export function WithAttributes() {
 
 export function ChildComponent() {
 	return _$_.tsrx_element((__anchor, __block) => {
-		var span_1 = root_6();
+		var span = root_6();
 
-		_$_.append(__anchor, span_1);
+		_$_.append(__anchor, span);
 	});
 }
 
 export function ParentWithChild() {
 	return _$_.tsrx_element((__anchor, __block) => {
-		var div_3 = root_7();
+		var div_2 = root_7();
 
 		{
-			var append_anchor = _$_.append_into(div_3);
+			var append_anchor = _$_.append_into(div_2);
 
 			_$_.render_component(ChildComponent, append_anchor, {});
-			_$_.pop(div_3);
+			_$_.pop(div_2);
 		}
 
-		_$_.append(__anchor, div_3);
+		_$_.append(__anchor, div_2);
 	});
 }
 
 export function FirstSibling() {
 	return _$_.tsrx_element((__anchor, __block) => {
-		var div_4 = root_8();
+		var div_3 = root_8();
 
-		_$_.append(__anchor, div_4);
+		_$_.append(__anchor, div_3);
 	});
 }
 
 export function SecondSibling() {
 	return _$_.tsrx_element((__anchor, __block) => {
-		var div_5 = root_9();
+		var div_4 = root_9();
 
-		_$_.append(__anchor, div_5);
+		_$_.append(__anchor, div_4);
 	});
 }
 
@@ -184,19 +184,19 @@ export function SiblingComponents() {
 
 export function Greeting(props) {
 	return _$_.tsrx_element((__anchor, __block) => {
-		var div_6 = root_12();
+		var div_5 = root_12();
 
 		{
-			var expression = _$_.child(div_6, true);
+			var expression = _$_.child(div_5, true);
 
-			_$_.pop(div_6);
+			_$_.pop(div_5);
 		}
 
 		_$_.render(() => {
 			_$_.set_text(expression, 'Hello ' + _$_.with_scope(__block, () => String(props.name ?? '')));
 		});
 
-		_$_.append(__anchor, div_6);
+		_$_.append(__anchor, div_5);
 	});
 }
 
@@ -215,22 +215,22 @@ export function ExpressionContent() {
 
 		_$_.expression(node_5, () => _$_.tsrx_element((__anchor, __block) => {
 			var fragment_7 = root_14();
-			var div_7 = _$_.first_child_frag(fragment_7);
+			var div_6 = _$_.first_child_frag(fragment_7);
 
 			{
-				var expression_1 = _$_.child(div_7);
+				var expression_1 = _$_.child(div_6);
 
 				_$_.expression(expression_1, () => value);
-				_$_.pop(div_7);
+				_$_.pop(div_6);
 			}
 
-			var span_2 = _$_.sibling(div_7);
+			var span_1 = _$_.sibling(div_6);
 
 			{
-				var expression_2 = _$_.child(span_2);
+				var expression_2 = _$_.child(span_1);
 
 				_$_.expression(expression_2, () => _$_.with_scope(__block, () => label.toUpperCase()));
-				_$_.pop(span_2);
+				_$_.pop(span_1);
 			}
 
 			_$_.next();
@@ -243,16 +243,16 @@ export function ExpressionContent() {
 
 function NestedHelperItem({ item }) {
 	return _$_.tsrx_element((__anchor, __block) => {
-		var div_8 = root_15();
+		var div_7 = root_15();
 
 		{
-			var expression_3 = _$_.child(div_8);
+			var expression_3 = _$_.child(div_7);
 
 			_$_.expression(expression_3, () => item);
-			_$_.pop(div_8);
+			_$_.pop(div_7);
 		}
 
-		_$_.append(__anchor, div_8);
+		_$_.append(__anchor, div_7);
 	});
 }
 
@@ -263,16 +263,16 @@ function NestedTsxTsrxFragment({ label }) {
 
 		_$_.expression(node_7, () => _$_.tsrx_element((__anchor, __block) => {
 			var fragment_9 = root_17();
-			var span_3 = _$_.first_child_frag(fragment_9);
+			var span_2 = _$_.first_child_frag(fragment_9);
 
 			{
-				var expression_4 = _$_.child(span_3, true);
+				var expression_4 = _$_.child(span_2, true);
 
 				expression_4.nodeValue = label;
-				_$_.pop(span_3);
+				_$_.pop(span_2);
 			}
 
-			var node_6 = _$_.sibling(span_3);
+			var node_6 = _$_.sibling(span_2);
 
 			_$_.for(
 				node_6,
@@ -292,25 +292,25 @@ function NestedTsxTsrxFragment({ label }) {
 
 export function NestedTsxTsrxExpressionValues() {
 	return _$_.tsrx_element((__anchor, __block) => {
-		var div_9 = root_18();
+		var div_8 = root_18();
 
 		{
-			var node_8 = _$_.child(div_9);
+			var node_8 = _$_.child(div_8);
 
 			_$_.for(
 				node_8,
 				() => [1, 2, 3],
 				(__anchor, item) => {
-					var div_10 = root_19();
+					var div_9 = root_19();
 
 					{
-						var expression_5 = _$_.child(div_10);
+						var expression_5 = _$_.child(div_9);
 
 						_$_.expression(expression_5, () => item);
-						_$_.pop(div_10);
+						_$_.pop(div_9);
 					}
 
-					_$_.append(__anchor, div_10);
+					_$_.append(__anchor, div_9);
 				},
 				0
 			);
@@ -318,10 +318,10 @@ export function NestedTsxTsrxExpressionValues() {
 			var node_9 = _$_.sibling(node_8);
 
 			_$_.render_component(NestedTsxTsrxFragment, node_9, { label: "from helper" });
-			_$_.pop(div_9);
+			_$_.pop(div_8);
 		}
 
-		_$_.append(__anchor, div_9);
+		_$_.append(__anchor, div_8);
 	});
 }
 
@@ -334,17 +334,17 @@ export function MixedTsrxCollectionText() {
 			_$_.expression(expression_6, () => [
 				'alpha ',
 				_$_.tsrx_element((__anchor, __block) => {
-					var strong_1 = root_20();
+					var strong = root_20();
 
-					_$_.append(__anchor, strong_1);
+					_$_.append(__anchor, strong);
 				}),
 				' gamma ',
 				[
 					'delta ',
 					_$_.tsrx_element((__anchor, __block) => {
-						var em_1 = root_21();
+						var em = root_21();
 
-						_$_.append(__anchor, em_1);
+						_$_.append(__anchor, em);
 					}),
 					' zeta'
 				]
@@ -353,16 +353,16 @@ export function MixedTsrxCollectionText() {
 			_$_.append(__anchor, fragment_10);
 		});
 
-		var div_11 = root_23();
+		var div_10 = root_23();
 
 		{
-			var expression_7 = _$_.child(div_11);
+			var expression_7 = _$_.child(div_10);
 
 			_$_.expression(expression_7, () => content);
-			_$_.pop(div_11);
+			_$_.pop(div_10);
 		}
 
-		_$_.append(__anchor, div_11);
+		_$_.append(__anchor, div_10);
 	});
 }
 
@@ -375,17 +375,17 @@ export function MixedTsrxCollectionSplitServerText() {
 			_$_.expression(expression_8, () => [
 				'alpha ',
 				_$_.tsrx_element((__anchor, __block) => {
-					var strong_2 = root_24();
+					var strong_1 = root_24();
 
-					_$_.append(__anchor, strong_2);
+					_$_.append(__anchor, strong_1);
 				}),
 				' gamma ',
 				[
 					'delta ',
 					_$_.tsrx_element((__anchor, __block) => {
-						var em_2 = root_25();
+						var em_1 = root_25();
 
-						_$_.append(__anchor, em_2);
+						_$_.append(__anchor, em_1);
 					}),
 					' zeta'
 				]
@@ -394,16 +394,16 @@ export function MixedTsrxCollectionSplitServerText() {
 			_$_.append(__anchor, fragment_11);
 		});
 
-		var div_12 = root_27();
+		var div_11 = root_27();
 
 		{
-			var expression_9 = _$_.child(div_12);
+			var expression_9 = _$_.child(div_11);
 
 			_$_.expression(expression_9, () => content);
-			_$_.pop(div_12);
+			_$_.pop(div_11);
 		}
 
-		_$_.append(__anchor, div_12);
+		_$_.append(__anchor, div_11);
 	});
 }
 
@@ -416,17 +416,17 @@ export function MixedTsrxCollectionSplitClientText() {
 			_$_.expression(expression_10, () => [
 				'alpha ',
 				_$_.tsrx_element((__anchor, __block) => {
-					var strong_3 = root_28();
+					var strong_2 = root_28();
 
-					_$_.append(__anchor, strong_3);
+					_$_.append(__anchor, strong_2);
 				}),
 				' gamma ',
 				[
 					'changed ',
 					_$_.tsrx_element((__anchor, __block) => {
-						var em_3 = root_29();
+						var em_2 = root_29();
 
-						_$_.append(__anchor, em_3);
+						_$_.append(__anchor, em_2);
 					}),
 					' zeta'
 				]
@@ -435,16 +435,16 @@ export function MixedTsrxCollectionSplitClientText() {
 			_$_.append(__anchor, fragment_12);
 		});
 
-		var div_13 = root_31();
+		var div_12 = root_31();
 
 		{
-			var expression_11 = _$_.child(div_13);
+			var expression_11 = _$_.child(div_12);
 
 			_$_.expression(expression_11, () => content);
-			_$_.pop(div_13);
+			_$_.pop(div_12);
 		}
 
-		_$_.append(__anchor, div_13);
+		_$_.append(__anchor, div_12);
 	});
 }
 
@@ -460,25 +460,25 @@ export function MixedTsrxCollectionPrimitiveServerText() {
 				' / ',
 				true,
 				_$_.tsrx_element((__anchor, __block) => {
-					var span_4 = root_32();
+					var span_3 = root_32();
 
-					_$_.append(__anchor, span_4);
+					_$_.append(__anchor, span_3);
 				})
 			]);
 
 			_$_.append(__anchor, fragment_13);
 		});
 
-		var div_14 = root_34();
+		var div_13 = root_34();
 
 		{
-			var expression_13 = _$_.child(div_14);
+			var expression_13 = _$_.child(div_13);
 
 			_$_.expression(expression_13, () => content);
-			_$_.pop(div_14);
+			_$_.pop(div_13);
 		}
 
-		_$_.append(__anchor, div_14);
+		_$_.append(__anchor, div_13);
 	});
 }
 
@@ -494,25 +494,25 @@ export function MixedTsrxCollectionPrimitiveClientText() {
 				' / ',
 				false,
 				_$_.tsrx_element((__anchor, __block) => {
-					var span_5 = root_35();
+					var span_4 = root_35();
 
-					_$_.append(__anchor, span_5);
+					_$_.append(__anchor, span_4);
 				})
 			]);
 
 			_$_.append(__anchor, fragment_14);
 		});
 
-		var div_15 = root_37();
+		var div_14 = root_37();
 
 		{
-			var expression_15 = _$_.child(div_15);
+			var expression_15 = _$_.child(div_14);
 
 			_$_.expression(expression_15, () => content);
-			_$_.pop(div_15);
+			_$_.pop(div_14);
 		}
 
-		_$_.append(__anchor, div_15);
+		_$_.append(__anchor, div_14);
 	});
 }
 
@@ -523,32 +523,32 @@ function createPrimitiveItems() {
 export function DynamicArrayFromCall() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		const items = _$_.with_scope(__block, createPrimitiveItems);
-		var div_16 = root_38();
+		var div_15 = root_38();
 
 		{
-			var expression_16 = _$_.child(div_16);
+			var expression_16 = _$_.child(div_15);
 
 			_$_.expression(expression_16, () => items);
-			_$_.pop(div_16);
+			_$_.pop(div_15);
 		}
 
-		_$_.append(__anchor, div_16);
+		_$_.append(__anchor, div_15);
 	});
 }
 
 export function DynamicArrayFromTrack() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		let lazy = _$_.track(['start:', ['one', 2], true, null, false, ':end'], __block, 'b5de6402');
-		var div_17 = root_39();
+		var div_16 = root_39();
 
 		{
-			var expression_17 = _$_.child(div_17);
+			var expression_17 = _$_.child(div_16);
 
 			_$_.expression(expression_17, () => lazy.value);
-			_$_.pop(div_17);
+			_$_.pop(div_16);
 		}
 
-		_$_.append(__anchor, div_17);
+		_$_.append(__anchor, div_16);
 	});
 }
 
@@ -560,16 +560,16 @@ export function DynamicArrayFromConditional() {
 			? ['start:', ['one', 2], true, null, false, ':end']
 			: ['fallback'];
 
-		var div_18 = root_40();
+		var div_17 = root_40();
 
 		{
-			var expression_18 = _$_.child(div_18);
+			var expression_18 = _$_.child(div_17);
 
 			_$_.expression(expression_18, () => items);
-			_$_.pop(div_18);
+			_$_.pop(div_17);
 		}
 
-		_$_.append(__anchor, div_18);
+		_$_.append(__anchor, div_17);
 	});
 }
 
@@ -577,25 +577,25 @@ export function DynamicArrayFromLogical() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		const condition = true;
 		const items = condition && ['start:', ['one', 2], true, null, false, ':end'];
-		var div_19 = root_41();
+		var div_18 = root_41();
 
 		{
-			var expression_19 = _$_.child(div_19);
+			var expression_19 = _$_.child(div_18);
 
 			_$_.expression(expression_19, () => items);
-			_$_.pop(div_19);
+			_$_.pop(div_18);
 		}
 
-		_$_.append(__anchor, div_19);
+		_$_.append(__anchor, div_18);
 	});
 }
 
 export function NestedTsrxInsideTopLevelTsxExpression() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		const content = _$_.tsrx_element((__anchor, __block) => {
-			var section_1 = root_42();
+			var section = root_42();
 
-			_$_.append(__anchor, section_1);
+			_$_.append(__anchor, section);
 		});
 
 		var fragment_15 = root_43();
@@ -616,9 +616,9 @@ export function NestedTsrxInsideTopLevelTsxExpression() {
 export function NestedTsrxElementsInsideTopLevelTsxValue() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		const content = _$_.tsrx_element((__anchor, __block) => {
-			var div_20 = root_45();
+			var div_19 = root_45();
 
-			_$_.append(__anchor, div_20);
+			_$_.append(__anchor, div_19);
 		});
 
 		var fragment_17 = root_46();
@@ -639,22 +639,22 @@ export function NestedTsrxElementsInsideTopLevelTsxValue() {
 export function TsxDeclaredBeforeTopLevelTsx() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		const nested = _$_.tsrx_element((__anchor, __block) => {
-			var span_6 = root_48();
+			var span_5 = root_48();
 
-			_$_.append(__anchor, span_6);
+			_$_.append(__anchor, span_5);
 		});
 
 		const content = _$_.tsrx_element((__anchor, __block) => {
-			var div_21 = root_49();
+			var div_20 = root_49();
 
 			{
-				var expression_22 = _$_.child(div_21);
+				var expression_22 = _$_.child(div_20);
 
 				_$_.expression(expression_22, () => nested);
-				_$_.pop(div_21);
+				_$_.pop(div_20);
 			}
 
-			_$_.append(__anchor, div_21);
+			_$_.append(__anchor, div_20);
 		});
 
 		var fragment_19 = root_50();
@@ -674,16 +674,16 @@ export function TsxDeclaredBeforeTopLevelTsx() {
 
 function TextProp(__props) {
 	return _$_.tsrx_element((__anchor, __block) => {
-		var div_22 = root_52();
+		var div_21 = root_52();
 
 		{
-			var expression_24 = _$_.child(div_22);
+			var expression_24 = _$_.child(div_21);
 
 			_$_.expression(expression_24, () => __props.children);
-			_$_.pop(div_22);
+			_$_.pop(div_21);
 		}
 
-		_$_.append(__anchor, div_22);
+		_$_.append(__anchor, div_21);
 	});
 }
 
@@ -703,9 +703,9 @@ export function TextPropWithToggle() {
 				}
 			});
 
-			var button_1 = _$_.sibling(node_13);
+			var button = _$_.sibling(node_13);
 
-			button_1.__click = () => _$_.set(lazy_1, true);
+			button.__click = () => _$_.set(lazy_1, true);
 			_$_.append(__anchor, fragment_22);
 		}));
 
@@ -741,22 +741,22 @@ export function StaticChildWithSiblings() {
 
 			_$_.render_component(StaticHeader, node_16, {});
 
-			var span_7 = _$_.sibling(node_16);
+			var span_6 = _$_.sibling(node_16);
 
 			{
-				var expression_25 = _$_.child(span_7, true);
+				var expression_25 = _$_.child(span_6, true);
 
 				expression_25.nodeValue = foo;
-				_$_.pop(span_7);
+				_$_.pop(span_6);
 			}
 
-			var span_8 = _$_.sibling(span_7);
+			var span_7 = _$_.sibling(span_6);
 
 			{
-				var expression_26 = _$_.child(span_8, true);
+				var expression_26 = _$_.child(span_7, true);
 
 				expression_26.nodeValue = foo;
-				_$_.pop(span_8);
+				_$_.pop(span_7);
 			}
 
 			_$_.next();
@@ -785,52 +785,52 @@ function Header() {
 
 function Actions({ playgroundVisible = false }) {
 	return _$_.tsrx_element((__anchor, __block) => {
-		var div_23 = root_61();
+		var div_22 = root_61();
 
 		{
-			var a_3 = _$_.child(div_23);
-			var a_2 = _$_.sibling(a_3);
-			var expression_27 = _$_.sibling(a_2);
+			var a_2 = _$_.child(div_22);
+			var a_1 = _$_.sibling(a_2);
+			var expression_27 = _$_.sibling(a_1);
 
 			_$_.expression(expression_27, () => playgroundVisible
 				? _$_.tsrx_element((__anchor, __block) => {
-					var a_1 = root_62();
+					var a = root_62();
 
-					_$_.append(__anchor, a_1);
+					_$_.append(__anchor, a);
 				})
 				: null);
 
-			_$_.pop(div_23);
+			_$_.pop(div_22);
 		}
 
-		_$_.append(__anchor, div_23);
+		_$_.append(__anchor, div_22);
 	});
 }
 
 function Layout({ children }) {
 	return _$_.tsrx_element((__anchor, __block) => {
-		var main_1 = root_63();
+		var main = root_63();
 
 		{
-			var div_24 = _$_.child(main_1);
+			var div_23 = _$_.child(main);
 
 			{
-				var expression_28 = _$_.child(div_24);
+				var expression_28 = _$_.child(div_23);
 
 				_$_.expression(expression_28, () => children);
-				_$_.pop(div_24);
+				_$_.pop(div_23);
 			}
 		}
 
-		_$_.append(__anchor, main_1);
+		_$_.append(__anchor, main);
 	});
 }
 
 function Content() {
 	return _$_.tsrx_element((__anchor, __block) => {
-		var div_25 = root_64();
+		var div_24 = root_64();
 
-		_$_.append(__anchor, div_25);
+		_$_.append(__anchor, div_24);
 	});
 }
 
@@ -862,22 +862,38 @@ export function WebsiteIndex() {
 
 function LastChild() {
 	return _$_.tsrx_element((__anchor, __block) => {
-		var footer_1 = root_66();
+		var footer = root_66();
 
-		_$_.append(__anchor, footer_1);
+		_$_.append(__anchor, footer);
 	});
 }
 
 export function ComponentAsLastSibling() {
 	return _$_.tsrx_element((__anchor, __block) => {
-		var div_26 = root_67();
+		var div_25 = root_67();
 
 		{
-			var h1_1 = _$_.child(div_26);
-			var p_1 = _$_.sibling(h1_1);
-			var node_23 = _$_.sibling(p_1);
+			var h1 = _$_.child(div_25);
+			var p = _$_.sibling(h1);
+			var node_23 = _$_.sibling(p);
 
 			_$_.render_component(LastChild, node_23, {});
+			_$_.pop(div_25);
+		}
+
+		_$_.append(__anchor, div_25);
+	});
+}
+
+function InnerContent() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		var div_26 = root_68();
+
+		{
+			var span_8 = _$_.child(div_26);
+			var node_24 = _$_.sibling(span_8);
+
+			_$_.render_component(LastChild, node_24, {});
 			_$_.pop(div_26);
 		}
 
@@ -885,35 +901,19 @@ export function ComponentAsLastSibling() {
 	});
 }
 
-function InnerContent() {
-	return _$_.tsrx_element((__anchor, __block) => {
-		var div_27 = root_68();
-
-		{
-			var span_9 = _$_.child(div_27);
-			var node_24 = _$_.sibling(span_9);
-
-			_$_.render_component(LastChild, node_24, {});
-			_$_.pop(div_27);
-		}
-
-		_$_.append(__anchor, div_27);
-	});
-}
-
 export function NestedComponentAsLastSibling() {
 	return _$_.tsrx_element((__anchor, __block) => {
-		var section_2 = root_69();
+		var section_1 = root_69();
 
 		{
-			var h2_1 = _$_.child(section_2);
-			var node_25 = _$_.sibling(h2_1);
+			var h2 = _$_.child(section_1);
+			var node_25 = _$_.sibling(h2);
 
 			_$_.render_component(InnerContent, node_25, {});
-			_$_.pop(section_2);
+			_$_.pop(section_1);
 		}
 
-		_$_.append(__anchor, section_2);
+		_$_.append(__anchor, section_1);
 	});
 }
 

--- a/packages/ripple/tests/hydration/compiled/client/composite.js
+++ b/packages/ripple/tests/hydration/compiled/client/composite.js
@@ -12,12 +12,28 @@ var root_7 = _$_.template(`<!>`, 1, 1);
 
 export function Layout(__props) {
 	return _$_.tsrx_element((__anchor, __block) => {
-		var div_1 = root();
+		var div = root();
 
 		{
-			var expression = _$_.child(div_1);
+			var expression = _$_.child(div);
 
 			_$_.expression(expression, () => __props.children);
+			_$_.pop(div);
+		}
+
+		_$_.append(__anchor, div);
+	});
+}
+
+export function TextWrappedLayout(__props) {
+	return _$_.tsrx_element((__anchor, __block) => {
+		var div_1 = root_1();
+
+		{
+			var expression_2 = _$_.child(div_1);
+			var expression_1 = _$_.sibling(expression_2);
+
+			_$_.expression(expression_1, () => __props.children);
 			_$_.pop(div_1);
 		}
 
@@ -25,27 +41,11 @@ export function Layout(__props) {
 	});
 }
 
-export function TextWrappedLayout(__props) {
-	return _$_.tsrx_element((__anchor, __block) => {
-		var div_2 = root_1();
-
-		{
-			var expression_2 = _$_.child(div_2);
-			var expression_1 = _$_.sibling(expression_2);
-
-			_$_.expression(expression_1, () => __props.children);
-			_$_.pop(div_2);
-		}
-
-		_$_.append(__anchor, div_2);
-	});
-}
-
 export function SingleChild() {
 	return _$_.tsrx_element((__anchor, __block) => {
-		var div_3 = root_2();
+		var div_2 = root_2();
 
-		_$_.append(__anchor, div_3);
+		_$_.append(__anchor, div_2);
 	});
 }
 

--- a/packages/ripple/tests/hydration/compiled/client/events.js
+++ b/packages/ripple/tests/hydration/compiled/client/events.js
@@ -183,11 +183,14 @@ export function ChildButton(props) {
 		_$_.render_event('Click', button_6, () => props.onClick);
 
 		{
-			var expression_7 = _$_.child(button_6);
+			var expression_7 = _$_.child(button_6, true);
 
-			_$_.expression(expression_7, () => props.label);
 			_$_.pop(button_6);
 		}
+
+		_$_.render(() => {
+			_$_.set_text(expression_7, props.label);
+		});
 
 		_$_.append(__anchor, button_6);
 	});

--- a/packages/ripple/tests/hydration/compiled/client/events.js
+++ b/packages/ripple/tests/hydration/compiled/client/events.js
@@ -14,58 +14,58 @@ import { track } from 'ripple';
 export function ClickCounter() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		let lazy = _$_.track(0, __block, 'a070e3a7');
-		var div_1 = root();
+		var div = root();
 
 		{
-			var button_1 = _$_.child(div_1);
+			var button = _$_.child(div);
 
-			button_1.__click = () => {
+			button.__click = () => {
 				_$_.update(lazy);
 			};
 
-			var span_1 = _$_.sibling(button_1);
+			var span = _$_.sibling(button);
 
 			{
-				var expression = _$_.child(span_1);
+				var expression = _$_.child(span);
 
 				_$_.expression(expression, () => lazy.value);
-				_$_.pop(span_1);
+				_$_.pop(span);
 			}
 		}
 
-		_$_.append(__anchor, div_1);
+		_$_.append(__anchor, div);
 	});
 }
 
 export function IncrementDecrement() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		let lazy_1 = _$_.track(0, __block, '87fcabdd');
-		var div_2 = root_1();
+		var div_1 = root_1();
 
 		{
-			var button_2 = _$_.child(div_2);
+			var button_1 = _$_.child(div_1);
 
-			button_2.__click = () => {
+			button_1.__click = () => {
 				_$_.update(lazy_1, -1);
 			};
 
-			var span_2 = _$_.sibling(button_2);
+			var span_1 = _$_.sibling(button_1);
 
 			{
-				var expression_1 = _$_.child(span_2);
+				var expression_1 = _$_.child(span_1);
 
 				_$_.expression(expression_1, () => lazy_1.value);
-				_$_.pop(span_2);
+				_$_.pop(span_1);
 			}
 
-			var button_3 = _$_.sibling(span_2);
+			var button_2 = _$_.sibling(span_1);
 
-			button_3.__click = () => {
+			button_2.__click = () => {
 				_$_.update(lazy_1);
 			};
 		}
 
-		_$_.append(__anchor, div_2);
+		_$_.append(__anchor, div_1);
 	});
 }
 
@@ -73,39 +73,39 @@ export function MultipleEvents() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		let lazy_2 = _$_.track(0, __block, '41b9f0b0');
 		let lazy_3 = _$_.track(0, __block, '72789f75');
-		var div_3 = root_2();
+		var div_2 = root_2();
 
 		{
-			var button_4 = _$_.child(div_3);
+			var button_3 = _$_.child(div_2);
 
-			button_4.__click = () => {
+			button_3.__click = () => {
 				_$_.update(lazy_2);
 			};
 
-			_$_.event('MouseEnter', button_4, () => {
+			_$_.event('MouseEnter', button_3, () => {
 				_$_.update(lazy_3);
 			});
 
-			var span_3 = _$_.sibling(button_4);
+			var span_2 = _$_.sibling(button_3);
 
 			{
-				var expression_2 = _$_.child(span_3);
+				var expression_2 = _$_.child(span_2);
 
 				_$_.expression(expression_2, () => lazy_2.value);
-				_$_.pop(span_3);
+				_$_.pop(span_2);
 			}
 
-			var span_4 = _$_.sibling(span_3);
+			var span_3 = _$_.sibling(span_2);
 
 			{
-				var expression_3 = _$_.child(span_4);
+				var expression_3 = _$_.child(span_3);
 
 				_$_.expression(expression_3, () => lazy_3.value);
-				_$_.pop(span_4);
+				_$_.pop(span_3);
 			}
 		}
 
-		_$_.append(__anchor, div_3);
+		_$_.append(__anchor, div_2);
 	});
 }
 
@@ -119,52 +119,52 @@ export function MultiStateUpdate() {
 			_$_.set(lazy_5, 'increment');
 		};
 
-		var div_4 = root_3();
+		var div_3 = root_3();
 
 		{
-			var button_5 = _$_.child(div_4);
+			var button_4 = _$_.child(div_3);
 
-			button_5.__click = handleClick;
+			button_4.__click = handleClick;
 
-			var span_5 = _$_.sibling(button_5);
+			var span_4 = _$_.sibling(button_4);
 
 			{
-				var expression_4 = _$_.child(span_5);
+				var expression_4 = _$_.child(span_4);
 
 				_$_.expression(expression_4, () => lazy_4.value);
-				_$_.pop(span_5);
+				_$_.pop(span_4);
 			}
 
-			var span_6 = _$_.sibling(span_5);
+			var span_5 = _$_.sibling(span_4);
 
 			{
-				var expression_5 = _$_.child(span_6);
+				var expression_5 = _$_.child(span_5);
 
 				_$_.expression(expression_5, () => lazy_5.value);
-				_$_.pop(span_6);
+				_$_.pop(span_5);
 			}
 		}
 
-		_$_.append(__anchor, div_4);
+		_$_.append(__anchor, div_3);
 	});
 }
 
 export function ToggleButton() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		let lazy_6 = _$_.track(false, __block, 'be823ec7');
-		var div_5 = root_4();
+		var div_4 = root_4();
 
 		{
-			var button_6 = _$_.child(div_5);
+			var button_5 = _$_.child(div_4);
 
-			button_6.__click = () => {
+			button_5.__click = () => {
 				_$_.set(lazy_6, !lazy_6.value);
 			};
 
 			{
-				var expression_6 = _$_.child(button_6, true);
+				var expression_6 = _$_.child(button_5, true);
 
-				_$_.pop(button_6);
+				_$_.pop(button_5);
 			}
 		}
 
@@ -172,34 +172,34 @@ export function ToggleButton() {
 			_$_.set_text(expression_6, lazy_6.value ? 'ON' : 'OFF');
 		});
 
-		_$_.append(__anchor, div_5);
+		_$_.append(__anchor, div_4);
 	});
 }
 
 export function ChildButton(props) {
 	return _$_.tsrx_element((__anchor, __block) => {
-		var button_7 = root_5();
+		var button_6 = root_5();
 
-		_$_.render_event('Click', button_7, () => props.onClick);
+		_$_.render_event('Click', button_6, () => props.onClick);
 
 		{
-			var expression_7 = _$_.child(button_7);
+			var expression_7 = _$_.child(button_6);
 
 			_$_.expression(expression_7, () => props.label);
-			_$_.pop(button_7);
+			_$_.pop(button_6);
 		}
 
-		_$_.append(__anchor, button_7);
+		_$_.append(__anchor, button_6);
 	});
 }
 
 export function ParentWithChildButton() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		let lazy_7 = _$_.track(0, __block, 'dcc2e0f9');
-		var div_6 = root_6();
+		var div_5 = root_6();
 
 		{
-			var node = _$_.child(div_6);
+			var node = _$_.child(div_5);
 
 			_$_.render_component(ChildButton, node, {
 				onClick: () => {
@@ -208,19 +208,19 @@ export function ParentWithChildButton() {
 				label: "Click me"
 			});
 
-			var span_7 = _$_.sibling(node);
+			var span_6 = _$_.sibling(node);
 
 			{
-				var expression_8 = _$_.child(span_7);
+				var expression_8 = _$_.child(span_6);
 
 				_$_.expression(expression_8, () => lazy_7.value);
-				_$_.pop(span_7);
+				_$_.pop(span_6);
 			}
 
-			_$_.pop(div_6);
+			_$_.pop(div_5);
 		}
 
-		_$_.append(__anchor, div_6);
+		_$_.append(__anchor, div_5);
 	});
 }
 

--- a/packages/ripple/tests/hydration/compiled/client/for.js
+++ b/packages/ripple/tests/hydration/compiled/client/for.js
@@ -84,65 +84,65 @@ import { track } from 'ripple';
 export function StaticForLoop() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		const items = ['Apple', 'Banana', 'Cherry'];
-		var ul_1 = root();
+		var ul = root();
 
 		{
 			_$_.for(
-				ul_1,
+				ul,
 				() => items,
 				(__anchor, item) => {
-					var li_1 = root_1();
+					var li = root_1();
 
 					{
-						var expression = _$_.child(li_1);
+						var expression = _$_.child(li);
 
 						_$_.expression(expression, () => item);
-						_$_.pop(li_1);
+						_$_.pop(li);
 					}
 
-					_$_.append(__anchor, li_1);
+					_$_.append(__anchor, li);
 				},
 				4
 			);
 
-			_$_.pop(ul_1);
+			_$_.pop(ul);
 		}
 
-		_$_.append(__anchor, ul_1);
+		_$_.append(__anchor, ul);
 	});
 }
 
 export function ForLoopWithIndex() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		const items = ['A', 'B', 'C'];
-		var ul_2 = root_2();
+		var ul_1 = root_2();
 
 		{
 			_$_.for(
-				ul_2,
+				ul_1,
 				() => items,
 				(__anchor, item, i) => {
-					var li_2 = root_3();
+					var li_1 = root_3();
 
 					{
-						var expression_1 = _$_.child(li_2, true);
+						var expression_1 = _$_.child(li_1, true);
 
-						_$_.pop(li_2);
+						_$_.pop(li_1);
 					}
 
 					_$_.render(() => {
 						_$_.set_text(expression_1, `${i.value}: ${item}`);
 					});
 
-					_$_.append(__anchor, li_2);
+					_$_.append(__anchor, li_1);
 				},
 				12
 			);
 
-			_$_.pop(ul_2);
+			_$_.pop(ul_1);
 		}
 
-		_$_.append(__anchor, ul_2);
+		_$_.append(__anchor, ul_1);
 	});
 }
 
@@ -154,32 +154,32 @@ export function KeyedForLoop() {
 			{ id: 3, name: 'Third' }
 		];
 
-		var ul_3 = root_4();
+		var ul_2 = root_4();
 
 		{
 			_$_.for_keyed(
-				ul_3,
+				ul_2,
 				() => items,
 				(__anchor, pattern) => {
-					var li_3 = root_5();
+					var li_2 = root_5();
 
 					{
-						var expression_2 = _$_.child(li_3);
+						var expression_2 = _$_.child(li_2);
 
 						_$_.expression(expression_2, () => _$_.get(pattern).name);
-						_$_.pop(li_3);
+						_$_.pop(li_2);
 					}
 
-					_$_.append(__anchor, li_3);
+					_$_.append(__anchor, li_2);
 				},
 				4,
 				(pattern) => _$_.get(pattern).id
 			);
 
-			_$_.pop(ul_3);
+			_$_.pop(ul_2);
 		}
 
-		_$_.append(__anchor, ul_3);
+		_$_.append(__anchor, ul_2);
 	});
 }
 
@@ -191,34 +191,34 @@ export function ReactiveForLoopAdd() {
 
 		_$_.expression(node, () => _$_.tsrx_element((__anchor, __block) => {
 			var fragment_1 = root_7();
-			var button_1 = _$_.first_child_frag(fragment_1);
+			var button = _$_.first_child_frag(fragment_1);
 
-			button_1.__click = () => {
+			button.__click = () => {
 				_$_.set(lazy, [...lazy.value, 'C']);
 			};
 
-			var ul_4 = _$_.sibling(button_1);
+			var ul_3 = _$_.sibling(button);
 
 			{
 				_$_.for(
-					ul_4,
+					ul_3,
 					() => lazy.value,
 					(__anchor, item) => {
-						var li_4 = root_8();
+						var li_3 = root_8();
 
 						{
-							var expression_3 = _$_.child(li_4);
+							var expression_3 = _$_.child(li_3);
 
 							_$_.expression(expression_3, () => item);
-							_$_.pop(li_4);
+							_$_.pop(li_3);
 						}
 
-						_$_.append(__anchor, li_4);
+						_$_.append(__anchor, li_3);
 					},
 					4
 				);
 
-				_$_.pop(ul_4);
+				_$_.pop(ul_3);
 			}
 
 			_$_.next();
@@ -237,34 +237,34 @@ export function ReactiveForLoopRemove() {
 
 		_$_.expression(node_1, () => _$_.tsrx_element((__anchor, __block) => {
 			var fragment_3 = root_10();
-			var button_2 = _$_.first_child_frag(fragment_3);
+			var button_1 = _$_.first_child_frag(fragment_3);
 
-			button_2.__click = () => {
+			button_1.__click = () => {
 				_$_.set(lazy_1, _$_.with_scope(__block, () => lazy_1.value.slice(0, -1)));
 			};
 
-			var ul_5 = _$_.sibling(button_2);
+			var ul_4 = _$_.sibling(button_1);
 
 			{
 				_$_.for(
-					ul_5,
+					ul_4,
 					() => lazy_1.value,
 					(__anchor, item) => {
-						var li_5 = root_11();
+						var li_4 = root_11();
 
 						{
-							var expression_4 = _$_.child(li_5);
+							var expression_4 = _$_.child(li_4);
 
 							_$_.expression(expression_4, () => item);
-							_$_.pop(li_5);
+							_$_.pop(li_4);
 						}
 
-						_$_.append(__anchor, li_5);
+						_$_.append(__anchor, li_4);
 					},
 					4
 				);
 
-				_$_.pop(ul_5);
+				_$_.pop(ul_4);
 			}
 
 			_$_.next();
@@ -278,28 +278,28 @@ export function ReactiveForLoopRemove() {
 export function ForLoopInteractive() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		let lazy_2 = _$_.track([0, 0, 0], __block, '36f563df');
-		var div_1 = root_12();
+		var div = root_12();
 
 		{
 			_$_.for(
-				div_1,
+				div,
 				() => lazy_2.value,
 				(__anchor, count, i) => {
-					var div_2 = root_13();
+					var div_1 = root_13();
 
 					{
-						var span_1 = _$_.child(div_2);
+						var span = _$_.child(div_1);
 
 						{
-							var expression_5 = _$_.child(span_1);
+							var expression_5 = _$_.child(span);
 
 							_$_.expression(expression_5, () => count);
-							_$_.pop(span_1);
+							_$_.pop(span);
 						}
 
-						var button_3 = _$_.sibling(span_1);
+						var button_2 = _$_.sibling(span);
 
-						button_3.__click = () => {
+						button_2.__click = () => {
 							const newCounts = [...lazy_2.value];
 
 							newCounts[i.value]++;
@@ -308,103 +308,103 @@ export function ForLoopInteractive() {
 					}
 
 					_$_.render(() => {
-						_$_.set_class(div_2, `item-${i.value}`, void 0, true);
+						_$_.set_class(div_1, `item-${i.value}`, void 0, true);
 					});
 
-					_$_.append(__anchor, div_2);
+					_$_.append(__anchor, div_1);
 				},
 				12
 			);
 
-			_$_.pop(div_1);
+			_$_.pop(div);
 		}
 
-		_$_.append(__anchor, div_1);
+		_$_.append(__anchor, div);
 	});
 }
 
 export function NestedForLoop() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		const grid = [[1, 2], [3, 4]];
-		var div_3 = root_14();
+		var div_2 = root_14();
 
 		{
 			_$_.for(
-				div_3,
+				div_2,
 				() => grid,
 				(__anchor, row, rowIndex) => {
-					var div_4 = root_15();
+					var div_3 = root_15();
 
 					{
 						_$_.for(
-							div_4,
+							div_3,
 							() => row,
 							(__anchor, cell, colIndex) => {
-								var span_2 = root_16();
+								var span_1 = root_16();
 
 								{
-									var expression_6 = _$_.child(span_2);
+									var expression_6 = _$_.child(span_1);
 
 									_$_.expression(expression_6, () => cell);
-									_$_.pop(span_2);
+									_$_.pop(span_1);
 								}
 
 								_$_.render(() => {
-									_$_.set_class(span_2, `cell-${rowIndex.value}-${colIndex.value}`, void 0, true);
+									_$_.set_class(span_1, `cell-${rowIndex.value}-${colIndex.value}`, void 0, true);
 								});
 
-								_$_.append(__anchor, span_2);
+								_$_.append(__anchor, span_1);
 							},
 							12
 						);
 
-						_$_.pop(div_4);
+						_$_.pop(div_3);
 
 						_$_.render(() => {
-							_$_.set_class(div_4, `row-${rowIndex.value}`, void 0, true);
+							_$_.set_class(div_3, `row-${rowIndex.value}`, void 0, true);
 						});
 					}
 
-					_$_.append(__anchor, div_4);
+					_$_.append(__anchor, div_3);
 				},
 				12
 			);
 
-			_$_.pop(div_3);
+			_$_.pop(div_2);
 		}
 
-		_$_.append(__anchor, div_3);
+		_$_.append(__anchor, div_2);
 	});
 }
 
 export function EmptyForLoop() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		const items = [];
-		var div_5 = root_17();
+		var div_4 = root_17();
 
 		{
 			_$_.for(
-				div_5,
+				div_4,
 				() => items,
 				(__anchor, item) => {
-					var span_3 = root_18();
+					var span_2 = root_18();
 
 					{
-						var expression_7 = _$_.child(span_3);
+						var expression_7 = _$_.child(span_2);
 
 						_$_.expression(expression_7, () => item);
-						_$_.pop(span_3);
+						_$_.pop(span_2);
 					}
 
-					_$_.append(__anchor, span_3);
+					_$_.append(__anchor, span_2);
 				},
 				4
 			);
 
-			_$_.pop(div_5);
+			_$_.pop(div_4);
 		}
 
-		_$_.append(__anchor, div_5);
+		_$_.append(__anchor, div_4);
 	});
 }
 
@@ -415,49 +415,49 @@ export function ForLoopComplexObjects() {
 			{ id: 2, name: 'Bob', role: 'User' }
 		];
 
-		var div_6 = root_19();
+		var div_5 = root_19();
 
 		{
 			_$_.for_keyed(
-				div_6,
+				div_5,
 				() => users,
 				(__anchor, pattern_1) => {
-					var div_7 = root_20();
+					var div_6 = root_20();
 
 					{
-						var span_4 = _$_.child(div_7);
+						var span_3 = _$_.child(div_6);
 
 						{
-							var expression_8 = _$_.child(span_4);
+							var expression_8 = _$_.child(span_3);
 
 							_$_.expression(expression_8, () => _$_.get(pattern_1).name);
-							_$_.pop(span_4);
+							_$_.pop(span_3);
 						}
 
-						var span_5 = _$_.sibling(span_4);
+						var span_4 = _$_.sibling(span_3);
 
 						{
-							var expression_9 = _$_.child(span_5);
+							var expression_9 = _$_.child(span_4);
 
 							_$_.expression(expression_9, () => _$_.get(pattern_1).role);
-							_$_.pop(span_5);
+							_$_.pop(span_4);
 						}
 					}
 
 					_$_.render(() => {
-						_$_.set_class(div_7, `user-${_$_.get(pattern_1).id}`, void 0, true);
+						_$_.set_class(div_6, `user-${_$_.get(pattern_1).id}`, void 0, true);
 					});
 
-					_$_.append(__anchor, div_7);
+					_$_.append(__anchor, div_6);
 				},
 				4,
 				(pattern_1) => _$_.get(pattern_1).id
 			);
 
-			_$_.pop(div_6);
+			_$_.pop(div_5);
 		}
 
-		_$_.append(__anchor, div_6);
+		_$_.append(__anchor, div_5);
 	});
 }
 
@@ -478,39 +478,39 @@ export function KeyedForLoopReorder() {
 
 		_$_.expression(node_2, () => _$_.tsrx_element((__anchor, __block) => {
 			var fragment_5 = root_22();
-			var button_4 = _$_.first_child_frag(fragment_5);
+			var button_3 = _$_.first_child_frag(fragment_5);
 
-			button_4.__click = () => {
+			button_3.__click = () => {
 				_$_.set(lazy_3, [lazy_3.value[2], lazy_3.value[0], lazy_3.value[1]]);
 			};
 
-			var ul_6 = _$_.sibling(button_4);
+			var ul_5 = _$_.sibling(button_3);
 
 			{
 				_$_.for_keyed(
-					ul_6,
+					ul_5,
 					() => lazy_3.value,
 					(__anchor, pattern_2) => {
-						var li_6 = root_23();
+						var li_5 = root_23();
 
 						{
-							var expression_10 = _$_.child(li_6);
+							var expression_10 = _$_.child(li_5);
 
 							_$_.expression(expression_10, () => _$_.get(pattern_2).name);
-							_$_.pop(li_6);
+							_$_.pop(li_5);
 						}
 
 						_$_.render(() => {
-							_$_.set_class(li_6, `item-${_$_.get(pattern_2).id}`, void 0, true);
+							_$_.set_class(li_5, `item-${_$_.get(pattern_2).id}`, void 0, true);
 						});
 
-						_$_.append(__anchor, li_6);
+						_$_.append(__anchor, li_5);
 					},
 					4,
 					(pattern_2) => _$_.get(pattern_2).id
 				);
 
-				_$_.pop(ul_6);
+				_$_.pop(ul_5);
 			}
 
 			_$_.next();
@@ -529,39 +529,39 @@ export function KeyedForLoopUpdate() {
 
 		_$_.expression(node_3, () => _$_.tsrx_element((__anchor, __block) => {
 			var fragment_7 = root_25();
-			var button_5 = _$_.first_child_frag(fragment_7);
+			var button_4 = _$_.first_child_frag(fragment_7);
 
-			button_5.__click = () => {
+			button_4.__click = () => {
 				_$_.set(lazy_4, _$_.with_scope(__block, () => lazy_4.value.map((item) => item.id === 1 ? { ...item, name: 'Updated' } : item)));
 			};
 
-			var ul_7 = _$_.sibling(button_5);
+			var ul_6 = _$_.sibling(button_4);
 
 			{
 				_$_.for_keyed(
-					ul_7,
+					ul_6,
 					() => lazy_4.value,
 					(__anchor, pattern_3) => {
-						var li_7 = root_26();
+						var li_6 = root_26();
 
 						{
-							var expression_11 = _$_.child(li_7);
+							var expression_11 = _$_.child(li_6);
 
 							_$_.expression(expression_11, () => _$_.get(pattern_3).name);
-							_$_.pop(li_7);
+							_$_.pop(li_6);
 						}
 
 						_$_.render(() => {
-							_$_.set_class(li_7, `item-${_$_.get(pattern_3).id}`, void 0, true);
+							_$_.set_class(li_6, `item-${_$_.get(pattern_3).id}`, void 0, true);
 						});
 
-						_$_.append(__anchor, li_7);
+						_$_.append(__anchor, li_6);
 					},
 					4,
 					(pattern_3) => _$_.get(pattern_3).id
 				);
 
-				_$_.pop(ul_7);
+				_$_.pop(ul_6);
 			}
 
 			_$_.next();
@@ -580,36 +580,36 @@ export function ForLoopMixedOperations() {
 
 		_$_.expression(node_4, () => _$_.tsrx_element((__anchor, __block) => {
 			var fragment_9 = root_28();
-			var button_6 = _$_.first_child_frag(fragment_9);
+			var button_5 = _$_.first_child_frag(fragment_9);
 
-			button_6.__click = () => {
+			button_5.__click = () => {
 				_$_.set(lazy_5, ['D', 'C', 'A', 'E']);
 			};
 
-			var ul_8 = _$_.sibling(button_6);
+			var ul_7 = _$_.sibling(button_5);
 
 			{
 				_$_.for(
-					ul_8,
+					ul_7,
 					() => lazy_5.value,
 					(__anchor, item) => {
-						var li_8 = root_29();
+						var li_7 = root_29();
 
-						_$_.set_class(li_8, `item-${item}`, void 0, true);
+						_$_.set_class(li_7, `item-${item}`, void 0, true);
 
 						{
-							var expression_12 = _$_.child(li_8);
+							var expression_12 = _$_.child(li_7);
 
 							_$_.expression(expression_12, () => item);
-							_$_.pop(li_8);
+							_$_.pop(li_7);
 						}
 
-						_$_.append(__anchor, li_8);
+						_$_.append(__anchor, li_7);
 					},
 					4
 				);
 
-				_$_.pop(ul_8);
+				_$_.pop(ul_7);
 			}
 
 			_$_.next();
@@ -629,47 +629,47 @@ export function ForLoopInsideIf() {
 
 		_$_.expression(node_6, () => _$_.tsrx_element((__anchor, __block) => {
 			var fragment_11 = root_31();
-			var button_7 = _$_.first_child_frag(fragment_11);
+			var button_6 = _$_.first_child_frag(fragment_11);
 
-			button_7.__click = () => {
+			button_6.__click = () => {
 				_$_.set(lazy_6, !lazy_6.value);
 			};
 
-			var button_8 = _$_.sibling(button_7);
+			var button_7 = _$_.sibling(button_6);
 
-			button_8.__click = () => {
+			button_7.__click = () => {
 				_$_.set(lazy_7, [...lazy_7.value, 'W']);
 			};
 
-			var node_5 = _$_.sibling(button_8);
+			var node_5 = _$_.sibling(button_7);
 
 			{
 				var consequent = (__anchor) => {
-					var ul_9 = root_32();
+					var ul_8 = root_32();
 
 					{
 						_$_.for(
-							ul_9,
+							ul_8,
 							() => lazy_7.value,
 							(__anchor, item) => {
-								var li_9 = root_33();
+								var li_8 = root_33();
 
 								{
-									var expression_13 = _$_.child(li_9);
+									var expression_13 = _$_.child(li_8);
 
 									_$_.expression(expression_13, () => item);
-									_$_.pop(li_9);
+									_$_.pop(li_8);
 								}
 
-								_$_.append(__anchor, li_9);
+								_$_.append(__anchor, li_8);
 							},
 							4
 						);
 
-						_$_.pop(ul_9);
+						_$_.pop(ul_8);
 					}
 
-					_$_.append(__anchor, ul_9);
+					_$_.append(__anchor, ul_8);
 				};
 
 				_$_.if(node_5, (__render) => {
@@ -692,34 +692,34 @@ export function ForLoopEmptyToPopulated() {
 
 		_$_.expression(node_7, () => _$_.tsrx_element((__anchor, __block) => {
 			var fragment_13 = root_35();
-			var button_9 = _$_.first_child_frag(fragment_13);
+			var button_8 = _$_.first_child_frag(fragment_13);
 
-			button_9.__click = () => {
+			button_8.__click = () => {
 				_$_.set(lazy_8, ['One', 'Two', 'Three']);
 			};
 
-			var ul_10 = _$_.sibling(button_9);
+			var ul_9 = _$_.sibling(button_8);
 
 			{
 				_$_.for(
-					ul_10,
+					ul_9,
 					() => lazy_8.value,
 					(__anchor, item) => {
-						var li_10 = root_36();
+						var li_9 = root_36();
 
 						{
-							var expression_14 = _$_.child(li_10);
+							var expression_14 = _$_.child(li_9);
 
 							_$_.expression(expression_14, () => item);
-							_$_.pop(li_10);
+							_$_.pop(li_9);
 						}
 
-						_$_.append(__anchor, li_10);
+						_$_.append(__anchor, li_9);
 					},
 					4
 				);
 
-				_$_.pop(ul_10);
+				_$_.pop(ul_9);
 			}
 
 			_$_.next();
@@ -738,34 +738,34 @@ export function ForLoopPopulatedToEmpty() {
 
 		_$_.expression(node_8, () => _$_.tsrx_element((__anchor, __block) => {
 			var fragment_15 = root_38();
-			var button_10 = _$_.first_child_frag(fragment_15);
+			var button_9 = _$_.first_child_frag(fragment_15);
 
-			button_10.__click = () => {
+			button_9.__click = () => {
 				_$_.set(lazy_9, []);
 			};
 
-			var ul_11 = _$_.sibling(button_10);
+			var ul_10 = _$_.sibling(button_9);
 
 			{
 				_$_.for(
-					ul_11,
+					ul_10,
 					() => lazy_9.value,
 					(__anchor, item) => {
-						var li_11 = root_39();
+						var li_10 = root_39();
 
 						{
-							var expression_15 = _$_.child(li_11);
+							var expression_15 = _$_.child(li_10);
 
 							_$_.expression(expression_15, () => item);
-							_$_.pop(li_11);
+							_$_.pop(li_10);
 						}
 
-						_$_.append(__anchor, li_11);
+						_$_.append(__anchor, li_10);
 					},
 					4
 				);
 
-				_$_.pop(ul_11);
+				_$_.pop(ul_10);
 			}
 
 			_$_.next();
@@ -779,73 +779,73 @@ export function ForLoopPopulatedToEmpty() {
 export function NestedForLoopReactive() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		let lazy_10 = _$_.track([[1, 2], [3, 4]], __block, 'a2f41fb3');
-		var div_8 = root_40();
+		var div_7 = root_40();
 
 		{
-			var button_11 = _$_.child(div_8);
+			var button_10 = _$_.child(div_7);
 
-			button_11.__click = () => {
+			button_10.__click = () => {
 				_$_.set(lazy_10, [...lazy_10.value, [5, 6]]);
 			};
 
-			var button_12 = _$_.sibling(button_11);
+			var button_11 = _$_.sibling(button_10);
 
-			button_12.__click = () => {
+			button_11.__click = () => {
 				const newGrid = _$_.with_scope(__block, () => lazy_10.value.map((row) => [...row]));
 
 				newGrid[0][0] = 99;
 				_$_.set(lazy_10, newGrid);
 			};
 
-			var div_9 = _$_.sibling(button_12);
+			var div_8 = _$_.sibling(button_11);
 
 			{
 				_$_.for(
-					div_9,
+					div_8,
 					() => lazy_10.value,
 					(__anchor, row, rowIndex) => {
-						var div_10 = root_41();
+						var div_9 = root_41();
 
 						{
 							_$_.for(
-								div_10,
+								div_9,
 								() => row,
 								(__anchor, cell, colIndex) => {
-									var span_6 = root_42();
+									var span_5 = root_42();
 
 									{
-										var expression_16 = _$_.child(span_6);
+										var expression_16 = _$_.child(span_5);
 
 										_$_.expression(expression_16, () => cell);
-										_$_.pop(span_6);
+										_$_.pop(span_5);
 									}
 
 									_$_.render(() => {
-										_$_.set_class(span_6, `cell-${rowIndex.value}-${colIndex.value}`, void 0, true);
+										_$_.set_class(span_5, `cell-${rowIndex.value}-${colIndex.value}`, void 0, true);
 									});
 
-									_$_.append(__anchor, span_6);
+									_$_.append(__anchor, span_5);
 								},
 								12
 							);
 
-							_$_.pop(div_10);
+							_$_.pop(div_9);
 
 							_$_.render(() => {
-								_$_.set_class(div_10, `row-${rowIndex.value}`, void 0, true);
+								_$_.set_class(div_9, `row-${rowIndex.value}`, void 0, true);
 							});
 						}
 
-						_$_.append(__anchor, div_10);
+						_$_.append(__anchor, div_9);
 					},
 					12
 				);
 
-				_$_.pop(div_9);
+				_$_.pop(div_8);
 			}
 		}
 
-		_$_.append(__anchor, div_8);
+		_$_.append(__anchor, div_7);
 	});
 }
 
@@ -868,95 +868,95 @@ export function ForLoopDeeplyNested() {
 			}
 		];
 
-		var div_11 = root_43();
+		var div_10 = root_43();
 
 		{
 			_$_.for_keyed(
-				div_11,
+				div_10,
 				() => departments,
 				(__anchor, pattern_4) => {
-					var div_12 = root_44();
+					var div_11 = root_44();
 
 					{
-						var h2_1 = _$_.child(div_12);
+						var h2 = _$_.child(div_11);
 
 						{
-							var expression_17 = _$_.child(h2_1);
+							var expression_17 = _$_.child(h2);
 
 							_$_.expression(expression_17, () => _$_.get(pattern_4).name);
-							_$_.pop(h2_1);
+							_$_.pop(h2);
 						}
 
-						var node_9 = _$_.sibling(h2_1);
+						var node_9 = _$_.sibling(h2);
 
 						_$_.for_keyed(
 							node_9,
 							() => _$_.get(pattern_4).teams,
 							(__anchor, pattern_5) => {
-								var div_13 = root_45();
+								var div_12 = root_45();
 
 								{
-									var h3_1 = _$_.child(div_13);
+									var h3 = _$_.child(div_12);
 
 									{
-										var expression_18 = _$_.child(h3_1);
+										var expression_18 = _$_.child(h3);
 
 										_$_.expression(expression_18, () => _$_.get(pattern_5).name);
-										_$_.pop(h3_1);
+										_$_.pop(h3);
 									}
 
-									var ul_12 = _$_.sibling(h3_1);
+									var ul_11 = _$_.sibling(h3);
 
 									{
 										_$_.for(
-											ul_12,
+											ul_11,
 											() => _$_.get(pattern_5).members,
 											(__anchor, member) => {
-												var li_12 = root_46();
+												var li_11 = root_46();
 
 												{
-													var expression_19 = _$_.child(li_12);
+													var expression_19 = _$_.child(li_11);
 
 													_$_.expression(expression_19, () => member);
-													_$_.pop(li_12);
+													_$_.pop(li_11);
 												}
 
-												_$_.append(__anchor, li_12);
+												_$_.append(__anchor, li_11);
 											},
 											4
 										);
 
-										_$_.pop(ul_12);
+										_$_.pop(ul_11);
 									}
 								}
 
 								_$_.render(() => {
-									_$_.set_class(div_13, `team-${_$_.get(pattern_5).id}`, void 0, true);
+									_$_.set_class(div_12, `team-${_$_.get(pattern_5).id}`, void 0, true);
 								});
 
-								_$_.append(__anchor, div_13);
+								_$_.append(__anchor, div_12);
 							},
 							0,
 							(pattern_5) => _$_.get(pattern_5).id
 						);
 
-						_$_.pop(div_12);
+						_$_.pop(div_11);
 					}
 
 					_$_.render(() => {
-						_$_.set_class(div_12, `dept-${_$_.get(pattern_4).id}`, void 0, true);
+						_$_.set_class(div_11, `dept-${_$_.get(pattern_4).id}`, void 0, true);
 					});
 
-					_$_.append(__anchor, div_12);
+					_$_.append(__anchor, div_11);
 				},
 				4,
 				(pattern_4) => _$_.get(pattern_4).id
 			);
 
-			_$_.pop(div_11);
+			_$_.pop(div_10);
 		}
 
-		_$_.append(__anchor, div_11);
+		_$_.append(__anchor, div_10);
 	});
 }
 
@@ -968,25 +968,25 @@ export function ForLoopIndexUpdate() {
 
 		_$_.expression(node_10, () => _$_.tsrx_element((__anchor, __block) => {
 			var fragment_17 = root_48();
-			var button_13 = _$_.first_child_frag(fragment_17);
+			var button_12 = _$_.first_child_frag(fragment_17);
 
-			button_13.__click = () => {
+			button_12.__click = () => {
 				_$_.set(lazy_11, ['Zeroth', ...lazy_11.value]);
 			};
 
-			var ul_13 = _$_.sibling(button_13);
+			var ul_12 = _$_.sibling(button_12);
 
 			{
 				_$_.for(
-					ul_13,
+					ul_12,
 					() => lazy_11.value,
 					(__anchor, item, i) => {
-						var li_13 = root_49();
+						var li_12 = root_49();
 
 						{
-							var expression_20 = _$_.child(li_13, true);
+							var expression_20 = _$_.child(li_12, true);
 
-							_$_.pop(li_13);
+							_$_.pop(li_12);
 						}
 
 						_$_.render(
@@ -1000,18 +1000,18 @@ export function ForLoopIndexUpdate() {
 								var __b = `item-${i.value}`;
 
 								if (__prev.b !== __b) {
-									_$_.set_class(li_13, __prev.b = __b, void 0, true);
+									_$_.set_class(li_12, __prev.b = __b, void 0, true);
 								}
 							},
 							{ a: ' ', b: Symbol() }
 						);
 
-						_$_.append(__anchor, li_13);
+						_$_.append(__anchor, li_12);
 					},
 					12
 				);
 
-				_$_.pop(ul_13);
+				_$_.pop(ul_12);
 			}
 
 			_$_.next();
@@ -1039,25 +1039,25 @@ export function KeyedForLoopWithIndex() {
 
 		_$_.expression(node_11, () => _$_.tsrx_element((__anchor, __block) => {
 			var fragment_19 = root_51();
-			var button_14 = _$_.first_child_frag(fragment_19);
+			var button_13 = _$_.first_child_frag(fragment_19);
 
-			button_14.__click = () => {
+			button_13.__click = () => {
 				_$_.set(lazy_12, [lazy_12.value[1], lazy_12.value[2], lazy_12.value[0]]);
 			};
 
-			var ul_14 = _$_.sibling(button_14);
+			var ul_13 = _$_.sibling(button_13);
 
 			{
 				_$_.for_keyed(
-					ul_14,
+					ul_13,
 					() => lazy_12.value,
 					(__anchor, pattern_6, i) => {
-						var li_14 = root_52();
+						var li_13 = root_52();
 
 						{
-							var expression_21 = _$_.child(li_14, true);
+							var expression_21 = _$_.child(li_13, true);
 
-							_$_.pop(li_14);
+							_$_.pop(li_13);
 						}
 
 						_$_.render(
@@ -1071,25 +1071,25 @@ export function KeyedForLoopWithIndex() {
 								var __b = i.value;
 
 								if (__prev.b !== __b) {
-									_$_.set_attribute(li_14, 'data-index', __prev.b = __b);
+									_$_.set_attribute(li_13, 'data-index', __prev.b = __b);
 								}
 
 								var __c = `item-${_$_.get(pattern_6).id}`;
 
 								if (__prev.c !== __c) {
-									_$_.set_class(li_14, __prev.c = __c, void 0, true);
+									_$_.set_class(li_13, __prev.c = __c, void 0, true);
 								}
 							},
 							{ a: ' ', b: void 0, c: Symbol() }
 						);
 
-						_$_.append(__anchor, li_14);
+						_$_.append(__anchor, li_13);
 					},
 					12,
 					(pattern_6, i) => _$_.get(pattern_6).id
 				);
 
-				_$_.pop(ul_14);
+				_$_.pop(ul_13);
 			}
 
 			_$_.next();
@@ -1108,38 +1108,38 @@ export function ForLoopWithSiblings() {
 
 		_$_.expression(node_13, () => _$_.tsrx_element((__anchor, __block) => {
 			var fragment_21 = root_54();
-			var div_14 = _$_.first_child_frag(fragment_21);
+			var div_13 = _$_.first_child_frag(fragment_21);
 
 			{
-				var header_1 = _$_.child(div_14);
-				var node_12 = _$_.sibling(header_1);
+				var header = _$_.child(div_13);
+				var node_12 = _$_.sibling(header);
 
 				_$_.for(
 					node_12,
 					() => lazy_13.value,
 					(__anchor, item) => {
-						var div_15 = root_55();
+						var div_14 = root_55();
 
-						_$_.set_class(div_15, `item-${item}`, void 0, true);
+						_$_.set_class(div_14, `item-${item}`, void 0, true);
 
 						{
-							var expression_22 = _$_.child(div_15);
+							var expression_22 = _$_.child(div_14);
 
 							_$_.expression(expression_22, () => item);
-							_$_.pop(div_15);
+							_$_.pop(div_14);
 						}
 
-						_$_.append(__anchor, div_15);
+						_$_.append(__anchor, div_14);
 					},
 					0
 				);
 
-				_$_.pop(div_14);
+				_$_.pop(div_13);
 			}
 
-			var button_15 = _$_.sibling(div_14);
+			var button_14 = _$_.sibling(div_13);
 
-			button_15.__click = () => {
+			button_14.__click = () => {
 				_$_.set(lazy_13, [...lazy_13.value, 'C']);
 			};
 
@@ -1159,11 +1159,11 @@ export function ForLoopItemState() {
 			{ id: 3, text: 'Todo 3' }
 		];
 
-		var div_16 = root_56();
+		var div_15 = root_56();
 
 		{
 			_$_.for_keyed(
-				div_16,
+				div_15,
 				() => initialItems,
 				(__anchor, pattern_7) => {
 					_$_.render_component(TodoItem, __anchor, {
@@ -1180,32 +1180,32 @@ export function ForLoopItemState() {
 				(pattern_7) => _$_.get(pattern_7).id
 			);
 
-			_$_.pop(div_16);
+			_$_.pop(div_15);
 		}
 
-		_$_.append(__anchor, div_16);
+		_$_.append(__anchor, div_15);
 	});
 }
 
 function TodoItem(props) {
 	return _$_.tsrx_element((__anchor, __block) => {
 		let lazy_14 = _$_.track(false, __block, '4f2402a4');
-		var div_17 = root_57();
+		var div_16 = root_57();
 
 		{
-			var input_1 = _$_.child(div_17);
+			var input = _$_.child(div_16);
 
-			input_1.__change = (e) => {
+			input.__change = (e) => {
 				_$_.set(lazy_14, e.target.checked);
 			};
 
-			var span_7 = _$_.sibling(input_1);
+			var span_6 = _$_.sibling(input);
 
 			{
-				var expression_23 = _$_.child(span_7);
+				var expression_23 = _$_.child(span_6);
 
 				_$_.expression(expression_23, () => props.text);
-				_$_.pop(span_7);
+				_$_.pop(span_6);
 			}
 		}
 
@@ -1214,56 +1214,56 @@ function TodoItem(props) {
 				var __a = lazy_14.value;
 
 				if (__prev.a !== __a) {
-					_$_.set_checked(input_1, __prev.a = __a);
+					_$_.set_checked(input, __prev.a = __a);
 				}
 
 				var __b = lazy_14.value ? 'completed' : 'pending';
 
 				if (__prev.b !== __b) {
-					_$_.set_class(span_7, __prev.b = __b, void 0, true);
+					_$_.set_class(span_6, __prev.b = __b, void 0, true);
 				}
 
 				var __c = `todo-${props.id}`;
 
 				if (__prev.c !== __c) {
-					_$_.set_class(div_17, __prev.c = __c, void 0, true);
+					_$_.set_class(div_16, __prev.c = __c, void 0, true);
 				}
 			},
 			{ a: void 0, b: Symbol(), c: Symbol() }
 		);
 
-		_$_.append(__anchor, div_17);
+		_$_.append(__anchor, div_16);
 	});
 }
 
 export function ForLoopSingleItem() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		const items = ['Only'];
-		var ul_15 = root_58();
+		var ul_14 = root_58();
 
 		{
 			_$_.for(
-				ul_15,
+				ul_14,
 				() => items,
 				(__anchor, item) => {
-					var li_15 = root_59();
+					var li_14 = root_59();
 
 					{
-						var expression_24 = _$_.child(li_15);
+						var expression_24 = _$_.child(li_14);
 
 						_$_.expression(expression_24, () => item);
-						_$_.pop(li_15);
+						_$_.pop(li_14);
 					}
 
-					_$_.append(__anchor, li_15);
+					_$_.append(__anchor, li_14);
 				},
 				4
 			);
 
-			_$_.pop(ul_15);
+			_$_.pop(ul_14);
 		}
 
-		_$_.append(__anchor, ul_15);
+		_$_.append(__anchor, ul_14);
 	});
 }
 
@@ -1275,36 +1275,36 @@ export function ForLoopAddAtBeginning() {
 
 		_$_.expression(node_14, () => _$_.tsrx_element((__anchor, __block) => {
 			var fragment_23 = root_61();
-			var button_16 = _$_.first_child_frag(fragment_23);
+			var button_15 = _$_.first_child_frag(fragment_23);
 
-			button_16.__click = () => {
+			button_15.__click = () => {
 				_$_.set(lazy_15, ['A', ...lazy_15.value]);
 			};
 
-			var ul_16 = _$_.sibling(button_16);
+			var ul_15 = _$_.sibling(button_15);
 
 			{
 				_$_.for(
-					ul_16,
+					ul_15,
 					() => lazy_15.value,
 					(__anchor, item) => {
-						var li_16 = root_62();
+						var li_15 = root_62();
 
-						_$_.set_class(li_16, `item-${item}`, void 0, true);
+						_$_.set_class(li_15, `item-${item}`, void 0, true);
 
 						{
-							var expression_25 = _$_.child(li_16);
+							var expression_25 = _$_.child(li_15);
 
 							_$_.expression(expression_25, () => item);
-							_$_.pop(li_16);
+							_$_.pop(li_15);
 						}
 
-						_$_.append(__anchor, li_16);
+						_$_.append(__anchor, li_15);
 					},
 					4
 				);
 
-				_$_.pop(ul_16);
+				_$_.pop(ul_15);
 			}
 
 			_$_.next();
@@ -1323,39 +1323,39 @@ export function ForLoopAddInMiddle() {
 
 		_$_.expression(node_15, () => _$_.tsrx_element((__anchor, __block) => {
 			var fragment_25 = root_64();
-			var button_17 = _$_.first_child_frag(fragment_25);
+			var button_16 = _$_.first_child_frag(fragment_25);
 
-			button_17.__click = () => {
+			button_16.__click = () => {
 				const copy = [...lazy_16.value];
 
 				_$_.with_scope(__block, () => copy.splice(1, 0, 'B'));
 				_$_.set(lazy_16, copy);
 			};
 
-			var ul_17 = _$_.sibling(button_17);
+			var ul_16 = _$_.sibling(button_16);
 
 			{
 				_$_.for(
-					ul_17,
+					ul_16,
 					() => lazy_16.value,
 					(__anchor, item) => {
-						var li_17 = root_65();
+						var li_16 = root_65();
 
-						_$_.set_class(li_17, `item-${item}`, void 0, true);
+						_$_.set_class(li_16, `item-${item}`, void 0, true);
 
 						{
-							var expression_26 = _$_.child(li_17);
+							var expression_26 = _$_.child(li_16);
 
 							_$_.expression(expression_26, () => item);
-							_$_.pop(li_17);
+							_$_.pop(li_16);
 						}
 
-						_$_.append(__anchor, li_17);
+						_$_.append(__anchor, li_16);
 					},
 					4
 				);
 
-				_$_.pop(ul_17);
+				_$_.pop(ul_16);
 			}
 
 			_$_.next();
@@ -1374,36 +1374,36 @@ export function ForLoopRemoveFromMiddle() {
 
 		_$_.expression(node_16, () => _$_.tsrx_element((__anchor, __block) => {
 			var fragment_27 = root_67();
-			var button_18 = _$_.first_child_frag(fragment_27);
+			var button_17 = _$_.first_child_frag(fragment_27);
 
-			button_18.__click = () => {
+			button_17.__click = () => {
 				_$_.set(lazy_17, _$_.with_scope(__block, () => lazy_17.value.filter((item) => item !== 'B')));
 			};
 
-			var ul_18 = _$_.sibling(button_18);
+			var ul_17 = _$_.sibling(button_17);
 
 			{
 				_$_.for(
-					ul_18,
+					ul_17,
 					() => lazy_17.value,
 					(__anchor, item) => {
-						var li_18 = root_68();
+						var li_17 = root_68();
 
-						_$_.set_class(li_18, `item-${item}`, void 0, true);
+						_$_.set_class(li_17, `item-${item}`, void 0, true);
 
 						{
-							var expression_27 = _$_.child(li_18);
+							var expression_27 = _$_.child(li_17);
 
 							_$_.expression(expression_27, () => item);
-							_$_.pop(li_18);
+							_$_.pop(li_17);
 						}
 
-						_$_.append(__anchor, li_18);
+						_$_.append(__anchor, li_17);
 					},
 					4
 				);
 
-				_$_.pop(ul_18);
+				_$_.pop(ul_17);
 			}
 
 			_$_.next();
@@ -1417,35 +1417,35 @@ export function ForLoopRemoveFromMiddle() {
 export function ForLoopLargeList() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		const items = _$_.with_scope(__block, () => Array.from({ length: 50 }, (_, i) => `Item ${i + 1}`));
-		var ul_19 = root_69();
+		var ul_18 = root_69();
 
 		{
 			_$_.for(
-				ul_19,
+				ul_18,
 				() => items,
 				(__anchor, item, i) => {
-					var li_19 = root_70();
+					var li_18 = root_70();
 
 					{
-						var expression_28 = _$_.child(li_19);
+						var expression_28 = _$_.child(li_18);
 
 						_$_.expression(expression_28, () => item);
-						_$_.pop(li_19);
+						_$_.pop(li_18);
 					}
 
 					_$_.render(() => {
-						_$_.set_class(li_19, `item-${i.value}`, void 0, true);
+						_$_.set_class(li_18, `item-${i.value}`, void 0, true);
 					});
 
-					_$_.append(__anchor, li_19);
+					_$_.append(__anchor, li_18);
 				},
 				12
 			);
 
-			_$_.pop(ul_19);
+			_$_.pop(ul_18);
 		}
 
-		_$_.append(__anchor, ul_19);
+		_$_.append(__anchor, ul_18);
 	});
 }
 
@@ -1457,39 +1457,39 @@ export function ForLoopSwap() {
 
 		_$_.expression(node_17, () => _$_.tsrx_element((__anchor, __block) => {
 			var fragment_29 = root_72();
-			var button_19 = _$_.first_child_frag(fragment_29);
+			var button_18 = _$_.first_child_frag(fragment_29);
 
-			button_19.__click = () => {
+			button_18.__click = () => {
 				const copy = [...lazy_18.value];
 
 				[copy[0], copy[3]] = [copy[3], copy[0]];
 				_$_.set(lazy_18, copy);
 			};
 
-			var ul_20 = _$_.sibling(button_19);
+			var ul_19 = _$_.sibling(button_18);
 
 			{
 				_$_.for(
-					ul_20,
+					ul_19,
 					() => lazy_18.value,
 					(__anchor, item) => {
-						var li_20 = root_73();
+						var li_19 = root_73();
 
-						_$_.set_class(li_20, `item-${item}`, void 0, true);
+						_$_.set_class(li_19, `item-${item}`, void 0, true);
 
 						{
-							var expression_29 = _$_.child(li_20);
+							var expression_29 = _$_.child(li_19);
 
 							_$_.expression(expression_29, () => item);
-							_$_.pop(li_20);
+							_$_.pop(li_19);
 						}
 
-						_$_.append(__anchor, li_20);
+						_$_.append(__anchor, li_19);
 					},
 					4
 				);
 
-				_$_.pop(ul_20);
+				_$_.pop(ul_19);
 			}
 
 			_$_.next();
@@ -1508,36 +1508,36 @@ export function ForLoopReverse() {
 
 		_$_.expression(node_18, () => _$_.tsrx_element((__anchor, __block) => {
 			var fragment_31 = root_75();
-			var button_20 = _$_.first_child_frag(fragment_31);
+			var button_19 = _$_.first_child_frag(fragment_31);
 
-			button_20.__click = () => {
+			button_19.__click = () => {
 				_$_.set(lazy_19, _$_.with_scope(__block, () => [...lazy_19.value].reverse()));
 			};
 
-			var ul_21 = _$_.sibling(button_20);
+			var ul_20 = _$_.sibling(button_19);
 
 			{
 				_$_.for(
-					ul_21,
+					ul_20,
 					() => lazy_19.value,
 					(__anchor, item) => {
-						var li_21 = root_76();
+						var li_20 = root_76();
 
-						_$_.set_class(li_21, `item-${item}`, void 0, true);
+						_$_.set_class(li_20, `item-${item}`, void 0, true);
 
 						{
-							var expression_30 = _$_.child(li_21);
+							var expression_30 = _$_.child(li_20);
 
 							_$_.expression(expression_30, () => item);
-							_$_.pop(li_21);
+							_$_.pop(li_20);
 						}
 
-						_$_.append(__anchor, li_21);
+						_$_.append(__anchor, li_20);
 					},
 					4
 				);
 
-				_$_.pop(ul_21);
+				_$_.pop(ul_20);
 			}
 
 			_$_.next();

--- a/packages/ripple/tests/hydration/compiled/client/for.js
+++ b/packages/ripple/tests/hydration/compiled/client/for.js
@@ -1202,9 +1202,8 @@ function TodoItem(props) {
 			var span_6 = _$_.sibling(input);
 
 			{
-				var expression_23 = _$_.child(span_6);
+				var expression_23 = _$_.child(span_6, true);
 
-				_$_.expression(expression_23, () => props.text);
 				_$_.pop(span_6);
 			}
 		}
@@ -1217,19 +1216,25 @@ function TodoItem(props) {
 					_$_.set_checked(input, __prev.a = __a);
 				}
 
-				var __b = lazy_14.value ? 'completed' : 'pending';
+				var __b = props.text;
 
 				if (__prev.b !== __b) {
-					_$_.set_class(span_6, __prev.b = __b, void 0, true);
+					_$_.set_text(expression_23, __prev.b = __b);
 				}
 
-				var __c = `todo-${props.id}`;
+				var __c = lazy_14.value ? 'completed' : 'pending';
 
 				if (__prev.c !== __c) {
-					_$_.set_class(div_16, __prev.c = __c, void 0, true);
+					_$_.set_class(span_6, __prev.c = __c, void 0, true);
+				}
+
+				var __d = `todo-${props.id}`;
+
+				if (__prev.d !== __d) {
+					_$_.set_class(div_16, __prev.d = __d, void 0, true);
 				}
 			},
-			{ a: void 0, b: Symbol(), c: Symbol() }
+			{ a: void 0, b: ' ', c: Symbol(), d: Symbol() }
 		);
 
 		_$_.append(__anchor, div_16);

--- a/packages/ripple/tests/hydration/compiled/client/head.js
+++ b/packages/ripple/tests/hydration/compiled/client/head.js
@@ -33,13 +33,13 @@ export function StaticTitle() {
 		var node = _$_.first_child_frag(fragment);
 
 		_$_.expression(node, () => _$_.tsrx_element((__anchor, __block) => {
-			var div_1 = root_1();
+			var div = root_1();
 
 			_$_.head('6e1f1b90', (__anchor) => {
 				_$_.document.title = 'Static Test Title';
 			});
 
-			_$_.append(__anchor, div_1);
+			_$_.append(__anchor, div);
 		}));
 
 		_$_.append(__anchor, fragment);
@@ -53,16 +53,16 @@ export function ReactiveTitle() {
 		var node_1 = _$_.first_child_frag(fragment_1);
 
 		_$_.expression(node_1, () => _$_.tsrx_element((__anchor, __block) => {
-			var div_2 = root_3();
+			var div_1 = root_3();
 
 			{
-				var span_1 = _$_.child(div_2);
+				var span = _$_.child(div_1);
 
 				{
-					var expression = _$_.child(span_1);
+					var expression = _$_.child(span);
 
 					_$_.expression(expression, () => lazy.value);
-					_$_.pop(span_1);
+					_$_.pop(span);
 				}
 			}
 
@@ -72,7 +72,7 @@ export function ReactiveTitle() {
 				});
 			});
 
-			_$_.append(__anchor, div_2);
+			_$_.append(__anchor, div_1);
 		}));
 
 		_$_.append(__anchor, fragment_1);
@@ -85,7 +85,7 @@ export function MultipleHeadElements() {
 		var node_2 = _$_.first_child_frag(fragment_2);
 
 		_$_.expression(node_2, () => _$_.tsrx_element((__anchor, __block) => {
-			var div_3 = root_5();
+			var div_2 = root_5();
 
 			_$_.head('07a54928', (__anchor) => {
 				var fragment_3 = root_6();
@@ -95,7 +95,7 @@ export function MultipleHeadElements() {
 				_$_.append(__anchor, fragment_3, true);
 			});
 
-			_$_.append(__anchor, div_3);
+			_$_.append(__anchor, div_2);
 		}));
 
 		_$_.append(__anchor, fragment_2);
@@ -109,24 +109,24 @@ export function ReactiveMetaTags() {
 		var node_3 = _$_.first_child_frag(fragment_4);
 
 		_$_.expression(node_3, () => _$_.tsrx_element((__anchor, __block) => {
-			var div_4 = root_8();
+			var div_3 = root_8();
 
 			{
-				var expression_1 = _$_.child(div_4);
+				var expression_1 = _$_.child(div_3);
 
 				_$_.expression(expression_1, () => lazy_1.value);
-				_$_.pop(div_4);
+				_$_.pop(div_3);
 			}
 
 			_$_.head('4ca6a546', (__anchor) => {
-				var meta_1 = root_9();
+				var meta = root_9();
 
 				_$_.document.title = 'My Page';
-				_$_.set_attribute(meta_1, 'content');
-				_$_.append(__anchor, meta_1);
+				_$_.set_attribute(meta, 'content');
+				_$_.append(__anchor, meta);
 			});
 
-			_$_.append(__anchor, div_4);
+			_$_.append(__anchor, div_3);
 		}));
 
 		_$_.append(__anchor, fragment_4);
@@ -140,13 +140,13 @@ export function TitleWithTemplate() {
 		var node_4 = _$_.first_child_frag(fragment_5);
 
 		_$_.expression(node_4, () => _$_.tsrx_element((__anchor, __block) => {
-			var div_5 = root_11();
+			var div_4 = root_11();
 
 			{
-				var expression_2 = _$_.child(div_5);
+				var expression_2 = _$_.child(div_4);
 
 				_$_.expression(expression_2, () => lazy_2.value);
-				_$_.pop(div_5);
+				_$_.pop(div_4);
 			}
 
 			_$_.head('10dc944d', (__anchor) => {
@@ -155,7 +155,7 @@ export function TitleWithTemplate() {
 				});
 			});
 
-			_$_.append(__anchor, div_5);
+			_$_.append(__anchor, div_4);
 		}));
 
 		_$_.append(__anchor, fragment_5);
@@ -168,13 +168,13 @@ export function EmptyTitle() {
 		var node_5 = _$_.first_child_frag(fragment_6);
 
 		_$_.expression(node_5, () => _$_.tsrx_element((__anchor, __block) => {
-			var div_6 = root_13();
+			var div_5 = root_13();
 
 			_$_.head('13ba9873', (__anchor) => {
 				_$_.document.title = '';
 			});
 
-			_$_.append(__anchor, div_6);
+			_$_.append(__anchor, div_5);
 		}));
 
 		_$_.append(__anchor, fragment_6);
@@ -189,13 +189,13 @@ export function ConditionalTitle() {
 		var node_6 = _$_.first_child_frag(fragment_7);
 
 		_$_.expression(node_6, () => _$_.tsrx_element((__anchor, __block) => {
-			var div_7 = root_15();
+			var div_6 = root_15();
 
 			{
-				var expression_3 = _$_.child(div_7);
+				var expression_3 = _$_.child(div_6);
 
 				_$_.expression(expression_3, () => lazy_4.value);
-				_$_.pop(div_7);
+				_$_.pop(div_6);
 			}
 
 			_$_.head('4b39c36b', (__anchor) => {
@@ -204,7 +204,7 @@ export function ConditionalTitle() {
 				});
 			});
 
-			_$_.append(__anchor, div_7);
+			_$_.append(__anchor, div_6);
 		}));
 
 		_$_.append(__anchor, fragment_7);
@@ -219,16 +219,16 @@ export function ComputedTitle() {
 		var node_7 = _$_.first_child_frag(fragment_8);
 
 		_$_.expression(node_7, () => _$_.tsrx_element((__anchor, __block) => {
-			var div_8 = root_17();
+			var div_7 = root_17();
 
 			{
-				var span_2 = _$_.child(div_8);
+				var span_1 = _$_.child(div_7);
 
 				{
-					var expression_4 = _$_.child(span_2);
+					var expression_4 = _$_.child(span_1);
 
 					_$_.expression(expression_4, () => lazy_5.value);
-					_$_.pop(span_2);
+					_$_.pop(span_1);
 				}
 			}
 
@@ -238,7 +238,7 @@ export function ComputedTitle() {
 				});
 			});
 
-			_$_.append(__anchor, div_8);
+			_$_.append(__anchor, div_7);
 		}));
 
 		_$_.append(__anchor, fragment_8);
@@ -251,19 +251,19 @@ export function MultipleHeadBlocks() {
 		var node_8 = _$_.first_child_frag(fragment_9);
 
 		_$_.expression(node_8, () => _$_.tsrx_element((__anchor, __block) => {
-			var div_9 = root_19();
+			var div_8 = root_19();
 
 			_$_.head('9a44f25d', (__anchor) => {
 				_$_.document.title = 'First Head';
 			});
 
 			_$_.head('0873e476', (__anchor) => {
-				var meta_2 = root_20();
+				var meta_1 = root_20();
 
-				_$_.append(__anchor, meta_2);
+				_$_.append(__anchor, meta_1);
 			});
 
-			_$_.append(__anchor, div_9);
+			_$_.append(__anchor, div_8);
 		}));
 
 		_$_.append(__anchor, fragment_9);
@@ -276,13 +276,13 @@ export function HeadWithStyle() {
 		var node_9 = _$_.first_child_frag(fragment_10);
 
 		_$_.expression(node_9, () => _$_.tsrx_element((__anchor, __block) => {
-			var div_10 = root_22();
+			var div_9 = root_22();
 
 			_$_.head('d75c5358', (__anchor) => {
 				_$_.document.title = 'Styled Page';
 			});
 
-			_$_.append(__anchor, div_10);
+			_$_.append(__anchor, div_9);
 		}));
 
 		_$_.append(__anchor, fragment_10);

--- a/packages/ripple/tests/hydration/compiled/client/hmr.js
+++ b/packages/ripple/tests/hydration/compiled/client/hmr.js
@@ -9,37 +9,37 @@ import { track } from 'ripple';
 
 export function Layout({ children }) {
 	return _$_.tsrx_element((__anchor, __block) => {
-		var div_1 = root();
+		var div = root();
 
 		{
-			var nav_1 = _$_.child(div_1);
-			var main_1 = _$_.sibling(nav_1);
+			var nav = _$_.child(div);
+			var main = _$_.sibling(nav);
 
 			{
-				var expression = _$_.child(main_1);
+				var expression = _$_.child(main);
 
 				_$_.expression(expression, () => children);
-				_$_.pop(main_1);
+				_$_.pop(main);
 			}
 		}
 
-		_$_.append(__anchor, div_1);
+		_$_.append(__anchor, div);
 	});
 }
 
 export function Content() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		let lazy = _$_.track(true, __block, '0bdb1500');
-		var div_2 = root_1();
+		var div_1 = root_1();
 
 		{
-			var node = _$_.child(div_2);
+			var node = _$_.child(div_1);
 
 			{
 				var consequent = (__anchor) => {
-					var p_1 = root_2();
+					var p = root_2();
 
-					_$_.append(__anchor, p_1);
+					_$_.append(__anchor, p);
 				};
 
 				_$_.if(node, (__render) => {
@@ -47,10 +47,10 @@ export function Content() {
 				});
 			}
 
-			_$_.pop(div_2);
+			_$_.pop(div_1);
 		}
 
-		_$_.append(__anchor, div_2);
+		_$_.append(__anchor, div_1);
 	});
 }
 

--- a/packages/ripple/tests/hydration/compiled/client/html-in-template.js
+++ b/packages/ripple/tests/hydration/compiled/client/html-in-template.js
@@ -9,40 +9,40 @@ var root_2 = _$_.template(`<div><template id="before"></template><!><template id
 export function SimpleTemplateHtml() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		const data = 'test data';
-		var template_1 = root();
+		var template = root();
 
-		template_1.innerHTML = data ?? template_1.innerHTML;
-		_$_.append(__anchor, template_1);
+		template.innerHTML = data ?? template.innerHTML;
+		_$_.append(__anchor, template);
 	});
 }
 
 export function TemplateWithJSON() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		const jsonData = _$_.with_scope(__block, () => JSON.stringify({ message: 'hello', count: 42 }));
-		var template_2 = root_1();
+		var template_1 = root_1();
 
-		template_2.innerHTML = jsonData ?? template_2.innerHTML;
-		_$_.append(__anchor, template_2);
+		template_1.innerHTML = jsonData ?? template_1.innerHTML;
+		_$_.append(__anchor, template_1);
 	});
 }
 
 export function TemplateAroundIfBlock() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		const show = true;
-		var div_1 = root_2();
+		var div = root_2();
 
 		{
-			var template_3 = _$_.child(div_1);
+			var template_2 = _$_.child(div);
 
-			template_3.innerHTML = "before" ?? template_3.innerHTML;
+			template_2.innerHTML = "before" ?? template_2.innerHTML;
 
-			var node = _$_.sibling(template_3);
+			var node = _$_.sibling(template_2);
 
 			{
 				var consequent = (__anchor) => {
-					var span_1 = root_3();
+					var span = root_3();
 
-					_$_.append(__anchor, span_1);
+					_$_.append(__anchor, span);
 				};
 
 				_$_.if(node, (__render) => {
@@ -50,12 +50,12 @@ export function TemplateAroundIfBlock() {
 				});
 			}
 
-			var template_4 = _$_.sibling(node);
+			var template_3 = _$_.sibling(node);
 
-			template_4.innerHTML = "after" ?? template_4.innerHTML;
-			_$_.pop(div_1);
+			template_3.innerHTML = "after" ?? template_3.innerHTML;
+			_$_.pop(div);
 		}
 
-		_$_.append(__anchor, div_1);
+		_$_.append(__anchor, div);
 	});
 }

--- a/packages/ripple/tests/hydration/compiled/client/html.js
+++ b/packages/ripple/tests/hydration/compiled/client/html.js
@@ -90,40 +90,40 @@ import { Fragment, track } from 'ripple';
 export function StaticHtml() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		const html = '<p><strong>Bold</strong> text</p>';
-		var div_1 = root();
+		var div = root();
 
-		div_1.innerHTML = html ?? div_1.innerHTML;
-		_$_.append(__anchor, div_1);
+		div.innerHTML = html ?? div.innerHTML;
+		_$_.append(__anchor, div);
 	});
 }
 
 export function DynamicHtml() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		const content = '<p>Dynamic <span>HTML</span> content</p>';
-		var div_2 = root_1();
+		var div_1 = root_1();
 
-		div_2.innerHTML = content ?? div_2.innerHTML;
-		_$_.append(__anchor, div_2);
+		div_1.innerHTML = content ?? div_1.innerHTML;
+		_$_.append(__anchor, div_1);
 	});
 }
 
 export function EmptyHtml() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		const html = '';
-		var div_3 = root_2();
+		var div_2 = root_2();
 
-		div_3.innerHTML = html ?? div_3.innerHTML;
-		_$_.append(__anchor, div_3);
+		div_2.innerHTML = html ?? div_2.innerHTML;
+		_$_.append(__anchor, div_2);
 	});
 }
 
 export function ComplexHtml() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		const html = '<div class="nested"><span>Nested <em>content</em></span></div>';
-		var section_1 = root_3();
+		var section = root_3();
 
-		section_1.innerHTML = html ?? section_1.innerHTML;
-		_$_.append(__anchor, section_1);
+		section.innerHTML = html ?? section.innerHTML;
+		_$_.append(__anchor, section);
 	});
 }
 
@@ -131,13 +131,13 @@ export function MultipleHtml() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		const html1 = '<p>First paragraph</p>';
 		const html2 = '<p>Second paragraph</p>';
-		var div_4 = root_4();
+		var div_3 = root_4();
 
 		{
-			var node = _$_.child(div_4);
+			var node = _$_.child(div_3);
 			var node_1 = _$_.sibling(node);
 
-			_$_.pop(div_4);
+			_$_.pop(div_3);
 		}
 
 		_$_.render(
@@ -148,44 +148,44 @@ export function MultipleHtml() {
 			{}
 		);
 
-		_$_.append(__anchor, div_4);
+		_$_.append(__anchor, div_3);
 	});
 }
 
 export function HtmlWithReactivity() {
 	return _$_.tsrx_element((__anchor, __block) => {
-		var div_5 = root_5();
+		var div_4 = root_5();
 
 		{
-			var node_2 = _$_.child(div_5);
+			var node_2 = _$_.child(div_4);
 
-			_$_.pop(div_5);
+			_$_.pop(div_4);
 		}
 
 		_$_.render(() => {
 			_$_.html(node_2, () => "<p>Count: 0</p>");
 		});
 
-		_$_.append(__anchor, div_5);
+		_$_.append(__anchor, div_4);
 	});
 }
 
 export function HtmlWrapper({ children }) {
 	return _$_.tsrx_element((__anchor, __block) => {
-		var div_6 = root_6();
+		var div_5 = root_6();
 
 		{
-			var div_7 = _$_.child(div_6);
+			var div_6 = _$_.child(div_5);
 
 			{
-				var expression = _$_.child(div_7);
+				var expression = _$_.child(div_6);
 
 				_$_.expression(expression, () => children);
-				_$_.pop(div_7);
+				_$_.pop(div_6);
 			}
 		}
 
-		_$_.append(__anchor, div_6);
+		_$_.append(__anchor, div_5);
 	});
 }
 
@@ -195,10 +195,10 @@ export function HtmlInChildren() {
 
 		_$_.render_component(HtmlWrapper, __anchor, {
 			children: _$_.tsrx_element((__anchor, __block) => {
-				var div_8 = root_7();
+				var div_7 = root_7();
 
-				div_8.innerHTML = content ?? div_8.innerHTML;
-				_$_.append(__anchor, div_8);
+				div_7.innerHTML = content ?? div_7.innerHTML;
+				_$_.append(__anchor, div_7);
 			})
 		});
 	});
@@ -211,10 +211,10 @@ export function HtmlInChildrenWithSiblings() {
 		_$_.render_component(HtmlWrapper, __anchor, {
 			children: _$_.tsrx_element((__anchor, __block) => {
 				var fragment = root_8();
-				var h1_1 = _$_.first_child_frag(fragment);
-				var div_9 = _$_.sibling(h1_1);
+				var h1 = _$_.first_child_frag(fragment);
+				var div_8 = _$_.sibling(h1);
 
-				div_9.innerHTML = content ?? div_9.innerHTML;
+				div_8.innerHTML = content ?? div_8.innerHTML;
 				_$_.next();
 				_$_.append(__anchor, fragment, true);
 			})
@@ -229,13 +229,13 @@ export function MultipleHtmlInChildren() {
 
 		_$_.render_component(HtmlWrapper, __anchor, {
 			children: _$_.tsrx_element((__anchor, __block) => {
-				var div_10 = root_9();
+				var div_9 = root_9();
 
 				{
-					var node_3 = _$_.child(div_10);
+					var node_3 = _$_.child(div_9);
 					var node_4 = _$_.sibling(node_3);
 
-					_$_.pop(div_10);
+					_$_.pop(div_9);
 				}
 
 				_$_.render(
@@ -246,7 +246,7 @@ export function MultipleHtmlInChildren() {
 					{}
 				);
 
-				_$_.append(__anchor, div_10);
+				_$_.append(__anchor, div_9);
 			})
 		});
 	});
@@ -255,20 +255,20 @@ export function MultipleHtmlInChildren() {
 export function HtmlWithComments() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		const content = '<p>Before comment</p><!-- TODO: Elaborate --><p>After comment</p>';
-		var div_11 = root_10();
+		var div_10 = root_10();
 
-		div_11.innerHTML = content ?? div_11.innerHTML;
-		_$_.append(__anchor, div_11);
+		div_10.innerHTML = content ?? div_10.innerHTML;
+		_$_.append(__anchor, div_10);
 	});
 }
 
 export function HtmlWithEmptyComment() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		const content = '<p>Before</p><!----><p>After</p>';
-		var div_12 = root_11();
+		var div_11 = root_11();
 
-		div_12.innerHTML = content ?? div_12.innerHTML;
-		_$_.append(__anchor, div_12);
+		div_11.innerHTML = content ?? div_11.innerHTML;
+		_$_.append(__anchor, div_11);
 	});
 }
 
@@ -278,10 +278,10 @@ export function HtmlWithCommentsInChildren() {
 
 		_$_.render_component(HtmlWrapper, __anchor, {
 			children: _$_.tsrx_element((__anchor, __block) => {
-				var div_13 = root_12();
+				var div_12 = root_12();
 
-				div_13.innerHTML = content ?? div_13.innerHTML;
-				_$_.append(__anchor, div_13);
+				div_12.innerHTML = content ?? div_12.innerHTML;
+				_$_.append(__anchor, div_12);
 			})
 		});
 	});
@@ -289,50 +289,50 @@ export function HtmlWithCommentsInChildren() {
 
 function DocFooter() {
 	return _$_.tsrx_element((__anchor, __block) => {
-		var footer_1 = root_13();
+		var footer = root_13();
 
-		_$_.append(__anchor, footer_1);
+		_$_.append(__anchor, footer);
 	});
 }
 
 export function DocLayout(__props) {
 	return _$_.tsrx_element((__anchor, __block) => {
-		var div_14 = root_14();
+		var div_13 = root_14();
 
 		{
-			var div_16 = _$_.child(div_14);
+			var div_15 = _$_.child(div_13);
 
 			{
-				var article_1 = _$_.child(div_16);
+				var article = _$_.child(div_15);
 
 				{
-					var div_15 = _$_.child(article_1);
+					var div_14 = _$_.child(article);
 
 					{
-						var expression_1 = _$_.child(div_15);
+						var expression_1 = _$_.child(div_14);
 
 						_$_.expression(expression_1, () => __props.children);
-						_$_.pop(div_15);
+						_$_.pop(div_14);
 					}
 				}
 
-				_$_.pop(article_1);
+				_$_.pop(article);
 
-				var node_5 = _$_.sibling(article_1);
+				var node_5 = _$_.sibling(article);
 
 				{
 					var consequent = (__anchor) => {
-						var div_17 = root_15();
+						var div_16 = root_15();
 
 						{
-							var a_1 = _$_.child(div_17);
+							var a = _$_.child(div_16);
 						}
 
 						_$_.render(() => {
-							_$_.set_attribute(a_1, 'href', `https://github.com/edit/${_$_.fallback(__props.editPath, '')}`);
+							_$_.set_attribute(a, 'href', `https://github.com/edit/${_$_.fallback(__props.editPath, '')}`);
 						});
 
-						_$_.append(__anchor, div_17);
+						_$_.append(__anchor, div_16);
 					};
 
 					_$_.if(node_5, (__render) => {
@@ -344,24 +344,24 @@ export function DocLayout(__props) {
 
 				{
 					var consequent_1 = (__anchor) => {
-						var nav_1 = root_16();
+						var nav = root_16();
 
 						{
-							var a_2 = _$_.child(nav_1);
+							var a_1 = _$_.child(nav);
 
 							{
-								var expression_2 = _$_.child(a_2);
+								var expression_2 = _$_.child(a_1);
 
 								_$_.expression(expression_2, () => _$_.fallback(__props.nextLink, null).text);
-								_$_.pop(a_2);
+								_$_.pop(a_1);
 							}
 						}
 
 						_$_.render(() => {
-							_$_.set_attribute(a_2, 'href', _$_.fallback(__props.nextLink, null).href);
+							_$_.set_attribute(a_1, 'href', _$_.fallback(__props.nextLink, null).href);
 						});
 
-						_$_.append(__anchor, nav_1);
+						_$_.append(__anchor, nav);
 					};
 
 					_$_.if(node_6, (__render) => {
@@ -372,53 +372,53 @@ export function DocLayout(__props) {
 				var node_7 = _$_.sibling(node_6);
 
 				_$_.render_component(DocFooter, node_7, {});
-				_$_.pop(div_16);
+				_$_.pop(div_15);
 			}
 
-			var aside_1 = _$_.sibling(div_16);
+			var aside = _$_.sibling(div_15);
 
 			{
-				var node_8 = _$_.child(aside_1);
+				var node_8 = _$_.child(aside);
 
 				{
 					var consequent_2 = (__anchor) => {
-						var div_18 = root_17();
+						var div_17 = root_17();
 
 						{
-							var ul_1 = _$_.child(div_18);
+							var ul = _$_.child(div_17);
 
 							{
 								_$_.for(
-									ul_1,
+									ul,
 									() => _$_.fallback(__props.toc, []),
 									(__anchor, item) => {
-										var li_1 = root_18();
+										var li = root_18();
 
 										{
-											var a_3 = _$_.child(li_1);
+											var a_2 = _$_.child(li);
 
 											{
-												var expression_3 = _$_.child(a_3);
+												var expression_3 = _$_.child(a_2);
 
 												_$_.expression(expression_3, () => item.text);
-												_$_.pop(a_3);
+												_$_.pop(a_2);
 											}
 										}
 
 										_$_.render(() => {
-											_$_.set_attribute(a_3, 'href', item.href);
+											_$_.set_attribute(a_2, 'href', item.href);
 										});
 
-										_$_.append(__anchor, li_1);
+										_$_.append(__anchor, li);
 									},
 									4
 								);
 
-								_$_.pop(ul_1);
+								_$_.pop(ul);
 							}
 						}
 
-						_$_.append(__anchor, div_18);
+						_$_.append(__anchor, div_17);
 					};
 
 					_$_.if(node_8, (__render) => {
@@ -426,11 +426,11 @@ export function DocLayout(__props) {
 					});
 				}
 
-				_$_.pop(aside_1);
+				_$_.pop(aside);
 			}
 		}
 
-		_$_.append(__anchor, div_14);
+		_$_.append(__anchor, div_13);
 	});
 }
 
@@ -447,10 +447,10 @@ export function HtmlWithServerData() {
 			],
 
 			children: _$_.tsrx_element((__anchor, __block) => {
-				var div_19 = root_19();
+				var div_18 = root_19();
 
-				div_19.innerHTML = content ?? div_19.innerHTML;
-				_$_.append(__anchor, div_19);
+				div_18.innerHTML = content ?? div_18.innerHTML;
+				_$_.append(__anchor, div_18);
 			})
 		});
 	});
@@ -462,10 +462,10 @@ export function HtmlWithClientDefaults() {
 
 		_$_.render_component(DocLayout, __anchor, {
 			children: _$_.tsrx_element((__anchor, __block) => {
-				var div_20 = root_20();
+				var div_19 = root_20();
 
-				div_20.innerHTML = content ?? div_20.innerHTML;
-				_$_.append(__anchor, div_20);
+				div_19.innerHTML = content ?? div_19.innerHTML;
+				_$_.append(__anchor, div_19);
 			})
 		});
 	});
@@ -477,10 +477,10 @@ export function HtmlWithUndefinedContent() {
 
 		_$_.render_component(DocLayout, __anchor, {
 			children: _$_.tsrx_element((__anchor, __block) => {
-				var div_21 = root_21();
+				var div_20 = root_21();
 
-				div_21.innerHTML = content ?? div_21.innerHTML;
-				_$_.append(__anchor, div_21);
+				div_20.innerHTML = content ?? div_20.innerHTML;
+				_$_.append(__anchor, div_20);
 			})
 		});
 	});
@@ -490,29 +490,29 @@ function DynamicHeading({ level, children }) {
 	return _$_.tsrx_element((__anchor, __block) => {
 		{
 			var switch_case_0 = (__anchor) => {
-				var h1_2 = root_22();
+				var h1_1 = root_22();
 
 				{
-					var expression_4 = _$_.child(h1_2);
+					var expression_4 = _$_.child(h1_1);
 
 					_$_.expression(expression_4, () => children);
-					_$_.pop(h1_2);
+					_$_.pop(h1_1);
 				}
 
-				_$_.append(__anchor, h1_2);
+				_$_.append(__anchor, h1_1);
 			};
 
 			var switch_case_1 = (__anchor) => {
-				var h2_1 = root_23();
+				var h2 = root_23();
 
 				{
-					var expression_5 = _$_.child(h2_1);
+					var expression_5 = _$_.child(h2);
 
 					_$_.expression(expression_5, () => children);
-					_$_.pop(h2_1);
+					_$_.pop(h2);
 				}
 
-				_$_.append(__anchor, h2_1);
+				_$_.append(__anchor, h2);
 			};
 
 			_$_.switch(
@@ -539,38 +539,38 @@ function DynamicHeading({ level, children }) {
 function CodeBlock({ code }) {
 	return _$_.tsrx_element((__anchor, __block) => {
 		const highlighted = `<pre class="shiki"><code>${code}</code></pre>`;
-		var div_22 = root_24();
+		var div_21 = root_24();
 
 		{
-			var div_23 = _$_.child(div_22);
+			var div_22 = _$_.child(div_21);
 
-			_$_.pop(div_23);
+			_$_.pop(div_22);
 
-			var div_24 = _$_.sibling(div_23);
+			var div_23 = _$_.sibling(div_22);
 
-			div_24.innerHTML = highlighted ?? div_24.innerHTML;
+			div_23.innerHTML = highlighted ?? div_23.innerHTML;
 		}
 
-		_$_.append(__anchor, div_22);
+		_$_.append(__anchor, div_21);
 	});
 }
 
 function ContentWrapper({ children }) {
 	return _$_.tsrx_element((__anchor, __block) => {
-		var div_25 = root_25();
+		var div_24 = root_25();
 
 		{
-			var div_26 = _$_.child(div_25);
+			var div_25 = _$_.child(div_24);
 
 			{
-				var expression_6 = _$_.child(div_26);
+				var expression_6 = _$_.child(div_25);
 
 				_$_.expression(expression_6, () => children);
-				_$_.pop(div_26);
+				_$_.pop(div_25);
 			}
 		}
 
-		_$_.append(__anchor, div_25);
+		_$_.append(__anchor, div_24);
 	});
 }
 
@@ -590,9 +590,9 @@ export function HtmlAfterSwitchInChildren() {
 					})
 				});
 
-				var p_2 = _$_.sibling(node_9);
-				var p_1 = _$_.sibling(p_2);
-				var node_10 = _$_.sibling(p_1);
+				var p_1 = _$_.sibling(node_9);
+				var p = _$_.sibling(p_1);
+				var node_10 = _$_.sibling(p);
 
 				_$_.render_component(CodeBlock, node_10, { code: "const x = 1;" });
 				_$_.append(__anchor, fragment_1);
@@ -605,29 +605,29 @@ function IfHeading({ primary, children }) {
 	return _$_.tsrx_element((__anchor, __block) => {
 		{
 			var consequent_3 = (__anchor) => {
-				var h1_3 = root_27();
+				var h1_2 = root_27();
 
 				{
-					var expression_8 = _$_.child(h1_3);
+					var expression_8 = _$_.child(h1_2);
 
 					_$_.expression(expression_8, () => children);
-					_$_.pop(h1_3);
+					_$_.pop(h1_2);
 				}
 
-				_$_.append(__anchor, h1_3);
+				_$_.append(__anchor, h1_2);
 			};
 
 			var alternate = (__anchor) => {
-				var h2_2 = root_28();
+				var h2_1 = root_28();
 
 				{
-					var expression_9 = _$_.child(h2_2);
+					var expression_9 = _$_.child(h2_1);
 
 					_$_.expression(expression_9, () => children);
-					_$_.pop(h2_2);
+					_$_.pop(h2_1);
 				}
 
-				_$_.append(__anchor, h2_2);
+				_$_.append(__anchor, h2_1);
 			};
 
 			_$_.if(
@@ -657,9 +657,9 @@ export function HtmlAfterIfInChildren() {
 					})
 				});
 
-				var p_4 = _$_.sibling(node_11);
-				var p_3 = _$_.sibling(p_4);
-				var node_12 = _$_.sibling(p_3);
+				var p_3 = _$_.sibling(node_11);
+				var p_2 = _$_.sibling(p_3);
+				var node_12 = _$_.sibling(p_2);
 
 				_$_.render_component(CodeBlock, node_12, { code: "const x = 1;" });
 				_$_.append(__anchor, fragment_2);
@@ -674,16 +674,16 @@ function ForList({ items }) {
 			__anchor,
 			() => items,
 			(__anchor, item) => {
-				var span_1 = root_30();
+				var span = root_30();
 
 				{
-					var expression_11 = _$_.child(span_1);
+					var expression_11 = _$_.child(span);
 
 					_$_.expression(expression_11, () => item);
-					_$_.pop(span_1);
+					_$_.pop(span);
 				}
 
-				_$_.append(__anchor, span_1);
+				_$_.append(__anchor, span);
 			},
 			16
 		);
@@ -699,8 +699,8 @@ export function HtmlAfterForInChildren() {
 
 				_$_.render_component(ForList, node_13, { items: ['Title', 'Subtitle'] });
 
-				var p_5 = _$_.sibling(node_13);
-				var node_14 = _$_.sibling(p_5);
+				var p_4 = _$_.sibling(node_13);
+				var node_14 = _$_.sibling(p_4);
 
 				_$_.render_component(CodeBlock, node_14, { code: "const x = 1;" });
 				_$_.append(__anchor, fragment_3);
@@ -714,21 +714,21 @@ function TryBox({ value }) {
 		_$_.try(
 			__anchor,
 			(__anchor) => {
-				var div_27 = root_32();
+				var div_26 = root_32();
 
 				{
-					var expression_12 = _$_.child(div_27, true);
+					var expression_12 = _$_.child(div_26, true);
 
 					expression_12.nodeValue = value;
-					_$_.pop(div_27);
+					_$_.pop(div_26);
 				}
 
-				_$_.append(__anchor, div_27);
+				_$_.append(__anchor, div_26);
 			},
 			(__anchor, e) => {
-				var span_2 = root_33();
+				var span_1 = root_33();
 
-				_$_.append(__anchor, span_2);
+				_$_.append(__anchor, span_1);
 			},
 			null,
 			true
@@ -745,8 +745,8 @@ export function HtmlAfterTryInChildren() {
 
 				_$_.render_component(TryBox, node_15, { value: "Title" });
 
-				var p_6 = _$_.sibling(node_15);
-				var node_16 = _$_.sibling(p_6);
+				var p_5 = _$_.sibling(node_15);
+				var node_16 = _$_.sibling(p_5);
 
 				_$_.render_component(CodeBlock, node_16, { code: "const x = 1;" });
 				_$_.append(__anchor, fragment_4);
@@ -757,16 +757,16 @@ export function HtmlAfterTryInChildren() {
 
 function Boxed({ children }) {
 	return _$_.tsrx_element((__anchor, __block) => {
-		var span_3 = root_35();
+		var span_2 = root_35();
 
 		{
-			var expression_13 = _$_.child(span_3);
+			var expression_13 = _$_.child(span_2);
 
 			_$_.expression(expression_13, () => children);
-			_$_.pop(span_3);
+			_$_.pop(span_2);
 		}
 
-		_$_.append(__anchor, span_3);
+		_$_.append(__anchor, span_2);
 	});
 }
 
@@ -793,8 +793,8 @@ export function HtmlAfterComponentInChildren() {
 
 				_$_.render_component(IndirectHeading, node_17, { text: "Title" });
 
-				var p_7 = _$_.sibling(node_17);
-				var node_18 = _$_.sibling(p_7);
+				var p_6 = _$_.sibling(node_17);
+				var node_18 = _$_.sibling(p_6);
 
 				_$_.render_component(CodeBlock, node_18, { code: "const x = 1;" });
 				_$_.append(__anchor, fragment_6);
@@ -805,16 +805,16 @@ export function HtmlAfterComponentInChildren() {
 
 function NavItem(__props) {
 	return _$_.tsrx_element((__anchor, __block) => {
-		var div_28 = root_38();
+		var div_27 = root_38();
 
 		{
-			var node_19 = _$_.child(div_28);
+			var node_19 = _$_.child(div_27);
 
 			{
 				var consequent_4 = (__anchor) => {
-					var div_29 = root_39();
+					var div_28 = root_39();
 
-					_$_.append(__anchor, div_29);
+					_$_.append(__anchor, div_28);
 				};
 
 				_$_.if(node_19, (__render) => {
@@ -822,20 +822,20 @@ function NavItem(__props) {
 				});
 			}
 
-			var a_4 = _$_.sibling(node_19);
+			var a_3 = _$_.sibling(node_19);
 
 			{
-				var span_4 = _$_.child(a_4);
+				var span_3 = _$_.child(a_3);
 
 				{
-					var expression_15 = _$_.child(span_4);
+					var expression_15 = _$_.child(span_3);
 
 					_$_.expression(expression_15, () => __props.text);
-					_$_.pop(span_4);
+					_$_.pop(span_3);
 				}
 			}
 
-			_$_.pop(div_28);
+			_$_.pop(div_27);
 		}
 
 		_$_.render(
@@ -843,61 +843,61 @@ function NavItem(__props) {
 				var __a = __props.href;
 
 				if (__prev.a !== __a) {
-					_$_.set_attribute(a_4, 'href', __prev.a = __a);
+					_$_.set_attribute(a_3, 'href', __prev.a = __a);
 				}
 
 				var __b = `nav-item${_$_.fallback(__props.active, false) ? ' active' : ''}`;
 
 				if (__prev.b !== __b) {
-					_$_.set_class(div_28, __prev.b = __b, void 0, true);
+					_$_.set_class(div_27, __prev.b = __b, void 0, true);
 				}
 			},
 			{ a: void 0, b: Symbol() }
 		);
 
-		_$_.append(__anchor, div_28);
+		_$_.append(__anchor, div_27);
 	});
 }
 
 function SidebarSection({ title, children }) {
 	return _$_.tsrx_element((__anchor, __block) => {
 		let lazy = _$_.track(true, __block, '6ac6906f');
-		var section_2 = root_40();
+		var section_1 = root_40();
 
 		{
-			var div_30 = _$_.child(section_2);
+			var div_29 = _$_.child(section_1);
 
 			{
-				var h2_3 = _$_.child(div_30);
+				var h2_2 = _$_.child(div_29);
 
 				{
-					var expression_16 = _$_.child(h2_3, true);
+					var expression_16 = _$_.child(h2_2, true);
 
 					expression_16.nodeValue = title;
-					_$_.pop(h2_3);
+					_$_.pop(h2_2);
 				}
 
-				var button_1 = _$_.sibling(h2_3);
+				var button = _$_.sibling(h2_2);
 
-				button_1.__click = () => _$_.set(lazy, !lazy.value);
+				button.__click = () => _$_.set(lazy, !lazy.value);
 			}
 
-			_$_.pop(div_30);
+			_$_.pop(div_29);
 
-			var node_20 = _$_.sibling(div_30);
+			var node_20 = _$_.sibling(div_29);
 
 			{
 				var consequent_5 = (__anchor) => {
-					var div_31 = root_41();
+					var div_30 = root_41();
 
 					{
-						var expression_17 = _$_.child(div_31);
+						var expression_17 = _$_.child(div_30);
 
 						_$_.expression(expression_17, () => children);
-						_$_.pop(div_31);
+						_$_.pop(div_30);
 					}
 
-					_$_.append(__anchor, div_31);
+					_$_.append(__anchor, div_30);
 				};
 
 				_$_.if(node_20, (__render) => {
@@ -905,25 +905,25 @@ function SidebarSection({ title, children }) {
 				});
 			}
 
-			_$_.pop(section_2);
+			_$_.pop(section_1);
 		}
 
-		_$_.append(__anchor, section_2);
+		_$_.append(__anchor, section_1);
 	});
 }
 
 function SideNav({ currentPath }) {
 	return _$_.tsrx_element((__anchor, __block) => {
-		var aside_2 = root_42();
+		var aside_1 = root_42();
 
 		{
-			var nav_2 = _$_.child(aside_2);
+			var nav_1 = _$_.child(aside_1);
 
 			{
-				var div_32 = _$_.child(nav_2);
+				var div_31 = _$_.child(nav_1);
 
 				{
-					var append_anchor = _$_.append_into(div_32);
+					var append_anchor = _$_.append_into(div_31);
 
 					_$_.render_component(SidebarSection, append_anchor, {
 						title: "Getting Started",
@@ -949,13 +949,13 @@ function SideNav({ currentPath }) {
 						})
 					});
 
-					_$_.pop(div_32);
+					_$_.pop(div_31);
 				}
 
-				var div_33 = _$_.sibling(div_32);
+				var div_32 = _$_.sibling(div_31);
 
 				{
-					var append_anchor_1 = _$_.append_into(div_33);
+					var append_anchor_1 = _$_.append_into(div_32);
 
 					_$_.render_component(SidebarSection, append_anchor_1, {
 						title: "Guide",
@@ -981,53 +981,53 @@ function SideNav({ currentPath }) {
 						})
 					});
 
-					_$_.pop(div_33);
+					_$_.pop(div_32);
 				}
 			}
 		}
 
-		_$_.append(__anchor, aside_2);
+		_$_.append(__anchor, aside_1);
 	});
 }
 
 function PageHeader() {
 	return _$_.tsrx_element((__anchor, __block) => {
-		var header_1 = root_45();
+		var header = root_45();
 
-		_$_.append(__anchor, header_1);
+		_$_.append(__anchor, header);
 	});
 }
 
 export function LayoutWithSidebarAndMain() {
 	return _$_.tsrx_element((__anchor, __block) => {
-		var div_34 = root_46();
+		var div_33 = root_46();
 
 		{
-			var node_25 = _$_.child(div_34);
+			var node_25 = _$_.child(div_33);
 
 			_$_.render_component(PageHeader, node_25, {});
 
-			var div_35 = _$_.sibling(node_25);
+			var div_34 = _$_.sibling(node_25);
 
 			{
-				var node_26 = _$_.child(div_35);
+				var node_26 = _$_.child(div_34);
 
 				_$_.render_component(SideNav, node_26, { currentPath: "/intro" });
 
-				var main_1 = _$_.sibling(node_26);
+				var main = _$_.sibling(node_26);
 
 				{
-					var div_36 = _$_.child(main_1);
+					var div_35 = _$_.child(main);
 
-					_$_.pop(div_36);
+					_$_.pop(div_35);
 
-					var node_27 = _$_.sibling(div_36);
+					var node_27 = _$_.sibling(div_35);
 
 					{
 						var consequent_6 = (__anchor) => {
-							var div_37 = root_47();
+							var div_36 = root_47();
 
-							_$_.append(__anchor, div_37);
+							_$_.append(__anchor, div_36);
 						};
 
 						_$_.if(node_27, (__render) => {
@@ -1038,52 +1038,52 @@ export function LayoutWithSidebarAndMain() {
 					var node_28 = _$_.sibling(node_27);
 
 					_$_.render_component(PageHeader, node_28, {});
-					_$_.pop(main_1);
+					_$_.pop(main);
 				}
 
-				_$_.pop(div_35);
+				_$_.pop(div_34);
 			}
 
-			_$_.pop(div_34);
+			_$_.pop(div_33);
 		}
 
-		_$_.append(__anchor, div_34);
+		_$_.append(__anchor, div_33);
 	});
 }
 
 function ArticleWrapper({ children }) {
 	return _$_.tsrx_element((__anchor, __block) => {
-		var article_2 = root_48();
+		var article_1 = root_48();
 
 		{
-			var div_38 = _$_.child(article_2);
+			var div_37 = _$_.child(article_1);
 
 			{
-				var expression_18 = _$_.child(div_38);
+				var expression_18 = _$_.child(div_37);
 
 				_$_.expression(expression_18, () => children);
-				_$_.pop(div_38);
+				_$_.pop(div_37);
 			}
 		}
 
-		_$_.append(__anchor, article_2);
+		_$_.append(__anchor, article_1);
 	});
 }
 
 function SimpleFooter() {
 	return _$_.tsrx_element((__anchor, __block) => {
-		var footer_2 = root_49();
+		var footer_1 = root_49();
 
-		_$_.append(__anchor, footer_2);
+		_$_.append(__anchor, footer_1);
 	});
 }
 
 export function ArticleWithChildrenThenSibling() {
 	return _$_.tsrx_element((__anchor, __block) => {
-		var div_39 = root_50();
+		var div_38 = root_50();
 
 		{
-			var node_29 = _$_.child(div_39);
+			var node_29 = _$_.child(div_38);
 
 			_$_.render_component(ArticleWrapper, node_29, {
 				children: _$_.tsrx_element((__anchor, __block) => {
@@ -1097,9 +1097,9 @@ export function ArticleWithChildrenThenSibling() {
 
 			{
 				var consequent_7 = (__anchor) => {
-					var div_40 = root_52();
+					var div_39 = root_52();
 
-					_$_.append(__anchor, div_40);
+					_$_.append(__anchor, div_39);
 				};
 
 				_$_.if(node_30, (__render) => {
@@ -1111,9 +1111,9 @@ export function ArticleWithChildrenThenSibling() {
 
 			{
 				var consequent_8 = (__anchor) => {
-					var nav_3 = root_53();
+					var nav_2 = root_53();
 
-					_$_.append(__anchor, nav_3);
+					_$_.append(__anchor, nav_2);
 				};
 
 				_$_.if(node_31, (__render) => {
@@ -1124,27 +1124,27 @@ export function ArticleWithChildrenThenSibling() {
 			var node_32 = _$_.sibling(node_31);
 
 			_$_.render_component(SimpleFooter, node_32, {});
-			_$_.pop(div_39);
+			_$_.pop(div_38);
 		}
 
-		_$_.append(__anchor, div_39);
+		_$_.append(__anchor, div_38);
 	});
 }
 
 export function ArticleWithHtmlChildThenSibling() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		const htmlContent = '<pre><code>const x = 1;</code></pre>';
-		var div_41 = root_54();
+		var div_40 = root_54();
 
 		{
-			var node_33 = _$_.child(div_41);
+			var node_33 = _$_.child(div_40);
 
 			_$_.render_component(ArticleWrapper, node_33, {
 				children: _$_.tsrx_element((__anchor, __block) => {
-					var div_42 = root_55();
+					var div_41 = root_55();
 
-					div_42.innerHTML = htmlContent ?? div_42.innerHTML;
-					_$_.append(__anchor, div_42);
+					div_41.innerHTML = htmlContent ?? div_41.innerHTML;
+					_$_.append(__anchor, div_41);
 				})
 			});
 
@@ -1152,9 +1152,9 @@ export function ArticleWithHtmlChildThenSibling() {
 
 			{
 				var consequent_9 = (__anchor) => {
-					var div_43 = root_56();
+					var div_42 = root_56();
 
-					_$_.append(__anchor, div_43);
+					_$_.append(__anchor, div_42);
 				};
 
 				_$_.if(node_34, (__render) => {
@@ -1165,40 +1165,40 @@ export function ArticleWithHtmlChildThenSibling() {
 			var node_35 = _$_.sibling(node_34);
 
 			_$_.render_component(SimpleFooter, node_35, {});
-			_$_.pop(div_41);
+			_$_.pop(div_40);
 		}
 
-		_$_.append(__anchor, div_41);
+		_$_.append(__anchor, div_40);
 	});
 }
 
 function InlineArticleLayout({ children }) {
 	return _$_.tsrx_element((__anchor, __block) => {
-		var div_44 = root_57();
+		var div_43 = root_57();
 
 		{
-			var article_3 = _$_.child(div_44);
+			var article_2 = _$_.child(div_43);
 
 			{
-				var div_45 = _$_.child(article_3);
+				var div_44 = _$_.child(article_2);
 
 				{
-					var expression_19 = _$_.child(div_45);
+					var expression_19 = _$_.child(div_44);
 
 					_$_.expression(expression_19, () => children);
-					_$_.pop(div_45);
+					_$_.pop(div_44);
 				}
 			}
 
-			_$_.pop(article_3);
+			_$_.pop(article_2);
 
-			var node_36 = _$_.sibling(article_3);
+			var node_36 = _$_.sibling(article_2);
 
 			{
 				var consequent_10 = (__anchor) => {
-					var div_46 = root_58();
+					var div_45 = root_58();
 
-					_$_.append(__anchor, div_46);
+					_$_.append(__anchor, div_45);
 				};
 
 				_$_.if(node_36, (__render) => {
@@ -1209,10 +1209,10 @@ function InlineArticleLayout({ children }) {
 			var node_37 = _$_.sibling(node_36);
 
 			_$_.render_component(SimpleFooter, node_37, {});
-			_$_.pop(div_44);
+			_$_.pop(div_43);
 		}
 
-		_$_.append(__anchor, div_44);
+		_$_.append(__anchor, div_43);
 	});
 }
 
@@ -1222,10 +1222,10 @@ export function InlineArticleWithHtmlChild() {
 
 		_$_.render_component(InlineArticleLayout, __anchor, {
 			children: _$_.tsrx_element((__anchor, __block) => {
-				var div_47 = root_59();
+				var div_46 = root_59();
 
-				div_47.innerHTML = htmlContent ?? div_47.innerHTML;
-				_$_.append(__anchor, div_47);
+				div_46.innerHTML = htmlContent ?? div_46.innerHTML;
+				_$_.append(__anchor, div_46);
 			})
 		});
 	});
@@ -1233,78 +1233,78 @@ export function InlineArticleWithHtmlChild() {
 
 function HeaderStub() {
 	return _$_.tsrx_element((__anchor, __block) => {
-		var header_2 = root_60();
+		var header_1 = root_60();
 
-		_$_.append(__anchor, header_2);
+		_$_.append(__anchor, header_1);
 	});
 }
 
 function SidebarStub() {
 	return _$_.tsrx_element((__anchor, __block) => {
-		var aside_3 = root_61();
+		var aside_2 = root_61();
 
-		_$_.append(__anchor, aside_3);
+		_$_.append(__anchor, aside_2);
 	});
 }
 
 function FooterStub() {
 	return _$_.tsrx_element((__anchor, __block) => {
-		var footer_3 = root_62();
+		var footer_2 = root_62();
 
-		_$_.append(__anchor, footer_3);
+		_$_.append(__anchor, footer_2);
 	});
 }
 
 function DocsLayoutInner(__props) {
 	return _$_.tsrx_element((__anchor, __block) => {
-		var div_48 = root_63();
+		var div_47 = root_63();
 
 		{
-			var node_38 = _$_.child(div_48);
+			var node_38 = _$_.child(div_47);
 
 			_$_.render_component(HeaderStub, node_38, {});
 
-			var div_49 = _$_.sibling(node_38);
+			var div_48 = _$_.sibling(node_38);
 
 			{
-				var node_39 = _$_.child(div_49);
+				var node_39 = _$_.child(div_48);
 
 				_$_.render_component(SidebarStub, node_39, {});
 
-				var main_2 = _$_.sibling(node_39);
+				var main_1 = _$_.sibling(node_39);
 
 				{
-					var div_53 = _$_.child(main_2);
+					var div_52 = _$_.child(main_1);
 
 					{
-						var div_52 = _$_.child(div_53);
+						var div_51 = _$_.child(div_52);
 
 						{
-							var div_51 = _$_.child(div_52);
+							var div_50 = _$_.child(div_51);
 
 							{
-								var article_4 = _$_.child(div_51);
+								var article_3 = _$_.child(div_50);
 
 								{
-									var div_50 = _$_.child(article_4);
+									var div_49 = _$_.child(article_3);
 
 									{
-										var expression_20 = _$_.child(div_50);
+										var expression_20 = _$_.child(div_49);
 
 										_$_.expression(expression_20, () => __props.children);
-										_$_.pop(div_50);
+										_$_.pop(div_49);
 									}
 								}
 
-								_$_.pop(article_4);
+								_$_.pop(article_3);
 
-								var node_40 = _$_.sibling(article_4);
+								var node_40 = _$_.sibling(article_3);
 
 								{
 									var consequent_11 = (__anchor) => {
-										var div_54 = root_64();
+										var div_53 = root_64();
 
-										_$_.append(__anchor, div_54);
+										_$_.append(__anchor, div_53);
 									};
 
 									_$_.if(node_40, (__render) => {
@@ -1316,24 +1316,24 @@ function DocsLayoutInner(__props) {
 
 								{
 									var consequent_12 = (__anchor) => {
-										var nav_4 = root_65();
+										var nav_3 = root_65();
 
 										{
-											var a_5 = _$_.child(nav_4);
+											var a_4 = _$_.child(nav_3);
 
 											{
-												var expression_21 = _$_.child(a_5);
+												var expression_21 = _$_.child(a_4);
 
 												_$_.expression(expression_21, () => _$_.fallback(__props.nextLink, null).text);
-												_$_.pop(a_5);
+												_$_.pop(a_4);
 											}
 										}
 
 										_$_.render(() => {
-											_$_.set_attribute(a_5, 'href', _$_.fallback(__props.nextLink, null).href);
+											_$_.set_attribute(a_4, 'href', _$_.fallback(__props.nextLink, null).href);
 										});
 
-										_$_.append(__anchor, nav_4);
+										_$_.append(__anchor, nav_3);
 									};
 
 									_$_.if(node_41, (__render) => {
@@ -1344,19 +1344,19 @@ function DocsLayoutInner(__props) {
 								var node_42 = _$_.sibling(node_41);
 
 								_$_.render_component(FooterStub, node_42, {});
-								_$_.pop(div_51);
+								_$_.pop(div_50);
 							}
 						}
 					}
 				}
 
-				_$_.pop(div_49);
+				_$_.pop(div_48);
 			}
 
-			_$_.pop(div_48);
+			_$_.pop(div_47);
 		}
 
-		_$_.append(__anchor, div_48);
+		_$_.append(__anchor, div_47);
 	});
 }
 
@@ -1368,10 +1368,10 @@ export function DocsLayoutWithData() {
 			editPath: "docs/styling.md",
 			nextLink: { href: '/next', text: 'Next' },
 			children: _$_.tsrx_element((__anchor, __block) => {
-				var div_55 = root_66();
+				var div_54 = root_66();
 
-				div_55.innerHTML = htmlContent ?? div_55.innerHTML;
-				_$_.append(__anchor, div_55);
+				div_54.innerHTML = htmlContent ?? div_54.innerHTML;
+				_$_.append(__anchor, div_54);
 			})
 		});
 	});
@@ -1383,10 +1383,10 @@ export function DocsLayoutWithoutData() {
 
 		_$_.render_component(DocsLayoutInner, __anchor, {
 			children: _$_.tsrx_element((__anchor, __block) => {
-				var div_56 = root_67();
+				var div_55 = root_67();
 
-				div_56.innerHTML = htmlContent ?? div_56.innerHTML;
-				_$_.append(__anchor, div_56);
+				div_55.innerHTML = htmlContent ?? div_55.innerHTML;
+				_$_.append(__anchor, div_55);
 			})
 		});
 	});
@@ -1394,62 +1394,62 @@ export function DocsLayoutWithoutData() {
 
 function DocsLayoutExact(__props) {
 	return _$_.tsrx_element((__anchor, __block) => {
-		var div_57 = root_68();
+		var div_56 = root_68();
 
 		{
-			var node_43 = _$_.child(div_57);
+			var node_43 = _$_.child(div_56);
 
 			_$_.render_component(HeaderStub, node_43, {});
 
-			var div_58 = _$_.sibling(node_43);
+			var div_57 = _$_.sibling(node_43);
 
 			{
-				var node_44 = _$_.child(div_58);
+				var node_44 = _$_.child(div_57);
 
 				_$_.render_component(SidebarStub, node_44, {});
 
-				var main_3 = _$_.sibling(node_44);
+				var main_2 = _$_.sibling(node_44);
 
 				{
-					var div_62 = _$_.child(main_3);
+					var div_61 = _$_.child(main_2);
 
 					{
-						var div_61 = _$_.child(div_62);
+						var div_60 = _$_.child(div_61);
 
 						{
-							var div_60 = _$_.child(div_61);
+							var div_59 = _$_.child(div_60);
 
 							{
-								var article_5 = _$_.child(div_60);
+								var article_4 = _$_.child(div_59);
 
 								{
-									var div_59 = _$_.child(article_5);
+									var div_58 = _$_.child(article_4);
 
 									{
-										var expression_22 = _$_.child(div_59);
+										var expression_22 = _$_.child(div_58);
 
 										_$_.expression(expression_22, () => __props.children);
-										_$_.pop(div_59);
+										_$_.pop(div_58);
 									}
 								}
 
-								_$_.pop(article_5);
+								_$_.pop(article_4);
 
-								var node_45 = _$_.sibling(article_5);
+								var node_45 = _$_.sibling(article_4);
 
 								{
 									var consequent_13 = (__anchor) => {
-										var div_63 = root_69();
+										var div_62 = root_69();
 
 										{
-											var a_6 = _$_.child(div_63);
+											var a_5 = _$_.child(div_62);
 										}
 
 										_$_.render(() => {
-											_$_.set_attribute(a_6, 'href', `/edit/${_$_.fallback(__props.editPath, '')}`);
+											_$_.set_attribute(a_5, 'href', `/edit/${_$_.fallback(__props.editPath, '')}`);
 										});
 
-										_$_.append(__anchor, div_63);
+										_$_.append(__anchor, div_62);
 									};
 
 									_$_.if(node_45, (__render) => {
@@ -1461,37 +1461,37 @@ function DocsLayoutExact(__props) {
 
 								{
 									var consequent_16 = (__anchor) => {
-										var nav_5 = root_70();
+										var nav_4 = root_70();
 
 										{
-											var node_47 = _$_.child(nav_5);
+											var node_47 = _$_.child(nav_4);
 
 											{
 												var consequent_14 = (__anchor) => {
-													var a_7 = root_71();
+													var a_6 = root_71();
 
 													{
-														var span_5 = _$_.child(a_7);
+														var span_4 = _$_.child(a_6);
 
 														{
-															var expression_23 = _$_.child(span_5);
+															var expression_23 = _$_.child(span_4);
 
 															_$_.expression(expression_23, () => _$_.fallback(__props.prevLink, null).text);
-															_$_.pop(span_5);
+															_$_.pop(span_4);
 														}
 													}
 
 													_$_.render(() => {
-														_$_.set_attribute(a_7, 'href', _$_.fallback(__props.prevLink, null).href);
+														_$_.set_attribute(a_6, 'href', _$_.fallback(__props.prevLink, null).href);
 													});
 
-													_$_.append(__anchor, a_7);
+													_$_.append(__anchor, a_6);
 												};
 
 												var alternate_1 = (__anchor) => {
-													var span_6 = root_72();
+													var span_5 = root_72();
 
-													_$_.append(__anchor, span_6);
+													_$_.append(__anchor, span_5);
 												};
 
 												_$_.if(node_47, (__render) => {
@@ -1503,24 +1503,24 @@ function DocsLayoutExact(__props) {
 
 											{
 												var consequent_15 = (__anchor) => {
-													var a_8 = root_73();
+													var a_7 = root_73();
 
 													{
-														var span_7 = _$_.child(a_8);
+														var span_6 = _$_.child(a_7);
 
 														{
-															var expression_24 = _$_.child(span_7);
+															var expression_24 = _$_.child(span_6);
 
 															_$_.expression(expression_24, () => _$_.fallback(__props.nextLink, null).text);
-															_$_.pop(span_7);
+															_$_.pop(span_6);
 														}
 													}
 
 													_$_.render(() => {
-														_$_.set_attribute(a_8, 'href', _$_.fallback(__props.nextLink, null).href);
+														_$_.set_attribute(a_7, 'href', _$_.fallback(__props.nextLink, null).href);
 													});
 
-													_$_.append(__anchor, a_8);
+													_$_.append(__anchor, a_7);
 												};
 
 												_$_.if(node_48, (__render) => {
@@ -1528,10 +1528,10 @@ function DocsLayoutExact(__props) {
 												});
 											}
 
-											_$_.pop(nav_5);
+											_$_.pop(nav_4);
 										}
 
-										_$_.append(__anchor, nav_5);
+										_$_.append(__anchor, nav_4);
 									};
 
 									_$_.if(node_46, (__render) => {
@@ -1542,52 +1542,52 @@ function DocsLayoutExact(__props) {
 								var node_49 = _$_.sibling(node_46);
 
 								_$_.render_component(FooterStub, node_49, {});
-								_$_.pop(div_60);
+								_$_.pop(div_59);
 							}
 						}
 
-						_$_.pop(div_61);
+						_$_.pop(div_60);
 
-						var aside_4 = _$_.sibling(div_61);
+						var aside_3 = _$_.sibling(div_60);
 
 						{
-							var node_50 = _$_.child(aside_4);
+							var node_50 = _$_.child(aside_3);
 
 							{
 								var consequent_17 = (__anchor) => {
-									var div_64 = root_74();
+									var div_63 = root_74();
 
 									{
-										var nav_6 = _$_.child(div_64);
+										var nav_5 = _$_.child(div_63);
 
 										{
 											_$_.for(
-												nav_6,
+												nav_5,
 												() => _$_.fallback(__props.toc, []),
 												(__anchor, item) => {
-													var a_9 = root_75();
+													var a_8 = root_75();
 
 													{
-														var expression_25 = _$_.child(a_9);
+														var expression_25 = _$_.child(a_8);
 
 														_$_.expression(expression_25, () => item.text);
-														_$_.pop(a_9);
+														_$_.pop(a_8);
 													}
 
 													_$_.render(() => {
-														_$_.set_attribute(a_9, 'href', item.href);
+														_$_.set_attribute(a_8, 'href', item.href);
 													});
 
-													_$_.append(__anchor, a_9);
+													_$_.append(__anchor, a_8);
 												},
 												4
 											);
 
-											_$_.pop(nav_6);
+											_$_.pop(nav_5);
 										}
 									}
 
-									_$_.append(__anchor, div_64);
+									_$_.append(__anchor, div_63);
 								};
 
 								_$_.if(node_50, (__render) => {
@@ -1595,18 +1595,18 @@ function DocsLayoutExact(__props) {
 								});
 							}
 
-							_$_.pop(aside_4);
+							_$_.pop(aside_3);
 						}
 					}
 				}
 
-				_$_.pop(div_58);
+				_$_.pop(div_57);
 			}
 
-			_$_.pop(div_57);
+			_$_.pop(div_56);
 		}
 
-		_$_.append(__anchor, div_57);
+		_$_.append(__anchor, div_56);
 	});
 }
 
@@ -1624,10 +1624,10 @@ export function DocsLayoutExactWithData() {
 			],
 
 			children: _$_.tsrx_element((__anchor, __block) => {
-				var div_65 = root_76();
+				var div_64 = root_76();
 
-				div_65.innerHTML = htmlContent ?? div_65.innerHTML;
-				_$_.append(__anchor, div_65);
+				div_64.innerHTML = htmlContent ?? div_64.innerHTML;
+				_$_.append(__anchor, div_64);
 			})
 		});
 	});
@@ -1647,10 +1647,10 @@ export function DocsLayoutExactWithoutData() {
 			nextLink,
 			toc,
 			children: _$_.tsrx_element((__anchor, __block) => {
-				var div_66 = root_77();
+				var div_65 = root_77();
 
-				div_66.innerHTML = htmlContent ?? div_66.innerHTML;
-				_$_.append(__anchor, div_66);
+				div_65.innerHTML = htmlContent ?? div_65.innerHTML;
+				_$_.append(__anchor, div_65);
 			})
 		});
 	});
@@ -1659,10 +1659,28 @@ export function DocsLayoutExactWithoutData() {
 export function TemplateWithHtmlContent() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		const data = { title: 'Test', value: 42 };
-		var div_67 = root_78();
+		var div_66 = root_78();
 
 		{
-			var template_1 = _$_.child(div_67);
+			var template = _$_.child(div_66);
+		}
+
+		_$_.render(() => {
+			template.innerHTML = _$_.with_scope(__block, () => JSON.stringify(data)) ?? template.innerHTML;
+		});
+
+		_$_.append(__anchor, div_66);
+	});
+}
+
+export function TemplateWithHtmlAndSiblings() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		const data = { name: 'Ripple', version: '1.0' };
+		var div_67 = root_79();
+
+		{
+			var h1_3 = _$_.child(div_67);
+			var template_1 = _$_.sibling(h1_3);
 		}
 
 		_$_.render(() => {
@@ -1673,14 +1691,20 @@ export function TemplateWithHtmlContent() {
 	});
 }
 
-export function TemplateWithHtmlAndSiblings() {
+function LayoutWithTemplate({ children, data }) {
 	return _$_.tsrx_element((__anchor, __block) => {
-		const data = { name: 'Ripple', version: '1.0' };
-		var div_68 = root_79();
+		var div_68 = root_80();
 
 		{
-			var h1_4 = _$_.child(div_68);
-			var template_2 = _$_.sibling(h1_4);
+			var template_2 = _$_.child(div_68);
+			var main_3 = _$_.sibling(template_2);
+
+			{
+				var expression_26 = _$_.child(main_3);
+
+				_$_.expression(expression_26, () => children);
+				_$_.pop(main_3);
+			}
 		}
 
 		_$_.render(() => {
@@ -1691,30 +1715,6 @@ export function TemplateWithHtmlAndSiblings() {
 	});
 }
 
-function LayoutWithTemplate({ children, data }) {
-	return _$_.tsrx_element((__anchor, __block) => {
-		var div_69 = root_80();
-
-		{
-			var template_3 = _$_.child(div_69);
-			var main_4 = _$_.sibling(template_3);
-
-			{
-				var expression_26 = _$_.child(main_4);
-
-				_$_.expression(expression_26, () => children);
-				_$_.pop(main_4);
-			}
-		}
-
-		_$_.render(() => {
-			template_3.innerHTML = _$_.with_scope(__block, () => JSON.stringify(data)) ?? template_3.innerHTML;
-		});
-
-		_$_.append(__anchor, div_69);
-	});
-}
-
 export function NestedTemplateInLayout() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		const doc = { title: 'Comparison', html: '<p>Content</p>' };
@@ -1722,13 +1722,13 @@ export function NestedTemplateInLayout() {
 		_$_.render_component(LayoutWithTemplate, __anchor, {
 			data: doc,
 			children: _$_.tsrx_element((__anchor, __block) => {
-				var div_70 = root_81();
+				var div_69 = root_81();
 
 				_$_.render(() => {
-					div_70.innerHTML = doc.html ?? div_70.innerHTML;
+					div_69.innerHTML = doc.html ?? div_69.innerHTML;
 				});
 
-				_$_.append(__anchor, div_70);
+				_$_.append(__anchor, div_69);
 			})
 		});
 	});
@@ -1739,19 +1739,30 @@ export function HtmlCodeBlocksWithSiblingChain() {
 		const html1 = '<span class="kw">const</span> <span class="id">a</span> = 1;';
 		const html2 = '<span class="kw">const</span> <span class="id">b</span> = 2;';
 		const html3 = '<span class="kw">const</span> <span class="id">c</span> = 3;';
-		var section_3 = root_82();
+		var section_2 = root_82();
 
 		{
-			var p_10 = _$_.child(section_3);
-			var h2_4 = _$_.sibling(p_10);
-			var p_9 = _$_.sibling(h2_4);
-			var p_8 = _$_.sibling(p_9);
-			var pre_1 = _$_.sibling(p_8);
+			var p_9 = _$_.child(section_2);
+			var h2_3 = _$_.sibling(p_9);
+			var p_8 = _$_.sibling(h2_3);
+			var p_7 = _$_.sibling(p_8);
+			var pre = _$_.sibling(p_7);
 
 			{
-				var code_1 = _$_.child(pre_1);
+				var code_1 = _$_.child(pre);
 
 				code_1.innerHTML = html1 ?? code_1.innerHTML;
+			}
+
+			_$_.pop(pre);
+
+			var p_10 = _$_.sibling(pre);
+			var pre_1 = _$_.sibling(p_10);
+
+			{
+				var code_2 = _$_.child(pre_1);
+
+				code_2.innerHTML = html2 ?? code_2.innerHTML;
 			}
 
 			_$_.pop(pre_1);
@@ -1760,24 +1771,13 @@ export function HtmlCodeBlocksWithSiblingChain() {
 			var pre_2 = _$_.sibling(p_11);
 
 			{
-				var code_2 = _$_.child(pre_2);
-
-				code_2.innerHTML = html2 ?? code_2.innerHTML;
-			}
-
-			_$_.pop(pre_2);
-
-			var p_12 = _$_.sibling(pre_2);
-			var pre_3 = _$_.sibling(p_12);
-
-			{
-				var code_3 = _$_.child(pre_3);
+				var code_3 = _$_.child(pre_2);
 
 				code_3.innerHTML = html3 ?? code_3.innerHTML;
 			}
 		}
 
-		_$_.append(__anchor, section_3);
+		_$_.append(__anchor, section_2);
 	});
 }
 

--- a/packages/ripple/tests/hydration/compiled/client/if-children.js
+++ b/packages/ripple/tests/hydration/compiled/client/if-children.js
@@ -28,27 +28,27 @@ import { track } from 'ripple';
 export function IfWithChildren({ children }) {
 	return _$_.tsrx_element((__anchor, __block) => {
 		let lazy = _$_.track(true, __block, 'c64714b1');
-		var div_1 = root();
+		var div = root();
 
 		{
-			var div_2 = _$_.child(div_1);
+			var div_1 = _$_.child(div);
 
-			div_2.__click = () => _$_.set(lazy, !lazy.value);
+			div_1.__click = () => _$_.set(lazy, !lazy.value);
 
-			var node = _$_.sibling(div_2);
+			var node = _$_.sibling(div_1);
 
 			{
 				var consequent = (__anchor) => {
-					var div_3 = root_1();
+					var div_2 = root_1();
 
 					{
-						var expression = _$_.child(div_3);
+						var expression = _$_.child(div_2);
 
 						_$_.expression(expression, () => children);
-						_$_.pop(div_3);
+						_$_.pop(div_2);
 					}
 
-					_$_.append(__anchor, div_3);
+					_$_.append(__anchor, div_2);
 				};
 
 				_$_.if(node, (__render) => {
@@ -56,25 +56,25 @@ export function IfWithChildren({ children }) {
 				});
 			}
 
-			_$_.pop(div_1);
+			_$_.pop(div);
 		}
 
-		_$_.append(__anchor, div_1);
+		_$_.append(__anchor, div);
 	});
 }
 
 export function ChildItem({ text: label }) {
 	return _$_.tsrx_element((__anchor, __block) => {
-		var div_4 = root_2();
+		var div_3 = root_2();
 
 		{
-			var expression_1 = _$_.child(div_4, true);
+			var expression_1 = _$_.child(div_3, true);
 
 			expression_1.nodeValue = label;
-			_$_.pop(div_4);
+			_$_.pop(div_3);
 		}
 
-		_$_.append(__anchor, div_4);
+		_$_.append(__anchor, div_3);
 	});
 }
 
@@ -99,20 +99,20 @@ export function TestIfWithChildren() {
 export function IfWithStaticChildren() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		let lazy_1 = _$_.track(true, __block, '3bba8f77');
-		var div_5 = root_4();
+		var div_4 = root_4();
 
 		{
-			var div_6 = _$_.child(div_5);
+			var div_5 = _$_.child(div_4);
 
-			div_6.__click = () => _$_.set(lazy_1, !lazy_1.value);
+			div_5.__click = () => _$_.set(lazy_1, !lazy_1.value);
 
-			var node_3 = _$_.sibling(div_6);
+			var node_3 = _$_.sibling(div_5);
 
 			{
 				var consequent_1 = (__anchor) => {
-					var div_7 = root_5();
+					var div_6 = root_5();
 
-					_$_.append(__anchor, div_7);
+					_$_.append(__anchor, div_6);
 				};
 
 				_$_.if(node_3, (__render) => {
@@ -120,38 +120,38 @@ export function IfWithStaticChildren() {
 				});
 			}
 
-			_$_.pop(div_5);
+			_$_.pop(div_4);
 		}
 
-		_$_.append(__anchor, div_5);
+		_$_.append(__anchor, div_4);
 	});
 }
 
 export function IfWithSiblingsAndChildren({ children }) {
 	return _$_.tsrx_element((__anchor, __block) => {
 		let lazy_2 = _$_.track(true, __block, 'a1b8fb4c');
-		var section_1 = root_6();
+		var section = root_6();
 
 		{
-			var div_8 = _$_.child(section_1);
+			var div_7 = _$_.child(section);
 
-			div_8.__click = () => _$_.set(lazy_2, !lazy_2.value);
-			_$_.pop(div_8);
+			div_7.__click = () => _$_.set(lazy_2, !lazy_2.value);
+			_$_.pop(div_7);
 
-			var node_4 = _$_.sibling(div_8);
+			var node_4 = _$_.sibling(div_7);
 
 			{
 				var consequent_2 = (__anchor) => {
-					var div_9 = root_7();
+					var div_8 = root_7();
 
 					{
-						var expression_2 = _$_.child(div_9);
+						var expression_2 = _$_.child(div_8);
 
 						_$_.expression(expression_2, () => children);
-						_$_.pop(div_9);
+						_$_.pop(div_8);
 					}
 
-					_$_.append(__anchor, div_9);
+					_$_.append(__anchor, div_8);
 				};
 
 				_$_.if(node_4, (__render) => {
@@ -159,10 +159,10 @@ export function IfWithSiblingsAndChildren({ children }) {
 				});
 			}
 
-			_$_.pop(section_1);
+			_$_.pop(section);
 		}
 
-		_$_.append(__anchor, section_1);
+		_$_.append(__anchor, section);
 	});
 }
 
@@ -192,20 +192,20 @@ export function ElementWithChildrenThenIf() {
 
 		_$_.expression(node_8, () => _$_.tsrx_element((__anchor, __block) => {
 			var fragment_3 = root_10();
-			var div_11 = _$_.first_child_frag(fragment_3);
+			var div_10 = _$_.first_child_frag(fragment_3);
 
 			{
-				var div_10 = _$_.child(div_11);
+				var div_9 = _$_.child(div_10);
 
-				_$_.pop(div_10);
+				_$_.pop(div_9);
 
-				var node_7 = _$_.sibling(div_10);
+				var node_7 = _$_.sibling(div_9);
 
 				{
 					var consequent_3 = (__anchor) => {
-						var div_12 = root_11();
+						var div_11 = root_11();
 
-						_$_.append(__anchor, div_12);
+						_$_.append(__anchor, div_11);
 					};
 
 					_$_.if(node_7, (__render) => {
@@ -213,12 +213,12 @@ export function ElementWithChildrenThenIf() {
 					});
 				}
 
-				_$_.pop(div_11);
+				_$_.pop(div_10);
 			}
 
-			var button_1 = _$_.sibling(div_11);
+			var button = _$_.sibling(div_10);
 
-			button_1.__click = () => _$_.set(lazy_3, !lazy_3.value);
+			button.__click = () => _$_.set(lazy_3, !lazy_3.value);
 			_$_.next();
 			_$_.append(__anchor, fragment_3, true);
 		}));
@@ -235,20 +235,20 @@ export function DeepNestingThenIf() {
 
 		_$_.expression(node_10, () => _$_.tsrx_element((__anchor, __block) => {
 			var fragment_5 = root_13();
-			var section_2 = _$_.first_child_frag(fragment_5);
+			var section_1 = _$_.first_child_frag(fragment_5);
 
 			{
-				var article_1 = _$_.child(section_2);
+				var article = _$_.child(section_1);
 
-				_$_.pop(article_1);
+				_$_.pop(article);
 
-				var node_9 = _$_.sibling(article_1);
+				var node_9 = _$_.sibling(article);
 
 				{
 					var consequent_4 = (__anchor) => {
-						var footer_1 = root_14();
+						var footer = root_14();
 
-						_$_.append(__anchor, footer_1);
+						_$_.append(__anchor, footer);
 					};
 
 					_$_.if(node_9, (__render) => {
@@ -256,12 +256,12 @@ export function DeepNestingThenIf() {
 					});
 				}
 
-				_$_.pop(section_2);
+				_$_.pop(section_1);
 			}
 
-			var button_2 = _$_.sibling(section_2);
+			var button_1 = _$_.sibling(section_1);
 
-			button_2.__click = () => _$_.set(lazy_4, !lazy_4.value);
+			button_1.__click = () => _$_.set(lazy_4, !lazy_4.value);
 			_$_.next();
 			_$_.append(__anchor, fragment_5, true);
 		}));
@@ -273,39 +273,39 @@ export function DeepNestingThenIf() {
 export function DomElementChildrenThenSibling() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		let lazy_5 = _$_.track('code', __block, '33a1e97f');
-		var div_13 = root_15();
+		var div_12 = root_15();
 
 		{
-			var div_14 = _$_.child(div_13);
+			var div_13 = _$_.child(div_12);
 
 			{
-				var button_3 = _$_.child(div_14);
+				var button_2 = _$_.child(div_13);
 
-				button_3.__click = () => _$_.set(lazy_5, 'code');
+				button_2.__click = () => _$_.set(lazy_5, 'code');
 
-				var button_4 = _$_.sibling(button_3);
+				var button_3 = _$_.sibling(button_2);
 
-				button_4.__click = () => _$_.set(lazy_5, 'preview');
+				button_3.__click = () => _$_.set(lazy_5, 'preview');
 			}
 
-			_$_.pop(div_14);
+			_$_.pop(div_13);
 
-			var div_15 = _$_.sibling(div_14);
+			var div_14 = _$_.sibling(div_13);
 
 			{
-				var node_11 = _$_.child(div_15);
+				var node_11 = _$_.child(div_14);
 
 				{
 					var consequent_5 = (__anchor) => {
-						var pre_1 = root_16();
+						var pre = root_16();
 
-						_$_.append(__anchor, pre_1);
+						_$_.append(__anchor, pre);
 					};
 
 					var alternate = (__anchor) => {
-						var div_16 = root_17();
+						var div_15 = root_17();
 
-						_$_.append(__anchor, div_16);
+						_$_.append(__anchor, div_15);
 					};
 
 					_$_.if(node_11, (__render) => {
@@ -313,7 +313,7 @@ export function DomElementChildrenThenSibling() {
 					});
 				}
 
-				_$_.pop(div_15);
+				_$_.pop(div_14);
 			}
 		}
 
@@ -322,19 +322,19 @@ export function DomElementChildrenThenSibling() {
 				var __a = lazy_5.value === 'code' ? 'true' : 'false';
 
 				if (__prev.a !== __a) {
-					_$_.set_attribute(button_3, 'aria-selected', __prev.a = __a);
+					_$_.set_attribute(button_2, 'aria-selected', __prev.a = __a);
 				}
 
 				var __b = lazy_5.value === 'preview' ? 'true' : 'false';
 
 				if (__prev.b !== __b) {
-					_$_.set_attribute(button_4, 'aria-selected', __prev.b = __b);
+					_$_.set_attribute(button_3, 'aria-selected', __prev.b = __b);
 				}
 			},
 			{ a: void 0, b: void 0 }
 		);
 
-		_$_.append(__anchor, div_13);
+		_$_.append(__anchor, div_12);
 	});
 }
 
@@ -346,29 +346,29 @@ export function DomChildrenThenStaticSiblings() {
 
 		_$_.expression(node_12, () => _$_.tsrx_element((__anchor, __block) => {
 			var fragment_7 = root_19();
-			var div_17 = _$_.first_child_frag(fragment_7);
+			var div_16 = _$_.first_child_frag(fragment_7);
 
 			{
-				var ul_1 = _$_.child(div_17);
+				var ul = _$_.child(div_16);
 
 				{
-					var li_1 = _$_.child(ul_1);
+					var li = _$_.child(ul);
 
 					{
-						var expression_3 = _$_.child(li_1, true);
+						var expression_3 = _$_.child(li, true);
 
-						_$_.pop(li_1);
+						_$_.pop(li);
 					}
 				}
 
-				_$_.pop(ul_1);
+				_$_.pop(ul);
 			}
 
-			_$_.pop(div_17);
+			_$_.pop(div_16);
 
-			var button_5 = _$_.sibling(div_17);
+			var button_4 = _$_.sibling(div_16);
 
-			button_5.__click = () => _$_.update(lazy_6);
+			button_4.__click = () => _$_.update(lazy_6);
 			_$_.next();
 
 			_$_.render(() => {
@@ -384,25 +384,25 @@ export function DomChildrenThenStaticSiblings() {
 
 export function StaticListThenStaticSiblings() {
 	return _$_.tsrx_element((__anchor, __block) => {
-		var div_18 = root_20();
+		var div_17 = root_20();
 
 		{
-			var ul_2 = _$_.child(div_18);
+			var ul_1 = _$_.child(div_17);
 
 			{
-				var li_2 = _$_.child(ul_2);
+				var li_1 = _$_.child(ul_1);
+
+				_$_.pop(li_1);
+
+				var li_2 = _$_.sibling(li_1);
 
 				_$_.pop(li_2);
-
-				var li_3 = _$_.sibling(li_2);
-
-				_$_.pop(li_3);
 			}
 
-			_$_.pop(ul_2);
+			_$_.pop(ul_1);
 		}
 
-		_$_.append(__anchor, div_18);
+		_$_.append(__anchor, div_17);
 	});
 }
 

--- a/packages/ripple/tests/hydration/compiled/client/if-fragment-controlflow.js
+++ b/packages/ripple/tests/hydration/compiled/client/if-fragment-controlflow.js
@@ -38,10 +38,10 @@ export function IfFragmentForElement() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		const muzes = [{ muzeId: 'b' }, { muzeId: 'c' }];
 		const hasLoaded = true;
-		var div_1 = root();
+		var div = root();
 
 		{
-			var node = _$_.child(div_1);
+			var node = _$_.child(div);
 
 			{
 				var consequent = (__anchor) => {
@@ -56,16 +56,16 @@ export function IfFragmentForElement() {
 							node_1,
 							() => muzes,
 							(__anchor, pattern) => {
-								var p_1 = root_3();
+								var p = root_3();
 
 								{
-									var expression = _$_.child(p_1);
+									var expression = _$_.child(p);
 
 									_$_.expression(expression, () => _$_.get(pattern).muzeId);
-									_$_.pop(p_1);
+									_$_.pop(p);
 								}
 
-								_$_.append(__anchor, p_1);
+								_$_.append(__anchor, p);
 							},
 							0,
 							(pattern) => _$_.get(pattern).muzeId
@@ -82,10 +82,10 @@ export function IfFragmentForElement() {
 				});
 			}
 
-			_$_.pop(div_1);
+			_$_.pop(div);
 		}
 
-		_$_.append(__anchor, div_1);
+		_$_.append(__anchor, div);
 	});
 }
 
@@ -93,10 +93,10 @@ export function IfFragmentForIfIf() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		const muzes = [{ muzeId: 'b' }, { muzeId: 'c' }];
 		const hasLoaded = true;
-		var div_2 = root_4();
+		var div_1 = root_4();
 
 		{
-			var node_3 = _$_.child(div_2);
+			var node_3 = _$_.child(div_1);
 
 			{
 				var consequent_3 = (__anchor) => {
@@ -111,16 +111,16 @@ export function IfFragmentForIfIf() {
 							node_4,
 							() => muzes,
 							(__anchor, pattern_1) => {
-								var p_2 = root_7();
+								var p_1 = root_7();
 
 								{
-									var expression_1 = _$_.child(p_2);
+									var expression_1 = _$_.child(p_1);
 
 									_$_.expression(expression_1, () => _$_.get(pattern_1).muzeId);
-									_$_.pop(p_2);
+									_$_.pop(p_1);
 								}
 
-								_$_.append(__anchor, p_2);
+								_$_.append(__anchor, p_1);
 							},
 							0,
 							(pattern_1) => _$_.get(pattern_1).muzeId
@@ -130,9 +130,9 @@ export function IfFragmentForIfIf() {
 
 						{
 							var consequent_1 = (__anchor) => {
-								var span_1 = root_8();
+								var span = root_8();
 
-								_$_.append(__anchor, span_1);
+								_$_.append(__anchor, span);
 							};
 
 							_$_.if(node_5, (__render) => {
@@ -144,9 +144,9 @@ export function IfFragmentForIfIf() {
 
 						{
 							var consequent_2 = (__anchor) => {
-								var span_2 = root_9();
+								var span_1 = root_9();
 
-								_$_.append(__anchor, span_2);
+								_$_.append(__anchor, span_1);
 							};
 
 							_$_.if(node_6, (__render) => {
@@ -165,20 +165,20 @@ export function IfFragmentForIfIf() {
 				});
 			}
 
-			_$_.pop(div_2);
+			_$_.pop(div_1);
 		}
 
-		_$_.append(__anchor, div_2);
+		_$_.append(__anchor, div_1);
 	});
 }
 
 export function IfFragmentElements() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		const hasLoaded = true;
-		var div_3 = root_10();
+		var div_2 = root_10();
 
 		{
-			var node_8 = _$_.child(div_3);
+			var node_8 = _$_.child(div_2);
 
 			{
 				var consequent_4 = (__anchor) => {
@@ -199,10 +199,10 @@ export function IfFragmentElements() {
 				});
 			}
 
-			_$_.pop(div_3);
+			_$_.pop(div_2);
 		}
 
-		_$_.append(__anchor, div_3);
+		_$_.append(__anchor, div_2);
 	});
 }
 
@@ -220,16 +220,16 @@ export function ComponentBodyFragmentControlFlow() {
 				node_10,
 				() => muzes,
 				(__anchor, pattern_2) => {
-					var p_3 = root_15();
+					var p_2 = root_15();
 
 					{
-						var expression_2 = _$_.child(p_3);
+						var expression_2 = _$_.child(p_2);
 
 						_$_.expression(expression_2, () => _$_.get(pattern_2).muzeId);
-						_$_.pop(p_3);
+						_$_.pop(p_2);
 					}
 
-					_$_.append(__anchor, p_3);
+					_$_.append(__anchor, p_2);
 				},
 				0,
 				(pattern_2) => _$_.get(pattern_2).muzeId
@@ -259,16 +259,16 @@ export function ComponentBodyCodeBlockControlFlow() {
 					__anchor,
 					() => rows,
 					(__anchor, pattern_3) => {
-						var p_4 = root_17();
+						var p_3 = root_17();
 
 						{
-							var expression_3 = _$_.child(p_4);
+							var expression_3 = _$_.child(p_3);
 
 							_$_.expression(expression_3, () => _$_.get(pattern_3).muzeId);
-							_$_.pop(p_4);
+							_$_.pop(p_3);
 						}
 
-						_$_.append(__anchor, p_4);
+						_$_.append(__anchor, p_3);
 					},
 					16,
 					(pattern_3) => _$_.get(pattern_3).muzeId
@@ -286,10 +286,10 @@ export function IfCodeBlockControlFlow() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		const muzes = [{ muzeId: 'b' }, { muzeId: 'c' }];
 		const hasLoaded = true;
-		var div_4 = root_19();
+		var div_3 = root_19();
 
 		{
-			var node_13 = _$_.child(div_4);
+			var node_13 = _$_.child(div_3);
 
 			{
 				var consequent_5 = (__anchor) => {
@@ -307,16 +307,16 @@ export function IfCodeBlockControlFlow() {
 								__anchor,
 								() => rows,
 								(__anchor, pattern_4) => {
-									var p_5 = root_21();
+									var p_4 = root_21();
 
 									{
-										var expression_5 = _$_.child(p_5);
+										var expression_5 = _$_.child(p_4);
 
 										_$_.expression(expression_5, () => _$_.get(pattern_4).muzeId);
-										_$_.pop(p_5);
+										_$_.pop(p_4);
 									}
 
-									_$_.append(__anchor, p_5);
+									_$_.append(__anchor, p_4);
 								},
 								16,
 								(pattern_4) => _$_.get(pattern_4).muzeId
@@ -334,10 +334,10 @@ export function IfCodeBlockControlFlow() {
 				});
 			}
 
-			_$_.pop(div_4);
+			_$_.pop(div_3);
 		}
 
-		_$_.append(__anchor, div_4);
+		_$_.append(__anchor, div_3);
 	});
 }
 
@@ -345,16 +345,16 @@ export function IfElseFragment() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		const muzes = [{ muzeId: 'b' }, { muzeId: 'c' }];
 		const hasLoaded = false;
-		var div_5 = root_23();
+		var div_4 = root_23();
 
 		{
-			var node_15 = _$_.child(div_5);
+			var node_15 = _$_.child(div_4);
 
 			{
 				var consequent_6 = (__anchor) => {
-					var span_3 = root_24();
+					var span_2 = root_24();
 
-					_$_.append(__anchor, span_3);
+					_$_.append(__anchor, span_2);
 				};
 
 				var alternate = (__anchor) => {
@@ -369,16 +369,16 @@ export function IfElseFragment() {
 							node_16,
 							() => muzes,
 							(__anchor, pattern_5) => {
-								var p_6 = root_27();
+								var p_5 = root_27();
 
 								{
-									var expression_7 = _$_.child(p_6);
+									var expression_7 = _$_.child(p_5);
 
 									_$_.expression(expression_7, () => _$_.get(pattern_5).muzeId);
-									_$_.pop(p_6);
+									_$_.pop(p_5);
 								}
 
-								_$_.append(__anchor, p_6);
+								_$_.append(__anchor, p_5);
 							},
 							0,
 							(pattern_5) => _$_.get(pattern_5).muzeId
@@ -395,10 +395,10 @@ export function IfElseFragment() {
 				});
 			}
 
-			_$_.pop(div_5);
+			_$_.pop(div_4);
 		}
 
-		_$_.append(__anchor, div_5);
+		_$_.append(__anchor, div_4);
 	});
 }
 
@@ -406,17 +406,17 @@ export function IfDivFragment() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		const muzes = [{ muzeId: 'b' }, { muzeId: 'c' }];
 		const hasLoaded = true;
-		var div_6 = root_28();
+		var div_5 = root_28();
 
 		{
-			var node_18 = _$_.child(div_6);
+			var node_18 = _$_.child(div_5);
 
 			{
 				var consequent_7 = (__anchor) => {
-					var section_1 = root_29();
+					var section = root_29();
 
 					{
-						var node_20 = _$_.child(section_1);
+						var node_20 = _$_.child(section);
 
 						_$_.expression(node_20, () => _$_.tsrx_element((__anchor, __block) => {
 							var fragment_14 = root_30();
@@ -426,16 +426,16 @@ export function IfDivFragment() {
 								node_19,
 								() => muzes,
 								(__anchor, pattern_6) => {
-									var p_7 = root_31();
+									var p_6 = root_31();
 
 									{
-										var expression_8 = _$_.child(p_7);
+										var expression_8 = _$_.child(p_6);
 
 										_$_.expression(expression_8, () => _$_.get(pattern_6).muzeId);
-										_$_.pop(p_7);
+										_$_.pop(p_6);
 									}
 
-									_$_.append(__anchor, p_7);
+									_$_.append(__anchor, p_6);
 								},
 								0,
 								(pattern_6) => _$_.get(pattern_6).muzeId
@@ -444,10 +444,10 @@ export function IfDivFragment() {
 							_$_.append(__anchor, fragment_14);
 						}));
 
-						_$_.pop(section_1);
+						_$_.pop(section);
 					}
 
-					_$_.append(__anchor, section_1);
+					_$_.append(__anchor, section);
 				};
 
 				_$_.if(node_18, (__render) => {
@@ -455,9 +455,9 @@ export function IfDivFragment() {
 				});
 			}
 
-			_$_.pop(div_6);
+			_$_.pop(div_5);
 		}
 
-		_$_.append(__anchor, div_6);
+		_$_.append(__anchor, div_5);
 	});
 }

--- a/packages/ripple/tests/hydration/compiled/client/if.js
+++ b/packages/ripple/tests/hydration/compiled/client/if.js
@@ -29,9 +29,9 @@ export function IfTruthy() {
 
 		{
 			var consequent = (__anchor) => {
-				var div_1 = root();
+				var div = root();
 
-				_$_.append(__anchor, div_1);
+				_$_.append(__anchor, div);
 			};
 
 			_$_.if(
@@ -51,9 +51,9 @@ export function IfFalsy() {
 
 		{
 			var consequent_1 = (__anchor) => {
-				var div_2 = root_1();
+				var div_1 = root_1();
 
-				_$_.append(__anchor, div_2);
+				_$_.append(__anchor, div_1);
 			};
 
 			_$_.if(
@@ -73,15 +73,15 @@ export function IfElse() {
 
 		{
 			var consequent_2 = (__anchor) => {
-				var div_3 = root_2();
+				var div_2 = root_2();
 
-				_$_.append(__anchor, div_3);
+				_$_.append(__anchor, div_2);
 			};
 
 			var alternate = (__anchor) => {
-				var div_4 = root_3();
+				var div_3 = root_3();
 
-				_$_.append(__anchor, div_4);
+				_$_.append(__anchor, div_3);
 			};
 
 			_$_.if(
@@ -103,19 +103,19 @@ export function ReactiveIf() {
 
 		_$_.expression(node_1, () => _$_.tsrx_element((__anchor, __block) => {
 			var fragment_1 = root_5();
-			var button_1 = _$_.first_child_frag(fragment_1);
+			var button = _$_.first_child_frag(fragment_1);
 
-			button_1.__click = () => {
+			button.__click = () => {
 				_$_.set(lazy, !lazy.value);
 			};
 
-			var node = _$_.sibling(button_1);
+			var node = _$_.sibling(button);
 
 			{
 				var consequent_3 = (__anchor) => {
-					var div_5 = root_6();
+					var div_4 = root_6();
 
-					_$_.append(__anchor, div_5);
+					_$_.append(__anchor, div_4);
 				};
 
 				_$_.if(node, (__render) => {
@@ -138,25 +138,25 @@ export function ReactiveIfElse() {
 
 		_$_.expression(node_3, () => _$_.tsrx_element((__anchor, __block) => {
 			var fragment_3 = root_8();
-			var button_2 = _$_.first_child_frag(fragment_3);
+			var button_1 = _$_.first_child_frag(fragment_3);
 
-			button_2.__click = () => {
+			button_1.__click = () => {
 				_$_.set(lazy_1, !lazy_1.value);
 			};
 
-			var node_2 = _$_.sibling(button_2);
+			var node_2 = _$_.sibling(button_1);
 
 			{
 				var consequent_4 = (__anchor) => {
-					var div_6 = root_9();
+					var div_5 = root_9();
 
-					_$_.append(__anchor, div_6);
+					_$_.append(__anchor, div_5);
 				};
 
 				var alternate_1 = (__anchor) => {
-					var div_7 = root_10();
+					var div_6 = root_10();
 
-					_$_.append(__anchor, div_7);
+					_$_.append(__anchor, div_6);
 				};
 
 				_$_.if(node_2, (__render) => {
@@ -180,33 +180,33 @@ export function NestedIf() {
 
 		_$_.expression(node_6, () => _$_.tsrx_element((__anchor, __block) => {
 			var fragment_5 = root_12();
-			var button_3 = _$_.first_child_frag(fragment_5);
+			var button_2 = _$_.first_child_frag(fragment_5);
 
-			button_3.__click = () => {
+			button_2.__click = () => {
 				_$_.set(lazy_2, !lazy_2.value);
 			};
 
-			var button_4 = _$_.sibling(button_3);
+			var button_3 = _$_.sibling(button_2);
 
-			button_4.__click = () => {
+			button_3.__click = () => {
 				_$_.set(lazy_3, !lazy_3.value);
 			};
 
-			var node_4 = _$_.sibling(button_4);
+			var node_4 = _$_.sibling(button_3);
 
 			{
 				var consequent_6 = (__anchor) => {
-					var div_8 = root_13();
+					var div_7 = root_13();
 
 					{
-						var expression = _$_.child(div_8);
+						var expression = _$_.child(div_7);
 						var node_5 = _$_.sibling(expression);
 
 						{
 							var consequent_5 = (__anchor) => {
-								var span_1 = root_14();
+								var span = root_14();
 
-								_$_.append(__anchor, span_1);
+								_$_.append(__anchor, span);
 							};
 
 							_$_.if(node_5, (__render) => {
@@ -214,10 +214,10 @@ export function NestedIf() {
 							});
 						}
 
-						_$_.pop(div_8);
+						_$_.pop(div_7);
 					}
 
-					_$_.append(__anchor, div_8);
+					_$_.append(__anchor, div_7);
 				};
 
 				_$_.if(node_4, (__render) => {
@@ -235,48 +235,48 @@ export function NestedIf() {
 export function IfElseIfChain() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		let lazy_4 = _$_.track('loading', __block, '4c69c94a');
-		var div_9 = root_15();
+		var div_8 = root_15();
 
 		{
-			var button_5 = _$_.child(div_9);
+			var button_4 = _$_.child(div_8);
+
+			button_4.__click = () => {
+				_$_.set(lazy_4, 'success');
+			};
+
+			var button_5 = _$_.sibling(button_4);
 
 			button_5.__click = () => {
-				_$_.set(lazy_4, 'success');
+				_$_.set(lazy_4, 'error');
 			};
 
 			var button_6 = _$_.sibling(button_5);
 
 			button_6.__click = () => {
-				_$_.set(lazy_4, 'error');
-			};
-
-			var button_7 = _$_.sibling(button_6);
-
-			button_7.__click = () => {
 				_$_.set(lazy_4, 'loading');
 			};
 
-			var node_7 = _$_.sibling(button_7);
+			var node_7 = _$_.sibling(button_6);
 
 			{
 				var consequent_7 = (__anchor) => {
-					var div_10 = root_16();
+					var div_9 = root_16();
 
-					_$_.append(__anchor, div_10);
+					_$_.append(__anchor, div_9);
 				};
 
 				var alternate_3 = (__anchor) => {
 					{
 						var consequent_8 = (__anchor) => {
-							var div_11 = root_17();
+							var div_10 = root_17();
 
-							_$_.append(__anchor, div_11);
+							_$_.append(__anchor, div_10);
 						};
 
 						var alternate_2 = (__anchor) => {
-							var div_12 = root_18();
+							var div_11 = root_18();
 
-							_$_.append(__anchor, div_12);
+							_$_.append(__anchor, div_11);
 						};
 
 						_$_.if(
@@ -294,10 +294,10 @@ export function IfElseIfChain() {
 				});
 			}
 
-			_$_.pop(div_9);
+			_$_.pop(div_8);
 		}
 
-		_$_.append(__anchor, div_9);
+		_$_.append(__anchor, div_8);
 	});
 }
 

--- a/packages/ripple/tests/hydration/compiled/client/mixed-control-flow.js
+++ b/packages/ripple/tests/hydration/compiled/client/mixed-control-flow.js
@@ -29,11 +29,11 @@ export function MixedControlFlowStatic() {
 			{ id: 3, kind: 'a', enabled: false }
 		];
 
-		var section_1 = root();
+		var section = root();
 
 		{
 			_$_.for_keyed(
-				section_1,
+				section,
 				() => rows,
 				(__anchor, pattern) => {
 					{
@@ -43,12 +43,12 @@ export function MixedControlFlowStatic() {
 									_$_.try(
 										__anchor,
 										(__anchor) => {
-											var div_1 = root_1();
+											var div = root_1();
 
 											{
-												var expression = _$_.child(div_1, true);
+												var expression = _$_.child(div, true);
 
-												_$_.pop(div_1);
+												_$_.pop(div);
 											}
 
 											_$_.render(
@@ -62,23 +62,23 @@ export function MixedControlFlowStatic() {
 													var __b = `row row-${_$_.get(pattern).id} kind-a`;
 
 													if (__prev.b !== __b) {
-														_$_.set_class(div_1, __prev.b = __b, void 0, true);
+														_$_.set_class(div, __prev.b = __b, void 0, true);
 													}
 												},
 												{ a: ' ', b: Symbol() }
 											);
 
-											_$_.append(__anchor, div_1);
+											_$_.append(__anchor, div);
 										},
 										null,
 										(__anchor) => {
-											var div_2 = root_2();
+											var div_1 = root_2();
 
 											_$_.render(() => {
-												_$_.set_class(div_2, `pending pending-${_$_.get(pattern).id}`, void 0, true);
+												_$_.set_class(div_1, `pending pending-${_$_.get(pattern).id}`, void 0, true);
 											});
 
-											_$_.append(__anchor, div_2);
+											_$_.append(__anchor, div_1);
 										},
 										true
 									);
@@ -88,12 +88,12 @@ export function MixedControlFlowStatic() {
 									_$_.try(
 										__anchor,
 										(__anchor) => {
-											var div_3 = root_3();
+											var div_2 = root_3();
 
 											{
-												var expression_1 = _$_.child(div_3, true);
+												var expression_1 = _$_.child(div_2, true);
 
-												_$_.pop(div_3);
+												_$_.pop(div_2);
 											}
 
 											_$_.render(
@@ -107,23 +107,23 @@ export function MixedControlFlowStatic() {
 													var __b = `row row-${_$_.get(pattern).id} kind-b`;
 
 													if (__prev.b !== __b) {
-														_$_.set_class(div_3, __prev.b = __b, void 0, true);
+														_$_.set_class(div_2, __prev.b = __b, void 0, true);
 													}
 												},
 												{ a: ' ', b: Symbol() }
 											);
 
-											_$_.append(__anchor, div_3);
+											_$_.append(__anchor, div_2);
 										},
 										null,
 										(__anchor) => {
-											var div_4 = root_4();
+											var div_3 = root_4();
 
 											_$_.render(() => {
-												_$_.set_class(div_4, `pending pending-${_$_.get(pattern).id}`, void 0, true);
+												_$_.set_class(div_3, `pending pending-${_$_.get(pattern).id}`, void 0, true);
 											});
 
-											_$_.append(__anchor, div_4);
+											_$_.append(__anchor, div_3);
 										},
 										true
 									);
@@ -162,10 +162,10 @@ export function MixedControlFlowStatic() {
 				(pattern) => _$_.get(pattern).id
 			);
 
-			_$_.pop(section_1);
+			_$_.pop(section);
 		}
 
-		_$_.append(__anchor, section_1);
+		_$_.append(__anchor, section);
 	});
 }
 
@@ -179,33 +179,33 @@ export function MixedControlFlowReactive() {
 
 		_$_.expression(node_1, () => _$_.tsrx_element((__anchor, __block) => {
 			var fragment_1 = root_6();
-			var button_1 = _$_.first_child_frag(fragment_1);
+			var button = _$_.first_child_frag(fragment_1);
+
+			button.__click = () => {
+				_$_.set(lazy, !lazy.value);
+			};
+
+			var button_1 = _$_.sibling(button);
 
 			button_1.__click = () => {
-				_$_.set(lazy, !lazy.value);
+				_$_.set(lazy_1, lazy_1.value === 'a' ? 'b' : 'a');
 			};
 
 			var button_2 = _$_.sibling(button_1);
 
 			button_2.__click = () => {
-				_$_.set(lazy_1, lazy_1.value === 'a' ? 'b' : 'a');
-			};
-
-			var button_3 = _$_.sibling(button_2);
-
-			button_3.__click = () => {
 				_$_.set(lazy_2, [...lazy_2.value, { id: 3, label: 'Three' }]);
 			};
 
-			var node = _$_.sibling(button_3);
+			var node = _$_.sibling(button_2);
 
 			{
 				var consequent_1 = (__anchor) => {
-					var div_5 = root_7();
+					var div_4 = root_7();
 
 					{
 						_$_.for_keyed(
-							div_5,
+							div_4,
 							() => lazy_2.value,
 							(__anchor, pattern_1) => {
 								{
@@ -213,12 +213,12 @@ export function MixedControlFlowReactive() {
 										_$_.try(
 											__anchor,
 											(__anchor) => {
-												var p_1 = root_8();
+												var p = root_8();
 
 												{
-													var expression_2 = _$_.child(p_1, true);
+													var expression_2 = _$_.child(p, true);
 
-													_$_.pop(p_1);
+													_$_.pop(p);
 												}
 
 												_$_.render(
@@ -232,19 +232,19 @@ export function MixedControlFlowReactive() {
 														var __b = `item item-${_$_.get(pattern_1).id}`;
 
 														if (__prev.b !== __b) {
-															_$_.set_class(p_1, __prev.b = __b, void 0, true);
+															_$_.set_class(p, __prev.b = __b, void 0, true);
 														}
 													},
 													{ a: ' ', b: Symbol() }
 												);
 
-												_$_.append(__anchor, p_1);
+												_$_.append(__anchor, p);
 											},
 											null,
 											(__anchor) => {
-												var p_2 = root_9();
+												var p_1 = root_9();
 
-												_$_.append(__anchor, p_2);
+												_$_.append(__anchor, p_1);
 											},
 											true
 										);
@@ -254,12 +254,12 @@ export function MixedControlFlowReactive() {
 										_$_.try(
 											__anchor,
 											(__anchor) => {
-												var p_3 = root_10();
+												var p_2 = root_10();
 
 												{
-													var expression_3 = _$_.child(p_3, true);
+													var expression_3 = _$_.child(p_2, true);
 
-													_$_.pop(p_3);
+													_$_.pop(p_2);
 												}
 
 												_$_.render(
@@ -273,19 +273,19 @@ export function MixedControlFlowReactive() {
 														var __b = `item item-${_$_.get(pattern_1).id}`;
 
 														if (__prev.b !== __b) {
-															_$_.set_class(p_3, __prev.b = __b, void 0, true);
+															_$_.set_class(p_2, __prev.b = __b, void 0, true);
 														}
 													},
 													{ a: ' ', b: Symbol() }
 												);
 
-												_$_.append(__anchor, p_3);
+												_$_.append(__anchor, p_2);
 											},
 											null,
 											(__anchor) => {
-												var p_4 = root_11();
+												var p_3 = root_11();
 
-												_$_.append(__anchor, p_4);
+												_$_.append(__anchor, p_3);
 											},
 											true
 										);
@@ -314,10 +314,10 @@ export function MixedControlFlowReactive() {
 							(pattern_1) => _$_.get(pattern_1).id
 						);
 
-						_$_.pop(div_5);
+						_$_.pop(div_4);
 					}
 
-					_$_.append(__anchor, div_5);
+					_$_.append(__anchor, div_4);
 				};
 
 				_$_.if(node, (__render) => {
@@ -341,8 +341,8 @@ export function MixedControlFlowAsyncPending() {
 
 		_$_.expression(node_3, () => _$_.tsrx_element((__anchor, __block) => {
 			var fragment_3 = root_13();
-			var div_6 = _$_.first_child_frag(fragment_3);
-			var node_2 = _$_.sibling(div_6);
+			var div_5 = _$_.first_child_frag(fragment_3);
+			var node_2 = _$_.sibling(div_5);
 
 			_$_.for(
 				node_2,
@@ -359,27 +359,27 @@ export function MixedControlFlowAsyncPending() {
 										},
 										null,
 										(__anchor) => {
-											var div_7 = root_14();
+											var div_6 = root_14();
 
-											_$_.set_class(div_7, `pending-row pending-row-${row}`, void 0, true);
+											_$_.set_class(div_6, `pending-row pending-row-${row}`, void 0, true);
 
 											{
-												var expression_4 = _$_.child(div_7, true);
+												var expression_4 = _$_.child(div_6, true);
 
 												expression_4.nodeValue = `pending ${row}`;
-												_$_.pop(div_7);
+												_$_.pop(div_6);
 											}
 
-											_$_.append(__anchor, div_7);
+											_$_.append(__anchor, div_6);
 										},
 										true
 									);
 								};
 
 								var switch_case_default_2 = (__anchor) => {
-									var div_8 = root_15();
+									var div_7 = root_15();
 
-									_$_.append(__anchor, div_8);
+									_$_.append(__anchor, div_7);
 								};
 
 								_$_.switch(
@@ -424,16 +424,16 @@ export function MixedControlFlowAsyncPending() {
 function AsyncRow({ label }) {
 	return _$_.tsrx_element((__anchor, __block) => {
 		let lazy_3 = _$_.track_async(() => _$_.with_scope(__block, () => Promise.resolve(label)), __block, '10cc79a0');
-		var div_9 = root_16();
+		var div_8 = root_16();
 
 		{
-			var expression_5 = _$_.child(div_9);
+			var expression_5 = _$_.child(div_8);
 
 			_$_.expression(expression_5, () => lazy_3.value);
-			_$_.pop(div_9);
+			_$_.pop(div_8);
 		}
 
-		_$_.append(__anchor, div_9);
+		_$_.append(__anchor, div_8);
 	});
 }
 

--- a/packages/ripple/tests/hydration/compiled/client/nested-control-flow.js
+++ b/packages/ripple/tests/hydration/compiled/client/nested-control-flow.js
@@ -52,29 +52,29 @@ export function ForIf() {
 			{ id: 3, show: false, label: 'Three' }
 		];
 
-		var ul_1 = root();
+		var ul = root();
 
 		{
 			_$_.for_keyed(
-				ul_1,
+				ul,
 				() => items,
 				(__anchor, pattern) => {
 					{
 						var consequent = (__anchor) => {
-							var li_1 = root_1();
+							var li = root_1();
 
 							{
-								var expression = _$_.child(li_1);
+								var expression = _$_.child(li);
 
 								_$_.expression(expression, () => _$_.get(pattern).label);
-								_$_.pop(li_1);
+								_$_.pop(li);
 							}
 
 							_$_.render(() => {
-								_$_.set_class(li_1, `item item-${_$_.get(pattern).id}`, void 0, true);
+								_$_.set_class(li, `item item-${_$_.get(pattern).id}`, void 0, true);
 							});
 
-							_$_.append(__anchor, li_1);
+							_$_.append(__anchor, li);
 						};
 
 						_$_.if(
@@ -90,10 +90,10 @@ export function ForIf() {
 				(pattern) => _$_.get(pattern).id
 			);
 
-			_$_.pop(ul_1);
+			_$_.pop(ul);
 		}
 
-		_$_.append(__anchor, ul_1);
+		_$_.append(__anchor, ul);
 	});
 }
 
@@ -105,21 +105,21 @@ export function ForSwitch() {
 			{ id: 3, kind: 'a' }
 		];
 
-		var ul_2 = root_2();
+		var ul_1 = root_2();
 
 		{
 			_$_.for_keyed(
-				ul_2,
+				ul_1,
 				() => items,
 				(__anchor, pattern_1) => {
 					{
 						var switch_case_0 = (__anchor) => {
-							var li_2 = root_3();
+							var li_1 = root_3();
 
 							{
-								var expression_1 = _$_.child(li_2, true);
+								var expression_1 = _$_.child(li_1, true);
 
-								_$_.pop(li_2);
+								_$_.pop(li_1);
 							}
 
 							_$_.render(
@@ -133,22 +133,22 @@ export function ForSwitch() {
 									var __b = `item item-${_$_.get(pattern_1).id} kind-a`;
 
 									if (__prev.b !== __b) {
-										_$_.set_class(li_2, __prev.b = __b, void 0, true);
+										_$_.set_class(li_1, __prev.b = __b, void 0, true);
 									}
 								},
 								{ a: ' ', b: Symbol() }
 							);
 
-							_$_.append(__anchor, li_2);
+							_$_.append(__anchor, li_1);
 						};
 
 						var switch_case_default = (__anchor) => {
-							var li_3 = root_4();
+							var li_2 = root_4();
 
 							{
-								var expression_2 = _$_.child(li_3, true);
+								var expression_2 = _$_.child(li_2, true);
 
-								_$_.pop(li_3);
+								_$_.pop(li_2);
 							}
 
 							_$_.render(
@@ -162,13 +162,13 @@ export function ForSwitch() {
 									var __b = `item item-${_$_.get(pattern_1).id} kind-b`;
 
 									if (__prev.b !== __b) {
-										_$_.set_class(li_3, __prev.b = __b, void 0, true);
+										_$_.set_class(li_2, __prev.b = __b, void 0, true);
 									}
 								},
 								{ a: ' ', b: Symbol() }
 							);
 
-							_$_.append(__anchor, li_3);
+							_$_.append(__anchor, li_2);
 						};
 
 						_$_.switch(
@@ -194,10 +194,10 @@ export function ForSwitch() {
 				(pattern_1) => _$_.get(pattern_1).id
 			);
 
-			_$_.pop(ul_2);
+			_$_.pop(ul_1);
 		}
 
-		_$_.append(__anchor, ul_2);
+		_$_.append(__anchor, ul_1);
 	});
 }
 
@@ -205,24 +205,24 @@ export function IfSwitch() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		const show = true;
 		const kind = 'a';
-		var div_1 = root_5();
+		var div = root_5();
 
 		{
-			var node = _$_.child(div_1);
+			var node = _$_.child(div);
 
 			{
 				var consequent_1 = (__anchor) => {
 					{
 						var switch_case_0_1 = (__anchor) => {
-							var p_1 = root_6();
+							var p = root_6();
 
-							_$_.append(__anchor, p_1);
+							_$_.append(__anchor, p);
 						};
 
 						var switch_case_default_1 = (__anchor) => {
-							var p_2 = root_7();
+							var p_1 = root_7();
 
-							_$_.append(__anchor, p_2);
+							_$_.append(__anchor, p_1);
 						};
 
 						_$_.switch(
@@ -250,10 +250,10 @@ export function IfSwitch() {
 				});
 			}
 
-			_$_.pop(div_1);
+			_$_.pop(div);
 		}
 
-		_$_.append(__anchor, div_1);
+		_$_.append(__anchor, div);
 	});
 }
 
@@ -261,24 +261,24 @@ export function IfSwitchHidden() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		const show = false;
 		const kind = 'a';
-		var div_2 = root_8();
+		var div_1 = root_8();
 
 		{
-			var node_1 = _$_.child(div_2);
+			var node_1 = _$_.child(div_1);
 
 			{
 				var consequent_2 = (__anchor) => {
 					{
 						var switch_case_0_2 = (__anchor) => {
-							var p_3 = root_9();
+							var p_2 = root_9();
 
-							_$_.append(__anchor, p_3);
+							_$_.append(__anchor, p_2);
 						};
 
 						var switch_case_default_2 = (__anchor) => {
-							var p_4 = root_10();
+							var p_3 = root_10();
 
-							_$_.append(__anchor, p_4);
+							_$_.append(__anchor, p_3);
 						};
 
 						_$_.switch(
@@ -306,33 +306,33 @@ export function IfSwitchHidden() {
 				});
 			}
 
-			_$_.pop(div_2);
+			_$_.pop(div_1);
 		}
 
-		_$_.append(__anchor, div_2);
+		_$_.append(__anchor, div_1);
 	});
 }
 
 export function ForIfSwitchSingle() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		const items = [{ id: 1, kind: 'a', show: true }];
-		var ul_3 = root_11();
+		var ul_2 = root_11();
 
 		{
 			_$_.for_keyed(
-				ul_3,
+				ul_2,
 				() => items,
 				(__anchor, pattern_2) => {
 					{
 						var consequent_3 = (__anchor) => {
 							{
 								var switch_case_0_3 = (__anchor) => {
-									var li_4 = root_12();
+									var li_3 = root_12();
 
 									{
-										var expression_3 = _$_.child(li_4, true);
+										var expression_3 = _$_.child(li_3, true);
 
-										_$_.pop(li_4);
+										_$_.pop(li_3);
 									}
 
 									_$_.render(
@@ -346,22 +346,22 @@ export function ForIfSwitchSingle() {
 											var __b = `item item-${_$_.get(pattern_2).id} kind-a`;
 
 											if (__prev.b !== __b) {
-												_$_.set_class(li_4, __prev.b = __b, void 0, true);
+												_$_.set_class(li_3, __prev.b = __b, void 0, true);
 											}
 										},
 										{ a: ' ', b: Symbol() }
 									);
 
-									_$_.append(__anchor, li_4);
+									_$_.append(__anchor, li_3);
 								};
 
 								var switch_case_default_3 = (__anchor) => {
-									var li_5 = root_13();
+									var li_4 = root_13();
 
 									{
-										var expression_4 = _$_.child(li_5, true);
+										var expression_4 = _$_.child(li_4, true);
 
-										_$_.pop(li_5);
+										_$_.pop(li_4);
 									}
 
 									_$_.render(
@@ -375,13 +375,13 @@ export function ForIfSwitchSingle() {
 											var __b = `item item-${_$_.get(pattern_2).id} kind-default`;
 
 											if (__prev.b !== __b) {
-												_$_.set_class(li_5, __prev.b = __b, void 0, true);
+												_$_.set_class(li_4, __prev.b = __b, void 0, true);
 											}
 										},
 										{ a: ' ', b: Symbol() }
 									);
 
-									_$_.append(__anchor, li_5);
+									_$_.append(__anchor, li_4);
 								};
 
 								_$_.switch(
@@ -417,10 +417,10 @@ export function ForIfSwitchSingle() {
 				(pattern_2) => _$_.get(pattern_2).id
 			);
 
-			_$_.pop(ul_3);
+			_$_.pop(ul_2);
 		}
 
-		_$_.append(__anchor, ul_3);
+		_$_.append(__anchor, ul_2);
 	});
 }
 
@@ -431,23 +431,23 @@ export function ForIfSwitchMulti() {
 			{ id: 2, kind: 'b', show: true }
 		];
 
-		var ul_4 = root_14();
+		var ul_3 = root_14();
 
 		{
 			_$_.for_keyed(
-				ul_4,
+				ul_3,
 				() => items,
 				(__anchor, pattern_3) => {
 					{
 						var consequent_4 = (__anchor) => {
 							{
 								var switch_case_0_4 = (__anchor) => {
-									var li_6 = root_15();
+									var li_5 = root_15();
 
 									{
-										var expression_5 = _$_.child(li_6, true);
+										var expression_5 = _$_.child(li_5, true);
 
-										_$_.pop(li_6);
+										_$_.pop(li_5);
 									}
 
 									_$_.render(
@@ -461,22 +461,22 @@ export function ForIfSwitchMulti() {
 											var __b = `item item-${_$_.get(pattern_3).id} kind-a`;
 
 											if (__prev.b !== __b) {
-												_$_.set_class(li_6, __prev.b = __b, void 0, true);
+												_$_.set_class(li_5, __prev.b = __b, void 0, true);
 											}
 										},
 										{ a: ' ', b: Symbol() }
 									);
 
-									_$_.append(__anchor, li_6);
+									_$_.append(__anchor, li_5);
 								};
 
 								var switch_case_default_4 = (__anchor) => {
-									var li_7 = root_16();
+									var li_6 = root_16();
 
 									{
-										var expression_6 = _$_.child(li_7, true);
+										var expression_6 = _$_.child(li_6, true);
 
-										_$_.pop(li_7);
+										_$_.pop(li_6);
 									}
 
 									_$_.render(
@@ -490,13 +490,13 @@ export function ForIfSwitchMulti() {
 											var __b = `item item-${_$_.get(pattern_3).id} kind-b`;
 
 											if (__prev.b !== __b) {
-												_$_.set_class(li_7, __prev.b = __b, void 0, true);
+												_$_.set_class(li_6, __prev.b = __b, void 0, true);
 											}
 										},
 										{ a: ' ', b: Symbol() }
 									);
 
-									_$_.append(__anchor, li_7);
+									_$_.append(__anchor, li_6);
 								};
 
 								_$_.switch(
@@ -532,10 +532,10 @@ export function ForIfSwitchMulti() {
 				(pattern_3) => _$_.get(pattern_3).id
 			);
 
-			_$_.pop(ul_4);
+			_$_.pop(ul_3);
 		}
 
-		_$_.append(__anchor, ul_4);
+		_$_.append(__anchor, ul_3);
 	});
 }
 
@@ -547,23 +547,23 @@ export function ForIfSwitchWithDisabled() {
 			{ id: 3, kind: 'a', show: true }
 		];
 
-		var ul_5 = root_17();
+		var ul_4 = root_17();
 
 		{
 			_$_.for_keyed(
-				ul_5,
+				ul_4,
 				() => items,
 				(__anchor, pattern_4) => {
 					{
 						var consequent_5 = (__anchor) => {
 							{
 								var switch_case_0_5 = (__anchor) => {
-									var li_8 = root_18();
+									var li_7 = root_18();
 
 									{
-										var expression_7 = _$_.child(li_8, true);
+										var expression_7 = _$_.child(li_7, true);
 
-										_$_.pop(li_8);
+										_$_.pop(li_7);
 									}
 
 									_$_.render(
@@ -577,22 +577,22 @@ export function ForIfSwitchWithDisabled() {
 											var __b = `item item-${_$_.get(pattern_4).id} kind-a`;
 
 											if (__prev.b !== __b) {
-												_$_.set_class(li_8, __prev.b = __b, void 0, true);
+												_$_.set_class(li_7, __prev.b = __b, void 0, true);
 											}
 										},
 										{ a: ' ', b: Symbol() }
 									);
 
-									_$_.append(__anchor, li_8);
+									_$_.append(__anchor, li_7);
 								};
 
 								var switch_case_default_5 = (__anchor) => {
-									var li_9 = root_19();
+									var li_8 = root_19();
 
 									{
-										var expression_8 = _$_.child(li_9, true);
+										var expression_8 = _$_.child(li_8, true);
 
-										_$_.pop(li_9);
+										_$_.pop(li_8);
 									}
 
 									_$_.render(
@@ -606,13 +606,13 @@ export function ForIfSwitchWithDisabled() {
 											var __b = `item item-${_$_.get(pattern_4).id} kind-b`;
 
 											if (__prev.b !== __b) {
-												_$_.set_class(li_9, __prev.b = __b, void 0, true);
+												_$_.set_class(li_8, __prev.b = __b, void 0, true);
 											}
 										},
 										{ a: ' ', b: Symbol() }
 									);
 
-									_$_.append(__anchor, li_9);
+									_$_.append(__anchor, li_8);
 								};
 
 								_$_.switch(
@@ -648,44 +648,44 @@ export function ForIfSwitchWithDisabled() {
 				(pattern_4) => _$_.get(pattern_4).id
 			);
 
-			_$_.pop(ul_5);
+			_$_.pop(ul_4);
 		}
 
-		_$_.append(__anchor, ul_5);
+		_$_.append(__anchor, ul_4);
 	});
 }
 
 export function SwitchTry() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		const kind = 'a';
-		var div_3 = root_20();
+		var div_2 = root_20();
 
 		{
-			var node_2 = _$_.child(div_3);
+			var node_2 = _$_.child(div_2);
 
 			{
 				var switch_case_0_6 = (__anchor) => {
 					_$_.try(
 						__anchor,
 						(__anchor) => {
-							var p_5 = root_21();
+							var p_4 = root_21();
 
-							_$_.append(__anchor, p_5);
+							_$_.append(__anchor, p_4);
 						},
 						null,
 						(__anchor) => {
-							var p_6 = root_22();
+							var p_5 = root_22();
 
-							_$_.append(__anchor, p_6);
+							_$_.append(__anchor, p_5);
 						},
 						true
 					);
 				};
 
 				var switch_case_default_6 = (__anchor) => {
-					var p_7 = root_23();
+					var p_6 = root_23();
 
-					_$_.append(__anchor, p_7);
+					_$_.append(__anchor, p_6);
 				};
 
 				_$_.switch(node_2, () => {
@@ -703,21 +703,21 @@ export function SwitchTry() {
 				});
 			}
 
-			_$_.pop(div_3);
+			_$_.pop(div_2);
 		}
 
-		_$_.append(__anchor, div_3);
+		_$_.append(__anchor, div_2);
 	});
 }
 
 export function ForSwitchTry() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		const items = [{ id: 1, kind: 'a' }, { id: 2, kind: 'b' }];
-		var ul_6 = root_24();
+		var ul_5 = root_24();
 
 		{
 			_$_.for_keyed(
-				ul_6,
+				ul_5,
 				() => items,
 				(__anchor, pattern_5) => {
 					{
@@ -725,12 +725,12 @@ export function ForSwitchTry() {
 							_$_.try(
 								__anchor,
 								(__anchor) => {
-									var li_10 = root_25();
+									var li_9 = root_25();
 
 									{
-										var expression_9 = _$_.child(li_10, true);
+										var expression_9 = _$_.child(li_9, true);
 
-										_$_.pop(li_10);
+										_$_.pop(li_9);
 									}
 
 									_$_.render(
@@ -744,22 +744,22 @@ export function ForSwitchTry() {
 											var __b = `item item-${_$_.get(pattern_5).id} kind-a`;
 
 											if (__prev.b !== __b) {
-												_$_.set_class(li_10, __prev.b = __b, void 0, true);
+												_$_.set_class(li_9, __prev.b = __b, void 0, true);
 											}
 										},
 										{ a: ' ', b: Symbol() }
 									);
 
-									_$_.append(__anchor, li_10);
+									_$_.append(__anchor, li_9);
 								},
 								null,
 								(__anchor) => {
-									var li_11 = root_26();
+									var li_10 = root_26();
 
 									{
-										var expression_10 = _$_.child(li_11, true);
+										var expression_10 = _$_.child(li_10, true);
 
-										_$_.pop(li_11);
+										_$_.pop(li_10);
 									}
 
 									_$_.render(
@@ -773,13 +773,13 @@ export function ForSwitchTry() {
 											var __b = `pending pending-${_$_.get(pattern_5).id}`;
 
 											if (__prev.b !== __b) {
-												_$_.set_class(li_11, __prev.b = __b, void 0, true);
+												_$_.set_class(li_10, __prev.b = __b, void 0, true);
 											}
 										},
 										{ a: ' ', b: Symbol() }
 									);
 
-									_$_.append(__anchor, li_11);
+									_$_.append(__anchor, li_10);
 								},
 								true
 							);
@@ -789,12 +789,12 @@ export function ForSwitchTry() {
 							_$_.try(
 								__anchor,
 								(__anchor) => {
-									var li_12 = root_27();
+									var li_11 = root_27();
 
 									{
-										var expression_11 = _$_.child(li_12, true);
+										var expression_11 = _$_.child(li_11, true);
 
-										_$_.pop(li_12);
+										_$_.pop(li_11);
 									}
 
 									_$_.render(
@@ -808,22 +808,22 @@ export function ForSwitchTry() {
 											var __b = `item item-${_$_.get(pattern_5).id} kind-b`;
 
 											if (__prev.b !== __b) {
-												_$_.set_class(li_12, __prev.b = __b, void 0, true);
+												_$_.set_class(li_11, __prev.b = __b, void 0, true);
 											}
 										},
 										{ a: ' ', b: Symbol() }
 									);
 
-									_$_.append(__anchor, li_12);
+									_$_.append(__anchor, li_11);
 								},
 								null,
 								(__anchor) => {
-									var li_13 = root_28();
+									var li_12 = root_28();
 
 									{
-										var expression_12 = _$_.child(li_13, true);
+										var expression_12 = _$_.child(li_12, true);
 
-										_$_.pop(li_13);
+										_$_.pop(li_12);
 									}
 
 									_$_.render(
@@ -837,13 +837,13 @@ export function ForSwitchTry() {
 											var __b = `pending pending-${_$_.get(pattern_5).id}`;
 
 											if (__prev.b !== __b) {
-												_$_.set_class(li_13, __prev.b = __b, void 0, true);
+												_$_.set_class(li_12, __prev.b = __b, void 0, true);
 											}
 										},
 										{ a: ' ', b: Symbol() }
 									);
 
-									_$_.append(__anchor, li_13);
+									_$_.append(__anchor, li_12);
 								},
 								true
 							);
@@ -872,21 +872,21 @@ export function ForSwitchTry() {
 				(pattern_5) => _$_.get(pattern_5).id
 			);
 
-			_$_.pop(ul_6);
+			_$_.pop(ul_5);
 		}
 
-		_$_.append(__anchor, ul_6);
+		_$_.append(__anchor, ul_5);
 	});
 }
 
 export function ForIfTry() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		const items = [{ id: 1, show: true }, { id: 2, show: true }];
-		var ul_7 = root_29();
+		var ul_6 = root_29();
 
 		{
 			_$_.for_keyed(
-				ul_7,
+				ul_6,
 				() => items,
 				(__anchor, pattern_6) => {
 					{
@@ -894,12 +894,12 @@ export function ForIfTry() {
 							_$_.try(
 								__anchor,
 								(__anchor) => {
-									var li_14 = root_30();
+									var li_13 = root_30();
 
 									{
-										var expression_13 = _$_.child(li_14, true);
+										var expression_13 = _$_.child(li_13, true);
 
-										_$_.pop(li_14);
+										_$_.pop(li_13);
 									}
 
 									_$_.render(
@@ -913,22 +913,22 @@ export function ForIfTry() {
 											var __b = `item item-${_$_.get(pattern_6).id}`;
 
 											if (__prev.b !== __b) {
-												_$_.set_class(li_14, __prev.b = __b, void 0, true);
+												_$_.set_class(li_13, __prev.b = __b, void 0, true);
 											}
 										},
 										{ a: ' ', b: Symbol() }
 									);
 
-									_$_.append(__anchor, li_14);
+									_$_.append(__anchor, li_13);
 								},
 								null,
 								(__anchor) => {
-									var li_15 = root_31();
+									var li_14 = root_31();
 
 									{
-										var expression_14 = _$_.child(li_15, true);
+										var expression_14 = _$_.child(li_14, true);
 
-										_$_.pop(li_15);
+										_$_.pop(li_14);
 									}
 
 									_$_.render(
@@ -942,13 +942,13 @@ export function ForIfTry() {
 											var __b = `pending pending-${_$_.get(pattern_6).id}`;
 
 											if (__prev.b !== __b) {
-												_$_.set_class(li_15, __prev.b = __b, void 0, true);
+												_$_.set_class(li_14, __prev.b = __b, void 0, true);
 											}
 										},
 										{ a: ' ', b: Symbol() }
 									);
 
-									_$_.append(__anchor, li_15);
+									_$_.append(__anchor, li_14);
 								},
 								true
 							);
@@ -967,21 +967,21 @@ export function ForIfTry() {
 				(pattern_6) => _$_.get(pattern_6).id
 			);
 
-			_$_.pop(ul_7);
+			_$_.pop(ul_6);
 		}
 
-		_$_.append(__anchor, ul_7);
+		_$_.append(__anchor, ul_6);
 	});
 }
 
 export function ForIfSwitchTrySingle() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		const items = [{ id: 1, kind: 'a', show: true }];
-		var ul_8 = root_32();
+		var ul_7 = root_32();
 
 		{
 			_$_.for_keyed(
-				ul_8,
+				ul_7,
 				() => items,
 				(__anchor, pattern_7) => {
 					{
@@ -991,12 +991,12 @@ export function ForIfSwitchTrySingle() {
 									_$_.try(
 										__anchor,
 										(__anchor) => {
-											var li_16 = root_33();
+											var li_15 = root_33();
 
 											{
-												var expression_15 = _$_.child(li_16, true);
+												var expression_15 = _$_.child(li_15, true);
 
-												_$_.pop(li_16);
+												_$_.pop(li_15);
 											}
 
 											_$_.render(
@@ -1010,22 +1010,22 @@ export function ForIfSwitchTrySingle() {
 													var __b = `item item-${_$_.get(pattern_7).id} kind-a`;
 
 													if (__prev.b !== __b) {
-														_$_.set_class(li_16, __prev.b = __b, void 0, true);
+														_$_.set_class(li_15, __prev.b = __b, void 0, true);
 													}
 												},
 												{ a: ' ', b: Symbol() }
 											);
 
-											_$_.append(__anchor, li_16);
+											_$_.append(__anchor, li_15);
 										},
 										null,
 										(__anchor) => {
-											var li_17 = root_34();
+											var li_16 = root_34();
 
 											{
-												var expression_16 = _$_.child(li_17, true);
+												var expression_16 = _$_.child(li_16, true);
 
-												_$_.pop(li_17);
+												_$_.pop(li_16);
 											}
 
 											_$_.render(
@@ -1039,13 +1039,13 @@ export function ForIfSwitchTrySingle() {
 													var __b = `pending pending-${_$_.get(pattern_7).id}`;
 
 													if (__prev.b !== __b) {
-														_$_.set_class(li_17, __prev.b = __b, void 0, true);
+														_$_.set_class(li_16, __prev.b = __b, void 0, true);
 													}
 												},
 												{ a: ' ', b: Symbol() }
 											);
 
-											_$_.append(__anchor, li_17);
+											_$_.append(__anchor, li_16);
 										},
 										true
 									);
@@ -1055,12 +1055,12 @@ export function ForIfSwitchTrySingle() {
 									_$_.try(
 										__anchor,
 										(__anchor) => {
-											var li_18 = root_35();
+											var li_17 = root_35();
 
 											{
-												var expression_17 = _$_.child(li_18, true);
+												var expression_17 = _$_.child(li_17, true);
 
-												_$_.pop(li_18);
+												_$_.pop(li_17);
 											}
 
 											_$_.render(
@@ -1074,22 +1074,22 @@ export function ForIfSwitchTrySingle() {
 													var __b = `item item-${_$_.get(pattern_7).id} kind-default`;
 
 													if (__prev.b !== __b) {
-														_$_.set_class(li_18, __prev.b = __b, void 0, true);
+														_$_.set_class(li_17, __prev.b = __b, void 0, true);
 													}
 												},
 												{ a: ' ', b: Symbol() }
 											);
 
-											_$_.append(__anchor, li_18);
+											_$_.append(__anchor, li_17);
 										},
 										null,
 										(__anchor) => {
-											var li_19 = root_36();
+											var li_18 = root_36();
 
 											{
-												var expression_18 = _$_.child(li_19, true);
+												var expression_18 = _$_.child(li_18, true);
 
-												_$_.pop(li_19);
+												_$_.pop(li_18);
 											}
 
 											_$_.render(
@@ -1103,13 +1103,13 @@ export function ForIfSwitchTrySingle() {
 													var __b = `pending pending-${_$_.get(pattern_7).id}`;
 
 													if (__prev.b !== __b) {
-														_$_.set_class(li_19, __prev.b = __b, void 0, true);
+														_$_.set_class(li_18, __prev.b = __b, void 0, true);
 													}
 												},
 												{ a: ' ', b: Symbol() }
 											);
 
-											_$_.append(__anchor, li_19);
+											_$_.append(__anchor, li_18);
 										},
 										true
 									);
@@ -1148,10 +1148,10 @@ export function ForIfSwitchTrySingle() {
 				(pattern_7) => _$_.get(pattern_7).id
 			);
 
-			_$_.pop(ul_8);
+			_$_.pop(ul_7);
 		}
 
-		_$_.append(__anchor, ul_8);
+		_$_.append(__anchor, ul_7);
 	});
 }
 
@@ -1162,11 +1162,11 @@ export function ForIfSwitchTryMulti() {
 			{ id: 2, kind: 'b', show: true }
 		];
 
-		var ul_9 = root_37();
+		var ul_8 = root_37();
 
 		{
 			_$_.for_keyed(
-				ul_9,
+				ul_8,
 				() => items,
 				(__anchor, pattern_8) => {
 					{
@@ -1176,12 +1176,12 @@ export function ForIfSwitchTryMulti() {
 									_$_.try(
 										__anchor,
 										(__anchor) => {
-											var li_20 = root_38();
+											var li_19 = root_38();
 
 											{
-												var expression_19 = _$_.child(li_20, true);
+												var expression_19 = _$_.child(li_19, true);
 
-												_$_.pop(li_20);
+												_$_.pop(li_19);
 											}
 
 											_$_.render(
@@ -1195,22 +1195,22 @@ export function ForIfSwitchTryMulti() {
 													var __b = `item item-${_$_.get(pattern_8).id} kind-a`;
 
 													if (__prev.b !== __b) {
-														_$_.set_class(li_20, __prev.b = __b, void 0, true);
+														_$_.set_class(li_19, __prev.b = __b, void 0, true);
 													}
 												},
 												{ a: ' ', b: Symbol() }
 											);
 
-											_$_.append(__anchor, li_20);
+											_$_.append(__anchor, li_19);
 										},
 										null,
 										(__anchor) => {
-											var li_21 = root_39();
+											var li_20 = root_39();
 
 											{
-												var expression_20 = _$_.child(li_21, true);
+												var expression_20 = _$_.child(li_20, true);
 
-												_$_.pop(li_21);
+												_$_.pop(li_20);
 											}
 
 											_$_.render(
@@ -1224,13 +1224,13 @@ export function ForIfSwitchTryMulti() {
 													var __b = `pending pending-${_$_.get(pattern_8).id}`;
 
 													if (__prev.b !== __b) {
-														_$_.set_class(li_21, __prev.b = __b, void 0, true);
+														_$_.set_class(li_20, __prev.b = __b, void 0, true);
 													}
 												},
 												{ a: ' ', b: Symbol() }
 											);
 
-											_$_.append(__anchor, li_21);
+											_$_.append(__anchor, li_20);
 										},
 										true
 									);
@@ -1240,12 +1240,12 @@ export function ForIfSwitchTryMulti() {
 									_$_.try(
 										__anchor,
 										(__anchor) => {
-											var li_22 = root_40();
+											var li_21 = root_40();
 
 											{
-												var expression_21 = _$_.child(li_22, true);
+												var expression_21 = _$_.child(li_21, true);
 
-												_$_.pop(li_22);
+												_$_.pop(li_21);
 											}
 
 											_$_.render(
@@ -1259,22 +1259,22 @@ export function ForIfSwitchTryMulti() {
 													var __b = `item item-${_$_.get(pattern_8).id} kind-b`;
 
 													if (__prev.b !== __b) {
-														_$_.set_class(li_22, __prev.b = __b, void 0, true);
+														_$_.set_class(li_21, __prev.b = __b, void 0, true);
 													}
 												},
 												{ a: ' ', b: Symbol() }
 											);
 
-											_$_.append(__anchor, li_22);
+											_$_.append(__anchor, li_21);
 										},
 										null,
 										(__anchor) => {
-											var li_23 = root_41();
+											var li_22 = root_41();
 
 											{
-												var expression_22 = _$_.child(li_23, true);
+												var expression_22 = _$_.child(li_22, true);
 
-												_$_.pop(li_23);
+												_$_.pop(li_22);
 											}
 
 											_$_.render(
@@ -1288,13 +1288,13 @@ export function ForIfSwitchTryMulti() {
 													var __b = `pending pending-${_$_.get(pattern_8).id}`;
 
 													if (__prev.b !== __b) {
-														_$_.set_class(li_23, __prev.b = __b, void 0, true);
+														_$_.set_class(li_22, __prev.b = __b, void 0, true);
 													}
 												},
 												{ a: ' ', b: Symbol() }
 											);
 
-											_$_.append(__anchor, li_23);
+											_$_.append(__anchor, li_22);
 										},
 										true
 									);
@@ -1333,9 +1333,9 @@ export function ForIfSwitchTryMulti() {
 				(pattern_8) => _$_.get(pattern_8).id
 			);
 
-			_$_.pop(ul_9);
+			_$_.pop(ul_8);
 		}
 
-		_$_.append(__anchor, ul_9);
+		_$_.append(__anchor, ul_8);
 	});
 }

--- a/packages/ripple/tests/hydration/compiled/client/portal.js
+++ b/packages/ripple/tests/hydration/compiled/client/portal.js
@@ -14,11 +14,11 @@ import { Portal, track } from 'ripple';
 
 export function SimplePortal() {
 	return _$_.tsrx_element((__anchor, __block) => {
-		var div_1 = root();
+		var div = root();
 
 		{
-			var h1_1 = _$_.child(div_1);
-			var node = _$_.sibling(h1_1);
+			var h1 = _$_.child(div);
+			var node = _$_.sibling(h1);
 
 			_$_.render_component(Portal, node, {
 				get target() {
@@ -26,30 +26,30 @@ export function SimplePortal() {
 				},
 
 				children: _$_.tsrx_element((__anchor, __block) => {
-					var div_2 = root_1();
+					var div_1 = root_1();
 
-					_$_.append(__anchor, div_2);
+					_$_.append(__anchor, div_1);
 				})
 			});
 
-			_$_.pop(div_1);
+			_$_.pop(div);
 		}
 
-		_$_.append(__anchor, div_1);
+		_$_.append(__anchor, div);
 	});
 }
 
 export function ConditionalPortal() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		let lazy = _$_.track(true, __block, '4f6df174');
-		var div_3 = root_2();
+		var div_2 = root_2();
 
 		{
-			var button_1 = _$_.child(div_3);
+			var button = _$_.child(div_2);
 
-			button_1.__click = () => _$_.set(lazy, !lazy.value);
+			button.__click = () => _$_.set(lazy, !lazy.value);
 
-			var node_1 = _$_.sibling(button_1);
+			var node_1 = _$_.sibling(button);
 
 			{
 				var consequent = (__anchor) => {
@@ -59,9 +59,9 @@ export function ConditionalPortal() {
 						},
 
 						children: _$_.tsrx_element((__anchor, __block) => {
-							var div_4 = root_3();
+							var div_3 = root_3();
 
-							_$_.append(__anchor, div_4);
+							_$_.append(__anchor, div_3);
 						})
 					});
 				};
@@ -71,20 +71,20 @@ export function ConditionalPortal() {
 				});
 			}
 
-			_$_.pop(div_3);
+			_$_.pop(div_2);
 		}
 
-		_$_.append(__anchor, div_3);
+		_$_.append(__anchor, div_2);
 	});
 }
 
 export function PortalWithMainContent() {
 	return _$_.tsrx_element((__anchor, __block) => {
-		var div_5 = root_4();
+		var div_4 = root_4();
 
 		{
-			var div_6 = _$_.child(div_5);
-			var node_2 = _$_.sibling(div_6);
+			var div_5 = _$_.child(div_4);
+			var node_2 = _$_.sibling(div_5);
 
 			_$_.render_component(Portal, node_2, {
 				get target() {
@@ -92,29 +92,29 @@ export function PortalWithMainContent() {
 				},
 
 				children: _$_.tsrx_element((__anchor, __block) => {
-					var div_7 = root_5();
+					var div_6 = root_5();
 
-					_$_.append(__anchor, div_7);
+					_$_.append(__anchor, div_6);
 				})
 			});
 
-			_$_.pop(div_5);
+			_$_.pop(div_4);
 		}
 
-		_$_.append(__anchor, div_5);
+		_$_.append(__anchor, div_4);
 	});
 }
 
 export function NestedContentWithPortal() {
 	return _$_.tsrx_element((__anchor, __block) => {
-		var div_8 = root_6();
+		var div_7 = root_6();
 
 		{
-			var div_9 = _$_.child(div_8);
+			var div_8 = _$_.child(div_7);
 
-			_$_.pop(div_9);
+			_$_.pop(div_8);
 
-			var node_3 = _$_.sibling(div_9);
+			var node_3 = _$_.sibling(div_8);
 
 			_$_.render_component(Portal, node_3, {
 				get target() {
@@ -122,16 +122,16 @@ export function NestedContentWithPortal() {
 				},
 
 				children: _$_.tsrx_element((__anchor, __block) => {
-					var div_10 = root_7();
+					var div_9 = root_7();
 
-					_$_.append(__anchor, div_10);
+					_$_.append(__anchor, div_9);
 				})
 			});
 
-			_$_.pop(div_8);
+			_$_.pop(div_7);
 		}
 
-		_$_.append(__anchor, div_8);
+		_$_.append(__anchor, div_7);
 	});
 }
 

--- a/packages/ripple/tests/hydration/compiled/client/reactivity.js
+++ b/packages/ripple/tests/hydration/compiled/client/reactivity.js
@@ -12,36 +12,36 @@ import { track } from 'ripple';
 export function TrackedState() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		let lazy = _$_.track(0, __block, 'c1818584');
-		var div_1 = root();
+		var div = root();
 
 		{
-			var expression = _$_.child(div_1);
+			var expression = _$_.child(div);
 
 			_$_.expression(expression, () => lazy.value);
-			_$_.pop(div_1);
+			_$_.pop(div);
 		}
 
-		_$_.append(__anchor, div_1);
+		_$_.append(__anchor, div);
 	});
 }
 
 export function CounterWithInitial(props) {
 	return _$_.tsrx_element((__anchor, __block) => {
 		let lazy_1 = _$_.track(props.initial, __block, '03ea4348');
-		var div_2 = root_1();
+		var div_1 = root_1();
 
 		{
-			var span_1 = _$_.child(div_2);
+			var span = _$_.child(div_1);
 
 			{
-				var expression_1 = _$_.child(span_1);
+				var expression_1 = _$_.child(span);
 
 				_$_.expression(expression_1, () => lazy_1.value);
-				_$_.pop(span_1);
+				_$_.pop(span);
 			}
 		}
 
-		_$_.append(__anchor, div_2);
+		_$_.append(__anchor, div_1);
 	});
 }
 
@@ -56,16 +56,16 @@ export function ComputedValues() {
 		let lazy_2 = _$_.track(2, __block, 'b78281db');
 		let lazy_3 = _$_.track(3, __block, 'a0cf6c6d');
 		const sum = () => lazy_2.value + lazy_3.value;
-		var div_3 = root_2();
+		var div_2 = root_2();
 
 		{
-			var expression_2 = _$_.child(div_3);
+			var expression_2 = _$_.child(div_2);
 
 			_$_.expression(expression_2, sum);
-			_$_.pop(div_3);
+			_$_.pop(div_2);
 		}
 
-		_$_.append(__anchor, div_3);
+		_$_.append(__anchor, div_2);
 	});
 }
 
@@ -74,38 +74,38 @@ export function MultipleTracked() {
 		let lazy_4 = _$_.track(10, __block, '843522de');
 		let lazy_5 = _$_.track(20, __block, '1308996d');
 		let lazy_6 = _$_.track(30, __block, '048c3fd0');
-		var div_4 = root_3();
+		var div_3 = root_3();
 
 		{
-			var div_5 = _$_.child(div_4);
+			var div_4 = _$_.child(div_3);
 
 			{
-				var expression_3 = _$_.child(div_5);
+				var expression_3 = _$_.child(div_4);
 
 				_$_.expression(expression_3, () => lazy_4.value);
+				_$_.pop(div_4);
+			}
+
+			var div_5 = _$_.sibling(div_4);
+
+			{
+				var expression_4 = _$_.child(div_5);
+
+				_$_.expression(expression_4, () => lazy_5.value);
 				_$_.pop(div_5);
 			}
 
 			var div_6 = _$_.sibling(div_5);
 
 			{
-				var expression_4 = _$_.child(div_6);
-
-				_$_.expression(expression_4, () => lazy_5.value);
-				_$_.pop(div_6);
-			}
-
-			var div_7 = _$_.sibling(div_6);
-
-			{
-				var expression_5 = _$_.child(div_7);
+				var expression_5 = _$_.child(div_6);
 
 				_$_.expression(expression_5, () => lazy_6.value);
-				_$_.pop(div_7);
+				_$_.pop(div_6);
 			}
 		}
 
-		_$_.append(__anchor, div_4);
+		_$_.append(__anchor, div_3);
 	});
 }
 
@@ -114,15 +114,15 @@ export function DerivedState() {
 		let lazy_7 = _$_.track('John', __block, '6015eeca');
 		let lazy_8 = _$_.track('Doe', __block, '4fa9a20e');
 		const fullName = () => `${lazy_7.value} ${lazy_8.value}`;
-		var div_8 = root_4();
+		var div_7 = root_4();
 
 		{
-			var expression_6 = _$_.child(div_8);
+			var expression_6 = _$_.child(div_7);
 
 			_$_.expression(expression_6, fullName);
-			_$_.pop(div_8);
+			_$_.pop(div_7);
 		}
 
-		_$_.append(__anchor, div_8);
+		_$_.append(__anchor, div_7);
 	});
 }

--- a/packages/ripple/tests/hydration/compiled/client/switch.js
+++ b/packages/ripple/tests/hydration/compiled/client/switch.js
@@ -35,21 +35,21 @@ export function SwitchStatic() {
 
 		{
 			var switch_case_0 = (__anchor) => {
-				var div_1 = root();
+				var div = root();
+
+				_$_.append(__anchor, div);
+			};
+
+			var switch_case_1 = (__anchor) => {
+				var div_1 = root_1();
 
 				_$_.append(__anchor, div_1);
 			};
 
-			var switch_case_1 = (__anchor) => {
-				var div_2 = root_1();
+			var switch_case_default = (__anchor) => {
+				var div_2 = root_2();
 
 				_$_.append(__anchor, div_2);
-			};
-
-			var switch_case_default = (__anchor) => {
-				var div_3 = root_2();
-
-				_$_.append(__anchor, div_3);
 			};
 
 			_$_.switch(
@@ -85,31 +85,31 @@ export function SwitchReactive() {
 
 		_$_.expression(node_1, () => _$_.tsrx_element((__anchor, __block) => {
 			var fragment_1 = root_4();
-			var button_1 = _$_.first_child_frag(fragment_1);
+			var button = _$_.first_child_frag(fragment_1);
 
-			button_1.__click = () => {
+			button.__click = () => {
 				if (lazy.value === 'a') _$_.set(lazy, 'b'); else if (lazy.value === 'b') _$_.set(lazy, 'c'); else _$_.set(lazy, 'a');
 			};
 
-			var node = _$_.sibling(button_1);
+			var node = _$_.sibling(button);
 
 			{
 				var switch_case_0_1 = (__anchor) => {
-					var div_4 = root_5();
+					var div_3 = root_5();
+
+					_$_.append(__anchor, div_3);
+				};
+
+				var switch_case_1_1 = (__anchor) => {
+					var div_4 = root_6();
 
 					_$_.append(__anchor, div_4);
 				};
 
-				var switch_case_1_1 = (__anchor) => {
-					var div_5 = root_6();
+				var switch_case_default_1 = (__anchor) => {
+					var div_5 = root_7();
 
 					_$_.append(__anchor, div_5);
-				};
-
-				var switch_case_default_1 = (__anchor) => {
-					var div_6 = root_7();
-
-					_$_.append(__anchor, div_6);
 				};
 
 				_$_.switch(node, () => {
@@ -144,15 +144,15 @@ export function SwitchFallthrough() {
 
 		{
 			var switch_case_0_2 = (__anchor) => {
-				var div_7 = root_8();
+				var div_6 = root_8();
 
-				_$_.append(__anchor, div_7);
+				_$_.append(__anchor, div_6);
 			};
 
 			var switch_case_default_2 = (__anchor) => {
-				var div_8 = root_9();
+				var div_7 = root_9();
 
-				_$_.append(__anchor, div_8);
+				_$_.append(__anchor, div_7);
 			};
 
 			_$_.switch(
@@ -187,31 +187,31 @@ export function SwitchNumericLevels() {
 
 		_$_.expression(node_3, () => _$_.tsrx_element((__anchor, __block) => {
 			var fragment_3 = root_11();
-			var button_2 = _$_.first_child_frag(fragment_3);
+			var button_1 = _$_.first_child_frag(fragment_3);
 
-			button_2.__click = () => {
+			button_1.__click = () => {
 				if (lazy_1.value === 1) _$_.set(lazy_1, 2); else if (lazy_1.value === 2) _$_.set(lazy_1, 3); else _$_.set(lazy_1, 1);
 			};
 
-			var node_2 = _$_.sibling(button_2);
+			var node_2 = _$_.sibling(button_1);
 
 			{
 				var switch_case_0_3 = (__anchor) => {
-					var div_9 = root_12();
+					var div_8 = root_12();
+
+					_$_.append(__anchor, div_8);
+				};
+
+				var switch_case_1_2 = (__anchor) => {
+					var div_9 = root_13();
 
 					_$_.append(__anchor, div_9);
 				};
 
-				var switch_case_1_2 = (__anchor) => {
-					var div_10 = root_13();
+				var switch_case_2 = (__anchor) => {
+					var div_10 = root_14();
 
 					_$_.append(__anchor, div_10);
-				};
-
-				var switch_case_2 = (__anchor) => {
-					var div_11 = root_14();
-
-					_$_.append(__anchor, div_11);
 				};
 
 				_$_.switch(node_2, () => {
@@ -248,31 +248,31 @@ export function SwitchBlockScoped() {
 
 		_$_.expression(node_5, () => _$_.tsrx_element((__anchor, __block) => {
 			var fragment_5 = root_16();
-			var button_3 = _$_.first_child_frag(fragment_5);
+			var button_2 = _$_.first_child_frag(fragment_5);
 
-			button_3.__click = () => {
+			button_2.__click = () => {
 				if (lazy_2.value === 1) _$_.set(lazy_2, 2); else if (lazy_2.value === 2) _$_.set(lazy_2, 3); else _$_.set(lazy_2, 1);
 			};
 
-			var node_4 = _$_.sibling(button_3);
+			var node_4 = _$_.sibling(button_2);
 
 			{
 				var switch_case_0_4 = (__anchor) => {
-					var div_12 = root_17();
+					var div_11 = root_17();
+
+					_$_.append(__anchor, div_11);
+				};
+
+				var switch_case_1_3 = (__anchor) => {
+					var div_12 = root_18();
 
 					_$_.append(__anchor, div_12);
 				};
 
-				var switch_case_1_3 = (__anchor) => {
-					var div_13 = root_18();
+				var switch_case_2_1 = (__anchor) => {
+					var div_13 = root_19();
 
 					_$_.append(__anchor, div_13);
-				};
-
-				var switch_case_2_1 = (__anchor) => {
-					var div_14 = root_19();
-
-					_$_.append(__anchor, div_14);
 				};
 
 				_$_.switch(node_4, () => {
@@ -309,31 +309,31 @@ export function SwitchNoBreak() {
 
 		_$_.expression(node_7, () => _$_.tsrx_element((__anchor, __block) => {
 			var fragment_7 = root_21();
-			var button_4 = _$_.first_child_frag(fragment_7);
+			var button_3 = _$_.first_child_frag(fragment_7);
 
-			button_4.__click = () => {
+			button_3.__click = () => {
 				if (lazy_3.value === 1) _$_.set(lazy_3, 2); else if (lazy_3.value === 2) _$_.set(lazy_3, 3); else _$_.set(lazy_3, 1);
 			};
 
-			var node_6 = _$_.sibling(button_4);
+			var node_6 = _$_.sibling(button_3);
 
 			{
 				var switch_case_0_5 = (__anchor) => {
-					var div_15 = root_22();
+					var div_14 = root_22();
+
+					_$_.append(__anchor, div_14);
+				};
+
+				var switch_case_1_4 = (__anchor) => {
+					var div_15 = root_23();
 
 					_$_.append(__anchor, div_15);
 				};
 
-				var switch_case_1_4 = (__anchor) => {
-					var div_16 = root_23();
+				var switch_case_2_2 = (__anchor) => {
+					var div_16 = root_24();
 
 					_$_.append(__anchor, div_16);
-				};
-
-				var switch_case_2_2 = (__anchor) => {
-					var div_17 = root_24();
-
-					_$_.append(__anchor, div_17);
 				};
 
 				_$_.switch(node_6, () => {

--- a/packages/ripple/tests/hydration/compiled/client/track-async-serialization.js
+++ b/packages/ripple/tests/hydration/compiled/client/track-async-serialization.js
@@ -33,16 +33,16 @@ const formatValue = function (...args) {
 function ServerCallResult({ count }) {
 	return _$_.tsrx_element((__anchor, __block) => {
 		let lazy = _$_.track_async(() => _$_.with_scope(__block, () => formatValue(count.value)), __block, '2e21cbe9');
-		var p_1 = root();
+		var p = root();
 
 		{
-			var expression = _$_.child(p_1);
+			var expression = _$_.child(p);
 
 			_$_.expression(expression, () => lazy.value);
-			_$_.pop(p_1);
+			_$_.pop(p);
 		}
 
-		_$_.append(__anchor, p_1);
+		_$_.append(__anchor, p);
 	});
 }
 
@@ -54,13 +54,13 @@ export function AsyncWithServerCall() {
 
 		_$_.expression(node_1, () => _$_.tsrx_element((__anchor, __block) => {
 			var fragment_1 = root_2();
-			var button_1 = _$_.first_child_frag(fragment_1);
+			var button = _$_.first_child_frag(fragment_1);
 
-			button_1.__click = () => {
+			button.__click = () => {
 				_$_.update(lazy_1);
 			};
 
-			var node = _$_.sibling(button_1);
+			var node = _$_.sibling(button);
 
 			_$_.try(
 				node,
@@ -73,9 +73,9 @@ export function AsyncWithServerCall() {
 				},
 				null,
 				(__anchor) => {
-					var p_2 = root_3();
+					var p_1 = root_3();
 
-					_$_.append(__anchor, p_2);
+					_$_.append(__anchor, p_1);
 				}
 			);
 
@@ -92,22 +92,22 @@ export function AsyncSimpleValue() {
 			__anchor,
 			(__anchor) => {
 				let lazy_2 = _$_.track_async(() => _$_.with_scope(__block, () => Promise.resolve('hydrated value')), __block, '4e502c38');
-				var p_3 = root_4();
+				var p_2 = root_4();
 
 				{
-					var expression_1 = _$_.child(p_3);
+					var expression_1 = _$_.child(p_2);
 
 					_$_.expression(expression_1, () => lazy_2.value);
-					_$_.pop(p_3);
+					_$_.pop(p_2);
 				}
 
-				_$_.append(__anchor, p_3);
+				_$_.append(__anchor, p_2);
 			},
 			null,
 			(__anchor) => {
-				var p_4 = root_5();
+				var p_3 = root_5();
 
-				_$_.append(__anchor, p_4);
+				_$_.append(__anchor, p_3);
 			},
 			true
 		);
@@ -120,22 +120,22 @@ export function AsyncNumericValue() {
 			__anchor,
 			(__anchor) => {
 				let lazy_3 = _$_.track_async(() => _$_.with_scope(__block, () => Promise.resolve(42)), __block, '14891754');
-				var span_1 = root_6();
+				var span = root_6();
 
 				{
-					var expression_2 = _$_.child(span_1);
+					var expression_2 = _$_.child(span);
 
 					_$_.expression(expression_2, () => lazy_3.value);
-					_$_.pop(span_1);
+					_$_.pop(span);
 				}
 
-				_$_.append(__anchor, span_1);
+				_$_.append(__anchor, span);
 			},
 			null,
 			(__anchor) => {
-				var span_2 = root_7();
+				var span_1 = root_7();
 
-				_$_.append(__anchor, span_2);
+				_$_.append(__anchor, span_1);
 			},
 			true
 		);
@@ -148,35 +148,35 @@ export function AsyncObjectValue() {
 			__anchor,
 			(__anchor) => {
 				let lazy_4 = _$_.track_async(() => _$_.with_scope(__block, () => Promise.resolve({ name: 'Alice', age: 30 })), __block, 'f325448a');
-				var div_1 = root_8();
+				var div = root_8();
 
 				{
-					var span_3 = _$_.child(div_1);
+					var span_2 = _$_.child(div);
 
 					{
-						var expression_3 = _$_.child(span_3);
+						var expression_3 = _$_.child(span_2);
 
 						_$_.expression(expression_3, () => lazy_4.value.name);
-						_$_.pop(span_3);
+						_$_.pop(span_2);
 					}
 
-					var span_4 = _$_.sibling(span_3);
+					var span_3 = _$_.sibling(span_2);
 
 					{
-						var expression_4 = _$_.child(span_4);
+						var expression_4 = _$_.child(span_3);
 
 						_$_.expression(expression_4, () => lazy_4.value.age);
-						_$_.pop(span_4);
+						_$_.pop(span_3);
 					}
 				}
 
-				_$_.append(__anchor, div_1);
+				_$_.append(__anchor, div);
 			},
 			null,
 			(__anchor) => {
-				var div_2 = root_9();
+				var div_1 = root_9();
 
-				_$_.append(__anchor, div_2);
+				_$_.append(__anchor, div_1);
 			},
 			true
 		);
@@ -190,35 +190,35 @@ export function AsyncMultipleValues() {
 			(__anchor) => {
 				let lazy_5 = _$_.track_async(() => _$_.with_scope(__block, () => Promise.resolve('alpha')), __block, 'ab8199a0');
 				let lazy_6 = _$_.track_async(() => _$_.with_scope(__block, () => Promise.resolve('beta')), __block, 'fb7ad40b');
-				var div_3 = root_10();
+				var div_2 = root_10();
 
 				{
-					var span_5 = _$_.child(div_3);
+					var span_4 = _$_.child(div_2);
 
 					{
-						var expression_5 = _$_.child(span_5);
+						var expression_5 = _$_.child(span_4);
 
 						_$_.expression(expression_5, () => lazy_5.value);
-						_$_.pop(span_5);
+						_$_.pop(span_4);
 					}
 
-					var span_6 = _$_.sibling(span_5);
+					var span_5 = _$_.sibling(span_4);
 
 					{
-						var expression_6 = _$_.child(span_6);
+						var expression_6 = _$_.child(span_5);
 
 						_$_.expression(expression_6, () => lazy_6.value);
-						_$_.pop(span_6);
+						_$_.pop(span_5);
 					}
 				}
 
-				_$_.append(__anchor, div_3);
+				_$_.append(__anchor, div_2);
 			},
 			null,
 			(__anchor) => {
-				var div_4 = root_11();
+				var div_3 = root_11();
 
-				_$_.append(__anchor, div_4);
+				_$_.append(__anchor, div_3);
 			},
 			true
 		);
@@ -231,33 +231,33 @@ export function AsyncWithCatch() {
 			__anchor,
 			(__anchor) => {
 				let lazy_7 = _$_.track_async(() => _$_.with_scope(__block, () => Promise.reject(new Error('fetch failed'))), __block, '99982de5');
-				var p_5 = root_12();
+				var p_4 = root_12();
 
 				{
-					var expression_7 = _$_.child(p_5);
+					var expression_7 = _$_.child(p_4);
 
 					_$_.expression(expression_7, () => lazy_7.value);
+					_$_.pop(p_4);
+				}
+
+				_$_.append(__anchor, p_4);
+			},
+			(__anchor, e) => {
+				var p_5 = root_13();
+
+				{
+					var expression_8 = _$_.child(p_5);
+
+					_$_.expression(expression_8, () => e.message);
 					_$_.pop(p_5);
 				}
 
 				_$_.append(__anchor, p_5);
 			},
-			(__anchor, e) => {
-				var p_6 = root_13();
-
-				{
-					var expression_8 = _$_.child(p_6);
-
-					_$_.expression(expression_8, () => e.message);
-					_$_.pop(p_6);
-				}
+			(__anchor) => {
+				var p_6 = root_14();
 
 				_$_.append(__anchor, p_6);
-			},
-			(__anchor) => {
-				var p_7 = root_14();
-
-				_$_.append(__anchor, p_7);
 			},
 			true
 		);
@@ -270,22 +270,22 @@ export function ChildWithError() {
 			__anchor,
 			(__anchor) => {
 				let lazy_8 = _$_.track_async(() => _$_.with_scope(__block, () => Promise.reject(new Error('child error'))), __block, '1dea4c85');
-				var p_8 = root_15();
+				var p_7 = root_15();
 
 				{
-					var expression_9 = _$_.child(p_8);
+					var expression_9 = _$_.child(p_7);
 
 					_$_.expression(expression_9, () => lazy_8.value);
-					_$_.pop(p_8);
+					_$_.pop(p_7);
 				}
 
-				_$_.append(__anchor, p_8);
+				_$_.append(__anchor, p_7);
 			},
 			null,
 			(__anchor) => {
-				var p_9 = root_16();
+				var p_8 = root_16();
 
-				_$_.append(__anchor, p_9);
+				_$_.append(__anchor, p_8);
 			},
 			true
 		);
@@ -300,16 +300,16 @@ export function ParentWithCatch() {
 				_$_.render_component(ChildWithError, __anchor, {});
 			},
 			(__anchor, e) => {
-				var p_10 = root_17();
+				var p_9 = root_17();
 
 				{
-					var expression_10 = _$_.child(p_10);
+					var expression_10 = _$_.child(p_9);
 
 					_$_.expression(expression_10, () => e.message);
-					_$_.pop(p_10);
+					_$_.pop(p_9);
 				}
 
-				_$_.append(__anchor, p_10);
+				_$_.append(__anchor, p_9);
 			},
 			null,
 			true
@@ -320,16 +320,16 @@ export function ParentWithCatch() {
 function ReactiveDependencyResult({ count }) {
 	return _$_.tsrx_element((__anchor, __block) => {
 		let lazy_9 = _$_.track_async(() => _$_.with_scope(__block, () => Promise.resolve(`count-${count.value}`)), __block, 'c9d12acf');
-		var p_11 = root_18();
+		var p_10 = root_18();
 
 		{
-			var expression_11 = _$_.child(p_11);
+			var expression_11 = _$_.child(p_10);
 
 			_$_.expression(expression_11, () => lazy_9.value);
-			_$_.pop(p_11);
+			_$_.pop(p_10);
 		}
 
-		_$_.append(__anchor, p_11);
+		_$_.append(__anchor, p_10);
 	});
 }
 
@@ -341,13 +341,13 @@ export function AsyncWithReactiveDependency() {
 
 		_$_.expression(node_3, () => _$_.tsrx_element((__anchor, __block) => {
 			var fragment_3 = root_20();
-			var button_2 = _$_.first_child_frag(fragment_3);
+			var button_1 = _$_.first_child_frag(fragment_3);
 
-			button_2.__click = () => {
+			button_1.__click = () => {
 				_$_.update(lazy_10);
 			};
 
-			var node_2 = _$_.sibling(button_2);
+			var node_2 = _$_.sibling(button_1);
 
 			_$_.try(
 				node_2,
@@ -360,9 +360,9 @@ export function AsyncWithReactiveDependency() {
 				},
 				null,
 				(__anchor) => {
-					var p_12 = root_21();
+					var p_11 = root_21();
 
-					_$_.append(__anchor, p_12);
+					_$_.append(__anchor, p_11);
 				}
 			);
 

--- a/packages/ripple/tests/hydration/compiled/client/try.js
+++ b/packages/ripple/tests/hydration/compiled/client/try.js
@@ -18,32 +18,32 @@ import { trackAsync } from 'ripple';
 
 export function RootPending() {
 	return _$_.tsrx_element((__anchor, __block) => {
-		var p_1 = root();
+		var p = root();
 
-		_$_.append(__anchor, p_1);
+		_$_.append(__anchor, p);
 	});
 }
 
 export function RootCatch({ error, reset }) {
 	return _$_.tsrx_element((__anchor, __block) => {
-		var section_1 = root_1();
+		var section = root_1();
 
 		{
-			var p_2 = _$_.child(section_1);
+			var p_1 = _$_.child(section);
 
 			{
-				var expression = _$_.child(p_2);
+				var expression = _$_.child(p_1);
 
 				_$_.expression(expression, () => error.message);
-				_$_.pop(p_2);
+				_$_.pop(p_1);
 			}
 
-			var button_1 = _$_.sibling(p_2);
+			var button = _$_.sibling(p_1);
 
-			_$_.event('Click', button_1, reset);
+			_$_.event('Click', button, reset);
 		}
 
-		_$_.append(__anchor, section_1);
+		_$_.append(__anchor, section);
 	});
 }
 
@@ -60,32 +60,32 @@ export function RootThrows() {
 export function RootAsyncDirect() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		let lazy = _$_.track_async(() => _$_.with_scope(__block, () => Promise.resolve('root async value')), __block, 'd6bf9e33');
-		var p_3 = root_3();
+		var p_2 = root_3();
 
 		{
-			var expression_1 = _$_.child(p_3);
+			var expression_1 = _$_.child(p_2);
 
 			_$_.expression(expression_1, () => lazy.value);
-			_$_.pop(p_3);
+			_$_.pop(p_2);
 		}
 
-		_$_.append(__anchor, p_3);
+		_$_.append(__anchor, p_2);
 	});
 }
 
 export function RootAsyncRejects() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		let lazy_1 = _$_.track_async(() => _$_.with_scope(__block, () => Promise.reject(new Error('root async failed'))), __block, 'd2fe7b64');
-		var p_4 = root_4();
+		var p_3 = root_4();
 
 		{
-			var expression_2 = _$_.child(p_4);
+			var expression_2 = _$_.child(p_3);
 
 			_$_.expression(expression_2, () => lazy_1.value);
-			_$_.pop(p_4);
+			_$_.pop(p_3);
 		}
 
-		_$_.append(__anchor, p_4);
+		_$_.append(__anchor, p_3);
 	});
 }
 
@@ -98,9 +98,9 @@ export function AsyncListInTryPending() {
 			},
 			null,
 			(__anchor) => {
-				var p_5 = root_5();
+				var p_4 = root_5();
 
-				_$_.append(__anchor, p_5);
+				_$_.append(__anchor, p_4);
 			},
 			true
 		);
@@ -110,31 +110,31 @@ export function AsyncListInTryPending() {
 function AsyncList() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		let lazy_2 = _$_.track_async(() => _$_.with_scope(__block, () => Promise.resolve(['alpha', 'beta', 'gamma'])), __block, 'b3d31627');
-		var ul_1 = root_6();
+		var ul = root_6();
 
 		{
 			_$_.for(
-				ul_1,
+				ul,
 				() => lazy_2.value,
 				(__anchor, item) => {
-					var li_1 = root_7();
+					var li = root_7();
 
 					{
-						var expression_3 = _$_.child(li_1);
+						var expression_3 = _$_.child(li);
 
 						_$_.expression(expression_3, () => item);
-						_$_.pop(li_1);
+						_$_.pop(li);
 					}
 
-					_$_.append(__anchor, li_1);
+					_$_.append(__anchor, li);
 				},
 				4
 			);
 
-			_$_.pop(ul_1);
+			_$_.pop(ul);
 		}
 
-		_$_.append(__anchor, ul_1);
+		_$_.append(__anchor, ul);
 	});
 }
 
@@ -145,8 +145,8 @@ export function AsyncTryWithLeadingSibling() {
 
 		_$_.expression(node_1, () => _$_.tsrx_element((__anchor, __block) => {
 			var fragment_2 = root_9();
-			var div_1 = _$_.first_child_frag(fragment_2);
-			var node = _$_.sibling(div_1);
+			var div = _$_.first_child_frag(fragment_2);
+			var node = _$_.sibling(div);
 
 			_$_.try(
 				node,
@@ -155,9 +155,9 @@ export function AsyncTryWithLeadingSibling() {
 				},
 				null,
 				(__anchor) => {
-					var div_2 = root_10();
+					var div_1 = root_10();
 
-					_$_.append(__anchor, div_2);
+					_$_.append(__anchor, div_1);
 				}
 			);
 
@@ -171,15 +171,15 @@ export function AsyncTryWithLeadingSibling() {
 function AsyncContent() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		let lazy_3 = _$_.track_async(() => _$_.with_scope(__block, () => Promise.resolve('ready')), __block, '15ea8758');
-		var div_3 = root_11();
+		var div_2 = root_11();
 
 		{
-			var expression_4 = _$_.child(div_3);
+			var expression_4 = _$_.child(div_2);
 
 			_$_.expression(expression_4, () => lazy_3.value);
-			_$_.pop(div_3);
+			_$_.pop(div_2);
 		}
 
-		_$_.append(__anchor, div_3);
+		_$_.append(__anchor, div_2);
 	});
 }

--- a/packages/tsrx-ripple/src/analyze/index.js
+++ b/packages/tsrx-ripple/src/analyze/index.js
@@ -1213,7 +1213,7 @@ function visit_function(node, context) {
 		const styleClasses = new Map();
 		/** @type {TopScopedClasses} */
 		const topScopedClasses = new Map();
-		const render_body = get_native_tsrx_function_body(node);
+		const render_body = get_native_tsrx_function_body(node, context.state.scopes);
 		const component_state = {
 			...context.state,
 			component: node,
@@ -1225,7 +1225,6 @@ function visit_function(node, context) {
 		context.next(component_state);
 
 		const css = collect_tsrx_stylesheet(render_body);
-		/** @type {any} */ (node).css = css;
 		/** @type {any} */ (node.metadata).css = css;
 
 		if (css !== null) {
@@ -1752,15 +1751,6 @@ const visitors = {
 	},
 
 	CallExpression(node, context) {
-		// bug in our acorn [parser]: it uses typeParameters instead of typeArguments
-		// @ts-expect-error
-		if (node.typeParameters) {
-			// @ts-expect-error
-			node.typeArguments = node.typeParameters;
-			// @ts-expect-error
-			delete node.typeParameters;
-		}
-
 		const callee = node.callee;
 
 		if (is_children_template_expression(/** @type {AST.Expression} */ (callee), context)) {
@@ -2026,8 +2016,11 @@ const visitors = {
 			if (state.to_ts || state.mode === 'server') {
 				pattern_id = pattern;
 			} else {
+				// The transforms substitute the generated pattern id for the
+				// destructured left when lowering a keyed @for — communicated
+				// via metadata rather than rewriting the source declaration.
 				pattern_id = b.id(scope.generate('pattern'));
-				/** @type {AST.VariableDeclaration} */ (node.left).declarations[0].id = pattern_id;
+				node.metadata.tsrx_for_pattern_id = pattern_id;
 			}
 
 			for (const path of paths) {
@@ -2156,14 +2149,6 @@ const visitors = {
 	},
 
 	TSTypeReference(node, context) {
-		// bug in our acorn parser: it uses typeParameters instead of typeArguments
-		// @ts-expect-error
-		if (node.typeParameters) {
-			// @ts-expect-error
-			node.typeArguments = node.typeParameters;
-			// @ts-expect-error
-			delete node.typeParameters;
-		}
 		context.next();
 	},
 
@@ -2756,10 +2741,11 @@ export function analyze(ast, filename, options = {}) {
 	const collect = !!(options.collect || options.loose);
 
 	// Template pre-passes: wrap value-position directives and lower `@{ … }`
-	// template children in place. Scope creation needs the lowered shapes (the
-	// code-block IIFEs carry bindings), so this must precede createScopes.
-	prepare_template_control_flow(ast);
-	lower_template_code_blocks(ast);
+	// template children. Scope creation needs the lowered shapes (the
+	// code-block IIFEs carry bindings), so this must precede createScopes. The
+	// passes are copy-on-write — the caller's parse tree is left pristine and
+	// everything downstream works on the rebuilt tree.
+	ast = lower_template_code_blocks(prepare_template_control_flow(ast));
 
 	const { scope, scopes } = createScopes(ast, scope_root, null, {
 		collect,

--- a/packages/tsrx-ripple/src/analyze/index.js
+++ b/packages/tsrx-ripple/src/analyze/index.js
@@ -63,7 +63,9 @@ import {
 	is_native_tsrx_function_node,
 	get_code_block_template_child,
 	is_template_child_position,
-	prepare_template_control_flow,
+	is_directive_render_position,
+	get_directive_value_wrapper,
+	analyze_directive_wrapping_values,
 	is_tsrx_component_function,
 } from '../utils.js';
 import {
@@ -1939,7 +1941,9 @@ const visitors = {
 	},
 
 	SwitchStatement: visit_switch_statement,
-	JSXSwitchExpression: visit_switch_statement,
+	JSXSwitchExpression(node, context) {
+		return analyze_directive_wrapping_values(node, context, visit_switch_statement);
+	},
 
 	ForOfStatement(node, context) {
 		if (context.state.regular_js || node.metadata?.regular_js) {
@@ -1975,6 +1979,14 @@ const visitors = {
 	 * @param {AnalysisContext} context
 	 */
 	JSXForExpression(node, context) {
+		const wrapper = node.metadata?.tsrx_value_wrapper;
+		if (
+			(!wrapper || !context.path.includes(wrapper)) &&
+			!is_directive_render_position(context.path.at(-1), node)
+		) {
+			context.visit(get_directive_value_wrapper(node));
+			return;
+		}
 		// `@for` covers for-of / for-in / for(;;): only the for-of form carries
 		// index/key bindings; the other forms analyze like their plain statements.
 		if (node.statementType === 'ForInStatement') {
@@ -2154,7 +2166,9 @@ const visitors = {
 	},
 
 	IfStatement: visit_if_statement,
-	JSXIfExpression: visit_if_statement,
+	JSXIfExpression(node, context) {
+		return analyze_directive_wrapping_values(node, context, visit_if_statement);
+	},
 
 	ReturnStatement(node, context) {
 		const parent = context.path.at(-1);
@@ -2307,7 +2321,9 @@ const visitors = {
 	},
 
 	TryStatement: visit_try_statement,
-	JSXTryExpression: visit_try_statement,
+	JSXTryExpression(node, context) {
+		return analyze_directive_wrapping_values(node, context, visit_try_statement);
+	},
 
 	ForInStatement(node, context) {
 		context.next();
@@ -2761,14 +2777,6 @@ export function analyze(ast, filename, options = {}) {
 	const errors = options.errors ?? [];
 	const comments = options.comments ?? [];
 	const collect = !!(options.collect || options.loose);
-
-	// Template pre-pass: wrap value-position directives in a render fragment.
-	// The pass is copy-on-write — the caller's parse tree is left pristine and
-	// everything downstream works on the rebuilt tree. (`@{ … }` template
-	// children need no pre-pass: they are lowered lazily, at their points of
-	// use, via the memoized get_code_block_template_child/get_code_block_render
-	// accessors.)
-	ast = prepare_template_control_flow(ast);
 
 	const { scope, scopes } = createScopes(ast, scope_root, null, {
 		collect,

--- a/packages/tsrx-ripple/src/analyze/index.js
+++ b/packages/tsrx-ripple/src/analyze/index.js
@@ -6,6 +6,7 @@
 	AnalysisContext,
 	Context,
 	ScopeInterface,
+	Visitor,
 	Visitors,
 	Binding,
 	TopScopedClasses,
@@ -71,7 +72,9 @@ import {
 	is_droppable_template_text,
 	is_dynamic_element,
 	is_empty_expression_container,
+	is_template_directive,
 	is_template_element,
+	is_template_else_if,
 	is_template_fragment,
 	is_template_text_or_expression,
 	rendered_template_children,
@@ -276,6 +279,7 @@ function mark_control_flow_has_template(path, node) {
 			node.type === 'TryStatement' ||
 			node.type === 'IfStatement' ||
 			node.type === 'SwitchStatement' ||
+			is_template_directive(node) ||
 			is_template_fragment(node)
 		) {
 			node.metadata.has_template = true;
@@ -313,6 +317,7 @@ function is_function_or_class_boundary(node) {
  */
 function is_loop_statement(node) {
 	return (
+		node.type === 'JSXForExpression' ||
 		node.type === 'ForOfStatement' ||
 		node.type === 'ForStatement' ||
 		node.type === 'ForInStatement' ||
@@ -338,7 +343,7 @@ function is_inside_component_for_of(path) {
 		// directive enforces the no-return/no-continue rule; a plain JS `for…of`
 		// is ordinary JavaScript, so stop and report it as not template-owned.
 		if (node.type === 'ForOfStatement') {
-			return node.metadata?.tsrxDirective === 'for';
+			return false;
 		}
 	}
 	return false;
@@ -354,13 +359,15 @@ function is_inside_template_if(path) {
 		if (is_function_or_class_boundary(node)) {
 			return false;
 		}
-		if (node.type === 'IfStatement' && node.metadata?.tsrxDirective === 'if') {
-			return true;
-		}
-		if (node.type === 'IfStatement' && /** @type {any} */ (node).statementType === 'IfStatement') {
-			return true;
-		}
 		if (node.type === 'JSXIfExpression') {
+			return true;
+		}
+		// An `@else if` chain link is template-owned; any other plain `if` is
+		// ordinary JavaScript the walk passes through.
+		if (
+			node.type === 'IfStatement' &&
+			is_template_else_if(node, /** @type {AST.Node[]} */ (path.slice(0, i)))
+		) {
 			return true;
 		}
 	}
@@ -401,7 +408,7 @@ function break_targets_component_loop(path) {
 		// Only a `@for` template directive forbids it; plain JS loops are ordinary
 		// JavaScript where `break` is allowed.
 		if (is_loop_statement(node)) {
-			return node.type === 'ForOfStatement' && node.metadata?.tsrxDirective === 'for';
+			return node.type === 'JSXForExpression';
 		}
 	}
 	return false;
@@ -1321,6 +1328,190 @@ function is_children_template_expression(expression, context) {
 	return is_children_template_expression_in_scope(expression, context.state.scope, component_scope);
 }
 
+/**
+ * Shared by the plain statement and the `@`-directive forms — the logic is
+ * (almost) entirely common; directive-ness is derived from the node type
+ * where it matters.
+ * @type {Visitor<AST.SwitchStatement | AST.JSXSwitchExpression, AnalysisState, AST.Node>}
+ */
+const visit_switch_statement = (node, context) => {
+	if (context.state.regular_js || node.metadata?.regular_js) {
+		return context.next({ ...context.state, regular_js: true, component: undefined });
+	}
+
+	if (!is_inside_component(context)) {
+		return context.next();
+	}
+
+	context.visit(node.discriminant, context.state);
+
+	for (const switch_case of node.cases) {
+		// Skip empty cases
+		if (switch_case.consequent.length === 0) {
+			continue;
+		}
+
+		node.metadata = {
+			...node.metadata,
+			has_template: false,
+		};
+
+		context.visit(switch_case, context.state);
+	}
+};
+
+/**
+ * Shared by the plain statement and the `@`-directive forms — the logic is
+ * (almost) entirely common; directive-ness is derived from the node type
+ * where it matters.
+ * @type {Visitor<AST.IfStatement | AST.JSXIfExpression, AnalysisState, AST.Node>}
+ */
+const visit_if_statement = (node, context) => {
+	if (context.state.regular_js || node.metadata?.regular_js) {
+		return context.next({ ...context.state, regular_js: true, component: undefined });
+	}
+
+	if (!is_inside_component(context)) {
+		return context.next();
+	}
+
+	const is_template_directive =
+		node.type === 'JSXIfExpression' ||
+		is_template_else_if(node, /** @type {AST.Node[]} */ (context.path));
+
+	node.metadata = {
+		...node.metadata,
+		has_template: false,
+		has_throw: false,
+		has_continue: false,
+	};
+
+	const test_metadata = { tracking: false };
+	context.visit(node.test, { ...context.state, metadata: test_metadata });
+	if (test_metadata.tracking) {
+		/** @type {AST.TrackedNode} */ (node.test).tracked = true;
+	}
+
+	context.visit(node.consequent, context.state);
+
+	const consequent_body =
+		node.consequent.type === 'BlockStatement' ? node.consequent.body : [node.consequent];
+
+	if (
+		consequent_body.length === 1 &&
+		consequent_body[0].type === 'ReturnStatement' &&
+		!node.alternate
+	) {
+		node.metadata.lone_return = true;
+	}
+
+	const consequent_script_only = is_script_only_control_flow_body(node.consequent);
+
+	let alternate_script_only = false;
+	if (node.alternate) {
+		const saved_has_return = node.metadata.has_return;
+		const saved_returns = node.metadata.returns;
+		const saved_has_continue = node.metadata.has_continue;
+		node.metadata.has_template = false;
+		node.metadata.has_throw = false;
+		node.metadata.has_continue = false;
+		context.visit(node.alternate, context.state);
+
+		alternate_script_only = is_script_only_control_flow_body(node.alternate);
+
+		if (saved_has_return) {
+			node.metadata.has_return = true;
+			if (saved_returns) {
+				node.metadata.returns = [...saved_returns, ...(node.metadata.returns || [])];
+			}
+		}
+		if (saved_has_continue) {
+			node.metadata.has_continue = true;
+		}
+	}
+
+	if (!is_template_directive) {
+		if (node.metadata.has_template && !node.metadata.has_return) {
+			error(
+				'TSRX elements and text inside JavaScript control flow blocks must use template directives. Use `@if`, `@for`, `@switch`, or `@try` for template control flow.',
+				context.state.analysis.module.filename,
+				node,
+				context.state.collect ? context.state.analysis.errors : undefined,
+				context.state.analysis.comments,
+			);
+		} else if (!node.metadata.has_template && !node.metadata.has_continue) {
+			node.metadata.regular_js = true;
+		}
+		return;
+	}
+
+	if (
+		!node.metadata.has_template &&
+		!node.metadata.has_return &&
+		!node.metadata.has_throw &&
+		!node.metadata.has_continue &&
+		consequent_script_only &&
+		(!node.alternate || alternate_script_only)
+	) {
+		node.metadata.script_only = true;
+	}
+};
+
+/**
+ * Shared by the plain statement and the `@`-directive forms — the logic is
+ * (almost) entirely common; directive-ness is derived from the node type
+ * where it matters.
+ * @type {Visitor<AST.TryStatement | AST.JSXTryExpression, AnalysisState, AST.Node>}
+ */
+const visit_try_statement = (node, context) => {
+	const { state } = context;
+	if (state.regular_js || node.metadata?.regular_js) {
+		return context.next({ ...state, regular_js: true, component: undefined });
+	}
+
+	if (!is_inside_component(context)) {
+		return context.next();
+	}
+
+	if (node.pending) {
+		node.metadata = {
+			...node.metadata,
+			has_template: false,
+		};
+
+		context.visit(node.block, state);
+
+		if (!node.metadata.has_template && is_script_only_control_flow_body(node.block)) {
+			node.metadata.script_only = true;
+		}
+
+		node.metadata = {
+			...node.metadata,
+			has_template: false,
+		};
+
+		context.visit(node.pending, state);
+
+		if (
+			(node.pending.body || []).length > 0 &&
+			!node.metadata.has_template &&
+			is_script_only_control_flow_body(node.pending)
+		) {
+			node.metadata.script_only = true;
+		}
+	} else {
+		context.visit(node.block, state);
+	}
+
+	if (node.handler) {
+		context.visit(node.handler, state);
+	}
+
+	if (node.finalizer) {
+		context.visit(node.finalizer, state);
+	}
+};
+
 /** @type {Visitors<AST.Node, AnalysisState>} */
 const visitors = {
 	_(node, { state, next, path }) {
@@ -1754,31 +1945,8 @@ const visitors = {
 		context.next();
 	},
 
-	SwitchStatement(node, context) {
-		if (context.state.regular_js || node.metadata?.regular_js) {
-			return context.next({ ...context.state, regular_js: true, component: undefined });
-		}
-
-		if (!is_inside_component(context)) {
-			return context.next();
-		}
-
-		context.visit(node.discriminant, context.state);
-
-		for (const switch_case of node.cases) {
-			// Skip empty cases
-			if (switch_case.consequent.length === 0) {
-				continue;
-			}
-
-			node.metadata = {
-				...node.metadata,
-				has_template: false,
-			};
-
-			context.visit(switch_case, context.state);
-		}
-	},
+	SwitchStatement: visit_switch_statement,
+	JSXSwitchExpression: visit_switch_statement,
 
 	ForOfStatement(node, context) {
 		if (context.state.regular_js || node.metadata?.regular_js) {
@@ -1789,25 +1957,46 @@ const visitors = {
 			return context.next();
 		}
 
-		const is_template_directive = node.metadata?.tsrxDirective === 'for';
-		if (!is_template_directive) {
-			node.metadata = {
-				...node.metadata,
-				has_template: false,
-			};
-			context.next();
-			if (node.metadata.has_template) {
-				error(
-					'TSRX elements and text inside JavaScript control flow blocks must use template directives. Use `@if`, `@for`, `@switch`, or `@try` for template control flow.',
-					context.state.analysis.module.filename,
-					node,
-					context.state.collect ? context.state.analysis.errors : undefined,
-					context.state.analysis.comments,
-				);
-			} else {
-				node.metadata.regular_js = true;
-			}
-			return;
+		node.metadata = {
+			...node.metadata,
+			has_template: false,
+		};
+		context.next();
+		if (node.metadata.has_template) {
+			error(
+				'TSRX elements and text inside JavaScript control flow blocks must use template directives. Use `@if`, `@for`, `@switch`, or `@try` for template control flow.',
+				context.state.analysis.module.filename,
+				node,
+				context.state.collect ? context.state.analysis.errors : undefined,
+				context.state.analysis.comments,
+			);
+		} else {
+			node.metadata.regular_js = true;
+		}
+	},
+
+	/**
+	 * A `@for` directive — index/key bindings are template concerns; a plain
+	 * JS `for…of` never carries them.
+	 * @param {any} node
+	 * @param {AnalysisContext} context
+	 */
+	JSXForExpression(node, context) {
+		// `@for` covers for-of / for-in / for(;;): only the for-of form carries
+		// index/key bindings; the other forms analyze like their plain statements.
+		if (node.statementType === 'ForInStatement') {
+			return visitors.ForInStatement?.(node, context);
+		}
+		if (node.statementType === 'ForStatement') {
+			return visitors.ForStatement?.(node, context);
+		}
+
+		if (context.state.regular_js || node.metadata?.regular_js) {
+			return context.next({ ...context.state, regular_js: true, component: undefined });
+		}
+
+		if (!is_inside_component(context)) {
+			return context.next();
 		}
 
 		if (node.index) {
@@ -1976,94 +2165,8 @@ const visitors = {
 		context.next();
 	},
 
-	IfStatement(node, context) {
-		if (context.state.regular_js || node.metadata?.regular_js) {
-			return context.next({ ...context.state, regular_js: true, component: undefined });
-		}
-
-		if (!is_inside_component(context)) {
-			return context.next();
-		}
-
-		const is_template_directive = node.metadata?.tsrxDirective === 'if';
-
-		node.metadata = {
-			...node.metadata,
-			has_template: false,
-			has_throw: false,
-			has_continue: false,
-		};
-
-		const test_metadata = { tracking: false };
-		context.visit(node.test, { ...context.state, metadata: test_metadata });
-		if (test_metadata.tracking) {
-			/** @type {AST.TrackedNode} */ (node.test).tracked = true;
-		}
-
-		context.visit(node.consequent, context.state);
-
-		const consequent_body =
-			node.consequent.type === 'BlockStatement' ? node.consequent.body : [node.consequent];
-
-		if (
-			consequent_body.length === 1 &&
-			consequent_body[0].type === 'ReturnStatement' &&
-			!node.alternate
-		) {
-			node.metadata.lone_return = true;
-		}
-
-		const consequent_script_only = is_script_only_control_flow_body(node.consequent);
-
-		let alternate_script_only = false;
-		if (node.alternate) {
-			const saved_has_return = node.metadata.has_return;
-			const saved_returns = node.metadata.returns;
-			const saved_has_continue = node.metadata.has_continue;
-			node.metadata.has_template = false;
-			node.metadata.has_throw = false;
-			node.metadata.has_continue = false;
-			context.visit(node.alternate, context.state);
-
-			alternate_script_only = is_script_only_control_flow_body(node.alternate);
-
-			if (saved_has_return) {
-				node.metadata.has_return = true;
-				if (saved_returns) {
-					node.metadata.returns = [...saved_returns, ...(node.metadata.returns || [])];
-				}
-			}
-			if (saved_has_continue) {
-				node.metadata.has_continue = true;
-			}
-		}
-
-		if (!is_template_directive) {
-			if (node.metadata.has_template && !node.metadata.has_return) {
-				error(
-					'TSRX elements and text inside JavaScript control flow blocks must use template directives. Use `@if`, `@for`, `@switch`, or `@try` for template control flow.',
-					context.state.analysis.module.filename,
-					node,
-					context.state.collect ? context.state.analysis.errors : undefined,
-					context.state.analysis.comments,
-				);
-			} else if (!node.metadata.has_template && !node.metadata.has_continue) {
-				node.metadata.regular_js = true;
-			}
-			return;
-		}
-
-		if (
-			!node.metadata.has_template &&
-			!node.metadata.has_return &&
-			!node.metadata.has_throw &&
-			!node.metadata.has_continue &&
-			consequent_script_only &&
-			(!node.alternate || alternate_script_only)
-		) {
-			node.metadata.script_only = true;
-		}
-	},
+	IfStatement: visit_if_statement,
+	JSXIfExpression: visit_if_statement,
 
 	ReturnStatement(node, context) {
 		const parent = context.path.at(-1);
@@ -2215,54 +2318,8 @@ const visitors = {
 		context.next();
 	},
 
-	TryStatement(node, context) {
-		const { state } = context;
-		if (state.regular_js || node.metadata?.regular_js) {
-			return context.next({ ...state, regular_js: true, component: undefined });
-		}
-
-		if (!is_inside_component(context)) {
-			return context.next();
-		}
-
-		if (node.pending) {
-			node.metadata = {
-				...node.metadata,
-				has_template: false,
-			};
-
-			context.visit(node.block, state);
-
-			if (!node.metadata.has_template && is_script_only_control_flow_body(node.block)) {
-				node.metadata.script_only = true;
-			}
-
-			node.metadata = {
-				...node.metadata,
-				has_template: false,
-			};
-
-			context.visit(node.pending, state);
-
-			if (
-				(node.pending.body || []).length > 0 &&
-				!node.metadata.has_template &&
-				is_script_only_control_flow_body(node.pending)
-			) {
-				node.metadata.script_only = true;
-			}
-		} else {
-			context.visit(node.block, state);
-		}
-
-		if (node.handler) {
-			context.visit(node.handler, state);
-		}
-
-		if (node.finalizer) {
-			context.visit(node.finalizer, state);
-		}
-	},
+	TryStatement: visit_try_statement,
+	JSXTryExpression: visit_try_statement,
 
 	ForInStatement(node, context) {
 		context.next();

--- a/packages/tsrx-ripple/src/analyze/index.js
+++ b/packages/tsrx-ripple/src/analyze/index.js
@@ -61,6 +61,8 @@ import {
 	get_native_tsrx_function_body,
 	is_native_tsrx_template_node,
 	is_native_tsrx_function_node,
+	lower_template_code_blocks,
+	prepare_template_control_flow,
 	is_tsrx_component_function,
 } from '../utils.js';
 import {
@@ -2752,6 +2754,12 @@ export function analyze(ast, filename, options = {}) {
 	const errors = options.errors ?? [];
 	const comments = options.comments ?? [];
 	const collect = !!(options.collect || options.loose);
+
+	// Template pre-passes: wrap value-position directives and lower `@{ … }`
+	// template children in place. Scope creation needs the lowered shapes (the
+	// code-block IIFEs carry bindings), so this must precede createScopes.
+	prepare_template_control_flow(ast);
+	lower_template_code_blocks(ast);
 
 	const { scope, scopes } = createScopes(ast, scope_root, null, {
 		collect,

--- a/packages/tsrx-ripple/src/analyze/index.js
+++ b/packages/tsrx-ripple/src/analyze/index.js
@@ -61,7 +61,8 @@ import {
 	get_native_tsrx_function_body,
 	is_native_tsrx_template_node,
 	is_native_tsrx_function_node,
-	lower_template_code_blocks,
+	get_code_block_template_child,
+	is_template_child_position,
 	prepare_template_control_flow,
 	is_tsrx_component_function,
 } from '../utils.js';
@@ -2661,6 +2662,27 @@ const visitors = {
 		context.next();
 	},
 
+	JSXCodeBlock(node, context) {
+		const parent = context.path.at(-1);
+
+		// A `@{ … }` in a template-children slot, or the render slot of another
+		// code block (an `@{ @{ … } }` chain), analyzes as its lowered template
+		// form — the same memoized node the transforms will consume, so scope
+		// bindings and component analysis attach to what actually renders.
+		if (
+			is_template_child_position(context.path, node) ||
+			(parent?.type === 'JSXCodeBlock' && /** @type {any} */ (parent).render === node)
+		) {
+			const child = get_code_block_template_child(node, context.state.scopes);
+			if (child != null && child !== node) {
+				context.visit(child);
+			}
+			return;
+		}
+
+		context.next();
+	},
+
 	AwaitExpression(node, context) {
 		const parent_block = get_parent_block_node(context);
 
@@ -2740,12 +2762,13 @@ export function analyze(ast, filename, options = {}) {
 	const comments = options.comments ?? [];
 	const collect = !!(options.collect || options.loose);
 
-	// Template pre-passes: wrap value-position directives and lower `@{ … }`
-	// template children. Scope creation needs the lowered shapes (the
-	// code-block IIFEs carry bindings), so this must precede createScopes. The
-	// passes are copy-on-write — the caller's parse tree is left pristine and
-	// everything downstream works on the rebuilt tree.
-	ast = lower_template_code_blocks(prepare_template_control_flow(ast));
+	// Template pre-pass: wrap value-position directives in a render fragment.
+	// The pass is copy-on-write — the caller's parse tree is left pristine and
+	// everything downstream works on the rebuilt tree. (`@{ … }` template
+	// children need no pre-pass: they are lowered lazily, at their points of
+	// use, via the memoized get_code_block_template_child/get_code_block_render
+	// accessors.)
+	ast = prepare_template_control_flow(ast);
 
 	const { scope, scopes } = createScopes(ast, scope_root, null, {
 		collect,

--- a/packages/tsrx-ripple/src/analyze/index.js
+++ b/packages/tsrx-ripple/src/analyze/index.js
@@ -1198,7 +1198,7 @@ function visit_function(node, context) {
 			}
 		}
 
-		/** @type {ESTreeJSX.JSXElement[]} */
+		/** @type {Array<AST.TSRXJSXElement | AST.JSXStyleElement>} */
 		const elements = [];
 		const metadata = {};
 		const styleClasses = new Map();
@@ -2276,10 +2276,6 @@ const visitors = {
 		context.next();
 	},
 
-	/**
-	 * @param {any} node
-	 * @param {AnalysisContext} context
-	 */
 	JSXFragment(node, context) {
 		if (context.state.regular_js) {
 			return context.next();
@@ -2289,10 +2285,6 @@ const visitors = {
 		return context.next();
 	},
 
-	/**
-	 * @param {any} node
-	 * @param {AnalysisContext} context
-	 */
 	JSXStyleElement(node, context) {
 		if (context.state.regular_js || node.metadata?.regular_js) {
 			return context.next({ ...context.state, regular_js: true, component: undefined });
@@ -2307,10 +2299,6 @@ const visitors = {
 		// Children are stylesheet AST — nothing to analyze.
 	},
 
-	/**
-	 * @param {any} node
-	 * @param {AnalysisContext} context
-	 */
 	JSXElement(node, context) {
 		// A raw (non-template) element — an attribute value or other JSX that
 		// never entered the template traversal.
@@ -2597,7 +2585,7 @@ const visitors = {
 
 		return {
 			...node,
-			children: node.children.map((/** @type {any} */ child) => visit(child)),
+			children: node.children.map((child) => visit(child)),
 		};
 	},
 

--- a/packages/tsrx-ripple/src/analyze/index.js
+++ b/packages/tsrx-ripple/src/analyze/index.js
@@ -2415,6 +2415,24 @@ const visitors = {
 		return context.next();
 	},
 
+	/**
+	 * @param {any} node
+	 * @param {AnalysisContext} context
+	 */
+	JSXStyleElement(node, context) {
+		if (context.state.regular_js || node.metadata?.regular_js) {
+			return context.next({ ...context.state, regular_js: true, component: undefined });
+		}
+
+		mark_control_flow_has_template(context.path, node);
+
+		if (context.state.elements) {
+			context.state.elements.push(node);
+		}
+
+		// Children are stylesheet AST — nothing to analyze.
+	},
+
 	Element(node, context) {
 		if (context.state.regular_js || node.metadata?.regular_js) {
 			return context.next({ ...context.state, regular_js: true, component: undefined });

--- a/packages/tsrx-ripple/src/analyze/index.js
+++ b/packages/tsrx-ripple/src/analyze/index.js
@@ -1228,7 +1228,7 @@ function visit_function(node, context) {
 		context.next(component_state);
 
 		const css = collect_tsrx_stylesheet(render_body);
-		/** @type {any} */ (node.metadata).css = css;
+		node.metadata.component_css = css;
 
 		if (css !== null) {
 			analyzeCss(css);
@@ -1245,7 +1245,7 @@ function visit_function(node, context) {
 				prune();
 			}
 			if (topScopedClasses.size > 0) {
-				/** @type {any} */ (node.metadata).topScopedClasses = topScopedClasses;
+				node.metadata.topScopedClasses = topScopedClasses;
 			}
 		}
 

--- a/packages/tsrx-ripple/src/analyze/index.js
+++ b/packages/tsrx-ripple/src/analyze/index.js
@@ -65,8 +65,11 @@ import {
 import {
 	get_attribute_name_node,
 	get_attribute_value,
+	get_element_attributes,
+	get_element_id,
 	get_template_expression,
 	is_droppable_template_text,
+	is_dynamic_element,
 	is_empty_expression_container,
 	is_template_fragment,
 	is_template_text_or_expression,
@@ -2443,12 +2446,14 @@ const visitors = {
 		}
 
 		const { state, visit, path } = context;
-		const is_dynamic_element = node.isDynamic === true;
+		const element_id = get_element_id(node);
+		const element_attributes = get_element_attributes(node);
+		const is_dynamic = is_dynamic_element(node);
 		const is_dom_element = is_element_dom_element(node);
 		// Dynamic tags (`<{expr}>`) resolve at runtime: scoped CSS pruning must
 		// keep type selectors (the tag could be any element) and collect the
 		// element so its classes match and receive the scope hash.
-		if (is_dynamic_element) {
+		if (is_dynamic) {
 			node.metadata.dynamicElement = true;
 		}
 		/** @type {Set<AST.Identifier>} */
@@ -2457,14 +2462,14 @@ const visitors = {
 		mark_control_flow_has_template(path, node);
 
 		if (
-			!is_dynamic_element &&
+			!is_dynamic &&
 			!is_dom_element &&
-			is_children_template_expression(/** @type {AST.Expression} */ (node.id), context)
+			is_children_template_expression(/** @type {AST.Expression} */ (element_id), context)
 		) {
 			error(
 				'`children` cannot be rendered as a component. Render it with `{children}` or `{props.children}` instead.',
 				state.analysis.module.filename,
-				node.id,
+				element_id,
 				context.state.collect ? context.state.analysis.errors : undefined,
 				context.state.analysis.comments,
 			);
@@ -2473,9 +2478,9 @@ const visitors = {
 		validateNesting(node, context);
 
 		if (is_dom_element) {
-			if (/** @type {AST.Identifier} */ (node.id).name === 'head') {
+			if (/** @type {AST.Identifier} */ (element_id).name === 'head') {
 				// head validation
-				if (node.attributes.length > 0) {
+				if (element_attributes.length > 0) {
 					// TODO: could transform attributes as something, e.g. Text Node, and avoid a fatal error
 					error('<head> cannot have any attributes', state.analysis.module.filename, node);
 				}
@@ -2491,7 +2496,7 @@ const visitors = {
 				return;
 			}
 			if (state.inside_head) {
-				if (/** @type {AST.Identifier} */ (node.id).name === 'title') {
+				if (/** @type {AST.Identifier} */ (element_id).name === 'title') {
 					const children = normalize_children(node.children, context);
 
 					if (children.length !== 1 || !is_template_text_or_expression(children[0])) {
@@ -2505,16 +2510,16 @@ const visitors = {
 				}
 
 				// check for invalid elements in head
-				if (!valid_in_head.has(/** @type {AST.Identifier} */ (node.id).name)) {
+				if (!valid_in_head.has(/** @type {AST.Identifier} */ (element_id).name)) {
 					// TODO: could transform invalid elements as something, e.g. Text Node, and avoid a fatal error
 					error(
-						`<${/** @type {AST.Identifier} */ (node.id).name}> cannot be used in <head>`,
+						`<${/** @type {AST.Identifier} */ (element_id).name}> cannot be used in <head>`,
 						state.analysis.module.filename,
 						node,
 					);
 				}
 			} else {
-				if (/** @type {AST.Identifier} */ (node.id).name === 'script') {
+				if (/** @type {AST.Identifier} */ (element_id).name === 'script') {
 					const err_msg = '<script> cannot be used outside of <head>.';
 					error(
 						err_msg,
@@ -2534,13 +2539,13 @@ const visitors = {
 				}
 			}
 
-			const is_void = isVoidElement(/** @type {AST.Identifier} */ (node.id).name);
+			const is_void = isVoidElement(/** @type {AST.Identifier} */ (element_id).name);
 
 			if (state.elements) {
 				state.elements.push(node);
 			}
 
-			for (const attr of node.attributes) {
+			for (const attr of element_attributes) {
 				if (attr.type === 'JSXAttribute') {
 					const attr_name = get_attribute_name_node(attr);
 					const attr_value = get_attribute_value(attr);
@@ -2613,7 +2618,7 @@ const visitors = {
 
 			if (is_void && rendered_template_children(node.children, !!state.to_ts).length > 0) {
 				error(
-					`The <${/** @type {AST.Identifier} */ (node.id).name}> element is a void element and cannot have children`,
+					`The <${/** @type {AST.Identifier} */ (element_id).name}> element is a void element and cannot have children`,
 					state.analysis.module.filename,
 					node,
 					context.state.collect ? context.state.analysis.errors : undefined,
@@ -2621,11 +2626,11 @@ const visitors = {
 				);
 			}
 		} else {
-			if (is_dynamic_element && state.elements) {
+			if (is_dynamic && state.elements) {
 				state.elements.push(node);
 			}
 
-			for (const attr of node.attributes) {
+			for (const attr of element_attributes) {
 				if (attr.type === 'JSXAttribute') {
 					attribute_names.add(get_attribute_name_node(attr));
 					const attr_value = get_attribute_value(attr);
@@ -2654,7 +2659,7 @@ const visitors = {
 
 			// Validate that parent element attributes don't reference child-declared components
 			if (child_component_names.size > 0) {
-				for (const attr of node.attributes) {
+				for (const attr of element_attributes) {
 					const attr_value = attr.type === 'JSXAttribute' ? get_attribute_value(attr) : null;
 					if (attr.type === 'JSXAttribute' && attr_value?.type === 'Identifier') {
 						if (child_component_names.has(attr_value.name)) {

--- a/packages/tsrx-ripple/src/analyze/index.js
+++ b/packages/tsrx-ripple/src/analyze/index.js
@@ -1586,8 +1586,10 @@ const visitors = {
 	Identifier(node, context) {
 		const binding = context.state.scope.get(node.name);
 		const parent = context.path.at(-1);
+		// The TSRX dialect allows an Identifier import source (`from server`),
+		// which the estree type for `source` (a Literal) does not model.
 		const is_import_source =
-			parent?.type === 'ImportDeclaration' && /** @type {any} */ (parent).source === node;
+			parent?.type === 'ImportDeclaration' && /** @type {AST.Node} */ (parent.source) === node;
 
 		if (
 			!is_import_source &&
@@ -1975,7 +1977,7 @@ const visitors = {
 	/**
 	 * A `@for` directive — index/key bindings are template concerns; a plain
 	 * JS `for…of` never carries them.
-	 * @param {any} node
+	 * @param {AST.JSXForExpression} node
 	 * @param {AnalysisContext} context
 	 */
 	JSXForExpression(node, context) {
@@ -1988,12 +1990,10 @@ const visitors = {
 			return;
 		}
 		// `@for` covers for-of / for-in / for(;;): only the for-of form carries
-		// index/key bindings; the other forms analyze like their plain statements.
-		if (node.statementType === 'ForInStatement') {
-			return visitors.ForInStatement?.(node, context);
-		}
-		if (node.statementType === 'ForStatement') {
-			return visitors.ForStatement?.(node, context);
+		// index/key bindings; the other forms analyze like their plain statements
+		// (an ordinary traversal, same as the ForInStatement/ForStatement visitors).
+		if (node.statementType !== 'ForOfStatement') {
+			return context.next();
 		}
 
 		if (context.state.regular_js || node.metadata?.regular_js) {

--- a/packages/tsrx-ripple/src/analyze/index.js
+++ b/packages/tsrx-ripple/src/analyze/index.js
@@ -71,6 +71,7 @@ import {
 	is_droppable_template_text,
 	is_dynamic_element,
 	is_empty_expression_container,
+	is_template_element,
 	is_template_fragment,
 	is_template_text_or_expression,
 	rendered_template_children,
@@ -83,124 +84,6 @@ const TRACKED_INDEX_VALUE_ERROR =
 	'Do not access tracked values with [0]. Use .value or &[] lazy destructuring instead. Numeric tracked access leads to degraded performance.';
 const TRACKED_INDEX_REFERENCE_ERROR =
 	'Do not access tracked values with [1]. Use the tracked value directly instead. Numeric tracked access leads to degraded performance.';
-
-/**
- * Ripple analysis still works with internal Element nodes after parser
- * normalization. Keep that compatibility local by presenting those nodes to the
- * shared CSS pruner as native JSX only during pruning.
- *
- * @param {AST.Node[]} nodes
- * @returns {() => void}
- */
-function prepare_legacy_nodes_for_css_pruning(nodes) {
-	/** @type {{ node: any, type: string, native_tsrx: unknown, had_native_tsrx: boolean }[]} */
-	const changed = [];
-	const seen = new Set();
-
-	/** @param {any} node */
-	function visit(node) {
-		if (!node || typeof node !== 'object' || seen.has(node)) {
-			return;
-		}
-		seen.add(node);
-
-		if (node.type === 'Element') {
-			node.metadata ??= { path: [] };
-			changed.push({
-				node,
-				type: node.type,
-				native_tsrx: node.metadata.native_tsrx,
-				had_native_tsrx: Object.prototype.hasOwnProperty.call(node.metadata, 'native_tsrx'),
-			});
-			node.type = 'JSXElement';
-			node.metadata.native_tsrx = true;
-		}
-
-		if (Array.isArray(node.children)) {
-			for (const child of node.children) {
-				visit(child);
-			}
-		}
-	}
-
-	for (const node of nodes) {
-		visit(node);
-	}
-
-	return () => {
-		for (let i = changed.length - 1; i >= 0; i--) {
-			const entry = changed[i];
-			entry.node.type = entry.type;
-			if (entry.had_native_tsrx) {
-				entry.node.metadata.native_tsrx = entry.native_tsrx;
-			} else {
-				delete entry.node.metadata.native_tsrx;
-			}
-		}
-	};
-}
-
-/**
- * Scope creation lives in @tsrx/core and only understands JSX-shaped native
- * TSRX nodes. Ripple still normalizes to internal Element nodes before
- * analysis, so present them as JSX only while scopes are created.
- *
- * @param {AST.Node} node
- * @returns {() => void}
- */
-function prepare_legacy_nodes_for_core_scopes(node) {
-	/** @type {{ node: any, type: string, native_tsrx: unknown, had_native_tsrx: boolean }[]} */
-	const changed = [];
-	const seen = new Set();
-
-	/** @param {any} current */
-	function visit(current) {
-		if (!current || typeof current !== 'object' || seen.has(current)) {
-			return;
-		}
-		seen.add(current);
-
-		if (current.type === 'Element') {
-			current.metadata ??= { path: [] };
-			changed.push({
-				node: current,
-				type: current.type,
-				native_tsrx: current.metadata.native_tsrx,
-				had_native_tsrx: Object.prototype.hasOwnProperty.call(current.metadata, 'native_tsrx'),
-			});
-			current.type = 'JSXElement';
-			current.metadata.native_tsrx = true;
-		}
-
-		for (const key in current) {
-			if (key === 'parent' || key === 'loc' || key === 'range' || key === 'metadata') {
-				continue;
-			}
-			const value = current[key];
-			if (Array.isArray(value)) {
-				for (const child of value) {
-					visit(child);
-				}
-			} else if (value && typeof value === 'object') {
-				visit(value);
-			}
-		}
-	}
-
-	visit(node);
-
-	return () => {
-		for (let i = changed.length - 1; i >= 0; i--) {
-			const entry = changed[i];
-			entry.node.type = entry.type;
-			if (entry.had_native_tsrx) {
-				entry.node.metadata.native_tsrx = entry.native_tsrx;
-			} else {
-				delete entry.node.metadata.native_tsrx;
-			}
-		}
-	};
-}
 
 const mutating_method_names = new Set([
 	'add',
@@ -218,9 +101,6 @@ const mutating_method_names = new Set([
 	'splice',
 	'unshift',
 ]);
-
-const TEMPLATE_FRAGMENT_ERROR =
-	'JSX fragment syntax is not needed in TSRX templates. TSRX renders in immediate mode, so everything is already a fragment. Use `<>...</>` only in expression position.';
 
 /**
  * @param {AST.MemberExpression} node
@@ -497,7 +377,7 @@ function is_inside_template_child(path) {
 		if (is_function_or_class_boundary(node)) {
 			return false;
 		}
-		if (node.type === 'Element' || is_template_fragment(node)) {
+		if (is_template_element(node) || is_template_fragment(node)) {
 			return true;
 		}
 	}
@@ -1342,13 +1222,8 @@ function visit_function(node, context) {
 		if (css !== null) {
 			analyzeCss(css);
 			const prune = () => {
-				const restore_nodes = prepare_legacy_nodes_for_css_pruning(elements);
-				try {
-					for (const element of elements) {
-						pruneCss(css, element, styleClasses, topScopedClasses);
-					}
-				} finally {
-					restore_nodes();
+				for (const element of elements) {
+					pruneCss(css, element, styleClasses, topScopedClasses);
 				}
 			};
 			prune();
@@ -2401,10 +2276,6 @@ const visitors = {
 		context.next();
 	},
 
-	JSXElement(node, context) {
-		return context.next();
-	},
-
 	/**
 	 * @param {any} node
 	 * @param {AnalysisContext} context
@@ -2436,13 +2307,15 @@ const visitors = {
 		// Children are stylesheet AST — nothing to analyze.
 	},
 
-	Element(node, context) {
-		if (context.state.regular_js || node.metadata?.regular_js) {
-			return context.next({ ...context.state, regular_js: true, component: undefined });
+	JSXElement(node, context) {
+		// A raw (non-template) element — an attribute value or other JSX that
+		// never entered the template traversal.
+		if (!is_template_element(node)) {
+			return context.next();
 		}
 
-		if (!node.id) {
-			error(TEMPLATE_FRAGMENT_ERROR, context.state.analysis.module.filename, node);
+		if (context.state.regular_js || node.metadata?.regular_js) {
+			return context.next({ ...context.state, regular_js: true, component: undefined });
 		}
 
 		const { state, visit, path } = context;
@@ -2831,19 +2704,12 @@ export function analyze(ast, filename, options = {}) {
 	const comments = options.comments ?? [];
 	const collect = !!(options.collect || options.loose);
 
-	const restore_scope_nodes = prepare_legacy_nodes_for_core_scopes(ast);
-	let scope;
-	let scopes;
-	try {
-		({ scope, scopes } = createScopes(ast, scope_root, null, {
-			collect,
-			errors,
-			filename,
-			comments,
-		}));
-	} finally {
-		restore_scope_nodes();
-	}
+	const { scope, scopes } = createScopes(ast, scope_root, null, {
+		collect,
+		errors,
+		filename,
+		comments,
+	});
 
 	const analysis = /** @type {AnalysisResult} */ ({
 		module: { ast, scope, scopes, filename },

--- a/packages/tsrx-ripple/src/analyze/index.js
+++ b/packages/tsrx-ripple/src/analyze/index.js
@@ -1198,7 +1198,7 @@ function visit_function(node, context) {
 			}
 		}
 
-		/** @type {AST.Element[]} */
+		/** @type {ESTreeJSX.JSXElement[]} */
 		const elements = [];
 		const metadata = {};
 		const styleClasses = new Map();
@@ -2307,6 +2307,10 @@ const visitors = {
 		// Children are stylesheet AST — nothing to analyze.
 	},
 
+	/**
+	 * @param {any} node
+	 * @param {AnalysisContext} context
+	 */
 	JSXElement(node, context) {
 		// A raw (non-template) element — an attribute value or other JSX that
 		// never entered the template traversal.
@@ -2593,7 +2597,7 @@ const visitors = {
 
 		return {
 			...node,
-			children: node.children.map((child) => visit(child)),
+			children: node.children.map((/** @type {any} */ child) => visit(child)),
 		};
 	},
 

--- a/packages/tsrx-ripple/src/analyze/index.js
+++ b/packages/tsrx-ripple/src/analyze/index.js
@@ -63,6 +63,8 @@ import {
 	is_tsrx_component_function,
 } from '../utils.js';
 import {
+	get_attribute_name_node,
+	get_attribute_value,
 	get_template_expression,
 	is_droppable_template_text,
 	is_empty_expression_container,
@@ -2528,10 +2530,12 @@ const visitors = {
 			}
 
 			for (const attr of node.attributes) {
-				if (attr.type === 'Attribute') {
-					if (attr.value && attr.value.type === 'JSXEmptyExpression') {
+				if (attr.type === 'JSXAttribute') {
+					const attr_name = get_attribute_name_node(attr);
+					const attr_value = get_attribute_value(attr);
+					if (attr_value && attr_value.type === 'JSXEmptyExpression') {
 						const value = /** @type {ESTreeJSX.JSXEmptyExpression & AST.NodeWithLocation} */ (
-							attr.value
+							attr_value
 						);
 						error(
 							'attributes must only be assigned a non-empty expression',
@@ -2555,45 +2559,43 @@ const visitors = {
 							context.state.analysis.comments,
 						);
 					}
-					if (attr.name.type === 'Identifier') {
-						attribute_names.add(attr.name);
+					attribute_names.add(attr_name);
 
-						if (attr.name.name === 'key') {
+					if (attr_name.name === 'key') {
+						error(
+							'The `key` attribute is not a thing in Ripple, and cannot be used on DOM elements. If you are using a for loop, then use the `for (let item of items; key item.id)` syntax.',
+							state.analysis.module.filename,
+							attr,
+							context.state.collect ? context.state.analysis.errors : undefined,
+							context.state.analysis.comments,
+						);
+					}
+
+					if (isEventAttribute(attr_name.name)) {
+						if (attr_value === null) {
+							// A regular attribute can have no value (like `hidden`), but an
+							// event attribute like `<div onC>` has no handler to run
 							error(
-								'The `key` attribute is not a thing in Ripple, and cannot be used on DOM elements. If you are using a for loop, then use the `for (let item of items; key item.id)` syntax.',
+								`the \`${attr_name.name}\` event attribute must be assigned a handler expression`,
 								state.analysis.module.filename,
 								attr,
 								context.state.collect ? context.state.analysis.errors : undefined,
 								context.state.analysis.comments,
 							);
-						}
+						} else {
+							const handler = visit(/** @type {AST.Expression} */ (attr_value), state);
+							const is_delegated = is_delegated_event(attr_name.name, handler, context);
 
-						if (isEventAttribute(attr.name.name)) {
-							if (attr.value === null) {
-								// A regular attribute can have no value (like `hidden`), but an
-								// event attribute like `<div onC>` has no handler to run
-								error(
-									`the \`${attr.name.name}\` event attribute must be assigned a handler expression`,
-									state.analysis.module.filename,
-									attr,
-									context.state.collect ? context.state.analysis.errors : undefined,
-									context.state.analysis.comments,
-								);
-							} else {
-								const handler = visit(/** @type {AST.Expression} */ (attr.value), state);
-								const is_delegated = is_delegated_event(attr.name.name, handler, context);
-
-								if (is_delegated) {
-									if (attr.metadata === undefined) {
-										attr.metadata = { path: [...path] };
-									}
-
-									attr.metadata.delegated = is_delegated;
+							if (is_delegated) {
+								if (attr.metadata === undefined) {
+									attr.metadata = { path: [...path] };
 								}
+
+								attr.metadata.delegated = is_delegated;
 							}
-						} else if (attr.value !== null) {
-							visit(attr.value, state);
 						}
+					} else if (attr_value !== null) {
+						visit(attr_value, state);
 					}
 				}
 			}
@@ -2613,14 +2615,13 @@ const visitors = {
 			}
 
 			for (const attr of node.attributes) {
-				if (attr.type === 'Attribute') {
-					if (attr.name.type === 'Identifier') {
-						attribute_names.add(attr.name);
+				if (attr.type === 'JSXAttribute') {
+					attribute_names.add(get_attribute_name_node(attr));
+					const attr_value = get_attribute_value(attr);
+					if (attr_value !== null) {
+						visit(attr_value, state);
 					}
-					if (attr.value !== null) {
-						visit(attr.value, state);
-					}
-				} else if (attr.type === 'SpreadAttribute') {
+				} else if (attr.type === 'JSXSpreadAttribute') {
 					visit(attr.argument, state);
 				}
 			}
@@ -2643,21 +2644,18 @@ const visitors = {
 			// Validate that parent element attributes don't reference child-declared components
 			if (child_component_names.size > 0) {
 				for (const attr of node.attributes) {
-					if (
-						attr.type === 'Attribute' &&
-						attr.value !== null &&
-						attr.value.type === 'Identifier'
-					) {
-						if (child_component_names.has(attr.value.name)) {
+					const attr_value = attr.type === 'JSXAttribute' ? get_attribute_value(attr) : null;
+					if (attr.type === 'JSXAttribute' && attr_value?.type === 'Identifier') {
+						if (child_component_names.has(attr_value.name)) {
 							error(
-								`Cannot use component '${attr.value.name}' as a prop on its parent element. Component declarations inside children are not in scope for the parent element's attributes.`,
+								`Cannot use component '${attr_value.name}' as a prop on its parent element. Component declarations inside children are not in scope for the parent element's attributes.`,
 								state.analysis.module.filename,
-								attr.value,
+								attr_value,
 								context.state.collect ? context.state.analysis.errors : undefined,
 								context.state.analysis.comments,
 							);
 						}
-					} else if (attr.type === 'SpreadAttribute' && attr.argument.type === 'Identifier') {
+					} else if (attr.type === 'JSXSpreadAttribute' && attr.argument.type === 'Identifier') {
 						if (child_component_names.has(attr.argument.name)) {
 							error(
 								`Cannot use component '${attr.argument.name}' as a prop on its parent element. Component declarations inside children are not in scope for the parent element's attributes.`,

--- a/packages/tsrx-ripple/src/analyze/index.js
+++ b/packages/tsrx-ripple/src/analyze/index.js
@@ -62,6 +62,13 @@ import {
 	is_native_tsrx_function_node,
 	is_tsrx_component_function,
 } from '../utils.js';
+import {
+	get_template_expression,
+	is_droppable_template_text,
+	is_empty_expression_container,
+	is_template_text_or_expression,
+	rendered_template_children,
+} from '../template-ast.js';
 import is_reference from 'is-reference';
 
 const valid_in_head = new Set(['title', 'base', 'link', 'meta', 'style', 'script', 'noscript']);
@@ -2459,7 +2466,7 @@ const visitors = {
 					// TODO: could transform attributes as something, e.g. Text Node, and avoid a fatal error
 					error('<head> cannot have any attributes', state.analysis.module.filename, node);
 				}
-				if (node.children.length === 0) {
+				if (rendered_template_children(node.children, !!state.to_ts).length === 0) {
 					// TODO: could transform children as something, e.g. Text Node, and avoid a fatal error
 					error('<head> must have children', state.analysis.module.filename, node);
 				}
@@ -2474,10 +2481,7 @@ const visitors = {
 				if (/** @type {AST.Identifier} */ (node.id).name === 'title') {
 					const children = normalize_children(node.children, context);
 
-					if (
-						children.length !== 1 ||
-						(children[0].type !== 'TSRXExpression' && children[0].type !== 'Text')
-					) {
+					if (children.length !== 1 || !is_template_text_or_expression(children[0])) {
 						// TODO: could transform children as something, e.g. Text Node, and avoid a fatal error
 						error(
 							'<title> must have only contain text nodes',
@@ -2594,7 +2598,7 @@ const visitors = {
 				}
 			}
 
-			if (is_void && node.children.length > 0) {
+			if (is_void && rendered_template_children(node.children, !!state.to_ts).length > 0) {
 				error(
 					`The <${/** @type {AST.Identifier} */ (node.id).name}> element is a void element and cannot have children`,
 					state.analysis.module.filename,
@@ -2670,9 +2674,15 @@ const visitors = {
 			for (const child of node.children) {
 				if (is_native_tsrx_function_node(child)) {
 					visit(child, state);
-				} else if (child.type !== 'EmptyStatement') {
+				} else if (
+					child.type !== 'EmptyStatement' &&
+					!is_droppable_template_text(child, !!state.to_ts) &&
+					!is_empty_expression_container(child)
+				) {
 					implicit_children.push(
-						child.type === 'TSRXExpression' || child.type === 'Text' ? child.expression : child,
+						is_template_text_or_expression(child)
+							? get_template_expression(child, !!state.to_ts)
+							: child,
 					);
 				}
 			}
@@ -2700,31 +2710,29 @@ const visitors = {
 		};
 	},
 
-	TSRXExpression(node, context) {
+	JSXExpressionContainer(node, context) {
 		if (context.state.regular_js) {
 			return context.next();
 		}
 
-		mark_control_flow_has_template(context.path, node);
+		// A `{/* comment */}` container renders nothing — it must not mark the
+		// surrounding control flow as templated.
+		if (!is_empty_expression_container(node)) {
+			mark_control_flow_has_template(context.path, node);
+		}
 
 		context.next();
 	},
 
-	Text(node, context) {
+	JSXText(node, context) {
 		if (context.state.regular_js) {
 			return context.next();
 		}
 
-		mark_control_flow_has_template(context.path, node);
-
-		if (is_children_template_expression(/** @type {AST.Expression} */ (node.expression), context)) {
-			error(
-				'`children` cannot be rendered using explicit text interpolation. Use `{children}` or `{props.children}` instead.',
-				context.state.analysis.module.filename,
-				node.expression,
-				context.state.collect ? context.state.analysis.errors : undefined,
-				context.state.analysis.comments,
-			);
+		// Insignificant whitespace collapses to nothing at runtime — it must not
+		// mark the surrounding control flow as templated.
+		if (!is_droppable_template_text(node, !!context.state.to_ts)) {
+			mark_control_flow_has_template(context.path, node);
 		}
 
 		context.next();

--- a/packages/tsrx-ripple/src/analyze/index.js
+++ b/packages/tsrx-ripple/src/analyze/index.js
@@ -68,6 +68,7 @@ import {
 	get_template_expression,
 	is_droppable_template_text,
 	is_empty_expression_container,
+	is_template_fragment,
 	is_template_text_or_expression,
 	rendered_template_children,
 } from '../template-ast.js';
@@ -138,8 +139,8 @@ function prepare_legacy_nodes_for_css_pruning(nodes) {
 
 /**
  * Scope creation lives in @tsrx/core and only understands JSX-shaped native
- * TSRX nodes. Ripple still normalizes to internal Element/TsrxFragment nodes
- * before analysis, so present them as JSX only while scopes are created.
+ * TSRX nodes. Ripple still normalizes to internal Element nodes before
+ * analysis, so present them as JSX only while scopes are created.
  *
  * @param {AST.Node} node
  * @returns {() => void}
@@ -156,7 +157,7 @@ function prepare_legacy_nodes_for_core_scopes(node) {
 		}
 		seen.add(current);
 
-		if (current.type === 'Element' || current.type === 'TsrxFragment') {
+		if (current.type === 'Element') {
 			current.metadata ??= { path: [] };
 			changed.push({
 				node: current,
@@ -164,7 +165,7 @@ function prepare_legacy_nodes_for_core_scopes(node) {
 				native_tsrx: current.metadata.native_tsrx,
 				had_native_tsrx: Object.prototype.hasOwnProperty.call(current.metadata, 'native_tsrx'),
 			});
-			current.type = current.type === 'Element' ? 'JSXElement' : 'JSXFragment';
+			current.type = 'JSXElement';
 			current.metadata.native_tsrx = true;
 		}
 
@@ -392,7 +393,7 @@ function mark_control_flow_has_template(path, node) {
 			node.type === 'TryStatement' ||
 			node.type === 'IfStatement' ||
 			node.type === 'SwitchStatement' ||
-			node.type === 'TsrxFragment'
+			is_template_fragment(node)
 		) {
 			node.metadata.has_template = true;
 		}
@@ -493,7 +494,7 @@ function is_inside_template_child(path) {
 		if (is_function_or_class_boundary(node)) {
 			return false;
 		}
-		if (node.type === 'Element' || node.type === 'TsrxFragment') {
+		if (node.type === 'Element' || is_template_fragment(node)) {
 			return true;
 		}
 	}
@@ -2401,19 +2402,11 @@ const visitors = {
 		return context.next();
 	},
 
-	JSXFragment(node, context) {
-		if (!node.metadata?.native_tsrx) {
-			return context.next();
-		}
-
-		error(TEMPLATE_FRAGMENT_ERROR, context.state.analysis.module.filename, node);
-	},
-
 	/**
 	 * @param {any} node
 	 * @param {AnalysisContext} context
 	 */
-	TsrxFragment(node, context) {
+	JSXFragment(node, context) {
 		if (context.state.regular_js) {
 			return context.next();
 		}

--- a/packages/tsrx-ripple/src/analyze/index.js
+++ b/packages/tsrx-ripple/src/analyze/index.js
@@ -2687,7 +2687,7 @@ const visitors = {
 		// bindings and component analysis attach to what actually renders.
 		if (
 			is_template_child_position(context.path, node) ||
-			(parent?.type === 'JSXCodeBlock' && /** @type {any} */ (parent).render === node)
+			(parent?.type === 'JSXCodeBlock' && parent.render === node)
 		) {
 			const child = get_code_block_template_child(node, context.state.scopes);
 			if (child != null && child !== node) {

--- a/packages/tsrx-ripple/src/index.js
+++ b/packages/tsrx-ripple/src/index.js
@@ -6,7 +6,7 @@ import { createVolarMappingsResult, parseModule } from '@tsrx/core';
 import { analyze } from './analyze/index.js';
 import { transform_client } from './transform/client/index.js';
 import { transform_server } from './transform/server/index.js';
-import { normalize_jsx_tsrx_templates } from './utils.js';
+import { lower_template_code_blocks, prepare_template_control_flow } from './utils.js';
 
 /**
  * Parse Ripple source code to ESTree AST
@@ -17,35 +17,7 @@ import { normalize_jsx_tsrx_templates } from './utils.js';
  * @returns {AST.Program}
  */
 export function parse(source, filename, options) {
-	const ast = parseModule(source, filename, options);
-	normalize_jsx_tsrx_templates(ast);
-	strip_metadata_paths(ast);
-	return ast;
-}
-
-/**
- * Public parse results should be JSON/stringify friendly. Internal transforms
- * keep metadata.path through compile(), but parse() callers do not need the
- * circular ancestor arrays.
- * @param {any} node
- * @param {WeakSet<object>} [seen]
- * @returns {void}
- */
-function strip_metadata_paths(node, seen = new WeakSet()) {
-	if (!node || typeof node !== 'object' || seen.has(node)) return;
-	seen.add(node);
-	if (node.metadata?.path) {
-		delete node.metadata.path;
-	}
-	for (const key in node) {
-		if (key === 'parent') continue;
-		const value = node[key];
-		if (Array.isArray(value)) {
-			for (const child of value) strip_metadata_paths(child, seen);
-		} else if (value && typeof value === 'object') {
-			strip_metadata_paths(value, seen);
-		}
-	}
+	return parseModule(source, filename, options);
 }
 
 /**
@@ -64,7 +36,8 @@ export function compile(source, filename, options = {}) {
 		filename,
 		collect ? { ...options, collect, errors, comments } : undefined,
 	);
-	normalize_jsx_tsrx_templates(ast);
+	prepare_template_control_flow(ast);
+	lower_template_code_blocks(ast);
 	const analysis = analyze(
 		ast,
 		filename,
@@ -117,7 +90,8 @@ export function compile_to_volar_mappings(source, filename, options = {}) {
 		comments,
 	});
 	const ast_from_source = structuredClone(ast);
-	normalize_jsx_tsrx_templates(ast, { to_ts: true });
+	prepare_template_control_flow(ast);
+	lower_template_code_blocks(ast);
 	const analysis = analyze(ast, filename, {
 		to_ts: true,
 		collect: true,

--- a/packages/tsrx-ripple/src/index.js
+++ b/packages/tsrx-ripple/src/index.js
@@ -86,10 +86,6 @@ export function compile_to_volar_mappings(source, filename, options = {}) {
 		errors,
 		comments,
 	});
-	// Mapping generation walks the pristine source shapes. Analysis and the
-	// transform are copy-on-write — they rebuild their own tree and never
-	// mutate the parse tree — so the parsed AST *is* the source view.
-	const ast_from_source = ast;
 	const analysis = analyze(ast, filename, {
 		to_ts: true,
 		collect: true,
@@ -107,7 +103,10 @@ export function compile_to_volar_mappings(source, filename, options = {}) {
 
 	return createVolarMappingsResult({
 		ast: transformed.ast,
-		ast_from_source,
+		// Mapping generation walks the pristine source shapes. Analysis and the
+		// transform are copy-on-write — they rebuild their own tree and never
+		// mutate the parse tree — so the parsed AST *is* the source view.
+		ast_from_source: ast,
 		source,
 		generated_code: transformed.code,
 		source_map: transformed.map,

--- a/packages/tsrx-ripple/src/index.js
+++ b/packages/tsrx-ripple/src/index.js
@@ -6,7 +6,6 @@ import { createVolarMappingsResult, parseModule } from '@tsrx/core';
 import { analyze } from './analyze/index.js';
 import { transform_client } from './transform/client/index.js';
 import { transform_server } from './transform/server/index.js';
-import { lower_template_code_blocks, prepare_template_control_flow } from './utils.js';
 
 /**
  * Parse Ripple source code to ESTree AST
@@ -36,8 +35,6 @@ export function compile(source, filename, options = {}) {
 		filename,
 		collect ? { ...options, collect, errors, comments } : undefined,
 	);
-	prepare_template_control_flow(ast);
-	lower_template_code_blocks(ast);
 	const analysis = analyze(
 		ast,
 		filename,
@@ -89,9 +86,9 @@ export function compile_to_volar_mappings(source, filename, options = {}) {
 		errors,
 		comments,
 	});
+	// Mapping generation walks the pristine source shapes; clone before
+	// analysis lowers the template pre-passes in place.
 	const ast_from_source = structuredClone(ast);
-	prepare_template_control_flow(ast);
-	lower_template_code_blocks(ast);
 	const analysis = analyze(ast, filename, {
 		to_ts: true,
 		collect: true,

--- a/packages/tsrx-ripple/src/index.js
+++ b/packages/tsrx-ripple/src/index.js
@@ -86,9 +86,10 @@ export function compile_to_volar_mappings(source, filename, options = {}) {
 		errors,
 		comments,
 	});
-	// Mapping generation walks the pristine source shapes; clone before
-	// analysis lowers the template pre-passes in place.
-	const ast_from_source = structuredClone(ast);
+	// Mapping generation walks the pristine source shapes. Analysis and the
+	// transform are copy-on-write — they rebuild their own tree and never
+	// mutate the parse tree — so the parsed AST *is* the source view.
+	const ast_from_source = ast;
 	const analysis = analyze(ast, filename, {
 		to_ts: true,
 		collect: true,

--- a/packages/tsrx-ripple/src/template-ast.js
+++ b/packages/tsrx-ripple/src/template-ast.js
@@ -211,9 +211,6 @@ export function jsx_member_expression_to_member_expression(jsx_member) {
  * @returns {AST.Identifier | AST.MemberExpression | AST.Expression}
  */
 export function get_element_id(node) {
-	if (node.type === 'Element') {
-		return node.id;
-	}
 	node.metadata ??= { path: [] };
 	const metadata = /** @type {{ id_node?: AST.Expression }} */ (node.metadata);
 	if (metadata.id_node === undefined) {
@@ -252,15 +249,12 @@ export function get_element_id(node) {
 /**
  * A template element: an authored native element, or a raw JSX element that
  * `build_jsx_to_tsrx_element` marked native when pulling it into the template
- * machinery. (The interim `Element` leg is removed once normalization stops
- * producing Element nodes.)
+ * machinery.
  * @param {AST.Node | null | undefined} node
  * @returns {boolean}
  */
 export function is_template_element(node) {
-	return (
-		node?.type === 'Element' || (node?.type === 'JSXElement' && node.metadata?.native_tsrx === true)
-	);
+	return node?.type === 'JSXElement' && node.metadata?.native_tsrx === true;
 }
 
 /**
@@ -273,10 +267,6 @@ export function is_template_element(node) {
  * @returns {void}
  */
 export function set_element_id(node, id) {
-	if (node.type === 'Element') {
-		node.id = id;
-		return;
-	}
 	node.metadata ??= { path: [] };
 	node.metadata.id_node = id;
 }
@@ -287,7 +277,7 @@ export function set_element_id(node, id) {
  * @returns {Array<ESTreeJSX.JSXAttribute | ESTreeJSX.JSXSpreadAttribute>}
  */
 export function get_element_attributes(node) {
-	return node.type === 'Element' ? node.attributes : (node.openingElement?.attributes ?? []);
+	return node.openingElement?.attributes ?? [];
 }
 
 /**
@@ -295,24 +285,17 @@ export function get_element_attributes(node) {
  * @returns {boolean}
  */
 export function is_self_closing(node) {
-	return node.type === 'Element'
-		? node.selfClosing === true
-		: node.openingElement?.selfClosing === true;
+	return node.openingElement?.selfClosing === true;
 }
 
 /**
  * Whether the element has a dynamic `<{expr}>` tag that has not (yet) been
- * lowered to the `TsrxDynamic` component by `lower_dynamic_element`.
+ * lowered to the `TsrxDynamic` component by `lower_dynamic_element` (which
+ * clears these markers).
  * @param {any} node
  * @returns {boolean}
  */
 export function is_dynamic_element(node) {
-	if (node.type === 'Element') {
-		return node.isDynamic === true;
-	}
-	if (node.metadata?.dynamic_lowered === true) {
-		return false;
-	}
 	return (
 		node.isDynamic === true ||
 		node.openingElement?.isDynamic === true ||

--- a/packages/tsrx-ripple/src/template-ast.js
+++ b/packages/tsrx-ripple/src/template-ast.js
@@ -173,9 +173,9 @@ export function is_template_else_if(node, path) {
 	if (node.type !== 'IfStatement') {
 		return false;
 	}
-	let child = /** @type {any} */ (node);
+	let child = /** @type {AST.Node} */ (node);
 	for (let i = path.length - 1; i >= 0; i -= 1) {
-		const parent = /** @type {any} */ (path[i]);
+		const parent = path[i];
 		if (parent.type === 'JSXIfExpression' && parent.alternate === child) {
 			return true;
 		}

--- a/packages/tsrx-ripple/src/template-ast.js
+++ b/packages/tsrx-ripple/src/template-ast.js
@@ -144,6 +144,26 @@ export function is_empty_expression_container(node) {
 }
 
 /**
+ * A `<> … </>` fragment that is part of the template: an authored native
+ * fragment (`metadata.native_tsrx`, which the parser stamps on template and
+ * value-position fragments but not on fragments inside attribute values), a
+ * synthesized render-body fragment (`tsrx_render_fragment`), or a code-block
+ * chain wrapper (`tsrx_code_block_chain`). Compiler-generated directive
+ * wrappers set `native_tsrx` themselves. Raw JSX fragments (attribute values)
+ * are NOT template fragments — they lower through the raw-JSX value path.
+ * @param {AST.Node | null | undefined} node
+ * @returns {boolean}
+ */
+export function is_template_fragment(node) {
+	return (
+		node?.type === 'JSXFragment' &&
+		(node.metadata?.native_tsrx === true ||
+			node.metadata?.tsrx_render_fragment === true ||
+			node.metadata?.tsrx_code_block_chain === true)
+	);
+}
+
+/**
  * The attribute's name as a string, flattening `<ns:name>` namespaced names.
  * @param {ESTreeJSX.JSXAttribute} attr
  * @returns {string}

--- a/packages/tsrx-ripple/src/template-ast.js
+++ b/packages/tsrx-ripple/src/template-ast.js
@@ -243,7 +243,7 @@ export function get_element_id(node) {
 			});
 		}
 	}
-	return metadata.id_node;
+	return /** @type {AST.Expression} */ (metadata.id_node);
 }
 
 /**

--- a/packages/tsrx-ripple/src/template-ast.js
+++ b/packages/tsrx-ripple/src/template-ast.js
@@ -338,51 +338,14 @@ export function get_attribute_name(attr) {
 }
 
 /**
- * @param {ESTreeJSX.JSXAttribute} attr
- * @returns {number}
- */
-function attribute_name_end(attr) {
-	return /** @type {number} */ (
-		attr.name.end && attr.name.end > /** @type {number} */ (attr.name.start)
-			? attr.name.end
-			: /** @type {number} */ (attr.end) - 1
-	);
-}
-
-/**
- * @param {ESTreeJSX.JSXAttribute} attr
- * @returns {AST.Position | undefined}
- */
-function attribute_shorthand_end_loc(attr) {
-	return attr.loc?.end && attr.loc.end.column > 0
-		? { ...attr.loc.end, column: attr.loc.end.column - 1 }
-		: attr.loc?.end;
-}
-
-/**
- * Synthesize a plain `Identifier` spanning the attribute's name (for a
- * shorthand attribute, the name inside the braces).
- * @param {ESTreeJSX.JSXAttribute} attr
- * @returns {AST.Identifier}
- */
-function attribute_identifier(attr) {
-	const node = b.id(get_attribute_name(attr));
-	node.start = attr.name.start;
-	node.end = attribute_name_end(attr);
-	node.loc = /** @type {AST.SourceLocation} */ ({
-		start: attr.name.loc?.start ?? attr.loc?.start,
-		end: attr.name.loc?.end ?? attribute_shorthand_end_loc(attr),
-	});
-	return node;
-}
-
-/**
- * The attribute's name as a plain `Identifier`.
+ * The attribute's name as a plain `Identifier` spanning the name node (for a
+ * shorthand attribute, the name inside the braces — the parser always gives
+ * it a real span, even in loose mode).
  * @param {ESTreeJSX.JSXAttribute} attr
  * @returns {AST.Identifier}
  */
 export function get_attribute_name_node(attr) {
-	return attribute_identifier(attr);
+	return b.id(get_attribute_name(attr), /** @type {AST.NodeWithLocation} */ (attr.name));
 }
 
 /**
@@ -395,7 +358,7 @@ export function get_attribute_name_node(attr) {
  */
 export function get_attribute_value(attr) {
 	if (attr.shorthand === true) {
-		return attribute_identifier(attr);
+		return get_attribute_name_node(attr);
 	}
 	if (attr.value == null) {
 		return null;

--- a/packages/tsrx-ripple/src/template-ast.js
+++ b/packages/tsrx-ripple/src/template-ast.js
@@ -119,11 +119,7 @@ export function is_template_text_or_expression(node) {
 export function get_template_expression(node, to_ts) {
 	if (node.type === 'JSXText') {
 		const value = get_template_text_value(node, to_ts);
-		return b.literal(
-			value,
-			JSON.stringify(value),
-			/** @type {AST.NodeWithLocation} */ (/** @type {unknown} */ (node)),
-		);
+		return b.literal(value, JSON.stringify(value), /** @type {AST.NodeWithLocation} */ (node));
 	}
 	return /** @type {AST.Expression} */ (node.expression);
 }
@@ -186,20 +182,19 @@ export function is_template_else_if(node, path) {
 /**
  * A `<> … </>` fragment that is part of the template: an authored native
  * fragment (`metadata.native_tsrx`, which the parser stamps on template and
- * value-position fragments but not on fragments inside attribute values), a
- * synthesized render-body fragment (`tsrx_render_fragment`), or a code-block
- * chain wrapper (`tsrx_code_block_chain`). Compiler-generated directive
- * wrappers set `native_tsrx` themselves. Raw JSX fragments (attribute values)
- * are NOT template fragments — they lower through the raw-JSX value path.
+ * value-position fragments but not on fragments inside attribute values), or
+ * a synthesized render-body fragment (`tsrx_render_fragment` — deliberately
+ * NOT `native_tsrx`, so to_ts unwraps it instead of keeping it as authored).
+ * Compiler-generated directive wrappers and code-block chain wrappers set
+ * `native_tsrx` themselves. Raw JSX fragments (attribute values) are NOT
+ * template fragments — they lower through the raw-JSX value path.
  * @param {AST.Node | null | undefined} node
  * @returns {node is AST.TSRXJSXFragment}
  */
 export function is_template_fragment(node) {
 	return (
 		node?.type === 'JSXFragment' &&
-		(node.metadata?.native_tsrx === true ||
-			node.metadata?.tsrx_render_fragment === true ||
-			node.metadata?.tsrx_code_block_chain === true)
+		(node.metadata?.native_tsrx === true || node.metadata?.tsrx_render_fragment === true)
 	);
 }
 

--- a/packages/tsrx-ripple/src/template-ast.js
+++ b/packages/tsrx-ripple/src/template-ast.js
@@ -248,47 +248,46 @@ export function jsx_member_expression_to_member_expression(jsx_member) {
 /**
  * The element's tag as a plain expression: an `Identifier` for
  * `JSXIdentifier`/`JSXNamespacedName` names, a `MemberExpression` for
- * `<Foo.Bar>`, or the tag expression itself for a dynamic `<{expr}>` element.
- * Memoized on the element so the analyzer and transforms share one node.
- * `lower_dynamic_element` overwrites the memo when it rewrites a dynamic tag
- * to the `TsrxDynamic` component.
+ * `<Foo.Bar>` (or one planted directly in the name slot by a tag rewrite,
+ * e.g. `lower_dynamic_element`'s server component reference), or the tag
+ * expression itself for a dynamic `<{expr}>` element.
  * @param {AST.TSRXJSXElement | AST.JSXStyleElement} node
  * @returns {AST.Identifier | AST.MemberExpression | AST.Expression}
  */
 export function get_element_id(node) {
-	node.metadata ??= { path: [] };
-	const metadata = node.metadata;
-	if (metadata.id_node === undefined) {
-		const name = node.openingElement.name;
-		if (name.type === 'JSXIdentifier') {
-			metadata.id_node = /** @type {AST.Identifier} */ ({
-				type: 'Identifier',
-				name: name.name,
-				start: name.start,
-				end: name.end,
-			});
-		} else if (name.type === 'JSXMemberExpression') {
-			metadata.id_node = jsx_member_expression_to_member_expression(name);
-		} else if (name.type === 'JSXNamespacedName') {
-			metadata.id_node = /** @type {AST.Identifier} */ ({
-				type: 'Identifier',
-				name: name.namespace.name + ':' + name.name.name,
-				start: name.start,
-				end: name.end,
-			});
-		} else if (name.type === 'JSXExpressionContainer' && name.isDynamic === true) {
-			metadata.id_node = name.expression;
-		} else {
-			// Fallback - should not reach here
-			metadata.id_node = /** @type {AST.Identifier} */ ({
-				type: 'Identifier',
-				name: 'unknown',
-				start: name.start,
-				end: name.end,
-			});
-		}
+	const name = node.openingElement.name;
+	if (name.type === 'JSXIdentifier') {
+		return /** @type {AST.Identifier} */ ({
+			type: 'Identifier',
+			name: name.name,
+			start: name.start,
+			end: name.end,
+		});
 	}
-	return /** @type {AST.Expression} */ (metadata.id_node);
+	if (name.type === 'JSXMemberExpression') {
+		return jsx_member_expression_to_member_expression(name);
+	}
+	if (name.type === 'JSXNamespacedName') {
+		return /** @type {AST.Identifier} */ ({
+			type: 'Identifier',
+			name: name.namespace.name + ':' + name.name.name,
+			start: name.start,
+			end: name.end,
+		});
+	}
+	if (name.type === 'MemberExpression') {
+		return name;
+	}
+	if (name.type === 'JSXExpressionContainer' && name.isDynamic === true) {
+		return /** @type {AST.Expression} */ (name.expression);
+	}
+	// Fallback - should not reach here
+	return /** @type {AST.Identifier} */ ({
+		type: 'Identifier',
+		name: 'unknown',
+		start: name.start,
+		end: name.end,
+	});
 }
 
 /**
@@ -300,20 +299,6 @@ export function get_element_id(node) {
  */
 export function is_template_element(node) {
 	return node?.type === 'JSXElement' && node.metadata?.native_tsrx === true;
-}
-
-/**
- * Replace the element's derived id (used when a transform rewrites the tag —
- * dynamic elements lowering to `TsrxDynamic`, member-expression tags being
- * visited). Writes the memo on JSX elements; the interim `Element` leg writes
- * the `id` field directly.
- * @param {AST.TSRXJSXElement | AST.JSXStyleElement} node
- * @param {AST.Expression} id
- * @returns {void}
- */
-export function set_element_id(node, id) {
-	node.metadata ??= { path: [] };
-	node.metadata.id_node = id;
 }
 
 /**

--- a/packages/tsrx-ripple/src/template-ast.js
+++ b/packages/tsrx-ripple/src/template-ast.js
@@ -164,6 +164,19 @@ export function is_template_fragment(node) {
 }
 
 /**
+ * The CSS source of a `<style>` template element.
+ * @param {any} node
+ * @returns {string}
+ */
+export function get_style_css(node) {
+	return (
+		node.css ??
+		node.children?.find((/** @type {any} */ child) => child?.type === 'StyleSheet')?.source ??
+		''
+	);
+}
+
+/**
  * The attribute's name as a string, flattening `<ns:name>` namespaced names.
  * @param {ESTreeJSX.JSXAttribute} attr
  * @returns {string}

--- a/packages/tsrx-ripple/src/template-ast.js
+++ b/packages/tsrx-ripple/src/template-ast.js
@@ -140,9 +140,111 @@ export function get_template_expression(node, to_ts) {
  * @returns {boolean}
  */
 export function is_empty_expression_container(node) {
-	return (
-		node.type === 'JSXExpressionContainer' && node.expression?.type === 'JSXEmptyExpression'
+	return node.type === 'JSXExpressionContainer' && node.expression?.type === 'JSXEmptyExpression';
+}
+
+/**
+ * The attribute's name as a string, flattening `<ns:name>` namespaced names.
+ * @param {ESTreeJSX.JSXAttribute} attr
+ * @returns {string}
+ */
+export function get_attribute_name(attr) {
+	return attr.name.type === 'JSXIdentifier'
+		? attr.name.name
+		: attr.name.namespace.name + ':' + attr.name.name.name;
+}
+
+/**
+ * @param {ESTreeJSX.JSXAttribute} attr
+ * @returns {number}
+ */
+function attribute_name_end(attr) {
+	return /** @type {number} */ (
+		attr.name.end && attr.name.end > /** @type {number} */ (attr.name.start)
+			? attr.name.end
+			: /** @type {number} */ (attr.end) - 1
 	);
+}
+
+/**
+ * @param {ESTreeJSX.JSXAttribute} attr
+ * @returns {AST.Position | undefined}
+ */
+function attribute_shorthand_end_loc(attr) {
+	return attr.loc?.end && attr.loc.end.column > 0
+		? { ...attr.loc.end, column: attr.loc.end.column - 1 }
+		: attr.loc?.end;
+}
+
+/**
+ * The attribute's name as a plain `Identifier`, memoized on the attribute so
+ * the analyzer and transforms share one node (attribute-name identifiers are
+ * collected into sets and compared by identity).
+ * @param {ESTreeJSX.JSXAttribute} attr
+ * @returns {AST.Identifier}
+ */
+export function get_attribute_name_node(attr) {
+	attr.metadata ??= { path: [] };
+	const metadata = /** @type {{ attribute_name_node?: AST.Identifier }} */ (attr.metadata);
+	if (metadata.attribute_name_node === undefined) {
+		metadata.attribute_name_node = /** @type {AST.Identifier} */ ({
+			type: 'Identifier',
+			name: get_attribute_name(attr),
+			tracked: false,
+			start: attr.name.start,
+			end: attribute_name_end(attr),
+			loc: {
+				start: attr.name.loc?.start ?? attr.loc?.start,
+				end: attr.name.loc?.end ?? attribute_shorthand_end_loc(attr),
+			},
+		});
+	}
+	return metadata.attribute_name_node;
+}
+
+/**
+ * The attribute's value expression: `null` for a valueless attribute
+ * (`<div attr>`), the expression for a `{ … }` container value, a synthesized
+ * `Identifier` (memoized) for a shorthand attribute (`<div {foo}>`), and the
+ * literal itself for a quoted value.
+ * @param {ESTreeJSX.JSXAttribute} attr
+ * @returns {AST.Expression | null}
+ */
+export function get_attribute_value(attr) {
+	if (attr.shorthand === true) {
+		attr.metadata ??= { path: [] };
+		const metadata = /** @type {{ attribute_shorthand_value?: AST.Identifier }} */ (attr.metadata);
+		if (metadata.attribute_shorthand_value === undefined) {
+			metadata.attribute_shorthand_value = /** @type {AST.Identifier} */ ({
+				type: 'Identifier',
+				name: get_attribute_name(attr),
+				start: attr.name.start,
+				end: attribute_name_end(attr),
+				loc: {
+					start: attr.name.loc?.start ?? attr.loc?.start,
+					end: attr.name.loc?.end ?? attribute_shorthand_end_loc(attr),
+				},
+			});
+		}
+		return metadata.attribute_shorthand_value;
+	}
+	if (attr.value == null) {
+		return null;
+	}
+	return attr.value.type === 'JSXExpressionContainer'
+		? /** @type {AST.Expression} */ (attr.value.expression)
+		: /** @type {AST.Expression} */ (attr.value);
+}
+
+/**
+ * Whether the attribute's value was authored as a `{ … }` expression container
+ * (as opposed to a quoted literal). Replaces the old `value.was_expression`
+ * marker the normalizer stamped on unwrapped values.
+ * @param {ESTreeJSX.JSXAttribute} attr
+ * @returns {boolean}
+ */
+export function is_expression_attribute(attr) {
+	return attr.value?.type === 'JSXExpressionContainer';
 }
 
 /**

--- a/packages/tsrx-ripple/src/template-ast.js
+++ b/packages/tsrx-ripple/src/template-ast.js
@@ -466,18 +466,37 @@ export function is_expression_attribute(attr) {
 }
 
 /**
+ * Whether a `@{ … }` code block lowers to anything at all — setup statements
+ * or (possibly chained) render output. An empty-all-the-way-down block lowers
+ * to nothing and renders nothing.
+ * @param {AST.JSXCodeBlock} block
+ * @returns {boolean}
+ */
+export function code_block_renders_or_runs(block) {
+	if ((block.body || []).some((statement) => statement.type !== 'EmptyStatement')) {
+		return true;
+	}
+	const render = block.render;
+	if (render == null) return false;
+	return render.type !== 'JSXCodeBlock'
+		? true
+		: code_block_renders_or_runs(/** @type {AST.JSXCodeBlock} */ (render));
+}
+
+/**
  * The children that actually render: everything except empty statements,
- * insignificant whitespace text, and `{/* comment *​/}` containers.
+ * insignificant whitespace text, `{/* comment *​/}` containers, and `@{ … }`
+ * blocks that lower to nothing.
  * @param {AST.Node[]} children
  * @param {boolean} to_ts
  * @returns {AST.Node[]}
  */
 export function rendered_template_children(children, to_ts) {
-	return children.filter(
-		(child) =>
-			child != null &&
-			child.type !== 'EmptyStatement' &&
-			!is_droppable_template_text(child, to_ts) &&
-			!is_empty_expression_container(child),
-	);
+	return children.filter((child) => {
+		if (child == null || child.type === 'EmptyStatement') return false;
+		if (child.type === 'JSXCodeBlock') {
+			return code_block_renders_or_runs(/** @type {AST.JSXCodeBlock} */ (child));
+		}
+		return !is_droppable_template_text(child, to_ts) && !is_empty_expression_container(child);
+	});
 }

--- a/packages/tsrx-ripple/src/template-ast.js
+++ b/packages/tsrx-ripple/src/template-ast.js
@@ -1,0 +1,163 @@
+/**
+@import * as AST from 'estree';
+@import * as ESTreeJSX from 'estree-jsx';
+ */
+
+/**
+ * Accessors over the parser's JSX-shaped template AST. Ripple's analyzer and
+ * client/server transforms consume the parser AST directly; these helpers keep
+ * the JSX node-shape unwrapping (text values, expression children) in one
+ * place. Synthesized nodes are memoized on `node.metadata` so the analyzer and
+ * transforms — which walk the same tree — always agree on node identity.
+ */
+
+import { builders } from '@tsrx/core';
+const b = builders;
+
+/**
+ * @param {string} value
+ * @returns {string}
+ */
+function decode_jsx_text_entities(value) {
+	return value.replace(
+		/&(#x[0-9a-fA-F]+|#[0-9]+|amp|quot|apos|lt|gt);/g,
+		(/** @type {string} */ match, /** @type {string} */ entity) => {
+			if (entity === 'amp') return '&';
+			if (entity === 'quot') return '"';
+			if (entity === 'apos') return "'";
+			if (entity === 'lt') return '<';
+			if (entity === 'gt') return '>';
+			if (entity.startsWith('#x')) {
+				const code_point = Number.parseInt(entity.slice(2), 16);
+				return Number.isNaN(code_point) ? match : String.fromCodePoint(code_point);
+			}
+			if (entity.startsWith('#')) {
+				const code_point = Number.parseInt(entity.slice(1), 10);
+				return Number.isNaN(code_point) ? match : String.fromCodePoint(code_point);
+			}
+			return match;
+		},
+	);
+}
+
+/**
+ * The rendered text value of a `JSXText` template child. The whitespace
+ * collapse is a runtime-only concern: Ripple lowers text to explicit
+ * `_$_.text(...)` calls, so insignificant JSX whitespace (runs containing a
+ * newline) is trimmed or it would render as literal text. The type-only
+ * (`to_ts`) view keeps text verbatim — like the other targets — so it stays
+ * faithful to the source and its location; trimming there would leave the node
+ * lying about its size, producing a mismatched-length source mapping.
+ * @param {ESTreeJSX.JSXText} node
+ * @param {boolean} to_ts
+ * @returns {string}
+ */
+export function get_template_text_value(node, to_ts) {
+	const value = node.value;
+	const normalized = to_ts ? value : /[\r\n]/.test(value) ? value.trim() : value;
+	return decode_jsx_text_entities(normalized);
+}
+
+/**
+ * Whether a template child is insignificant whitespace that renders nothing
+ * (a `JSXText` run containing a newline that collapses to ''). Nothing is
+ * droppable in the `to_ts` view — text is kept verbatim there.
+ * @param {AST.Node} node
+ * @param {boolean} to_ts
+ * @returns {boolean}
+ */
+export function is_droppable_template_text(node, to_ts) {
+	return (
+		node.type === 'JSXText' &&
+		get_template_text_value(/** @type {ESTreeJSX.JSXText} */ (node), to_ts) === ''
+	);
+}
+
+/**
+ * A template child rendered through the text path (`_$_.text`/`set_text`):
+ * a raw `JSXText`, or a merged text run — a `JSXExpressionContainer` marked
+ * `metadata.tsrx_text` produced by `normalize_children` when adjacent
+ * text/expression children collapse into one text node.
+ * @param {AST.Node} node
+ * @returns {boolean}
+ */
+export function is_template_text(node) {
+	return (
+		node.type === 'JSXText' ||
+		(node.type === 'JSXExpressionContainer' && node.metadata?.tsrx_text === true)
+	);
+}
+
+/**
+ * A `{ … }` template child rendered through the expression path (not a merged
+ * text run).
+ * @param {AST.Node} node
+ * @returns {boolean}
+ */
+export function is_template_expression(node) {
+	return node.type === 'JSXExpressionContainer' && node.metadata?.tsrx_text !== true;
+}
+
+/**
+ * Any text or expression template child (`JSXText` or `JSXExpressionContainer`,
+ * merged or not).
+ * @param {AST.Node} node
+ * @returns {boolean}
+ */
+export function is_template_text_or_expression(node) {
+	return node.type === 'JSXText' || node.type === 'JSXExpressionContainer';
+}
+
+/**
+ * The rendered expression of a text/expression template child. A `JSXText`
+ * lowers to its (whitespace-collapsed) string literal, memoized on the node so
+ * every consumer shares one literal; a container yields its expression.
+ * @param {ESTreeJSX.JSXText | ESTreeJSX.JSXExpressionContainer} node
+ * @param {boolean} to_ts
+ * @returns {AST.Expression}
+ */
+export function get_template_expression(node, to_ts) {
+	if (node.type === 'JSXText') {
+		node.metadata ??= { path: [] };
+		const metadata = /** @type {{ template_expression?: AST.Literal }} */ (node.metadata);
+		if (metadata.template_expression === undefined) {
+			const value = get_template_text_value(node, to_ts);
+			metadata.template_expression = b.literal(
+				value,
+				JSON.stringify(value),
+				/** @type {AST.NodeWithLocation} */ (/** @type {unknown} */ (node)),
+			);
+		}
+		return metadata.template_expression;
+	}
+	return /** @type {AST.Expression} */ (node.expression);
+}
+
+/**
+ * A `{/* comment *​/}` template child — a container holding only a
+ * `JSXEmptyExpression`. Renders nothing.
+ * @param {AST.Node} node
+ * @returns {boolean}
+ */
+export function is_empty_expression_container(node) {
+	return (
+		node.type === 'JSXExpressionContainer' && node.expression?.type === 'JSXEmptyExpression'
+	);
+}
+
+/**
+ * The children that actually render: everything except empty statements,
+ * insignificant whitespace text, and `{/* comment *​/}` containers.
+ * @param {AST.Node[]} children
+ * @param {boolean} to_ts
+ * @returns {AST.Node[]}
+ */
+export function rendered_template_children(children, to_ts) {
+	return children.filter(
+		(child) =>
+			child != null &&
+			child.type !== 'EmptyStatement' &&
+			!is_droppable_template_text(child, to_ts) &&
+			!is_empty_expression_container(child),
+	);
+}

--- a/packages/tsrx-ripple/src/template-ast.js
+++ b/packages/tsrx-ripple/src/template-ast.js
@@ -215,34 +215,18 @@ export function is_template_fragment(node) {
  * @returns {AST.MemberExpression}
  */
 export function jsx_member_expression_to_member_expression(jsx_member) {
-	/** @type {AST.Expression} */
-	let object;
+	const object =
+		jsx_member.object.type === 'JSXMemberExpression'
+			? jsx_member_expression_to_member_expression(jsx_member.object)
+			: b.id(jsx_member.object.name, /** @type {AST.NodeWithLocation} */ (jsx_member.object));
 
-	if (jsx_member.object.type === 'JSXMemberExpression') {
-		object = jsx_member_expression_to_member_expression(jsx_member.object);
-	} else {
-		object = /** @type {AST.Identifier} */ ({
-			type: 'Identifier',
-			name: jsx_member.object.name,
-			start: jsx_member.object.start,
-			end: jsx_member.object.end,
-		});
-	}
-
-	return /** @type {AST.MemberExpression} */ ({
-		type: 'MemberExpression',
+	return b.member(
 		object,
-		property: /** @type {AST.Identifier} */ ({
-			type: 'Identifier',
-			name: jsx_member.property.name,
-			start: jsx_member.property.start,
-			end: jsx_member.property.end,
-		}),
-		computed: false,
-		optional: false,
-		start: jsx_member.start,
-		end: jsx_member.end,
-	});
+		b.id(jsx_member.property.name, /** @type {AST.NodeWithLocation} */ (jsx_member.property)),
+		false,
+		false,
+		/** @type {AST.NodeWithLocation} */ (jsx_member),
+	);
 }
 
 /**
@@ -257,23 +241,16 @@ export function jsx_member_expression_to_member_expression(jsx_member) {
 export function get_element_id(node) {
 	const name = node.openingElement.name;
 	if (name.type === 'JSXIdentifier') {
-		return /** @type {AST.Identifier} */ ({
-			type: 'Identifier',
-			name: name.name,
-			start: name.start,
-			end: name.end,
-		});
+		return b.id(name.name, /** @type {AST.NodeWithLocation} */ (name));
 	}
 	if (name.type === 'JSXMemberExpression') {
 		return jsx_member_expression_to_member_expression(name);
 	}
 	if (name.type === 'JSXNamespacedName') {
-		return /** @type {AST.Identifier} */ ({
-			type: 'Identifier',
-			name: name.namespace.name + ':' + name.name.name,
-			start: name.start,
-			end: name.end,
-		});
+		return b.id(
+			name.namespace.name + ':' + name.name.name,
+			/** @type {AST.NodeWithLocation} */ (name),
+		);
 	}
 	if (name.type === 'MemberExpression') {
 		return name;
@@ -282,12 +259,7 @@ export function get_element_id(node) {
 		return /** @type {AST.Expression} */ (name.expression);
 	}
 	// Fallback - should not reach here
-	return /** @type {AST.Identifier} */ ({
-		type: 'Identifier',
-		name: 'unknown',
-		start: name.start,
-		end: name.end,
-	});
+	return b.id('unknown', /** @type {AST.NodeWithLocation} */ (name));
 }
 
 /**
@@ -388,56 +360,42 @@ function attribute_shorthand_end_loc(attr) {
 }
 
 /**
- * The attribute's name as a plain `Identifier`, memoized on the attribute so
- * the analyzer and transforms share one node (attribute-name identifiers are
- * collected into sets and compared by identity).
+ * Synthesize a plain `Identifier` spanning the attribute's name (for a
+ * shorthand attribute, the name inside the braces).
+ * @param {ESTreeJSX.JSXAttribute} attr
+ * @returns {AST.Identifier}
+ */
+function attribute_identifier(attr) {
+	const node = b.id(get_attribute_name(attr));
+	node.start = attr.name.start;
+	node.end = attribute_name_end(attr);
+	node.loc = /** @type {AST.SourceLocation} */ ({
+		start: attr.name.loc?.start ?? attr.loc?.start,
+		end: attr.name.loc?.end ?? attribute_shorthand_end_loc(attr),
+	});
+	return node;
+}
+
+/**
+ * The attribute's name as a plain `Identifier`.
  * @param {ESTreeJSX.JSXAttribute} attr
  * @returns {AST.Identifier}
  */
 export function get_attribute_name_node(attr) {
-	attr.metadata ??= { path: [] };
-	const metadata = /** @type {{ attribute_name_node?: AST.Identifier }} */ (attr.metadata);
-	if (metadata.attribute_name_node === undefined) {
-		metadata.attribute_name_node = /** @type {AST.Identifier} */ ({
-			type: 'Identifier',
-			name: get_attribute_name(attr),
-			tracked: false,
-			start: attr.name.start,
-			end: attribute_name_end(attr),
-			loc: {
-				start: attr.name.loc?.start ?? attr.loc?.start,
-				end: attr.name.loc?.end ?? attribute_shorthand_end_loc(attr),
-			},
-		});
-	}
-	return metadata.attribute_name_node;
+	return attribute_identifier(attr);
 }
 
 /**
  * The attribute's value expression: `null` for a valueless attribute
  * (`<div attr>`), the expression for a `{ … }` container value, a synthesized
- * `Identifier` (memoized) for a shorthand attribute (`<div {foo}>`), and the
- * literal itself for a quoted value.
+ * `Identifier` for a shorthand attribute (`<div {foo}>`), and the literal
+ * itself for a quoted value.
  * @param {ESTreeJSX.JSXAttribute} attr
  * @returns {AST.Expression | null}
  */
 export function get_attribute_value(attr) {
 	if (attr.shorthand === true) {
-		attr.metadata ??= { path: [] };
-		const metadata = /** @type {{ attribute_shorthand_value?: AST.Identifier }} */ (attr.metadata);
-		if (metadata.attribute_shorthand_value === undefined) {
-			metadata.attribute_shorthand_value = /** @type {AST.Identifier} */ ({
-				type: 'Identifier',
-				name: get_attribute_name(attr),
-				start: attr.name.start,
-				end: attribute_name_end(attr),
-				loc: {
-					start: attr.name.loc?.start ?? attr.loc?.start,
-					end: attr.name.loc?.end ?? attribute_shorthand_end_loc(attr),
-				},
-			});
-		}
-		return metadata.attribute_shorthand_value;
+		return attribute_identifier(attr);
 	}
 	if (attr.value == null) {
 		return null;

--- a/packages/tsrx-ripple/src/template-ast.js
+++ b/packages/tsrx-ripple/src/template-ast.js
@@ -110,25 +110,20 @@ export function is_template_text_or_expression(node) {
 
 /**
  * The rendered expression of a text/expression template child. A `JSXText`
- * lowers to its (whitespace-collapsed) string literal, memoized on the node so
- * every consumer shares one literal; a container yields its expression.
+ * lowers to its (whitespace-collapsed) string literal; a container yields its
+ * expression.
  * @param {ESTreeJSX.JSXText | ESTreeJSX.JSXExpressionContainer} node
  * @param {boolean} to_ts
  * @returns {AST.Expression}
  */
 export function get_template_expression(node, to_ts) {
 	if (node.type === 'JSXText') {
-		node.metadata ??= { path: [] };
-		const metadata = /** @type {{ template_expression?: AST.Literal }} */ (node.metadata);
-		if (metadata.template_expression === undefined) {
-			const value = get_template_text_value(node, to_ts);
-			metadata.template_expression = b.literal(
-				value,
-				JSON.stringify(value),
-				/** @type {AST.NodeWithLocation} */ (/** @type {unknown} */ (node)),
-			);
-		}
-		return metadata.template_expression;
+		const value = get_template_text_value(node, to_ts);
+		return b.literal(
+			value,
+			JSON.stringify(value),
+			/** @type {AST.NodeWithLocation} */ (/** @type {unknown} */ (node)),
+		);
 	}
 	return /** @type {AST.Expression} */ (node.expression);
 }
@@ -363,9 +358,7 @@ export function get_attribute_value(attr) {
 	if (attr.value == null) {
 		return null;
 	}
-	return attr.value.type === 'JSXExpressionContainer'
-		? /** @type {AST.Expression} */ (attr.value.expression)
-		: /** @type {AST.Expression} */ (attr.value);
+	return attr.value.type === 'JSXExpressionContainer' ? attr.value.expression : attr.value;
 }
 
 /**

--- a/packages/tsrx-ripple/src/template-ast.js
+++ b/packages/tsrx-ripple/src/template-ast.js
@@ -144,6 +144,51 @@ export function is_empty_expression_container(node) {
 }
 
 /**
+ * A `@if`/`@for`/`@switch`/`@try` template control-flow directive — the
+ * parser's expression-form nodes. Directives keep these forms end to end; a
+ * plain `IfStatement`/`ForOfStatement`/… is always ordinary JavaScript, except
+ * the `@else if` chain links detected by {@link is_template_else_if}.
+ * @param {AST.Node | null | undefined} node
+ * @returns {boolean}
+ */
+export function is_template_directive(node) {
+	return (
+		node?.type === 'JSXIfExpression' ||
+		node?.type === 'JSXForExpression' ||
+		node?.type === 'JSXSwitchExpression' ||
+		node?.type === 'JSXTryExpression'
+	);
+}
+
+/**
+ * An `@else if` chain link: the parser emits a plain `IfStatement` for each
+ * `@else if` in an `@if` directive's `alternate`, so directive-ness is
+ * positional — consecutive `IfStatement` alternates rooted at a
+ * `JSXIfExpression`.
+ * @param {AST.Node} node
+ * @param {AST.Node[]} path — ancestor chain, innermost last
+ * @returns {boolean}
+ */
+export function is_template_else_if(node, path) {
+	if (node.type !== 'IfStatement') {
+		return false;
+	}
+	let child = /** @type {any} */ (node);
+	for (let i = path.length - 1; i >= 0; i -= 1) {
+		const parent = /** @type {any} */ (path[i]);
+		if (parent.type === 'JSXIfExpression' && parent.alternate === child) {
+			return true;
+		}
+		if (parent.type === 'IfStatement' && parent.alternate === child) {
+			child = parent;
+			continue;
+		}
+		return false;
+	}
+	return false;
+}
+
+/**
  * A `<> … </>` fragment that is part of the template: an authored native
  * fragment (`metadata.native_tsrx`, which the parser stamps on template and
  * value-position fragments but not on fragments inside attribute values), a

--- a/packages/tsrx-ripple/src/template-ast.js
+++ b/packages/tsrx-ripple/src/template-ast.js
@@ -149,7 +149,7 @@ export function is_empty_expression_container(node) {
  * plain `IfStatement`/`ForOfStatement`/… is always ordinary JavaScript, except
  * the `@else if` chain links detected by {@link is_template_else_if}.
  * @param {AST.Node | null | undefined} node
- * @returns {boolean}
+ * @returns {node is AST.JSXTemplateDirective}
  */
 export function is_template_directive(node) {
 	return (
@@ -314,6 +314,17 @@ export function is_template_element(node) {
 export function set_element_id(node, id) {
 	node.metadata ??= { path: [] };
 	node.metadata.id_node = id;
+}
+
+/**
+ * The element's tag as a plain `Identifier` — `null` for member-expression,
+ * namespaced, or dynamic tags.
+ * @param {any} node
+ * @returns {AST.Identifier | null}
+ */
+export function get_element_identifier(node) {
+	const id = get_element_id(node);
+	return id.type === 'Identifier' ? /** @type {AST.Identifier} */ (id) : null;
 }
 
 /**

--- a/packages/tsrx-ripple/src/template-ast.js
+++ b/packages/tsrx-ripple/src/template-ast.js
@@ -164,6 +164,163 @@ export function is_template_fragment(node) {
 }
 
 /**
+ * Converts a JSXMemberExpression to a plain MemberExpression.
+ * e.g., `<Foo.Bar.Baz>` → MemberExpression(MemberExpression(Foo, Bar), Baz)
+ * @param {ESTreeJSX.JSXMemberExpression} jsx_member
+ * @returns {AST.MemberExpression}
+ */
+export function jsx_member_expression_to_member_expression(jsx_member) {
+	/** @type {AST.Expression} */
+	let object;
+
+	if (jsx_member.object.type === 'JSXMemberExpression') {
+		object = jsx_member_expression_to_member_expression(jsx_member.object);
+	} else {
+		object = /** @type {AST.Identifier} */ ({
+			type: 'Identifier',
+			name: jsx_member.object.name,
+			start: jsx_member.object.start,
+			end: jsx_member.object.end,
+		});
+	}
+
+	return /** @type {AST.MemberExpression} */ ({
+		type: 'MemberExpression',
+		object,
+		property: /** @type {AST.Identifier} */ ({
+			type: 'Identifier',
+			name: jsx_member.property.name,
+			start: jsx_member.property.start,
+			end: jsx_member.property.end,
+		}),
+		computed: false,
+		optional: false,
+		start: jsx_member.start,
+		end: jsx_member.end,
+	});
+}
+
+/**
+ * The element's tag as a plain expression: an `Identifier` for
+ * `JSXIdentifier`/`JSXNamespacedName` names, a `MemberExpression` for
+ * `<Foo.Bar>`, or the tag expression itself for a dynamic `<{expr}>` element.
+ * Memoized on the element so the analyzer and transforms share one node.
+ * `lower_dynamic_element` overwrites the memo when it rewrites a dynamic tag
+ * to the `TsrxDynamic` component.
+ * @param {any} node
+ * @returns {AST.Identifier | AST.MemberExpression | AST.Expression}
+ */
+export function get_element_id(node) {
+	if (node.type === 'Element') {
+		return node.id;
+	}
+	node.metadata ??= { path: [] };
+	const metadata = /** @type {{ id_node?: AST.Expression }} */ (node.metadata);
+	if (metadata.id_node === undefined) {
+		const name = node.openingElement.name;
+		if (name.type === 'JSXIdentifier') {
+			metadata.id_node = /** @type {AST.Identifier} */ ({
+				type: 'Identifier',
+				name: name.name,
+				start: name.start,
+				end: name.end,
+			});
+		} else if (name.type === 'JSXMemberExpression') {
+			metadata.id_node = jsx_member_expression_to_member_expression(name);
+		} else if (name.type === 'JSXNamespacedName') {
+			metadata.id_node = /** @type {AST.Identifier} */ ({
+				type: 'Identifier',
+				name: name.namespace.name + ':' + name.name.name,
+				start: name.start,
+				end: name.end,
+			});
+		} else if (name.type === 'JSXExpressionContainer' && name.isDynamic === true) {
+			metadata.id_node = name.expression;
+		} else {
+			// Fallback - should not reach here
+			metadata.id_node = /** @type {AST.Identifier} */ ({
+				type: 'Identifier',
+				name: 'unknown',
+				start: name.start,
+				end: name.end,
+			});
+		}
+	}
+	return metadata.id_node;
+}
+
+/**
+ * A template element: an authored native element, or a raw JSX element that
+ * `build_jsx_to_tsrx_element` marked native when pulling it into the template
+ * machinery. (The interim `Element` leg is removed once normalization stops
+ * producing Element nodes.)
+ * @param {AST.Node | null | undefined} node
+ * @returns {boolean}
+ */
+export function is_template_element(node) {
+	return (
+		node?.type === 'Element' || (node?.type === 'JSXElement' && node.metadata?.native_tsrx === true)
+	);
+}
+
+/**
+ * Replace the element's derived id (used when a transform rewrites the tag —
+ * dynamic elements lowering to `TsrxDynamic`, member-expression tags being
+ * visited). Writes the memo on JSX elements; the interim `Element` leg writes
+ * the `id` field directly.
+ * @param {any} node
+ * @param {AST.Expression} id
+ * @returns {void}
+ */
+export function set_element_id(node, id) {
+	if (node.type === 'Element') {
+		node.id = id;
+		return;
+	}
+	node.metadata ??= { path: [] };
+	node.metadata.id_node = id;
+}
+
+/**
+ * The element's attributes (raw `JSXAttribute`/`JSXSpreadAttribute` nodes).
+ * @param {any} node
+ * @returns {Array<ESTreeJSX.JSXAttribute | ESTreeJSX.JSXSpreadAttribute>}
+ */
+export function get_element_attributes(node) {
+	return node.type === 'Element' ? node.attributes : (node.openingElement?.attributes ?? []);
+}
+
+/**
+ * @param {any} node
+ * @returns {boolean}
+ */
+export function is_self_closing(node) {
+	return node.type === 'Element'
+		? node.selfClosing === true
+		: node.openingElement?.selfClosing === true;
+}
+
+/**
+ * Whether the element has a dynamic `<{expr}>` tag that has not (yet) been
+ * lowered to the `TsrxDynamic` component by `lower_dynamic_element`.
+ * @param {any} node
+ * @returns {boolean}
+ */
+export function is_dynamic_element(node) {
+	if (node.type === 'Element') {
+		return node.isDynamic === true;
+	}
+	if (node.metadata?.dynamic_lowered === true) {
+		return false;
+	}
+	return (
+		node.isDynamic === true ||
+		node.openingElement?.isDynamic === true ||
+		node.openingElement?.name?.isDynamic === true
+	);
+}
+
+/**
  * The CSS source of a `<style>` template element.
  * @param {any} node
  * @returns {string}

--- a/packages/tsrx-ripple/src/template-ast.js
+++ b/packages/tsrx-ripple/src/template-ast.js
@@ -197,7 +197,7 @@ export function is_template_else_if(node, path) {
  * wrappers set `native_tsrx` themselves. Raw JSX fragments (attribute values)
  * are NOT template fragments — they lower through the raw-JSX value path.
  * @param {AST.Node | null | undefined} node
- * @returns {boolean}
+ * @returns {node is AST.TSRXJSXFragment}
  */
 export function is_template_fragment(node) {
 	return (
@@ -252,12 +252,12 @@ export function jsx_member_expression_to_member_expression(jsx_member) {
  * Memoized on the element so the analyzer and transforms share one node.
  * `lower_dynamic_element` overwrites the memo when it rewrites a dynamic tag
  * to the `TsrxDynamic` component.
- * @param {any} node
+ * @param {AST.TSRXJSXElement | AST.JSXStyleElement} node
  * @returns {AST.Identifier | AST.MemberExpression | AST.Expression}
  */
 export function get_element_id(node) {
 	node.metadata ??= { path: [] };
-	const metadata = /** @type {{ id_node?: AST.Expression }} */ (node.metadata);
+	const metadata = node.metadata;
 	if (metadata.id_node === undefined) {
 		const name = node.openingElement.name;
 		if (name.type === 'JSXIdentifier') {
@@ -296,7 +296,7 @@ export function get_element_id(node) {
  * `build_jsx_to_tsrx_element` marked native when pulling it into the template
  * machinery.
  * @param {AST.Node | null | undefined} node
- * @returns {boolean}
+ * @returns {node is AST.TSRXJSXElement}
  */
 export function is_template_element(node) {
 	return node?.type === 'JSXElement' && node.metadata?.native_tsrx === true;
@@ -307,7 +307,7 @@ export function is_template_element(node) {
  * dynamic elements lowering to `TsrxDynamic`, member-expression tags being
  * visited). Writes the memo on JSX elements; the interim `Element` leg writes
  * the `id` field directly.
- * @param {any} node
+ * @param {AST.TSRXJSXElement | AST.JSXStyleElement} node
  * @param {AST.Expression} id
  * @returns {void}
  */
@@ -319,17 +319,17 @@ export function set_element_id(node, id) {
 /**
  * The element's tag as a plain `Identifier` — `null` for member-expression,
  * namespaced, or dynamic tags.
- * @param {any} node
+ * @param {AST.TSRXJSXElement | AST.JSXStyleElement} node
  * @returns {AST.Identifier | null}
  */
 export function get_element_identifier(node) {
 	const id = get_element_id(node);
-	return id.type === 'Identifier' ? /** @type {AST.Identifier} */ (id) : null;
+	return id.type === 'Identifier' ? id : null;
 }
 
 /**
  * The element's attributes (raw `JSXAttribute`/`JSXSpreadAttribute` nodes).
- * @param {any} node
+ * @param {AST.TSRXJSXElement | AST.JSXStyleElement} node
  * @returns {Array<ESTreeJSX.JSXAttribute | ESTreeJSX.JSXSpreadAttribute>}
  */
 export function get_element_attributes(node) {
@@ -337,7 +337,7 @@ export function get_element_attributes(node) {
 }
 
 /**
- * @param {any} node
+ * @param {AST.TSRXJSXElement | AST.JSXStyleElement} node
  * @returns {boolean}
  */
 export function is_self_closing(node) {
@@ -348,28 +348,25 @@ export function is_self_closing(node) {
  * Whether the element has a dynamic `<{expr}>` tag that has not (yet) been
  * lowered to the `TsrxDynamic` component by `lower_dynamic_element` (which
  * clears these markers).
- * @param {any} node
+ * @param {AST.TSRXJSXElement | AST.JSXStyleElement} node
  * @returns {boolean}
  */
 export function is_dynamic_element(node) {
+	const name = node.openingElement?.name;
 	return (
 		node.isDynamic === true ||
 		node.openingElement?.isDynamic === true ||
-		node.openingElement?.name?.isDynamic === true
+		(name?.type === 'JSXExpressionContainer' && name.isDynamic === true)
 	);
 }
 
 /**
  * The CSS source of a `<style>` template element.
- * @param {any} node
+ * @param {AST.JSXStyleElement} node
  * @returns {string}
  */
 export function get_style_css(node) {
-	return (
-		node.css ??
-		node.children?.find((/** @type {any} */ child) => child?.type === 'StyleSheet')?.source ??
-		''
-	);
+	return node.css ?? node.children?.find((child) => child?.type === 'StyleSheet')?.source ?? '';
 }
 
 /**

--- a/packages/tsrx-ripple/src/template-ast.js
+++ b/packages/tsrx-ripple/src/template-ast.js
@@ -102,7 +102,7 @@ export function is_template_expression(node) {
  * Any text or expression template child (`JSXText` or `JSXExpressionContainer`,
  * merged or not).
  * @param {AST.Node} node
- * @returns {boolean}
+ * @returns {node is ESTreeJSX.JSXText | ESTreeJSX.JSXExpressionContainer}
  */
 export function is_template_text_or_expression(node) {
 	return node.type === 'JSXText' || node.type === 'JSXExpressionContainer';

--- a/packages/tsrx-ripple/src/transform/client/index.js
+++ b/packages/tsrx-ripple/src/transform/client/index.js
@@ -106,6 +106,14 @@ import {
 	strip_tsrx_style_elements,
 	wrap_code_block_in_iife,
 } from '../../utils.js';
+import {
+	get_template_expression,
+	get_template_text_value,
+	is_empty_expression_container,
+	is_template_expression,
+	is_template_text,
+	is_template_text_or_expression,
+} from '../../template-ast.js';
 import is_reference from 'is-reference';
 
 /**
@@ -1129,12 +1137,14 @@ function apply_updates(init, update, state) {
  */
 function visit_title_element(node, context) {
 	const normalized = normalize_children(node.children, context);
-	const content = normalized[0];
+	const content = /** @type {any} */ (normalized[0]);
 
 	const metadata = { tracking: false };
-	const visited = context.visit(content, { ...context.state, metadata });
 	const result = /** @type {AST.Expression} */ (
-		/** @type {{expression?: AST.Expression}} */ (visited).expression
+		context.visit(get_template_expression(content, !!context.state.to_ts), {
+			...context.state,
+			metadata,
+		})
 	);
 
 	if (metadata.tracking) {
@@ -2613,7 +2623,9 @@ const visitors = {
 							child.type === 'TsrxFragment' ||
 							(child.type === 'Element' &&
 								(child.id.type !== 'Identifier' || !is_element_dom_element(child))) ||
-							((child.type === 'TSRXExpression' || child.type === 'Text') &&
+							// A JSXText child is always a literal; only a `{ … }` container
+							// (including a merged text run) can hold a dynamic expression.
+							(child.type === 'JSXExpressionContainer' &&
 								child.expression.type !== 'Literal'),
 					);
 
@@ -3871,13 +3883,16 @@ function transform_tsrx_tsx_child(node, context) {
 		return null;
 	}
 
-	if (node.type === 'Text') {
-		const expression = /** @type {AST.Literal} */ (node.expression);
-		const value = String(expression.value ?? '');
+	if (node.type === 'JSXText') {
+		const value = get_template_text_value(node, true);
 		return setLocation(b.jsx_text(value, value), /** @type {AST.NodeWithLocation} */ (node));
 	}
 
-	if (node.type === 'TSRXExpression') {
+	if (node.type === 'JSXExpressionContainer') {
+		// A `{/* comment */}` container renders nothing.
+		if (is_empty_expression_container(node)) {
+			return null;
+		}
 		// An EMPTY fragment that is the container's expression (`<b>{<></>}</b>`) must
 		// stay `<></>`: the `{}` already supplies the wrapper, so the default
 		// `in_jsx_child = false` lowering to a bare `null` drops the source fragment.
@@ -3891,7 +3906,7 @@ function transform_tsrx_tsx_child(node, context) {
 				(/** @type {any} */ child) =>
 					child &&
 					child.type !== 'EmptyStatement' &&
-					(child.type !== 'Text' || String(child.expression?.value ?? '') !== ''),
+					(child.type !== 'JSXText' || get_template_text_value(child, true) !== ''),
 			);
 		const expression = is_empty_fragment
 			? build_tsrx_to_ts_expression(/** @type {AST.TsrxFragment} */ (expr), context, true)
@@ -4482,8 +4497,17 @@ function build_tsrx_ts_directive_value(node, context) {
 function transform_ts_child(node, context) {
 	const { state, visit } = context;
 
-	if (node.type === 'TSRXExpression' || node.type === 'Text') {
-		state.init?.push(b.stmt(/** @type {AST.Expression} */ (visit(node.expression, { ...state }))));
+	if (is_template_text_or_expression(node)) {
+		if (is_empty_expression_container(node)) {
+			return;
+		}
+		state.init?.push(
+			b.stmt(
+				/** @type {AST.Expression} */ (
+					visit(get_template_expression(/** @type {any} */ (node), true), { ...state })
+				),
+			),
+		);
 	} else if (node.type === 'Element') {
 		if (lower_dynamic_element(node)) {
 			state.imports.add(`import { Dynamic as ${dynamic_element_import_local} } from 'ripple'`);
@@ -4907,8 +4931,8 @@ function is_template_or_control_flow(node) {
 
 	return (
 		node.type === 'Element' ||
-		node.type === 'TSRXExpression' ||
-		node.type === 'Text' ||
+		node.type === 'JSXExpressionContainer' ||
+		node.type === 'JSXText' ||
 		node.type === 'TsrxFragment' ||
 		node.type === 'IfStatement' ||
 		node.type === 'ForOfStatement' ||
@@ -5117,10 +5141,7 @@ function element_has_dynamic_content(element) {
 		) {
 			return true;
 		}
-		if (
-			(child.type === 'TSRXExpression' || child.type === 'Text') &&
-			child.expression.type !== 'Literal'
-		) {
+		if (child.type === 'JSXExpressionContainer' && child.expression.type !== 'Literal') {
 			return true;
 		}
 		// Non-DOM element (component)
@@ -5234,7 +5255,7 @@ function transform_children(children, context) {
 		).length === 1 &&
 			normalized.some(
 				(node) =>
-					node.type === 'TSRXExpression' &&
+					is_template_expression(node) &&
 					is_children_template_expression(node.expression, state.scope),
 			)) ||
 		// At root level, non-literal expressions need a fragment template so the
@@ -5242,9 +5263,7 @@ function transform_children(children, context) {
 		// is a no-op when the value is a TSRXElement.
 		(root &&
 			normalized.some(
-				(node) =>
-					node.type === 'TSRXExpression' &&
-					/** @type {AST.TSRXExpression} */ (node).expression.type !== 'Literal',
+				(node) => is_template_expression(node) && node.expression.type !== 'Literal',
 			)) ||
 		normalized.filter(
 			(node) =>
@@ -5318,10 +5337,10 @@ function transform_children(children, context) {
 		return b.id(
 			node.type == 'Element' && is_element_dom_element(node)
 				? state.scope.generate(/** @type {AST.Identifier} */ (node.id).name)
-				: node.type == 'TSRXExpression'
-					? state.scope.generate('expression')
-					: node.type == 'Text'
-						? state.scope.generate('text')
+				: is_template_text(node)
+					? state.scope.generate('text')
+					: is_template_expression(node)
+						? state.scope.generate('expression')
 						: state.scope.generate('node'),
 			/** @type {AST.NodeWithLocation} */ (node.type === 'Element' ? node.openingElement : node),
 		);
@@ -5397,10 +5416,14 @@ function transform_children(children, context) {
 			/** @type {AST.Expression | undefined} */
 			let expression = undefined;
 			let is_create_text_only = false;
-			if (node.type === 'TSRXExpression' || node.type === 'Text') {
+			if (is_template_text_or_expression(node)) {
 				metadata = { tracking: false };
 				expression = /** @type {AST.Expression} */ (
-					visit(node.expression, { ...state, flush_node: null, metadata })
+					visit(get_template_expression(/** @type {any} */ (node), false), {
+						...state,
+						flush_node: null,
+						metadata,
+					})
 				);
 				is_create_text_only = normalized.length === 1 && expression.type === 'Literal';
 			}
@@ -5554,7 +5577,7 @@ function transform_children(children, context) {
 							child.type === 'TsrxFragment' ||
 							(child.type === 'Element' &&
 								(child.id.type !== 'Identifier' || !is_element_dom_element(child))) ||
-							((child.type === 'TSRXExpression' || child.type === 'Text') &&
+							(child.type === 'JSXExpressionContainer' &&
 								child.expression.type !== 'Literal'),
 					);
 
@@ -5585,7 +5608,7 @@ function transform_children(children, context) {
 					flush_node: /** @type {TransformClientState['flush_node']} */ (flush_node),
 					namespace: state.namespace,
 				});
-			} else if (node.type === 'TSRXExpression') {
+			} else if (is_template_expression(node)) {
 				const expr = /** @type {AST.Expression} */ (expression);
 				const is_static_native_tsrx_call = is_static_native_tsrx_function_call(
 					/** @type {AST.Expression} */ (node.expression),
@@ -5648,8 +5671,11 @@ function transform_children(children, context) {
 							: b.stmt(call),
 					);
 				}
-			} else if (node.type === 'Text') {
-				render_text_expression(node.expression, /** @type {AST.Expression} */ (expression));
+			} else if (is_template_text(node)) {
+				render_text_expression(
+					get_template_expression(/** @type {any} */ (node), false),
+					/** @type {AST.Expression} */ (expression),
+				);
 			} else if (node.type === 'ForOfStatement') {
 				skipped = 0;
 				node.is_controlled = is_controlled;

--- a/packages/tsrx-ripple/src/transform/client/index.js
+++ b/packages/tsrx-ripple/src/transform/client/index.js
@@ -147,8 +147,6 @@ function apply_tsrx_css_scoping(nodes, state) {
 	const style_classes = /** @type {any} */ (component.metadata).styleClasses ?? new Map();
 	const top_scoped_classes = /** @type {any} */ (component.metadata).topScopedClasses ?? new Map();
 
-	const restore_nodes = prepare_legacy_nodes_for_css_pruning(nodes);
-
 	/**
 	 * @param {AST.Node} node
 	 * @returns {void}
@@ -169,69 +167,9 @@ function apply_tsrx_css_scoping(nodes, state) {
 		}
 	}
 
-	try {
-		for (const node of nodes) {
-			visit_node(node);
-		}
-	} finally {
-		restore_nodes();
-	}
-}
-
-/**
- * Ripple still lowers JSX-shaped TSRX into internal Element nodes before its
- * renderer runs. Keep that compatibility local by presenting those nodes to the
- * shared CSS pruner as native JSX only during pruning.
- *
- * @param {AST.Node[]} nodes
- * @returns {() => void}
- */
-function prepare_legacy_nodes_for_css_pruning(nodes) {
-	/** @type {{ node: any, type: string, native_tsrx: unknown, had_native_tsrx: boolean }[]} */
-	const changed = [];
-	const seen = new Set();
-
-	/** @param {any} node */
-	function visit(node) {
-		if (!node || typeof node !== 'object' || seen.has(node)) {
-			return;
-		}
-		seen.add(node);
-
-		if (node.type === 'Element') {
-			node.metadata ??= { path: [] };
-			changed.push({
-				node,
-				type: node.type,
-				native_tsrx: node.metadata.native_tsrx,
-				had_native_tsrx: Object.prototype.hasOwnProperty.call(node.metadata, 'native_tsrx'),
-			});
-			node.type = 'JSXElement';
-			node.metadata.native_tsrx = true;
-		}
-
-		if (Array.isArray(node.children)) {
-			for (const child of node.children) {
-				visit(child);
-			}
-		}
-	}
-
 	for (const node of nodes) {
-		visit(node);
+		visit_node(node);
 	}
-
-	return () => {
-		for (let i = changed.length - 1; i >= 0; i--) {
-			const entry = changed[i];
-			entry.node.type = entry.type;
-			if (entry.had_native_tsrx) {
-				entry.node.metadata.native_tsrx = entry.native_tsrx;
-			} else {
-				delete entry.node.metadata.native_tsrx;
-			}
-		}
-	};
 }
 
 /**
@@ -2116,16 +2054,6 @@ const visitors = {
 		return element;
 	},
 
-	JSXElement(node, context) {
-		if (context.state.to_ts) {
-			return context.next();
-		}
-		if (context.state.jsx_to_tsrx_element || is_native_tsrx_value_position(context.path)) {
-			return build_jsx_to_tsrx_element(/** @type {AST.TSRXJSXElement} */ (node), context);
-		}
-		return context.next();
-	},
-
 	JSXStyleElement(node, context) {
 		const { state } = context;
 
@@ -2165,8 +2093,20 @@ const visitors = {
 		// analysis time and injected separately.
 	},
 
-	Element(node, context) {
+	JSXElement(node, context) {
 		const { state, visit } = context;
+
+		// A raw (non-template) element — an attribute value or other JSX that
+		// never entered the template traversal.
+		if (!is_template_element(node)) {
+			if (state.to_ts) {
+				return context.next();
+			}
+			if (state.jsx_to_tsrx_element || is_native_tsrx_value_position(context.path)) {
+				return build_jsx_to_tsrx_element(/** @type {AST.TSRXJSXElement} */ (node), context);
+			}
+			return context.next();
+		}
 
 		// The TS view needs the `<TsrxDynamic is={expr}>` component shape for type
 		// checking; production codegen keeps `node.id` as the dynamic expression

--- a/packages/tsrx-ripple/src/transform/client/index.js
+++ b/packages/tsrx-ripple/src/transform/client/index.js
@@ -131,7 +131,6 @@ import {
 	is_template_fragment,
 	is_template_text,
 	is_template_text_or_expression,
-	set_element_id,
 } from '../../template-ast.js';
 import is_reference from 'is-reference';
 
@@ -4779,7 +4778,6 @@ function transform_ts_child(node, context) {
 				visit(get_element_id(element), { ...state })
 			);
 
-			set_element_id(element, member);
 			// Plant the visited member tag on local copies for the printer — the
 			// source element is never mutated.
 			const opening = /** @type {ESTreeJSX.TSRXJSXOpeningElement} */ ({

--- a/packages/tsrx-ripple/src/transform/client/index.js
+++ b/packages/tsrx-ripple/src/transform/client/index.js
@@ -87,7 +87,8 @@ import {
 	ripple_import_requires_block,
 	strip_class_typescript_syntax,
 	strip_typescript_expression_wrappers,
-	jsx_to_ripple_node,
+	visit_children_without,
+	adopt_raw_template_jsx,
 	build_index_read,
 	build_index_write,
 	build_index_update,
@@ -200,30 +201,54 @@ function disable_style_anchor_verification(element) {
 }
 
 /**
+ * Copy-on-write: nodes on the changed spine are rebuilt (their scope mapping is
+ * mirrored onto the copies); untouched subtrees are shared with the input.
  * @param {AST.Node[]} body
  * @param {AST.Statement[]} setup
+ * @param {Map<AST.Node | AST.Node[], any>} [scopes]
  * @returns {AST.Node[]}
  */
-function insert_style_ref_setup_statements(body, setup) {
+function insert_style_ref_setup_statements(body, setup, scopes) {
 	if (setup.length === 0) {
 		return body;
 	}
 
 	let inserted = false;
 
+	/**
+	 * @template T
+	 * @param {T} original
+	 * @param {T} copy
+	 * @returns {T}
+	 */
+	const mirror_scope = (original, copy) => {
+		const scope = scopes?.get(/** @type {any} */ (original));
+		if (scope) scopes?.set(/** @type {any} */ (copy), scope);
+		return copy;
+	};
+
 	/** @param {AST.Node[]} nodes */
 	const insert_in_list = (nodes) => {
 		const index = nodes.findIndex((node) => node.metadata?.returned_tsrx_child);
 		if (index !== -1) {
 			inserted = true;
-			return [
+			return mirror_scope(nodes, [
 				...nodes.slice(0, index),
 				...setup.map((statement) => clone_expression_node(statement, false)),
 				...nodes.slice(index),
-			];
+			]);
 		}
 
-		return nodes.map(insert_in_statement);
+		/** @type {AST.Node[] | null} */
+		let out = null;
+		for (let i = 0; i < nodes.length; i++) {
+			const next = insert_in_statement(nodes[i]);
+			if (next !== nodes[i]) {
+				out ??= nodes.slice();
+				out[i] = next;
+			}
+		}
+		return out === null ? nodes : mirror_scope(nodes, out);
 	};
 
 	/** @param {AST.Node} node */
@@ -232,34 +257,57 @@ function insert_style_ref_setup_statements(body, setup) {
 			return node;
 		}
 		if (node.type === 'BlockStatement') {
-			node.body = /** @type {AST.Statement[]} */ (insert_in_list(node.body || []));
-			return node;
+			const list = node.body || [];
+			const node_body = /** @type {AST.Statement[]} */ (insert_in_list(list));
+			return node_body === list ? node : mirror_scope(node, { ...node, body: node_body });
 		}
 		if (node.type === 'IfStatement') {
-			node.consequent = /** @type {AST.Statement} */ (insert_in_statement(node.consequent));
+			/** @type {Record<string, any> | null} */
+			let updates = null;
+			const consequent = /** @type {AST.Statement} */ (insert_in_statement(node.consequent));
+			if (consequent !== node.consequent) (updates ??= {}).consequent = consequent;
 			if (node.alternate) {
-				node.alternate = /** @type {AST.Statement} */ (insert_in_statement(node.alternate));
+				const alternate = /** @type {AST.Statement} */ (insert_in_statement(node.alternate));
+				if (alternate !== node.alternate) (updates ??= {}).alternate = alternate;
 			}
-			return node;
+			return updates === null ? node : mirror_scope(node, { ...node, ...updates });
 		}
 		if (node.type === 'SwitchStatement') {
-			for (const switch_case of node.cases || []) {
-				switch_case.consequent = /** @type {AST.Statement[]} */ (
-					insert_in_list(switch_case.consequent || [])
-				);
+			const node_cases = node.cases || [];
+			/** @type {AST.SwitchCase[] | null} */
+			let cases = null;
+			for (let i = 0; i < node_cases.length; i++) {
+				const switch_case = node_cases[i];
+				const list = switch_case.consequent || [];
+				const consequent = /** @type {AST.Statement[]} */ (insert_in_list(list));
+				if (consequent !== list) {
+					cases ??= node_cases.slice();
+					cases[i] = mirror_scope(switch_case, { ...switch_case, consequent });
+				}
 			}
-			return node;
+			return cases === null ? node : mirror_scope(node, { ...node, cases });
 		}
 		if (node.type === 'TryStatement') {
-			node.block = /** @type {AST.BlockStatement} */ (insert_in_statement(node.block));
+			/** @type {Record<string, any> | null} */
+			let updates = null;
+			const block = /** @type {AST.BlockStatement} */ (insert_in_statement(node.block));
+			if (block !== node.block) (updates ??= {}).block = block;
 			if (node.handler?.body) {
-				node.handler.body = /** @type {AST.BlockStatement} */ (
+				const handler_body = /** @type {AST.BlockStatement} */ (
 					insert_in_statement(node.handler.body)
 				);
+				if (handler_body !== node.handler.body) {
+					(updates ??= {}).handler = mirror_scope(node.handler, {
+						...node.handler,
+						body: handler_body,
+					});
+				}
 			}
 			if (node.finalizer) {
-				node.finalizer = /** @type {AST.BlockStatement} */ (insert_in_statement(node.finalizer));
+				const finalizer = /** @type {AST.BlockStatement} */ (insert_in_statement(node.finalizer));
+				if (finalizer !== node.finalizer) (updates ??= {}).finalizer = finalizer;
 			}
+			return updates === null ? node : mirror_scope(node, { ...node, ...updates });
 		}
 		return node;
 	};
@@ -631,28 +679,24 @@ function visit_function(node, context) {
 		return context.next(SetStateForOutsideComponent(state));
 	}
 
-	delete node.returnType;
-	delete node.typeParameters;
-
-	for (const param of node.params) {
-		delete param.typeAnnotation;
-		// Handle AssignmentPattern (parameters with default values)
-		if (param.type === 'AssignmentPattern' && param.left) {
-			delete param.left.typeAnnotation;
-		}
-	}
-
-	// Replace lazy destructuring params with generated identifiers
+	// Strip parameter type annotations via copies (the source params are never
+	// mutated) and replace lazy destructuring params with generated identifiers
 	const transformed_params = node.params.map((param) => {
-		const pattern = param.type === 'AssignmentPattern' ? param.left : param;
+		/** @type {AST.Pattern} */
+		let param_out = param.typeAnnotation ? { ...param, typeAnnotation: undefined } : param;
+		// Handle AssignmentPattern (parameters with default values)
+		if (param_out.type === 'AssignmentPattern' && param_out.left?.typeAnnotation) {
+			param_out = { ...param_out, left: { ...param_out.left, typeAnnotation: undefined } };
+		}
+		const pattern = param_out.type === 'AssignmentPattern' ? param_out.left : param_out;
 		if (pattern.type === 'ObjectPattern' || pattern.type === 'ArrayPattern') {
 			const transformed_pattern = replace_lazy_param_pattern(pattern);
-			if (param.type === 'AssignmentPattern') {
-				return /** @type {AST.AssignmentPattern} */ ({ ...param, left: transformed_pattern });
+			if (param_out.type === 'AssignmentPattern') {
+				return /** @type {AST.AssignmentPattern} */ ({ ...param_out, left: transformed_pattern });
 			}
 			return transformed_pattern;
 		}
-		return param;
+		return param_out;
 	});
 
 	let body = /** @type {AST.BlockStatement | AST.Expression} */ (
@@ -681,6 +725,8 @@ function visit_function(node, context) {
 		...node,
 		params: transformed_params.map((param) => context.visit(param, state)),
 		body,
+		returnType: undefined,
+		typeParameters: undefined,
 	};
 }
 
@@ -769,12 +815,16 @@ function transform_native_tsrx_function(node, context) {
 		let props_param = node.params[0];
 
 		if (props_param.type === 'Identifier') {
-			delete props_param.typeAnnotation;
-			props = props_param;
+			props = props_param.typeAnnotation
+				? /** @type {AST.Pattern} */ ({ ...props_param, typeAnnotation: undefined })
+				: props_param;
 		} else if (props_param.type === 'ObjectPattern' || props_param.type === 'ArrayPattern') {
-			delete props_param.typeAnnotation;
 			if (!props_param.lazy) {
-				props = replace_lazy_param_pattern(props_param);
+				props = replace_lazy_param_pattern(
+					/** @type {AST.Pattern} */ (
+						props_param.typeAnnotation ? { ...props_param, typeAnnotation: undefined } : props_param
+					),
+				);
 			}
 		} else {
 			props = props_param;
@@ -791,7 +841,7 @@ function transform_native_tsrx_function(node, context) {
 		context.state.scope;
 	const node_id = node.type !== 'ArrowFunctionExpression' ? (node.id ?? null) : null;
 	const is_synthetic_children = node.metadata?.synthetic_children === true;
-	const raw_render_body = get_native_tsrx_function_body(node);
+	const raw_render_body = get_native_tsrx_function_body(node, context.state.scopes);
 	const css = get_component_css({ ...context.state, component: node });
 	const style_ref_setup = css
 		? createStyleRefSetupStatements(
@@ -804,7 +854,8 @@ function transform_native_tsrx_function(node, context) {
 			)
 		: [];
 	const render_body = strip_tsrx_style_elements(
-		insert_style_ref_setup_statements(raw_render_body, style_ref_setup),
+		insert_style_ref_setup_statements(raw_render_body, style_ref_setup, context.state.scopes),
+		context.state.scopes,
 	);
 	const transformed_body = transform_body(render_body, {
 		...context,
@@ -1366,7 +1417,7 @@ function SetStateForOutsideComponent(state, more_state = {}) {
  */
 function build_jsx_to_tsrx_element(node, context) {
 	const { state, visit, path } = context;
-	const result = jsx_to_ripple_node(/** @type {AST.Node} */ (node), path);
+	const result = adopt_raw_template_jsx(/** @type {AST.Node} */ (node));
 	const converted = Array.isArray(result) ? result : [result];
 	/** @type {AST.Node[]} */
 	const children = converted.filter((child) => child != null && child.type !== 'EmptyStatement');
@@ -1409,7 +1460,7 @@ const visit_switch_statement = (node, context) => {
 		return context.next();
 	}
 
-	const root_controlled = /** @type {any} */ (node).root_controlled === true;
+	const root_controlled = node.metadata?.root_controlled === true;
 	if (!root_controlled) {
 		context.state.template?.push('<!>');
 	}
@@ -1528,7 +1579,7 @@ const visit_if_statement = (node, context) => {
 		return;
 	}
 
-	const root_controlled = /** @type {any} */ (node).root_controlled === true;
+	const root_controlled = node.metadata?.root_controlled === true;
 	if (!root_controlled) {
 		context.state.template?.push('<!>');
 	}
@@ -1631,7 +1682,7 @@ const visit_try_statement = (node, context) => {
 	if (context.state.to_ts) {
 		return transform_ts_child(node, context);
 	}
-	const root_controlled = /** @type {any} */ (node).root_controlled === true;
+	const root_controlled = node.metadata?.root_controlled === true;
 	if (!root_controlled) {
 		context.state.template?.push('<!>');
 	}
@@ -1647,12 +1698,14 @@ const visit_try_statement = (node, context) => {
 		},
 	});
 
-	if (handler?.param) {
-		delete handler.param.typeAnnotation;
-	}
-	if (handler?.resetParam) {
-		delete handler.resetParam.typeAnnotation;
-	}
+	// Strip catch-param type annotations on copies embedded in the output; the
+	// source handler params are never mutated.
+	const handler_param = handler?.param
+		? /** @type {AST.Pattern} */ ({ ...handler.param, typeAnnotation: undefined })
+		: null;
+	const handler_reset_param = handler?.resetParam
+		? /** @type {AST.Pattern} */ ({ ...handler.resetParam, typeAnnotation: undefined })
+		: null;
 
 	const catch_arg =
 		handler === null
@@ -1660,10 +1713,10 @@ const visit_try_statement = (node, context) => {
 			: b.arrow(
 					[
 						b.id('__anchor'),
-						...(handler.param && handler.resetParam
-							? [handler.param, handler.resetParam]
-							: handler.param
-								? [handler.param]
+						...(handler_param && handler_reset_param
+							? [handler_param, handler_reset_param]
+							: handler_param
+								? [handler_param]
 								: []),
 					],
 					b.block(
@@ -1717,8 +1770,8 @@ const visit_for_of_statement = (node, context) => {
 	if (!is_inside_component(context)) {
 		return context.next();
 	}
-	const is_controlled = node.is_controlled;
-	const root_controlled = /** @type {any} */ (node).root_controlled === true;
+	const is_controlled = node.metadata?.is_controlled;
+	const root_controlled = node.metadata?.root_controlled === true;
 	const index = node.index;
 	const key = node.key;
 	let flags = is_controlled ? IS_CONTROLLED : 0;
@@ -1732,7 +1785,9 @@ const visit_for_of_statement = (node, context) => {
 	}
 
 	if (node.metadata?.script_only && !node.metadata?.has_template) {
-		const pattern = /** @type {AST.VariableDeclaration} */ (node.left).declarations[0].id;
+		const pattern =
+			node.metadata?.tsrx_for_pattern_id ??
+			/** @type {AST.VariableDeclaration} */ (node.left).declarations[0].id;
 		const body_scope = /** @type {ScopeInterface} */ (context.state.scopes.get(node.body));
 		const body = transform_body(/** @type {AST.BlockStatement} */ (node.body).body, {
 			...context,
@@ -1749,9 +1804,19 @@ const visit_for_of_statement = (node, context) => {
 			context.state.init?.push(b.var(index, b.literal(0)));
 		}
 
+		const left = /** @type {AST.VariableDeclaration} */ (
+			context.visit(/** @type {AST.Node} */ (node.left))
+		);
 		context.state.init?.push(
 			b.for_of(
-				/** @type {AST.VariableDeclaration} */ (context.visit(/** @type {AST.Node} */ (node.left))),
+				// A keyed loop iterates the generated pattern id (see the
+				// analyzer's tsrx_for_pattern_id), not the source destructuring.
+				node.metadata?.tsrx_for_pattern_id
+					? {
+							...left,
+							declarations: [{ ...left.declarations[0], id: node.metadata.tsrx_for_pattern_id }],
+						}
+					: left,
 				/** @type {AST.Expression} */ (context.visit(/** @type {AST.Node} */ (node.right))),
 				b.block(body),
 			),
@@ -1765,7 +1830,9 @@ const visit_for_of_statement = (node, context) => {
 	}
 
 	const id = root_controlled ? b.id('__anchor') : context.state.flush_node?.(false, is_controlled);
-	const pattern = /** @type {AST.VariableDeclaration} */ (node.left).declarations[0].id;
+	const pattern =
+		node.metadata?.tsrx_for_pattern_id ??
+		/** @type {AST.VariableDeclaration} */ (node.left).declarations[0].id;
 	const body_scope = /** @type {ScopeInterface} */ (context.state.scopes.get(node.body));
 	const body_nodes = /** @type {AST.BlockStatement} */ (node.body).body;
 	/** @type {AST.Statement[]} */
@@ -1911,21 +1978,21 @@ const visitors = {
 		if (state.to_ts && state.ancestor_server_block) {
 			/** @type {AST.VariableDeclaration[]} */
 			const locals = state.server_block_locals;
-			for (const spec of node.specifiers) {
+			// Rebuild the specifiers with obfuscated locals on copies — the source
+			// import declaration is never mutated.
+			const specifiers = node.specifiers.map((spec) => {
 				const original_name = spec.local.name;
 				const name = obfuscateIdentifier(original_name);
-				if (
+				const local =
 					spec.type !== 'ImportSpecifier' ||
 					(spec.imported && /** @type {AST.Identifier} */ (spec.imported).name !== spec.local.name)
-				) {
-					spec.local.name = name;
-				} else {
-					spec.local = b.id(name);
-				}
-				spec.local.metadata.source_name = original_name;
+						? { ...spec.local, name }
+						: b.id(name);
+				local.metadata = { ...local.metadata, source_name: original_name };
 				locals.push(b.const(original_name, b.id(name)));
-			}
-			state.imports.add(node);
+				return { ...spec, local };
+			});
+			state.imports.add(/** @type {AST.ImportDeclaration} */ ({ ...node, specifiers }));
 			return b.empty;
 		}
 
@@ -1947,9 +2014,6 @@ const visitors = {
 	},
 
 	CallExpression(node, context) {
-		if (!context.state.to_ts) {
-			delete node.typeArguments;
-		}
 		const callee = node.callee;
 		const parent = context.path.at(-1);
 
@@ -1978,6 +2042,7 @@ const visitors = {
 						...(requires_block ? [b.id('__block')] : []),
 						...node.arguments.map((arg) => context.visit(arg)),
 					]),
+					typeArguments: undefined,
 				};
 			}
 		}
@@ -1987,12 +2052,10 @@ const visitors = {
 			const track_method_name = matched_track_call === 'trackAsync' ? 'track_async' : 'track';
 			/** @type {(AST.Expression | AST.SpreadElement)[]} */
 			const call_args = [];
-			if (node.arguments.length === 0) {
-				node.arguments.push(b.void0);
-			}
+			const source_args = node.arguments.length === 0 ? [b.void0] : node.arguments;
 
-			for (let i = 0; i < node.arguments.length; i++) {
-				const arg = node.arguments[i];
+			for (let i = 0; i < source_args.length; i++) {
+				const arg = source_args[i];
 				call_args.push(/** @type {(AST.Expression | AST.SpreadElement)} */ (context.visit(arg)));
 				if (i === 0) {
 					call_args.push(b.id('__block'));
@@ -2004,6 +2067,7 @@ const visitors = {
 				...node,
 				callee: b.member(b.id('_$_'), b.id(track_method_name)),
 				arguments: call_args,
+				typeArguments: undefined,
 			});
 		}
 
@@ -2044,7 +2108,12 @@ const visitors = {
 			!context.path.some((node) => is_native_tsrx_function_node(node)) ||
 			is_declared_function_within_component(callee, context)
 		) {
-			return context.next();
+			if (context.state.to_ts) {
+				return context.next();
+			}
+			// Like `context.next()`, but on a copy without the TypeScript-only type
+			// arguments so they are neither visited nor emitted.
+			return visit_children_without(node, context, ['typeArguments']);
 		}
 
 		// Handle array methods that access the array
@@ -2075,6 +2144,7 @@ const visitors = {
 			arguments: /** @type {(AST.Expression | AST.SpreadElement)[]} */ (
 				node.arguments.map((arg) => context.visit(arg))
 			),
+			typeArguments: undefined,
 		};
 
 		// A generated code-block scope IIFE is already a zero-argument
@@ -2140,7 +2210,9 @@ const visitors = {
 			is_value_static(node)
 		) {
 			if (!context.state.to_ts) {
-				delete node.typeArguments;
+				// Like `context.next()`, but on a copy without the TypeScript-only
+				// type arguments so they are neither visited nor emitted.
+				return visit_children_without(node, context, ['typeArguments']);
 			}
 
 			return context.next();
@@ -2200,21 +2272,23 @@ const visitors = {
 
 	PropertyDefinition(node, context) {
 		if (!context.state.to_ts) {
-			delete node.typeAnnotation;
+			// Like `context.next()`, but on a copy without the TypeScript-only type
+			// annotation so it is neither visited nor emitted.
+			return visit_children_without(node, context, ['typeAnnotation']);
 		}
 		return context.next();
 	},
 
 	ClassDeclaration(node, context) {
 		if (!context.state.to_ts) {
-			strip_class_typescript_syntax(node, context);
+			return strip_class_typescript_syntax(node, context);
 		}
 		return context.next();
 	},
 
 	ClassExpression(node, context) {
 		if (!context.state.to_ts) {
-			strip_class_typescript_syntax(node, context);
+			return strip_class_typescript_syntax(node, context);
 		}
 		return context.next();
 	},
@@ -2230,9 +2304,15 @@ const visitors = {
 		) {
 			if (context.state.to_ts) {
 				// In TypeScript mode, convert to a regular assignment (drop the pattern)
-				node.expression.left.lazy = false;
 				delete node.expression.left.metadata.lazy_id;
-				return context.next();
+				const expression = {
+					...node.expression,
+					left: { ...node.expression.left, lazy: false },
+				};
+				return {
+					...node,
+					expression: /** @type {AST.Expression} */ (context.visit(expression)),
+				};
 			}
 			const right = /** @type {AST.Expression} */ (context.visit(node.expression.right));
 			return b.const(b.id(node.expression.left.metadata.lazy_id), right);
@@ -2241,36 +2321,45 @@ const visitors = {
 	},
 
 	VariableDeclaration(node, context) {
-		for (const declarator of node.declarations) {
-			if (!context.state.to_ts) {
-				delete declarator.id.typeAnnotation;
+		// Rewrite declarator ids on copies (strip type annotations, replace lazy
+		// destructuring patterns) — the source declarators are never mutated.
+		const declarations = node.declarations.map((declarator) => {
+			/** @type {AST.VariableDeclarator['id']} */
+			let id = declarator.id;
 
+			if (!context.state.to_ts) {
 				// Replace lazy destructuring patterns with the generated identifier
 				if (
-					(declarator.id.type === 'ObjectPattern' || declarator.id.type === 'ArrayPattern') &&
-					declarator.id.lazy &&
-					declarator.id.metadata?.lazy_id
+					(id.type === 'ObjectPattern' || id.type === 'ArrayPattern') &&
+					id.lazy &&
+					id.metadata?.lazy_id
 				) {
-					declarator.id = b.id(declarator.id.metadata.lazy_id);
+					id = b.id(id.metadata.lazy_id);
+				} else if (id.typeAnnotation) {
+					id = { ...id, typeAnnotation: undefined };
 				}
-			}
-		}
-
-		if (context.state.to_ts) {
-			for (const declarator of node.declarations) {
-				if (
-					(declarator.id.type === 'ObjectPattern' || declarator.id.type === 'ArrayPattern') &&
-					declarator.id.lazy
-				) {
-					declarator.id.lazy = false;
-					if (declarator.id.metadata?.lazy_id) {
-						delete declarator.id.metadata.lazy_id;
-					}
+			} else if ((id.type === 'ObjectPattern' || id.type === 'ArrayPattern') && id.lazy) {
+				if (id.metadata?.lazy_id) {
+					delete id.metadata.lazy_id;
 				}
+				id = { ...id, lazy: false };
 			}
-		}
 
-		return context.next();
+			if (id === declarator.id) {
+				return declarator;
+			}
+			const copy = { ...declarator, id };
+			const scope = context.state.scopes.get(declarator);
+			if (scope) context.state.scopes.set(copy, scope);
+			return copy;
+		});
+
+		return {
+			...node,
+			declarations: declarations.map(
+				(declarator) => /** @type {AST.VariableDeclarator} */ (context.visit(declarator)),
+			),
+		};
 	},
 
 	VariableDeclarator(node, context) {
@@ -2505,8 +2594,12 @@ const visitors = {
 		// The TS view needs the `<TsrxDynamic is={expr}>` component shape for type
 		// checking; production codegen keeps `node.id` as the dynamic expression
 		// and renders it directly via `_$_.composite` in the component branch.
-		if (state.to_ts && lower_dynamic_element(node)) {
-			state.imports.add(`import { Dynamic as ${dynamic_element_import_local} } from 'ripple'`);
+		if (state.to_ts) {
+			const lowered = lower_dynamic_element(node, undefined, state.scopes);
+			if (lowered) {
+				state.imports.add(`import { Dynamic as ${dynamic_element_import_local} } from 'ripple'`);
+				node = lowered;
+			}
 		}
 
 		const element_id = get_element_id(node);
@@ -3032,11 +3125,11 @@ const visitors = {
 				state.init?.push(b.block(init));
 			}
 		} else {
-			const root_controlled = /** @type {any} */ (node).root_controlled === true;
+			const root_controlled = node.metadata?.root_controlled === true;
 			// `append_into` is a `{ parent }` sentinel set by transform_children when
 			// every sibling is a static component: render directly into the parent,
 			// no `<!>` placeholder and no child()/sibling() navigation.
-			const append_into = node.append_into ?? null;
+			const append_into = node.metadata?.append_into ?? null;
 			const id = root_controlled
 				? b.id('__anchor')
 				: append_into
@@ -4507,8 +4600,10 @@ function transform_ts_child(node, context) {
 			state.init?.push(b.stmt(jsxElement));
 		}
 	} else if (is_template_element(node)) {
-		if (lower_dynamic_element(node)) {
+		const lowered = lower_dynamic_element(node, undefined, state.scopes);
+		if (lowered) {
 			state.imports.add(`import { Dynamic as ${dynamic_element_import_local} } from 'ripple'`);
+			node = lowered;
 		}
 
 		/** @type {ESTreeJSX.JSXElement['children']} */
@@ -4641,28 +4736,37 @@ function transform_ts_child(node, context) {
 			}
 		}
 
+		let element_source = /** @type {ESTreeJSX.JSXElement} */ (/** @type {unknown} */ (node));
+
 		if (get_element_id(node).type === 'MemberExpression') {
 			const member = /** @type {AST.MemberExpression} */ (
 				visit(get_element_id(node), { ...state })
 			);
 
 			set_element_id(node, member);
-			/** @type {ESTreeJSX.TSRXJSXOpeningElement} */ (node.openingElement).name = member;
-			if (node.closingElement) {
-				/** @type {ESTreeJSX.TSRXJSXClosingElement} */ (node.closingElement).name = setLocation(
-					{ ...member },
-					/** @type {AST.NodeWithLocation} */ (node.closingElement.name),
-					true,
-				);
-			}
+			// Plant the visited member tag on local copies for the printer — the
+			// source element is never mutated.
+			const opening = /** @type {ESTreeJSX.TSRXJSXOpeningElement} */ ({
+				...node.openingElement,
+				name: member,
+			});
+			const closing = node.closingElement
+				? /** @type {ESTreeJSX.TSRXJSXClosingElement} */ ({
+						...node.closingElement,
+						name: setLocation(
+							{ ...member },
+							/** @type {AST.NodeWithLocation} */ (node.closingElement.name),
+							true,
+						),
+					})
+				: null;
+			element_source = /** @type {ESTreeJSX.JSXElement} */ (
+				/** @type {unknown} */ ({ ...node, openingElement: opening, closingElement: closing })
+			);
 		}
 
 		/** @type {ESTreeJSX.JSXElement} */
-		const jsxElement = b.jsx_element(
-			/** @type {ESTreeJSX.JSXElement} */ (/** @type {unknown} */ (node)),
-			attributes,
-			children,
-		);
+		const jsxElement = b.jsx_element(element_source, attributes, children);
 		if (element_name === 'style') {
 			disable_style_anchor_verification(jsxElement);
 		}
@@ -5231,14 +5335,15 @@ function transform_template_element(node, state, visit, child_namespace) {
 function transform_children(children, context) {
 	const { visit, state, root } = context;
 	if (state.to_ts) {
-		for (const child of children) {
-			if (
-				is_template_element(child) &&
-				lower_dynamic_element(/** @type {AST.TSRXJSXElement} */ (child))
-			) {
+		children = children.map((child) => {
+			const lowered = is_template_element(child)
+				? lower_dynamic_element(/** @type {AST.TSRXJSXElement} */ (child), undefined, state.scopes)
+				: null;
+			if (lowered) {
 				state.imports.add(`import { Dynamic as ${dynamic_element_import_local} } from 'ripple'`);
 			}
-		}
+			return lowered ?? child;
+		});
 	}
 	const normalized = normalize_children(children, {
 		...context,
@@ -5320,7 +5425,10 @@ function transform_children(children, context) {
 				!is_element_dom_element(single_output) &&
 				!is_ripple_fragment_element(single_output, context)));
 	if (root_controlled) {
-		/** @type {any} */ (single_output).root_controlled = true;
+		/** @type {AST.Node} */ (single_output).metadata = {
+			.../** @type {AST.Node} */ (single_output).metadata,
+			root_controlled: true,
+		};
 	}
 
 	// All-component children can append directly into the parent element instead of
@@ -5347,7 +5455,7 @@ function transform_children(children, context) {
 		const append_anchor_id = b.id(state.scope.generate('append_anchor'));
 		state.init?.push(b.var(append_anchor_id, b.call('_$_.append_into', parent_id)));
 		for (const child of normalized) {
-			child.append_into = append_anchor_id;
+			child.metadata = { ...child.metadata, append_into: append_anchor_id };
 		}
 	}
 
@@ -5722,7 +5830,7 @@ function transform_children(children, context) {
 				(node.type === 'JSXForExpression' && node.statementType === 'ForOfStatement')
 			) {
 				skipped = 0;
-				node.is_controlled = is_controlled;
+				node.metadata = { ...node.metadata, is_controlled };
 				visit(node, {
 					...state,
 					flush_node: /** @type {TransformClientState['flush_node']} */ (flush_node),
@@ -5730,7 +5838,7 @@ function transform_children(children, context) {
 				});
 			} else if (node.type === 'IfStatement' || node.type === 'JSXIfExpression') {
 				skipped = 0;
-				node.is_controlled = is_controlled;
+				node.metadata = { ...node.metadata, is_controlled };
 				visit(node, {
 					...state,
 					flush_node: /** @type {TransformClientState['flush_node']} */ (flush_node),
@@ -5738,7 +5846,7 @@ function transform_children(children, context) {
 				});
 			} else if (node.type === 'TryStatement' || node.type === 'JSXTryExpression') {
 				skipped = 0;
-				node.is_controlled = is_controlled;
+				node.metadata = { ...node.metadata, is_controlled };
 				visit(node, {
 					...state,
 					flush_node: /** @type {TransformClientState['flush_node']} */ (flush_node),
@@ -5746,7 +5854,7 @@ function transform_children(children, context) {
 				});
 			} else if (node.type === 'SwitchStatement' || node.type === 'JSXSwitchExpression') {
 				skipped = 0;
-				node.is_controlled = is_controlled;
+				node.metadata = { ...node.metadata, is_controlled };
 				visit(node, {
 					...state,
 					flush_node: /** @type {TransformClientState['flush_node']} */ (flush_node),

--- a/packages/tsrx-ripple/src/transform/client/index.js
+++ b/packages/tsrx-ripple/src/transform/client/index.js
@@ -110,6 +110,7 @@ import {
 	get_attribute_name,
 	get_attribute_name_node,
 	get_attribute_value,
+	get_style_css,
 	get_template_expression,
 	get_template_text_value,
 	is_empty_expression_container,
@@ -2118,21 +2119,13 @@ const visitors = {
 		return context.next();
 	},
 
-	Element(node, context) {
-		const { state, visit } = context;
-
-		// The TS view needs the `<TsrxDynamic is={expr}>` component shape for type
-		// checking; production codegen keeps `node.id` as the dynamic expression
-		// and renders it directly via `_$_.composite` in the component branch.
-		if (state.to_ts && lower_dynamic_element(node)) {
-			state.imports.add(`import { Dynamic as ${dynamic_element_import_local} } from 'ripple'`);
-		}
+	JSXStyleElement(node, context) {
+		const { state } = context;
 
 		if (
-			is_style_element(node) &&
-			(state.regular_js ||
-				is_native_tsrx_value_position(context.path) ||
-				is_regular_js_statement_position(context.path))
+			state.regular_js ||
+			is_native_tsrx_value_position(context.path) ||
+			is_regular_js_statement_position(context.path)
 		) {
 			const expression = build_style_class_map_expression(node, context);
 			if (expression) {
@@ -2141,6 +2134,38 @@ const visitors = {
 				}
 				return expression;
 			}
+		}
+
+		if (state.to_ts) {
+			const fragment = /** @type {ESTreeJSX.JSXFragment} */ (
+				/** @type {unknown} */ ({
+					type: 'JSXFragment',
+					children: [node],
+					openingFragment: { type: 'JSXOpeningFragment', metadata: { path: [] } },
+					closingFragment: { type: 'JSXClosingFragment', metadata: { path: [] } },
+					metadata: { path: [], tsrx_render_fragment: true },
+				})
+			);
+			return build_tsrx_to_ts_expression(fragment, context);
+		}
+
+		if (state.inside_head) {
+			state.template?.push(`<style>${sanitizeTemplateString(get_style_css(node))}</style>`);
+			return;
+		}
+
+		// Component styles render nothing at runtime — their CSS is extracted at
+		// analysis time and injected separately.
+	},
+
+	Element(node, context) {
+		const { state, visit } = context;
+
+		// The TS view needs the `<TsrxDynamic is={expr}>` component shape for type
+		// checking; production codegen keeps `node.id` as the dynamic expression
+		// and renders it directly via `_$_.composite` in the component branch.
+		if (state.to_ts && lower_dynamic_element(node)) {
+			state.imports.add(`import { Dynamic as ${dynamic_element_import_local} } from 'ripple'`);
 		}
 
 		if (state.to_ts) {
@@ -2178,10 +2203,6 @@ const visitors = {
 		}
 
 		if (context.state.inside_head) {
-			if (node.id.type === 'Identifier' && node.id.name === 'style') {
-				state.template?.push(`<style>${sanitizeTemplateString(node.css)}</style>`);
-				return;
-			}
 			// Inline scripts (`<script>{code}</script>`) are rendered by injecting
 			// the child content as the script's text. Scripts with no inline body
 			// (e.g. `<script src={...} />`) carry their behavior in attributes, so
@@ -3912,7 +3933,7 @@ function transform_tsrx_tsx_child(node, context) {
 		);
 	}
 
-	if (node.type === 'Element') {
+	if (node.type === 'Element' || node.type === 'JSXStyleElement') {
 		const expression = transform_ts_child(node, {
 			...context,
 			state: { ...context.state, init: null },
@@ -4503,6 +4524,20 @@ function transform_ts_child(node, context) {
 				),
 			),
 		);
+	} else if (node.type === 'JSXStyleElement') {
+		// to_ts: emit an empty `<style>` element for type-only mappings. The CSS
+		// children are TSRX stylesheet AST, never printed as TSX children, and
+		// style attributes were never carried over.
+		const jsxElement = b.jsx_element(/** @type {any} */ (node), [], []);
+		disable_style_anchor_verification(jsxElement);
+		if (!state.init) {
+			return jsxElement;
+		}
+		if (/** @type {any} */ (node).unclosed) {
+			state.init?.push(/** @type {AST.Statement} */ (/** @type {unknown} */ (jsxElement)));
+		} else {
+			state.init?.push(b.stmt(jsxElement));
+		}
 	} else if (node.type === 'Element') {
 		if (lower_dynamic_element(node)) {
 			state.imports.add(`import { Dynamic as ${dynamic_element_import_local} } from 'ripple'`);
@@ -4926,6 +4961,7 @@ function is_template_or_control_flow(node) {
 
 	return (
 		node.type === 'Element' ||
+		node.type === 'JSXStyleElement' ||
 		node.type === 'JSXExpressionContainer' ||
 		node.type === 'JSXText' ||
 		is_template_fragment(node) ||
@@ -5333,11 +5369,13 @@ function transform_children(children, context) {
 		return b.id(
 			node.type == 'Element' && is_element_dom_element(node)
 				? state.scope.generate(/** @type {AST.Identifier} */ (node.id).name)
-				: is_template_text(node)
-					? state.scope.generate('text')
-					: is_template_expression(node)
-						? state.scope.generate('expression')
-						: state.scope.generate('node'),
+				: node.type === 'JSXStyleElement'
+					? state.scope.generate('style')
+					: is_template_text(node)
+						? state.scope.generate('text')
+						: is_template_expression(node)
+							? state.scope.generate('expression')
+							: state.scope.generate('node'),
 			/** @type {AST.NodeWithLocation} */ (node.type === 'Element' ? node.openingElement : node),
 		);
 	};
@@ -5595,6 +5633,16 @@ function transform_children(children, context) {
 						state.init?.push(b.stmt(b.call('_$_.pop', id)));
 					}
 				}
+			} else if (node.type === 'JSXStyleElement') {
+				// A `<style>` in `<head>` renders as a static template element; the
+				// visitor pushes its markup (or nothing outside head).
+				skipped++;
+
+				visit(node, {
+					...state,
+					flush_node: /** @type {TransformClientState['flush_node']} */ (flush_node),
+					namespace: state.namespace,
+				});
 			} else if (is_template_fragment(node)) {
 				skipped = 0;
 

--- a/packages/tsrx-ripple/src/transform/client/index.js
+++ b/packages/tsrx-ripple/src/transform/client/index.js
@@ -110,15 +110,21 @@ import {
 	get_attribute_name,
 	get_attribute_name_node,
 	get_attribute_value,
+	get_element_attributes,
+	get_element_id,
 	get_style_css,
 	get_template_expression,
 	get_template_text_value,
+	is_dynamic_element,
 	is_empty_expression_container,
 	is_expression_attribute,
+	is_self_closing,
+	is_template_element,
 	is_template_expression,
 	is_template_fragment,
 	is_template_text,
 	is_template_text_or_expression,
+	set_element_id,
 } from '../../template-ast.js';
 import is_reference from 'is-reference';
 
@@ -1251,7 +1257,7 @@ function create_element_ref_target_type(node, state) {
 	if (!is_element_dom_element(node)) {
 		return null;
 	}
-	const element_name = /** @type {AST.Identifier} */ (node.id).name;
+	const element_name = /** @type {AST.Identifier} */ (get_element_id(node)).name;
 	const namespace =
 		element_name === 'svg' ? 'svg' : element_name === 'math' ? 'mathml' : state.namespace;
 	return create_element_ref_target_type_for_name(element_name, namespace);
@@ -1334,15 +1340,16 @@ function ripple_namespace_requires_block(name) {
  * @returns {boolean}
  */
 function is_ripple_fragment_element(node, context) {
-	if (node.id.type === 'Identifier') {
-		return node.id.name === 'Fragment' && is_ripple_import(node.id, context);
+	const id = get_element_id(node);
+	if (id.type === 'Identifier') {
+		return id.name === 'Fragment' && is_ripple_import(id, context);
 	}
 
 	return (
-		node.id.type === 'MemberExpression' &&
-		node.id.property.type === 'Identifier' &&
-		node.id.property.name === 'Fragment' &&
-		is_ripple_import(node.id, context)
+		id.type === 'MemberExpression' &&
+		id.property.type === 'Identifier' &&
+		id.property.name === 'Fragment' &&
+		is_ripple_import(id, context)
 	);
 }
 
@@ -1351,7 +1358,7 @@ function is_ripple_fragment_element(node, context) {
  * @returns {ESTreeJSX.JSXAttribute | null}
  */
 function get_inner_html_attribute(node) {
-	for (const attr of node.attributes) {
+	for (const attr of get_element_attributes(node)) {
 		if (attr.type === 'JSXAttribute' && get_attribute_name(attr) === 'innerHTML') {
 			return attr;
 		}
@@ -2168,6 +2175,9 @@ const visitors = {
 			state.imports.add(`import { Dynamic as ${dynamic_element_import_local} } from 'ripple'`);
 		}
 
+		const element_id = get_element_id(node);
+		const element_attributes = get_element_attributes(node);
+
 		if (state.to_ts) {
 			const fragment = /** @type {ESTreeJSX.JSXFragment} */ (
 				/** @type {unknown} */ ({
@@ -2207,7 +2217,11 @@ const visitors = {
 			// the child content as the script's text. Scripts with no inline body
 			// (e.g. `<script src={...} />`) carry their behavior in attributes, so
 			// they fall through to generic element handling instead.
-			if (node.id.type === 'Identifier' && node.id.name === 'script' && node.children.length > 0) {
+			if (
+				element_id.type === 'Identifier' &&
+				element_id.name === 'script' &&
+				node.children.length > 0
+			) {
 				const id = state.flush_node?.();
 				state.template?.push('<!>');
 				context.state.init?.push(
@@ -2220,12 +2234,12 @@ const visitors = {
 		}
 
 		const is_dom_element = is_element_dom_element(node);
-		const is_spreading = node.attributes.some((attr) => attr.type === 'JSXSpreadAttribute');
+		const is_spreading = element_attributes.some((attr) => attr.type === 'JSXSpreadAttribute');
 		/** @type {(AST.Property | AST.SpreadElement)[] | null} */
 		const spread_attributes = is_spreading ? [] : null;
 		const child_namespace = is_dom_element
 			? determine_namespace_for_children(
-					/** @type {AST.Identifier} */ (node.id).name,
+					/** @type {AST.Identifier} */ (element_id).name,
 					state.namespace,
 				)
 			: state.namespace;
@@ -2262,7 +2276,7 @@ const visitors = {
 			let style_attribute = null;
 			/** @type {TransformClientState['update']} */
 			const local_updates = [];
-			const element_name = /** @type {AST.Identifier} */ (node.id).name;
+			const element_name = /** @type {AST.Identifier} */ (element_id).name;
 			const is_void = is_void_element(element_name);
 			/** @type {AST.CSS.StyleSheet['hash'] | null} */
 			const scoping_hash =
@@ -2271,7 +2285,7 @@ const visitors = {
 
 			state.template?.push(`<${element_name}`);
 
-			for (const attr of node.attributes) {
+			for (const attr of element_attributes) {
 				if (attr.type === 'JSXAttribute') {
 					const attr_value = get_attribute_value(attr);
 					{
@@ -2545,7 +2559,7 @@ const visitors = {
 					const hash_arg = scoping_hash ? b.literal(scoping_hash) : undefined;
 					const is_html =
 						context.state.namespace === 'html' &&
-						/** @type {AST.Identifier} */ (node.id).name !== 'svg';
+						/** @type {AST.Identifier} */ (element_id).name !== 'svg';
 
 					if (metadata.tracking) {
 						local_updates.push({
@@ -2614,7 +2628,7 @@ const visitors = {
 			const update = [];
 
 			if (!is_void) {
-				const element_name = /** @type {AST.Identifier} */ (node.id).name;
+				const element_name = /** @type {AST.Identifier} */ (element_id).name;
 				const render_children = inner_html_attribute === null ? node.children : [];
 				// Special handling for <template> elements
 				if (element_name === 'template' && render_children.length > 0) {
@@ -2649,8 +2663,8 @@ const visitors = {
 							child.type === 'ForOfStatement' ||
 							child.type === 'SwitchStatement' ||
 							is_template_fragment(child) ||
-							(child.type === 'Element' &&
-								(child.id.type !== 'Identifier' || !is_element_dom_element(child))) ||
+							(is_template_element(child) &&
+								(get_element_id(child).type !== 'Identifier' || !is_element_dom_element(child))) ||
 							// A JSXText child is always a literal; only a `{ … }` container
 							// (including a merged text run) can hold a dynamic expression.
 							(child.type === 'JSXExpressionContainer' && child.expression.type !== 'Literal'),
@@ -2694,13 +2708,13 @@ const visitors = {
 
 			const apply_parent_css_scope = state.applyParentCssScope;
 
-			const is_spreading = node.attributes.some((attr) => attr.type === 'JSXSpreadAttribute');
+			const is_spreading = element_attributes.some((attr) => attr.type === 'JSXSpreadAttribute');
 			/** @type {(AST.Property | AST.SpreadElement)[]} */
 			const props = [];
 			/** @type {AST.Property | null} */
 			let children_prop = null;
 
-			for (const attr of node.attributes) {
+			for (const attr of element_attributes) {
 				if (attr.type === 'JSXAttribute') {
 					{
 						const attr_name = get_attribute_name(attr);
@@ -2792,7 +2806,7 @@ const visitors = {
 			}
 
 			if (node.metadata.scoped && get_component_css(state)) {
-				const hasClassAttr = node.attributes.some(
+				const hasClassAttr = element_attributes.some(
 					(attr) => attr.type === 'JSXAttribute' && get_attribute_name(attr) === 'class',
 				);
 				if (!hasClassAttr) {
@@ -2847,7 +2861,7 @@ const visitors = {
 
 			const metadata = { tracking: false };
 			// We visit, but only to gather metadata
-			b.call(/** @type {AST.Expression} */ (visit(node.id, { ...state, metadata })));
+			b.call(/** @type {AST.Expression} */ (visit(element_id, { ...state, metadata })));
 
 			// We're calling a component from within svg/mathml context
 			const is_with_ns = state.namespace !== DEFAULT_NAMESPACE;
@@ -2890,10 +2904,10 @@ const visitors = {
 			// Dynamic tags (`<{expr}>`) always render through composite: the runtime
 			// resolves the expression value (component function, tag string, or
 			// null) and re-renders when a tracked expression changes.
-			if (metadata.tracking || node.isDynamic === true) {
+			if (metadata.tracking || is_dynamic_element(node)) {
 				const shared = b.call(
 					'_$_.composite',
-					b.thunk(/** @type {AST.Expression} */ (visit(node.id, state))),
+					b.thunk(/** @type {AST.Expression} */ (visit(element_id, state))),
 					id,
 					object_props,
 				);
@@ -2905,7 +2919,7 @@ const visitors = {
 			} else {
 				const shared = b.call(
 					'_$_.render_component',
-					/** @type {AST.Expression} */ (visit(node.id, state)),
+					/** @type {AST.Expression} */ (visit(element_id, state)),
 					id,
 					object_props,
 				);
@@ -3933,7 +3947,7 @@ function transform_tsrx_tsx_child(node, context) {
 		);
 	}
 
-	if (node.type === 'Element' || node.type === 'JSXStyleElement') {
+	if (is_template_element(node) || node.type === 'JSXStyleElement') {
 		const expression = transform_ts_child(node, {
 			...context,
 			state: { ...context.state, init: null },
@@ -4538,7 +4552,7 @@ function transform_ts_child(node, context) {
 		} else {
 			state.init?.push(b.stmt(jsxElement));
 		}
-	} else if (node.type === 'Element') {
+	} else if (is_template_element(node)) {
 		if (lower_dynamic_element(node)) {
 			state.imports.add(`import { Dynamic as ${dynamic_element_import_local} } from 'ripple'`);
 		}
@@ -4548,15 +4562,15 @@ function transform_ts_child(node, context) {
 		let has_children_props = false;
 		const is_dom_element = is_element_dom_element(node);
 		const element_name =
-			/** @type {AST.Node} */ (node.id).type === 'Identifier'
-				? /** @type {AST.Identifier} */ (node.id).name
+			/** @type {AST.Node} */ (get_element_id(node)).type === 'Identifier'
+				? /** @type {AST.Identifier} */ (get_element_id(node)).name
 				: null;
 		const child_namespace =
 			is_dom_element && element_name !== null
 				? determine_namespace_for_children(element_name, state.namespace)
 				: state.namespace;
 
-		const attributes = node.attributes.map((attr) => {
+		const attributes = get_element_attributes(node).map((attr) => {
 			if (attr.type === 'JSXAttribute') {
 				const name = visit(get_attribute_name_node(attr), state);
 				const attr_value = /** @type { AST.Expression & AST.NodeWithLocation | null} */ (
@@ -4636,7 +4650,12 @@ function transform_ts_child(node, context) {
 			}
 		});
 
-		if (!node.selfClosing && !node.unclosed && !has_children_props && node.children.length > 0) {
+		if (
+			!is_self_closing(node) &&
+			!node.unclosed &&
+			!has_children_props &&
+			node.children.length > 0
+		) {
 			const component_scope = /** @type {ScopeInterface} */ (context.state.scopes.get(node));
 			const child_context = {
 				...context,
@@ -4668,10 +4687,12 @@ function transform_ts_child(node, context) {
 			}
 		}
 
-		if (node.id.type === 'MemberExpression') {
-			const member = /** @type {AST.MemberExpression} */ (visit(node.id, { ...state }));
+		if (get_element_id(node).type === 'MemberExpression') {
+			const member = /** @type {AST.MemberExpression} */ (
+				visit(get_element_id(node), { ...state })
+			);
 
-			node.id = member;
+			set_element_id(node, member);
 			/** @type {ESTreeJSX.TSRXJSXOpeningElement} */ (node.openingElement).name = member;
 			if (node.closingElement) {
 				/** @type {ESTreeJSX.TSRXJSXClosingElement} */ (node.closingElement).name = setLocation(
@@ -4960,7 +4981,7 @@ function is_template_or_control_flow(node) {
 	}
 
 	return (
-		node.type === 'Element' ||
+		is_template_element(node) ||
 		node.type === 'JSXStyleElement' ||
 		node.type === 'JSXExpressionContainer' ||
 		node.type === 'JSXText' ||
@@ -5024,7 +5045,7 @@ function is_native_tsrx_value_position(path) {
 	const parent = path.at(-1);
 	return !(
 		is_native_tsrx_statement_position(path) ||
-		parent?.type === 'Element' ||
+		is_template_element(parent) ||
 		is_template_fragment(parent)
 	);
 }
@@ -5150,7 +5171,7 @@ function build_native_tsrx_value_expression(children, source_node, context) {
  */
 function element_has_dynamic_content(element) {
 	// Check for dynamic attributes
-	for (const attr of element.attributes) {
+	for (const attr of get_element_attributes(element)) {
 		if (attr.type === 'JSXAttribute') {
 			const attr_value = get_attribute_value(attr);
 			// Dynamic value expression (not null, not Literal)
@@ -5178,15 +5199,15 @@ function element_has_dynamic_content(element) {
 		}
 		// Non-DOM element (component)
 		if (
-			child.type === 'Element' &&
-			(child.id.type !== 'Identifier' || !is_element_dom_element(child))
+			is_template_element(child) &&
+			(get_element_id(child).type !== 'Identifier' || !is_element_dom_element(child))
 		) {
 			return true;
 		}
 		// Recursively check DOM element children
 		if (
-			child.type === 'Element' &&
-			child.id.type === 'Identifier' &&
+			is_template_element(child) &&
+			get_element_id(child).type === 'Identifier' &&
 			is_element_dom_element(child)
 		) {
 			if (element_has_dynamic_content(child)) {
@@ -5252,7 +5273,7 @@ function transform_children(children, context) {
 	const { visit, state, root } = context;
 	if (state.to_ts) {
 		for (const child of children) {
-			if (child.type === 'Element' && lower_dynamic_element(child)) {
+			if (is_template_element(child) && lower_dynamic_element(child)) {
 				state.imports.add(`import { Dynamic as ${dynamic_element_import_local} } from 'ripple'`);
 			}
 		}
@@ -5264,7 +5285,8 @@ function transform_children(children, context) {
 
 	const head_elements = /** @type {AST.Element[]} */ (
 		children.filter(
-			(node) => node.type === 'Element' && node.id.type === 'Identifier' && node.id.name === 'head',
+			(node) =>
+				is_template_element(node) && /** @type {any} */ (get_element_id(node)).name === 'head',
 		)
 	);
 
@@ -5276,8 +5298,8 @@ function transform_children(children, context) {
 				node.type === 'ForOfStatement' ||
 				node.type === 'SwitchStatement' ||
 				is_template_fragment(node) ||
-				(node.type === 'Element' &&
-					(node.id.type !== 'Identifier' || !is_element_dom_element(node))),
+				(is_template_element(node) &&
+					(get_element_id(node).type !== 'Identifier' || !is_element_dom_element(node))),
 		) ||
 		(normalized.filter(
 			(node) =>
@@ -5325,11 +5347,11 @@ function transform_children(children, context) {
 			// A single static component child (`render_component`, not a dynamic/
 			// composite tag, DOM element, or ripple `Fragment`) renders before
 			// __anchor too.
-			(single_output.type === 'Element' &&
-				single_output.isDynamic !== true &&
-				single_output.id.type === 'Identifier' &&
-				!(/** @type {any} */ (single_output.id).tracked) &&
-				single_output.id.name !== 'children' &&
+			(is_template_element(single_output) &&
+				!is_dynamic_element(single_output) &&
+				get_element_id(single_output).type === 'Identifier' &&
+				!(/** @type {any} */ (get_element_id(single_output)).tracked) &&
+				/** @type {AST.Identifier} */ (get_element_id(single_output)).name !== 'children' &&
 				!is_element_dom_element(single_output) &&
 				!is_ripple_fragment_element(single_output, context)));
 	if (root_controlled) {
@@ -5342,11 +5364,11 @@ function transform_children(children, context) {
 	// the component's root, dropping the placeholder comment nodes from the template.
 	/** @param {AST.Node} n */
 	const is_static_component_child = (n) =>
-		n.type === 'Element' &&
-		/** @type {any} */ (n).isDynamic !== true &&
-		n.id.type === 'Identifier' &&
-		!n.id.tracked &&
-		n.id.name !== 'children' &&
+		is_template_element(n) &&
+		!is_dynamic_element(n) &&
+		get_element_id(n).type === 'Identifier' &&
+		!(/** @type {any} */ (get_element_id(n)).tracked) &&
+		/** @type {AST.Identifier} */ (get_element_id(n)).name !== 'children' &&
 		!is_element_dom_element(n) &&
 		!is_ripple_fragment_element(n, context);
 	const all_component_append =
@@ -5367,8 +5389,8 @@ function transform_children(children, context) {
 	/** @param {AST.Node} node */
 	const get_id = (node) => {
 		return b.id(
-			node.type == 'Element' && is_element_dom_element(node)
-				? state.scope.generate(/** @type {AST.Identifier} */ (node.id).name)
+			is_template_element(node) && is_element_dom_element(node)
+				? state.scope.generate(/** @type {AST.Identifier} */ (get_element_id(node)).name)
 				: node.type === 'JSXStyleElement'
 					? state.scope.generate('style')
 					: is_template_text(node)
@@ -5376,7 +5398,7 @@ function transform_children(children, context) {
 						: is_template_expression(node)
 							? state.scope.generate('expression')
 							: state.scope.generate('node'),
-			/** @type {AST.NodeWithLocation} */ (node.type === 'Element' ? node.openingElement : node),
+			/** @type {AST.NodeWithLocation} */ (is_template_element(node) ? node.openingElement : node),
 		);
 	};
 
@@ -5386,7 +5408,7 @@ function transform_children(children, context) {
 			? b.id(
 					state.scope.generate('fragment'),
 					/** @type {AST.NodeWithLocation} */ (
-						node.type === 'Element' ? node.openingElement : node
+						is_template_element(node) ? node.openingElement : node
 					),
 				)
 			: get_id(node);
@@ -5565,7 +5587,7 @@ function transform_children(children, context) {
 				}
 			};
 
-			if (node.type === 'Element') {
+			if (is_template_element(node)) {
 				if (is_element_dom_element(node)) {
 					skipped++;
 				} else {
@@ -5596,8 +5618,8 @@ function transform_children(children, context) {
 					// the Element visitor doesn't add pop() for it
 					const has_dom_element_children = node.children.some(
 						(child) =>
-							child.type === 'Element' &&
-							child.id.type === 'Identifier' &&
+							is_template_element(child) &&
+							get_element_id(child).type === 'Identifier' &&
 							is_element_dom_element(child),
 					);
 
@@ -5609,8 +5631,8 @@ function transform_children(children, context) {
 							child.type === 'ForOfStatement' ||
 							child.type === 'SwitchStatement' ||
 							is_template_fragment(child) ||
-							(child.type === 'Element' &&
-								(child.id.type !== 'Identifier' || !is_element_dom_element(child))) ||
+							(is_template_element(child) &&
+								(get_element_id(child).type !== 'Identifier' || !is_element_dom_element(child))) ||
 							(child.type === 'JSXExpressionContainer' && child.expression.type !== 'Literal'),
 					);
 
@@ -5774,7 +5796,7 @@ function transform_children(children, context) {
 		const title_element = /** @type {AST.Element} */ (
 			children.find(
 				(node) =>
-					node.type === 'Element' && node.id.type === 'Identifier' && node.id.name === 'title',
+					is_template_element(node) && /** @type {any} */ (get_element_id(node)).name === 'title',
 			)
 		);
 

--- a/packages/tsrx-ripple/src/transform/client/index.js
+++ b/packages/tsrx-ripple/src/transform/client/index.js
@@ -107,9 +107,13 @@ import {
 	wrap_code_block_in_iife,
 } from '../../utils.js';
 import {
+	get_attribute_name,
+	get_attribute_name_node,
+	get_attribute_value,
 	get_template_expression,
 	get_template_text_value,
 	is_empty_expression_container,
+	is_expression_attribute,
 	is_template_expression,
 	is_template_text,
 	is_template_text_or_expression,
@@ -1338,15 +1342,11 @@ function is_ripple_fragment_element(node, context) {
 
 /**
  * @param {AST.Element} node
- * @returns {AST.Attribute | null}
+ * @returns {ESTreeJSX.JSXAttribute | null}
  */
 function get_inner_html_attribute(node) {
 	for (const attr of node.attributes) {
-		if (
-			attr.type === 'Attribute' &&
-			attr.name.type === 'Identifier' &&
-			attr.name.name === 'innerHTML'
-		) {
+		if (attr.type === 'JSXAttribute' && get_attribute_name(attr) === 'innerHTML') {
 			return attr;
 		}
 	}
@@ -1355,17 +1355,18 @@ function get_inner_html_attribute(node) {
 }
 
 /**
- * @param {AST.Attribute} attr
+ * @param {ESTreeJSX.JSXAttribute} attr
  * @param {VisitorClientContext} context
  * @returns {AST.Expression}
  */
 function get_attribute_value_expression(attr, context) {
-	if (attr.value === null) {
+	const value = get_attribute_value(attr);
+	if (value === null) {
 		return b.literal('');
 	}
 
 	return /** @type {AST.Expression} */ (
-		context.visit(attr.value, {
+		context.visit(value, {
 			...context.state,
 			flush_node: null,
 			metadata: { tracking: false },
@@ -2193,7 +2194,7 @@ const visitors = {
 		}
 
 		const is_dom_element = is_element_dom_element(node);
-		const is_spreading = node.attributes.some((attr) => attr.type === 'SpreadAttribute');
+		const is_spreading = node.attributes.some((attr) => attr.type === 'JSXSpreadAttribute');
 		/** @type {(AST.Property | AST.SpreadElement)[] | null} */
 		const spread_attributes = is_spreading ? [] : null;
 		const child_namespace = is_dom_element
@@ -2229,9 +2230,9 @@ const visitors = {
 		};
 
 		if (is_dom_element) {
-			/** @type {AST.Attribute | null} */
+			/** @type {ESTreeJSX.JSXAttribute | null} */
 			let class_attribute = null;
-			/** @type {AST.Attribute | null} */
+			/** @type {ESTreeJSX.JSXAttribute | null} */
 			let style_attribute = null;
 			/** @type {TransformClientState['update']} */
 			const local_updates = [];
@@ -2245,16 +2246,17 @@ const visitors = {
 			state.template?.push(`<${element_name}`);
 
 			for (const attr of node.attributes) {
-				if (attr.type === 'Attribute') {
-					if (attr.name.type === 'Identifier') {
-						const name = attr.name.name;
+				if (attr.type === 'JSXAttribute') {
+					const attr_value = get_attribute_value(attr);
+					{
+						const name = get_attribute_name(attr);
 
 						if (name === 'innerHTML') {
 							const metadata = { tracking: false };
 							const expression =
-								attr.value === null
+								attr_value === null
 									? b.literal('')
-									: /** @type {AST.Expression} */ (visit(attr.value, { ...state, metadata }));
+									: /** @type {AST.Expression} */ (visit(attr_value, { ...state, metadata }));
 
 							if (is_spreading) {
 								spread_attributes?.push(b.prop('init', b.literal('innerHTML'), expression));
@@ -2276,7 +2278,7 @@ const visitors = {
 											),
 										),
 									expression,
-									identity: attr.value ?? b.literal(''),
+									identity: attr_value ?? b.literal(''),
 									initial: b.member(/** @type {AST.Identifier} */ (id), 'innerHTML'),
 								});
 							} else {
@@ -2296,7 +2298,7 @@ const visitors = {
 							continue;
 						}
 
-						if (attr.value === null) {
+						if (attr_value === null) {
 							// omit a valueless event attr (analyze errored); `hidden` etc. still emit
 							if (!isEventAttribute(name)) {
 								handle_static_attr(name, true);
@@ -2307,26 +2309,26 @@ const visitors = {
 						if (name === 'ref') {
 							const id = state.flush_node?.();
 							const metadata = { tracking: false };
-							const source = get_ref_source_argument(attr.value);
+							const source = get_ref_source_argument(attr_value);
 							const ref_value =
 								source.type === 'ArrayExpression'
-									? create_ref_value_call(attr.value, context)
-									: /** @type {AST.Expression} */ (visit(attr.value, { ...state, metadata }));
+									? create_ref_value_call(attr_value, context)
+									: /** @type {AST.Expression} */ (visit(attr_value, { ...state, metadata }));
 							const ref_args = [/** @type {AST.Expression} */ (id), b.thunk(ref_value)];
 							if (source.type !== 'ArrayExpression') {
-								add_ref_setter_arg(ref_args, attr.value, ref_value);
+								add_ref_setter_arg(ref_args, attr_value, ref_value);
 							}
 							state.init?.push(b.stmt(b.call('_$_.ref', ...ref_args)));
 							continue;
 						}
 
 						if (
-							attr.value.type === 'Literal' &&
+							attr_value.type === 'Literal' &&
 							name !== 'class' &&
 							name !== 'style' &&
 							!(name === 'value' && element_name === 'option')
 						) {
-							handle_static_attr(name, attr.value.value);
+							handle_static_attr(name, attr_value.value);
 							continue;
 						}
 
@@ -2334,14 +2336,14 @@ const visitors = {
 							const id = state.flush_node?.();
 							const metadata = { tracking: false };
 							const expression = /** @type {AST.Expression} */ (
-								visit(attr.value, { ...state, metadata })
+								visit(attr_value, { ...state, metadata })
 							);
 
 							if (metadata.tracking) {
 								local_updates.push({
 									operation: (key) => b.stmt(b.call('_$_.set_value', id, key)),
 									expression,
-									identity: attr.value,
+									identity: attr_value,
 									initial: b.void0,
 								});
 							} else {
@@ -2367,14 +2369,14 @@ const visitors = {
 							const id = state.flush_node?.();
 							const metadata = { tracking: false };
 							const expression = /** @type {AST.Expression} */ (
-								visit(attr.value, { ...state, metadata })
+								visit(attr_value, { ...state, metadata })
 							);
 
 							if (metadata.tracking) {
 								local_updates.push({
 									operation: (key) => b.stmt(b.call('_$_.set_checked', id, key)),
 									expression,
-									identity: attr.value,
+									identity: attr_value,
 									initial: b.void0,
 								});
 							} else {
@@ -2387,14 +2389,14 @@ const visitors = {
 							const id = state.flush_node?.();
 							const metadata = { tracking: false };
 							const expression = /** @type {AST.Expression} */ (
-								visit(attr.value, { ...state, metadata })
+								visit(attr_value, { ...state, metadata })
 							);
 
 							if (metadata.tracking) {
 								local_updates.push({
 									operation: (key) => b.stmt(b.call('_$_.set_selected', id, key)),
 									expression,
-									identity: attr.value,
+									identity: attr_value,
 									initial: b.void0,
 								});
 							} else {
@@ -2406,7 +2408,7 @@ const visitors = {
 						if (isEventAttribute(name)) {
 							const metadata = { tracking: false };
 							let handler = /** @type {AST.Expression} */ (
-								visit(attr.value, { ...state, metadata })
+								visit(attr_value, { ...state, metadata })
 							);
 							const id = state.flush_node?.();
 
@@ -2443,7 +2445,7 @@ const visitors = {
 						}
 						const metadata = { tracking: false };
 						const expression = /** @type {AST.Expression} */ (
-							visit(attr.value, { ...state, metadata })
+							visit(attr_value, { ...state, metadata })
 						);
 						// All other attributes
 						if (metadata.tracking) {
@@ -2466,7 +2468,7 @@ const visitors = {
 									operation: (key) =>
 										b.stmt(b.call('_$_.set_attribute', id, b.literal(attribute), key)),
 									expression,
-									identity: attr.value,
+									identity: attr_value,
 									initial: b.void0,
 								});
 							}
@@ -2490,7 +2492,7 @@ const visitors = {
 							}
 						}
 					}
-				} else if (attr.type === 'SpreadAttribute') {
+				} else if (attr.type === 'JSXSpreadAttribute') {
 					spread_attributes?.push(
 						b.spread(/** @type {AST.Expression} */ (visit(attr.argument, state))),
 					);
@@ -2498,7 +2500,7 @@ const visitors = {
 			}
 
 			if (class_attribute !== null) {
-				const attr_value = /** @type {AST.Expression} */ (class_attribute.value);
+				const attr_value = /** @type {AST.Expression} */ (get_attribute_value(class_attribute));
 				if (attr_value.type === 'Literal') {
 					let value = attr_value.value;
 
@@ -2506,7 +2508,7 @@ const visitors = {
 						value = `${scoping_hash} ${value}`;
 					}
 
-					handle_static_attr(class_attribute.name.name, value);
+					handle_static_attr('class', value);
 				} else {
 					const id = state.flush_node?.();
 					const metadata = { tracking: false };
@@ -2538,9 +2540,9 @@ const visitors = {
 			}
 
 			if (style_attribute !== null) {
-				const attr_value = /** @type {AST.Expression} */ (style_attribute.value);
+				const attr_value = /** @type {AST.Expression} */ (get_attribute_value(style_attribute));
 				if (attr_value.type === 'Literal') {
-					handle_static_attr(style_attribute.name.name, attr_value.value);
+					handle_static_attr('style', attr_value.value);
 				} else {
 					const id = state.flush_node?.();
 					const metadata = { tracking: false };
@@ -2625,8 +2627,7 @@ const visitors = {
 								(child.id.type !== 'Identifier' || !is_element_dom_element(child))) ||
 							// A JSXText child is always a literal; only a `{ … }` container
 							// (including a merged text run) can hold a dynamic expression.
-							(child.type === 'JSXExpressionContainer' &&
-								child.expression.type !== 'Literal'),
+							(child.type === 'JSXExpressionContainer' && child.expression.type !== 'Literal'),
 					);
 
 				if (needs_pop) {
@@ -2667,26 +2668,28 @@ const visitors = {
 
 			const apply_parent_css_scope = state.applyParentCssScope;
 
-			const is_spreading = node.attributes.some((attr) => attr.type === 'SpreadAttribute');
+			const is_spreading = node.attributes.some((attr) => attr.type === 'JSXSpreadAttribute');
 			/** @type {(AST.Property | AST.SpreadElement)[]} */
 			const props = [];
 			/** @type {AST.Property | null} */
 			let children_prop = null;
 
 			for (const attr of node.attributes) {
-				if (attr.type === 'Attribute') {
-					if (attr.name.type === 'Identifier') {
+				if (attr.type === 'JSXAttribute') {
+					{
+						const attr_name = get_attribute_name(attr);
+						const attr_value = get_attribute_value(attr);
 						const metadata = { tracking: false };
-						if (attr.name.name === 'ref' && attr.value !== null) {
-							props.push(b.prop('init', b.key('ref'), create_ref_value_call(attr.value, context)));
+						if (attr_name === 'ref' && attr_value !== null) {
+							props.push(b.prop('init', b.key('ref'), create_ref_value_call(attr_value, context)));
 							continue;
 						}
 
 						let property =
-							attr.value === null
+							attr_value === null
 								? b.literal(true)
 								: /** @type {AST.Expression} */ (
-										visit(attr.value, { ...state, flush_node: null, metadata })
+										visit(attr_value, { ...state, flush_node: null, metadata })
 									);
 						if (property.type === 'Identifier') {
 							const binding = state.scope.get(property.name);
@@ -2700,7 +2703,7 @@ const visitors = {
 						}
 
 						const scoped_hash = get_component_css_hash(state);
-						if (attr.name.name === 'class' && node.metadata.scoped && scoped_hash) {
+						if (attr_name === 'class' && node.metadata.scoped && scoped_hash) {
 							if (property.type === 'Literal') {
 								property = b.literal(`${scoped_hash} ${property.value}`);
 							} else {
@@ -2709,7 +2712,7 @@ const visitors = {
 						}
 
 						if (metadata.tracking) {
-							if (attr.name.name === 'children') {
+							if (attr_name === 'children') {
 								children_prop = b.prop(
 									'get',
 									b.id('children'),
@@ -2726,12 +2729,12 @@ const visitors = {
 							props.push(
 								b.prop(
 									'get',
-									b.key(attr.name.name),
+									b.key(attr_name),
 									b.function(null, [], b.block([b.return(property)])),
 								),
 							);
 						} else {
-							if (attr.name.name === 'children') {
+							if (attr_name === 'children') {
 								children_prop = b.prop(
 									'init',
 									b.id('children'),
@@ -2741,20 +2744,10 @@ const visitors = {
 								continue;
 							}
 
-							props.push(b.prop('init', b.key(attr.name.name), property));
+							props.push(b.prop('init', b.key(attr_name), property));
 						}
-					} else {
-						props.push(
-							b.prop(
-								'init',
-								b.key(attr.name.name),
-								/** @type {AST.Expression} */ (
-									visit(/** @type {AST.Node} */ (attr.value), { ...state, flush_node: null })
-								),
-							),
-						);
 					}
-				} else if (attr.type === 'SpreadAttribute') {
+				} else if (attr.type === 'JSXSpreadAttribute') {
 					props.push(
 						b.spread(
 							/** @type {AST.Expression} */
@@ -2774,10 +2767,7 @@ const visitors = {
 
 			if (node.metadata.scoped && get_component_css(state)) {
 				const hasClassAttr = node.attributes.some(
-					(attr) =>
-						attr.type === 'Attribute' &&
-						attr.name.type === 'Identifier' &&
-						attr.name.name === 'class',
+					(attr) => attr.type === 'JSXAttribute' && get_attribute_name(attr) === 'class',
 				);
 				if (!hasClassAttr) {
 					const name = is_spreading ? '#class' : 'class';
@@ -4527,10 +4517,10 @@ function transform_ts_child(node, context) {
 				: state.namespace;
 
 		const attributes = node.attributes.map((attr) => {
-			if (attr.type === 'Attribute') {
-				const name = visit(attr.name, state);
+			if (attr.type === 'JSXAttribute') {
+				const name = visit(get_attribute_name_node(attr), state);
 				const attr_value = /** @type { AST.Expression & AST.NodeWithLocation | null} */ (
-					attr.value
+					get_attribute_value(attr)
 				);
 				/** @type {string} */
 				let prop_name;
@@ -4540,8 +4530,8 @@ function transform_ts_child(node, context) {
 					name_node = name;
 					prop_name = name.name;
 				} else {
-					name_node = attr.name;
-					prop_name = attr.name.name || 'unknown';
+					name_node = get_attribute_name_node(attr);
+					prop_name = get_attribute_name(attr) || 'unknown';
 				}
 				const ref_target_type =
 					prop_name === 'ref' ? create_element_ref_target_type(node, state) : null;
@@ -4568,7 +4558,7 @@ function transform_ts_child(node, context) {
 					jsx_name,
 					// match the source code usage of expressions for literals
 					// for proper source mapping to avoid turning strings into expressions
-					attr_value?.type === 'Literal' && !attr_value.was_expression
+					attr_value?.type === 'Literal' && !is_expression_attribute(attr)
 						? /** @type {AST.Literal} */ (value)
 						: b.jsx_expression_container(
 								/** @type {AST.Expression} */ (value),
@@ -4594,7 +4584,7 @@ function transform_ts_child(node, context) {
 					/** @type {AST.NodeWithLocation} */ (attr),
 				);
 				return jsx_attr;
-			} else if (attr.type === 'SpreadAttribute') {
+			} else if (attr.type === 'JSXSpreadAttribute') {
 				const argument = visit(attr.argument, state);
 				return b.jsx_spread_attribute(
 					/** @type {AST.Expression} */ (argument),
@@ -4602,7 +4592,7 @@ function transform_ts_child(node, context) {
 				);
 			} else {
 				// Should not happen
-				throw new Error(`Unexpected attribute type: ${/** @type {AST.Attribute} */ (attr).type}`);
+				throw new Error(`Unexpected attribute type: ${/** @type {AST.Node} */ (attr).type}`);
 			}
 		});
 
@@ -5120,12 +5110,13 @@ function build_native_tsrx_value_expression(children, source_node, context) {
 function element_has_dynamic_content(element) {
 	// Check for dynamic attributes
 	for (const attr of element.attributes) {
-		if (attr.type === 'Attribute') {
+		if (attr.type === 'JSXAttribute') {
+			const attr_value = get_attribute_value(attr);
 			// Dynamic value expression (not null, not Literal)
-			if (attr.value !== null && attr.value.type !== 'Literal') {
+			if (attr_value !== null && attr_value.type !== 'Literal') {
 				return true;
 			}
-		} else if (attr.type === 'SpreadAttribute') {
+		} else if (attr.type === 'JSXSpreadAttribute') {
 			return true;
 		}
 	}
@@ -5577,8 +5568,7 @@ function transform_children(children, context) {
 							child.type === 'TsrxFragment' ||
 							(child.type === 'Element' &&
 								(child.id.type !== 'Identifier' || !is_element_dom_element(child))) ||
-							(child.type === 'JSXExpressionContainer' &&
-								child.expression.type !== 'Literal'),
+							(child.type === 'JSXExpressionContainer' && child.expression.type !== 'Literal'),
 					);
 
 					const has_following_renderable_sibling = normalized

--- a/packages/tsrx-ripple/src/transform/client/index.js
+++ b/packages/tsrx-ripple/src/transform/client/index.js
@@ -41,7 +41,6 @@ import {
 	object,
 	renderCssResult,
 	prepareStylesheetForRender,
-	pruneCss,
 	collectStyleRefAttributes,
 	createStyleClassMap,
 	createStyleClassMapFromStylesheet,
@@ -129,50 +128,6 @@ import {
 import is_reference from 'is-reference';
 
 /**
- * Re-run CSS pruning on JSX converted into Ripple template nodes so it receives
- * the same scoped metadata as normal Ripple template elements before codegen.
- *
- * @param {AST.Node[]} nodes
- * @param {TransformClientState} state
- * @returns {void}
- */
-function apply_tsrx_css_scoping(nodes, state) {
-	const component = state.component;
-	const css = get_component_css(state);
-	if (!component || !css) {
-		return;
-	}
-	const stylesheet = /** @type {AST.CSS.StyleSheet} */ (css);
-
-	const style_classes = /** @type {any} */ (component.metadata).styleClasses ?? new Map();
-	const top_scoped_classes = /** @type {any} */ (component.metadata).topScopedClasses ?? new Map();
-
-	/**
-	 * @param {AST.Node} node
-	 * @returns {void}
-	 */
-	function visit_node(node) {
-		if (node.type === 'Element') {
-			pruneCss(stylesheet, node, style_classes, top_scoped_classes);
-			for (const child of node.children) {
-				visit_node(child);
-			}
-			return;
-		}
-
-		if ('children' in node && Array.isArray(node.children)) {
-			for (const child of node.children) {
-				visit_node(/** @type {AST.Node} */ (child));
-			}
-		}
-	}
-
-	for (const node of nodes) {
-		visit_node(node);
-	}
-}
-
-/**
  * @param {TransformClientState} state
  * @returns {AST.CSS.StyleSheet | null}
  */
@@ -190,7 +145,7 @@ function get_component_css_hash(state) {
 }
 
 /**
- * @param {AST.Element} node
+ * @param {ESTreeJSX.JSXElement | AST.JSXStyleElement} node
  * @param {TransformClientContext} context
  * @returns {AST.ObjectExpression | null}
  */
@@ -212,7 +167,7 @@ function build_style_class_map_expression(node, context) {
 }
 
 /**
- * @param {AST.Element} node
+ * @param {ESTreeJSX.JSXElement | AST.JSXStyleElement} node
  * @param {TransformClientContext} context
  * @returns {void}
  */
@@ -730,20 +685,22 @@ function visit_function(node, context) {
 /**
  * @param {AST.Node | null | undefined} node
  * @param {boolean} [allow_direct_template]
- * @returns {AST.Element | ESTreeJSX.JSXFragment | null}
+ * @returns {ESTreeJSX.JSXElement | ESTreeJSX.JSXFragment | null}
  */
 function get_native_tsrx_return_template_node(node, allow_direct_template = false) {
 	if (!node) return null;
 	if (allow_direct_template && is_native_tsrx_template_node(node)) {
-		return /** @type {AST.Element | ESTreeJSX.JSXFragment} */ (/** @type {unknown} */ (node));
+		return /** @type {ESTreeJSX.JSXElement | ESTreeJSX.JSXFragment} */ (
+			/** @type {unknown} */ (node)
+		);
 	}
 	if (node.type === 'ReturnStatement' && is_native_tsrx_template_node(node.argument)) {
-		return /** @type {AST.Element | ESTreeJSX.JSXFragment} */ (
+		return /** @type {ESTreeJSX.JSXElement | ESTreeJSX.JSXFragment} */ (
 			/** @type {unknown} */ (node.argument)
 		);
 	}
 	if (node.type === 'JSXCodeBlock' && is_native_tsrx_template_node(node.render)) {
-		return /** @type {AST.Element | ESTreeJSX.JSXFragment} */ (
+		return /** @type {ESTreeJSX.JSXElement | ESTreeJSX.JSXFragment} */ (
 			/** @type {unknown} */ (node.render)
 		);
 	}
@@ -903,7 +860,7 @@ function transform_native_tsrx_function(node, context) {
 }
 
 /**
- * @param {AST.Element} node
+ * @param {ESTreeJSX.JSXElement} node
  * @param {number} index
  * @param {TransformClientContext} context
  */
@@ -920,7 +877,7 @@ function visit_head_element(node, index, context) {
 	const template = [];
 
 	transform_children(
-		node.children,
+		/** @type {AST.Node[]} */ (node.children),
 		/** @type {VisitorClientContext} */ ({
 			visit,
 			state: { ...state, init, update, final, template, inside_head: true },
@@ -1086,11 +1043,11 @@ function apply_updates(init, update, state) {
 }
 
 /**
- * @param {AST.Element} node
+ * @param {ESTreeJSX.JSXElement} node
  * @param {TransformClientContext} context
  */
 function visit_title_element(node, context) {
-	const normalized = normalize_children(node.children, context);
+	const normalized = normalize_children(/** @type {AST.Node[]} */ (node.children), context);
 	const content = /** @type {any} */ (normalized[0]);
 
 	const metadata = { tracking: false };
@@ -1187,7 +1144,7 @@ function create_ref_value_call(source_argument, context) {
 }
 
 /**
- * @param {AST.Element} node
+ * @param {ESTreeJSX.JSXElement} node
  * @param {TransformClientState} state
  * @returns {AST.TypeNode | null}
  */
@@ -1273,7 +1230,7 @@ function ripple_namespace_requires_block(name) {
 }
 
 /**
- * @param {AST.Element} node
+ * @param {AST.Node} node
  * @param {TransformClientContext | VisitorClientContext} context
  * @returns {boolean}
  */
@@ -1292,7 +1249,7 @@ function is_ripple_fragment_element(node, context) {
 }
 
 /**
- * @param {AST.Element} node
+ * @param {ESTreeJSX.JSXElement | AST.TSRXJSXElement} node
  * @returns {ESTreeJSX.JSXAttribute | null}
  */
 function get_inner_html_attribute(node) {
@@ -1335,7 +1292,7 @@ function normalize_inner_html_expression(expression, id) {
 }
 
 /**
- * @param {AST.Element} node
+ * @param {ESTreeJSX.JSXElement | AST.TSRXJSXElement} node
  * @param {VisitorClientContext} context
  * @returns {void}
  */
@@ -1364,7 +1321,7 @@ function visit_ripple_fragment_element(node, context) {
 	}
 
 	transform_children(
-		node.children,
+		/** @type {AST.Node[]} */ (node.children),
 		/** @type {VisitorClientContext} */ ({
 			visit,
 			state,
@@ -1411,8 +1368,6 @@ function build_jsx_to_tsrx_element(node, context) {
 	const converted = Array.isArray(result) ? result : [result];
 	/** @type {AST.Node[]} */
 	const children = converted.filter((child) => child != null && child.type !== 'EmptyStatement');
-
-	apply_tsrx_css_scoping(children, state);
 
 	const children_component = create_native_tsrx_render_function(
 		[],
@@ -2015,10 +1970,9 @@ const visitors = {
 				: expression;
 		}
 
-		const children_filtered = node.children.filter((child) => {
+		const children_filtered = /** @type {AST.Node[]} */ (node.children).filter((child) => {
 			return child != null && child.type !== 'EmptyStatement';
 		});
-		apply_tsrx_css_scoping(children_filtered, state);
 
 		const children_component = create_native_tsrx_render_function([], children_filtered, node);
 
@@ -2111,7 +2065,7 @@ const visitors = {
 		// The TS view needs the `<TsrxDynamic is={expr}>` component shape for type
 		// checking; production codegen keeps `node.id` as the dynamic expression
 		// and renders it directly via `_$_.composite` in the component branch.
-		if (state.to_ts && lower_dynamic_element(node)) {
+		if (state.to_ts && lower_dynamic_element(/** @type {ESTreeJSX.JSXElement} */ (node))) {
 			state.imports.add(`import { Dynamic as ${dynamic_element_import_local} } from 'ripple'`);
 		}
 
@@ -2166,7 +2120,11 @@ const visitors = {
 				state.template?.push('<!>');
 				context.state.init?.push(
 					b.stmt(
-						b.call('_$_.script', id, /** @type {AST.Literal} */ (visit(node.children[0], state))),
+						b.call(
+							'_$_.script',
+							id,
+							/** @type {AST.Literal} */ (visit(/** @type {AST.Node} */ (node.children[0]), state)),
+						),
 					),
 				);
 				return;
@@ -2569,7 +2527,9 @@ const visitors = {
 
 			if (!is_void) {
 				const element_name = /** @type {AST.Identifier} */ (element_id).name;
-				const render_children = inner_html_attribute === null ? node.children : [];
+				const render_children = /** @type {AST.Node[]} */ (
+					inner_html_attribute === null ? node.children : []
+				);
 				// Special handling for <template> elements
 				if (element_name === 'template' && render_children.length > 0) {
 					transform_template_element(node, state, visit, child_namespace);
@@ -2756,13 +2716,13 @@ const visitors = {
 				}
 			}
 
-			for (const child of node.children) {
+			for (const child of /** @type {AST.Node[]} */ (node.children)) {
 				if (is_native_tsrx_function_node(child)) {
 					state.init?.push(/** @type {AST.Statement} */ (visit(child, state)));
 				}
 			}
 
-			const children_filtered = node.children.filter(
+			const children_filtered = /** @type {AST.Node[]} */ (node.children).filter(
 				(child) => child.type !== 'EmptyStatement' && !is_native_tsrx_function_node(child),
 			);
 
@@ -3747,7 +3707,7 @@ function transform_tsrx_ts_children(children, context) {
  * remain inline JSX; fragments with setup statements need an IIFE so declarations
  * stay in statement position.
  *
- * @param {ESTreeJSX.JSXFragment} node
+ * @param {ESTreeJSX.JSXFragment | AST.TSRXJSXFragment} node
  * @param {VisitorClientContext} context
  * @param {boolean} [in_jsx_child]
  * @returns {TsrxTsViewNode}
@@ -3776,14 +3736,14 @@ function build_tsrx_to_ts_expression(node, context, in_jsx_child = false) {
 }
 
 /**
- * @param {AST.TSRXExpression | AST.Text} node
+ * @param {ESTreeJSX.JSXExpressionContainer | ESTreeJSX.JSXText} node
  * @returns {AST.NodeWithLocation | undefined}
  */
 function get_tsrx_expression_container_location(node) {
 	if (node.loc) return /** @type {AST.NodeWithLocation} */ (node);
 
 	const expression = /** @type {AST.Expression & Partial<AST.NodeWithLocation>} */ (
-		node.expression
+		/** @type {ESTreeJSX.JSXExpressionContainer} */ (node).expression
 	);
 	if (!expression.loc || node.start == null || node.end == null) {
 		return undefined;
@@ -3869,7 +3829,7 @@ function transform_tsrx_tsx_child(node, context) {
 		// Build it as a JSX child instead. Non-empty fragments keep their existing
 		// lowering (e.g. `{<>{a}</>}` still unwraps to `{a}`). This matches the JSX
 		// targets and how the same fragment survives in an attribute value.
-		const expr = node.expression;
+		const expr = /** @type {any} */ (node.expression);
 		const is_empty_fragment =
 			is_template_fragment(expr) &&
 			!(expr.children || []).some(
@@ -3901,7 +3861,11 @@ function transform_tsrx_tsx_child(node, context) {
 		// `in_jsx_child` mode already returns a valid JSX child (a fragment, or a
 		// `{expr}` container kept for type visibility), so use it as-is. Only a bare
 		// expression (which can happen in other positions) needs wrapping.
-		const expression = build_tsrx_to_ts_expression(node, context, true);
+		const expression = build_tsrx_to_ts_expression(
+			/** @type {ESTreeJSX.JSXFragment} */ (node),
+			context,
+			true,
+		);
 		if (
 			expression.type === 'JSXElement' ||
 			expression.type === 'JSXFragment' ||
@@ -4461,7 +4425,7 @@ function build_tsrx_ts_directive_value(node, context) {
 }
 
 /**
- * @param {AST.Node} node
+ * @param {any} node
  * @param {TransformClientContext} context
  */
 function transform_ts_child(node, context) {
@@ -5078,7 +5042,6 @@ function build_native_tsrx_value_expression(children, source_node, context) {
 			delete metadata.regular_js;
 			return { ...child, metadata };
 		});
-	apply_tsrx_css_scoping(children_filtered, state);
 
 	const children_component = create_native_tsrx_render_function([], children_filtered, source_node);
 
@@ -5106,7 +5069,7 @@ function build_native_tsrx_value_expression(children, source_node, context) {
  * - Dynamic text children (non-Literal Text nodes)
  * - Non-DOM element children (components)
  * - Dynamic descendants (recursive)
- * @param {AST.Element} element
+ * @param {ESTreeJSX.JSXElement} element
  * @returns {boolean}
  */
 function element_has_dynamic_content(element) {
@@ -5124,7 +5087,7 @@ function element_has_dynamic_content(element) {
 	}
 
 	// Check children for dynamic content
-	for (const child of element.children) {
+	for (const child of /** @type {AST.Node[]} */ (element.children)) {
 		if (
 			child.type === 'IfStatement' ||
 			child.type === 'TryStatement' ||
@@ -5150,7 +5113,7 @@ function element_has_dynamic_content(element) {
 			get_element_id(child).type === 'Identifier' &&
 			is_element_dom_element(child)
 		) {
-			if (element_has_dynamic_content(child)) {
+			if (element_has_dynamic_content(/** @type {ESTreeJSX.JSXElement} */ (child))) {
 				return true;
 			}
 		}
@@ -5165,7 +5128,7 @@ function element_has_dynamic_content(element) {
  * goes into template.content (a DocumentFragment). We handle them like textarea
  * elements where children become innerHTML content.
  *
- * @param {AST.Element} node - The template element node
+ * @param {ESTreeJSX.JSXElement | AST.TSRXJSXElement} node - The template element node
  * @param {TransformClientState} state - The transform state
  * @param {(node: AST.Node, state?: TransformClientState) => AST.Node} visit - The visitor function
  * @param {'html' | 'svg' | 'mathml'} child_namespace - The namespace for child elements
@@ -5181,7 +5144,7 @@ function transform_template_element(node, state, visit, child_namespace) {
 	});
 
 	transform_children(
-		node.children,
+		/** @type {AST.Node[]} */ (node.children),
 		/** @type {VisitorClientContext} */ ({
 			visit,
 			state: child_state,
@@ -5213,7 +5176,10 @@ function transform_children(children, context) {
 	const { visit, state, root } = context;
 	if (state.to_ts) {
 		for (const child of children) {
-			if (is_template_element(child) && lower_dynamic_element(child)) {
+			if (
+				is_template_element(child) &&
+				lower_dynamic_element(/** @type {ESTreeJSX.JSXElement} */ (child))
+			) {
 				state.imports.add(`import { Dynamic as ${dynamic_element_import_local} } from 'ripple'`);
 			}
 		}
@@ -5223,7 +5189,7 @@ function transform_children(children, context) {
 		state: { ...state, keep_component_style: state.to_ts ? true : state.keep_component_style },
 	});
 
-	const head_elements = /** @type {AST.Element[]} */ (
+	const head_elements = /** @type {ESTreeJSX.JSXElement[]} */ (
 		children.filter(
 			(node) =>
 				is_template_element(node) && /** @type {any} */ (get_element_id(node)).name === 'head',
@@ -5250,14 +5216,15 @@ function transform_children(children, context) {
 			normalized.some(
 				(node) =>
 					is_template_expression(node) &&
-					is_children_template_expression(node.expression, state.scope),
+					is_children_template_expression(/** @type {any} */ (node).expression, state.scope),
 			)) ||
 		// At root level, non-literal expressions need a fragment template so the
 		// anchor has a parent node. Without a parent, expression()'s .before() call
 		// is a no-op when the value is a TSRXElement.
 		(root &&
 			normalized.some(
-				(node) => is_template_expression(node) && node.expression.type !== 'Literal',
+				(node) =>
+					is_template_expression(node) && /** @type {any} */ (node).expression.type !== 'Literal',
 			)) ||
 		normalized.filter(
 			(node) =>
@@ -5338,7 +5305,9 @@ function transform_children(children, context) {
 						: is_template_expression(node)
 							? state.scope.generate('expression')
 							: state.scope.generate('node'),
-			/** @type {AST.NodeWithLocation} */ (is_template_element(node) ? node.openingElement : node),
+			/** @type {AST.NodeWithLocation} */ (
+				is_template_element(node) ? /** @type {any} */ (node).openingElement : node
+			),
 		);
 	};
 
@@ -5348,7 +5317,7 @@ function transform_children(children, context) {
 			? b.id(
 					state.scope.generate('fragment'),
 					/** @type {AST.NodeWithLocation} */ (
-						is_template_element(node) ? node.openingElement : node
+						is_template_element(node) ? /** @type {any} */ (node).openingElement : node
 					),
 				)
 			: get_id(node);
@@ -5553,10 +5522,16 @@ function transform_children(children, context) {
 				// and component (non-DOM element) children. We need to ALSO add pop()
 				// when there are DOM element children, which the Element visitor doesn't cover.
 				const next_node = normalized[node_idx + 1];
-				if (next_node && is_element_dom_element(node) && node.children.length > 0) {
+				if (
+					next_node &&
+					is_element_dom_element(node) &&
+					/** @type {AST.Node[]} */ (/** @type {any} */ (node).children).length > 0
+				) {
 					// Check if any child is a DOM element - this causes navigation but
 					// the Element visitor doesn't add pop() for it
-					const has_dom_element_children = node.children.some(
+					const has_dom_element_children = /** @type {AST.Node[]} */ (
+						/** @type {any} */ (node).children
+					).some(
 						(child) =>
 							is_template_element(child) &&
 							get_element_id(child).type === 'Identifier' &&
@@ -5564,7 +5539,9 @@ function transform_children(children, context) {
 					);
 
 					// Check if the Element visitor already added pop()
-					const element_visitor_adds_pop = node.children.some(
+					const element_visitor_adds_pop = /** @type {AST.Node[]} */ (
+						/** @type {any} */ (node).children
+					).some(
 						(child) =>
 							child.type === 'IfStatement' ||
 							child.type === 'TryStatement' ||
@@ -5616,7 +5593,7 @@ function transform_children(children, context) {
 			} else if (is_template_expression(node)) {
 				const expr = /** @type {AST.Expression} */ (expression);
 				const is_static_native_tsrx_call = is_static_native_tsrx_function_call(
-					/** @type {AST.Expression} */ (node.expression),
+					/** @type {AST.Expression} */ (/** @type {any} */ (node).expression),
 					/** @type {VisitorClientContext} */ ({ ...context, state }),
 				);
 
@@ -5648,13 +5625,13 @@ function transform_children(children, context) {
 							: b.stmt(call),
 					);
 				} else if (
-					!is_children_template_expression(node.expression, state.scope) &&
-					is_stringish_expression(node.expression, state)
+					!is_children_template_expression(/** @type {any} */ (node).expression, state.scope) &&
+					is_stringish_expression(/** @type {any} */ (node).expression, state)
 				) {
-					render_text_expression(node.expression, expr);
+					render_text_expression(/** @type {any} */ (node).expression, expr);
 				} else if (
 					normalized.length === 1 &&
-					!is_children_template_expression(node.expression, state.scope)
+					!is_children_template_expression(/** @type {any} */ (node).expression, state.scope)
 				) {
 					skipped++;
 					state.template?.push(' ');
@@ -5733,7 +5710,7 @@ function transform_children(children, context) {
 	}
 
 	if (context.state.inside_head) {
-		const title_element = /** @type {AST.Element} */ (
+		const title_element = /** @type {ESTreeJSX.JSXElement} */ (
 			children.find(
 				(node) =>
 					is_template_element(node) && /** @type {any} */ (get_element_id(node)).name === 'title',

--- a/packages/tsrx-ripple/src/transform/client/index.js
+++ b/packages/tsrx-ripple/src/transform/client/index.js
@@ -107,6 +107,7 @@ import {
 	strip_tsrx_style_elements,
 	wrap_code_block_in_iife,
 	visit_directive_wrapping_values,
+	replace_with_statements,
 	get_code_block_render,
 	get_code_block_template_child,
 	lower_code_block_children,
@@ -117,6 +118,7 @@ import {
 	get_attribute_value,
 	get_element_attributes,
 	get_element_id,
+	get_element_identifier,
 	get_style_css,
 	get_template_expression,
 	get_template_text_value,
@@ -139,8 +141,7 @@ import is_reference from 'is-reference';
  * @returns {AST.CSS.StyleSheet | null}
  */
 function get_component_css(state) {
-	const component = /** @type {any} */ (state.component);
-	return component?.css ?? component?.metadata?.css ?? null;
+	return state.component?.metadata.component_css ?? null;
 }
 
 /**
@@ -220,14 +221,14 @@ function insert_style_ref_setup_statements(body, setup, scopes) {
 	let inserted = false;
 
 	/**
-	 * @template T
+	 * @template {AST.Node | AST.Node[]} T
 	 * @param {T} original
 	 * @param {T} copy
 	 * @returns {T}
 	 */
 	const mirror_scope = (original, copy) => {
-		const scope = scopes?.get(/** @type {any} */ (original));
-		if (scope) scopes?.set(/** @type {any} */ (copy), scope);
+		const scope = scopes?.get(original);
+		if (scope) scopes?.set(copy, scope);
 		return copy;
 	};
 
@@ -266,7 +267,7 @@ function insert_style_ref_setup_statements(body, setup, scopes) {
 			return node_body === list ? node : mirror_scope(node, { ...node, body: node_body });
 		}
 		if (node.type === 'IfStatement') {
-			/** @type {Record<string, any> | null} */
+			/** @type {{ consequent?: AST.Statement; alternate?: AST.Statement } | null} */
 			let updates = null;
 			const consequent = /** @type {AST.Statement} */ (insert_in_statement(node.consequent));
 			if (consequent !== node.consequent) (updates ??= {}).consequent = consequent;
@@ -292,7 +293,7 @@ function insert_style_ref_setup_statements(body, setup, scopes) {
 			return cases === null ? node : mirror_scope(node, { ...node, cases });
 		}
 		if (node.type === 'TryStatement') {
-			/** @type {Record<string, any> | null} */
+			/** @type {{ block?: AST.BlockStatement; handler?: AST.CatchClause; finalizer?: AST.BlockStatement } | null} */
 			let updates = null;
 			const block = /** @type {AST.BlockStatement} */ (insert_in_statement(node.block));
 			if (block !== node.block) (updates ??= {}).block = block;
@@ -328,7 +329,7 @@ function insert_style_ref_setup_statements(body, setup, scopes) {
  * @returns {AST.TypeNode | undefined}
  */
 function unwrap_type_annotation(type_annotation) {
-	/** @type {any} */
+	/** @type {AST.TypeNode | undefined | null} */
 	let annotation = type_annotation;
 
 	while (annotation) {
@@ -355,14 +356,11 @@ function is_string_type_annotation(type_annotation) {
 	if (!annotation) return false;
 
 	if (annotation.type === 'TSStringKeyword') return true;
-	if (
-		annotation.type === 'TSLiteralType' &&
-		/** @type {any} */ (annotation.literal)?.type === 'Literal'
-	) {
-		return typeof (/** @type {any} */ (annotation.literal).value) === 'string';
+	if (annotation.type === 'TSLiteralType' && annotation.literal.type === 'Literal') {
+		return typeof annotation.literal.value === 'string';
 	}
 	if (annotation.type === 'TSUnionType') {
-		return annotation.types.every((type) => is_string_type_annotation(/** @type {any} */ (type)));
+		return annotation.types.every((type) => is_string_type_annotation(type));
 	}
 
 	return false;
@@ -471,7 +469,7 @@ function is_stringish_expression(expression, state, visited = new Set()) {
 
 	if (expression.type === 'TSAsExpression' || expression.type === 'TSTypeAssertion') {
 		return (
-			is_string_type_annotation(/** @type {any} */ (expression.typeAnnotation)) ||
+			is_string_type_annotation(expression.typeAnnotation) ||
 			is_stringish_expression(/** @type {AST.Expression} */ (expression.expression), state, visited)
 		);
 	}
@@ -1108,7 +1106,9 @@ function apply_updates(init, update, state) {
  */
 function visit_title_element(node, context) {
 	const normalized = normalize_children(/** @type {AST.Node[]} */ (node.children), context);
-	const content = /** @type {any} */ (normalized[0]);
+	const content = /** @type {ESTreeJSX.JSXText | ESTreeJSX.JSXExpressionContainer} */ (
+		normalized[0]
+	);
 
 	const metadata = { tracking: false };
 	const result = /** @type {AST.Expression} */ (
@@ -1150,7 +1150,7 @@ function set_hidden_import_from_ripple(name, context, is_obfuscated = false) {
 }
 
 /**
- * @param {any} source_argument
+ * @param {ESTreeJSX.JSXExpressionContainer | AST.Expression} source_argument
  * @param {VisitorClientContext} context
  * @returns {AST.CallExpression}
  */
@@ -1204,7 +1204,7 @@ function create_ref_value_call(source_argument, context) {
 }
 
 /**
- * @param {ESTreeJSX.JSXElement} node
+ * @param {AST.TSRXJSXElement} node
  * @param {TransformClientState} state
  * @returns {AST.TypeNode | null}
  */
@@ -1219,18 +1219,18 @@ function create_element_ref_target_type(node, state) {
 }
 
 /**
- * @param {any} source_argument
- * @returns {any}
+ * @param {ESTreeJSX.JSXExpressionContainer | AST.Expression} source_argument
+ * @returns {AST.Expression}
  */
 function get_ref_source_argument(source_argument) {
 	return source_argument.type === 'JSXExpressionContainer'
-		? source_argument.expression
+		? /** @type {AST.Expression} */ (source_argument.expression)
 		: source_argument;
 }
 
 /**
  * @param {AST.Expression[]} args
- * @param {any} source_argument
+ * @param {ESTreeJSX.JSXExpressionContainer | AST.Expression} source_argument
  * @param {AST.Expression} argument
  * @returns {void}
  */
@@ -1767,7 +1767,7 @@ const visit_try_statement = (node, context) => {
 
 /**
  * Shared by the plain statement and the `@`-directive forms.
- * @type {Visitor<AST.ForOfStatement | AST.JSXForExpression, TransformClientState, AST.Node>}
+ * @type {Visitor<AST.ForOfStatement | AST.JSXForOfExpression, TransformClientState, AST.Node>}
  */
 const visit_for_of_statement = (node, context) => {
 	if (context.state.regular_js) {
@@ -1975,7 +1975,7 @@ const visitors = {
 		const { state } = context;
 
 		if (get_submodule_import_source_name(node) === 'server') {
-			return /** @type {any} */ (transform_server_module_import(node, state));
+			return replace_with_statements(transform_server_module_import(node, state));
 		}
 
 		if (!state.to_ts && node.importKind === 'type') {
@@ -3874,12 +3874,10 @@ function build_tsrx_to_ts_expression(node, context, in_jsx_child = false) {
 	// authored `<> … </>` (no wrapper flag) keeps flowing through the normal path.
 	if (node.metadata?.tsrx_generated_wrapper === true) {
 		const only = /** @type {AST.Node | undefined} */ (
-			(node.children || []).find(
-				(/** @type {any} */ child) => child && child.type !== 'EmptyStatement',
-			)
+			(node.children || []).find((child) => child && child.type !== 'EmptyStatement')
 		);
 		if (only && is_template_directive(only)) {
-			const value = build_tsrx_ts_directive_value(/** @type {any} */ (only), context);
+			const value = build_tsrx_ts_directive_value(only, context);
 			return in_jsx_child ? b.jsx_expression_container(value) : value;
 		}
 	}
@@ -3985,11 +3983,17 @@ function transform_tsrx_tsx_child(node, context) {
 		// Build it as a JSX child instead. Non-empty fragments keep their existing
 		// lowering (e.g. `{<>{a}</>}` still unwraps to `{a}`). This matches the JSX
 		// targets and how the same fragment survives in an attribute value.
-		const expr = /** @type {any} */ (node.expression);
+		const expr = node.expression;
+		// Both fragment shapes carry AST.Node children (the strict estree-jsx
+		// children are a subset).
+		const fragment_children =
+			expr.type === 'JSXFragment' && is_template_fragment(expr)
+				? /** @type {AST.Node[]} */ (expr.children || [])
+				: null;
 		const is_empty_fragment =
-			is_template_fragment(expr) &&
-			!(expr.children || []).some(
-				(/** @type {any} */ child) =>
+			fragment_children !== null &&
+			!fragment_children.some(
+				(child) =>
 					child &&
 					child.type !== 'EmptyStatement' &&
 					(child.type !== 'JSXText' || get_template_text_value(child, true) !== ''),
@@ -4094,9 +4098,7 @@ function transform_tsrx_ts_render_children(children, context) {
 				child.type === 'SwitchStatement' ||
 				child.type === 'TryStatement'
 			) {
-				body.push(
-					transform_tsrx_ts_render_control_flow_statement(/** @type {any} */ (child), context),
-				);
+				body.push(transform_tsrx_ts_render_control_flow_statement(child, context));
 			} else {
 				body.push(
 					...transform_tsrx_ts_statements_to_render_body(
@@ -4349,12 +4351,13 @@ function transform_tsrx_ts_render_control_flow_statement(node, context) {
  * LEAF is returned, so the value is not a void IIFE. Render position never reaches
  * here — only the generated value-wrapper fragment does (see
  * `build_tsrx_to_ts_expression`).
- * @param {any} node
+ * @param {AST.JSXTemplateDirective | AST.IfStatement} node — a directive, or a
+ * plain `IfStatement` link of an `@else if` chain (the recursion below)
  * @param {VisitorClientContext} context
  * @returns {AST.Expression}
  */
 function build_tsrx_ts_directive_value(node, context) {
-	const scoped = (/** @type {AST.Node} */ scope_node) => ({
+	const scoped = (/** @type {AST.Node | AST.Node[]} */ scope_node) => ({
 		...context,
 		// Everything lowered as a directive's branch/case value is value content, so a
 		// directive nested in a fragment here lowers to a value (see transform_tsrx_tsx_child).
@@ -4367,7 +4370,7 @@ function build_tsrx_ts_directive_value(node, context) {
 	});
 	// Combine a render expression into a JSX child so multiple siblings can be
 	// merged into one fragment.
-	const to_fragment_child = (/** @type {any} */ expr) =>
+	const to_fragment_child = (/** @type {TsrxTsViewNode} */ expr) =>
 		expr?.type === 'JSXElement' ||
 		expr?.type === 'JSXFragment' ||
 		expr?.type === 'JSXText' ||
@@ -4383,7 +4386,7 @@ function build_tsrx_ts_directive_value(node, context) {
 	// kept before the return so they share the IIFE scope.
 	const branch_returning_body = (
 		/** @type {AST.Node[]} */ body,
-		/** @type {AST.Node} */ scope_node,
+		/** @type {AST.Node | AST.Node[]} */ scope_node,
 	) => {
 		const ctx = scoped(scope_node);
 		/** @type {AST.Statement[]} */
@@ -4423,13 +4426,15 @@ function build_tsrx_ts_directive_value(node, context) {
 		return b.call(b.thunk(b.block(stmts)));
 	};
 
-	if (node.type === 'JSXIfExpression') {
+	// An `@else if` chain link recurses here as a plain `IfStatement` — it
+	// lowers exactly like the rooting `@if`, to the ternary's next arm.
+	if (node.type === 'JSXIfExpression' || node.type === 'IfStatement') {
 		const cons_body =
 			node.consequent.type === 'BlockStatement' ? node.consequent.body : [node.consequent];
 		const consequent = branch_value(cons_body, node.consequent);
 		let alternate = /** @type {AST.Expression} */ (b.literal(null));
 		if (node.alternate) {
-			const alt = /** @type {any} */ (node.alternate);
+			const alt = node.alternate;
 			alternate =
 				alt.type === 'IfStatement'
 					? build_tsrx_ts_directive_value(alt, scoped(alt))
@@ -4442,13 +4447,16 @@ function build_tsrx_ts_directive_value(node, context) {
 		);
 	}
 
-	if (node.type === 'JSXForExpression') {
+	if (
+		node.type === 'JSXForExpression' &&
+		(node.statementType === 'ForOfStatement' || node.statementType === 'ForInStatement')
+	) {
 		// `@for await` iterates an AsyncIterable, which `Array.from` does NOT accept.
 		// Accumulate with a real `for await` loop instead (the runtime renders via
 		// `_$_.for`; this is the to_ts type view only). Await the async IIFE so the
 		// binding types as the item array, not a `Promise` — the enclosing component is
 		// async, since `for await` requires it.
-		if (node.await) {
+		if (node.statementType === 'ForOfStatement' && node.await) {
 			const items_id = b.id('$$items');
 			/** @type {AST.Statement[]} */
 			const loop_body = [];
@@ -4506,7 +4514,7 @@ function build_tsrx_ts_directive_value(node, context) {
 		// `node.left` is a `const x` VariableDeclaration; the `.map` callback needs the
 		// bare pattern (`x`), not the declaration statement. `; index i` becomes the
 		// callback's second parameter (`(x, i)`), not a dropped reference.
-		const left = /** @type {any} */ (node.left);
+		const left = node.left;
 		const param = left.type === 'VariableDeclaration' ? left.declarations[0].id : left;
 		const params = [/** @type {AST.Pattern} */ (context.visit(param))];
 		if (node.index) {
@@ -4546,7 +4554,7 @@ function build_tsrx_ts_directive_value(node, context) {
 	}
 
 	if (node.type === 'JSXSwitchExpression') {
-		const cases = node.cases.map((/** @type {any} */ sc) =>
+		const cases = node.cases.map((sc) =>
 			b.switch_case(
 				sc.test ? /** @type {AST.Expression} */ (context.visit(sc.test)) : null,
 				branch_returning_body(flatten_switch_consequent(sc.consequent), sc.consequent),
@@ -4560,40 +4568,47 @@ function build_tsrx_ts_directive_value(node, context) {
 		return b.call(b.thunk(b.block([switch_stmt, b.return(b.literal(null))])));
 	}
 
-	// TryStatement: try/catch/pending leaves return; a `finally` must not.
-	const try_body = b.block(
-		branch_returning_body(node.block.body, node.block),
-		/** @type {AST.NodeWithLocation} */ (node.block),
-	);
-	let catch_handler = null;
-	if (node.handler) {
-		catch_handler = b.catch_clause(
-			node.handler.param || null,
-			node.handler.resetParam || null,
-			b.block(
-				branch_returning_body(node.handler.body.body, node.handler.body),
-				/** @type {AST.NodeWithLocation} */ (node.handler.body),
-			),
-			/** @type {AST.NodeWithLocation} */ (node.handler),
+	if (node.type === 'JSXTryExpression') {
+		// TryStatement: try/catch/pending leaves return; a `finally` must not.
+		const try_body = b.block(
+			branch_returning_body(node.block.body, node.block),
+			/** @type {AST.NodeWithLocation} */ (node.block),
 		);
+		let catch_handler = null;
+		if (node.handler) {
+			catch_handler = b.catch_clause(
+				node.handler.param || null,
+				node.handler.resetParam || null,
+				b.block(
+					branch_returning_body(node.handler.body.body, node.handler.body),
+					/** @type {AST.NodeWithLocation} */ (node.handler.body),
+				),
+				/** @type {AST.NodeWithLocation} */ (node.handler),
+			);
+		}
+		const pending = node.pending
+			? b.block(
+					branch_returning_body(node.pending.body, node.pending),
+					/** @type {AST.NodeWithLocation} */ (node.pending),
+				)
+			: null;
+		const finalizer = node.finalizer
+			? b.block(
+					transform_body(node.finalizer.body, scoped(node.finalizer)),
+					/** @type {AST.NodeWithLocation} */ (node.finalizer),
+				)
+			: null;
+		return b.call(b.thunk(b.block([b.try(try_body, catch_handler, finalizer, pending)])));
 	}
-	const pending = node.pending
-		? b.block(
-				branch_returning_body(node.pending.body, node.pending),
-				/** @type {AST.NodeWithLocation} */ (node.pending),
-			)
-		: null;
-	const finalizer = node.finalizer
-		? b.block(
-				transform_body(node.finalizer.body, scoped(node.finalizer)),
-				/** @type {AST.NodeWithLocation} */ (node.finalizer),
-			)
-		: null;
-	return b.call(b.thunk(b.block([b.try(try_body, catch_handler, finalizer, pending)])));
+
+	// Only `@for (;;)` remains — it renders repeatedly with no item binding, so
+	// it has no value form (previously this fell into the `@try` lowering and
+	// crashed on the missing `block`).
+	throw new Error('A `@for (;;)` directive cannot be used as a value.');
 }
 
 /**
- * @param {any} node
+ * @param {AST.Node} node
  * @param {TransformClientContext} context
  */
 function transform_ts_child(node, context) {
@@ -4605,46 +4620,43 @@ function transform_ts_child(node, context) {
 		}
 		state.init?.push(
 			b.stmt(
-				/** @type {AST.Expression} */ (
-					visit(get_template_expression(/** @type {any} */ (node), true), { ...state })
-				),
+				/** @type {AST.Expression} */ (visit(get_template_expression(node, true), { ...state })),
 			),
 		);
 	} else if (node.type === 'JSXStyleElement') {
 		// to_ts: emit an empty `<style>` element for type-only mappings. The CSS
 		// children are TSRX stylesheet AST, never printed as TSX children, and
 		// style attributes were never carried over.
-		const jsxElement = b.jsx_element(/** @type {any} */ (node), [], []);
+		const jsxElement = b.jsx_element(node, [], []);
 		disable_style_anchor_verification(jsxElement);
 		if (!state.init) {
 			return jsxElement;
 		}
-		if (/** @type {any} */ (node).unclosed) {
+		if (node.unclosed) {
 			state.init?.push(/** @type {AST.Statement} */ (/** @type {unknown} */ (jsxElement)));
 		} else {
 			state.init?.push(b.stmt(jsxElement));
 		}
 	} else if (is_template_element(node)) {
-		const lowered = lower_dynamic_element(node, undefined, state.scopes);
+		// is_template_element stays a boolean predicate — narrow the element once.
+		let element = /** @type {AST.TSRXJSXElement} */ (node);
+		const lowered = lower_dynamic_element(element, undefined, state.scopes);
 		if (lowered) {
 			state.imports.add(`import { Dynamic as ${dynamic_element_import_local} } from 'ripple'`);
-			node = lowered;
+			element = lowered;
 		}
 
 		/** @type {TsrxTsxChild[]} */
 		const children = [];
 		let has_children_props = false;
-		const is_dom_element = is_element_dom_element(node);
-		const element_name =
-			/** @type {AST.Node} */ (get_element_id(node)).type === 'Identifier'
-				? /** @type {AST.Identifier} */ (get_element_id(node)).name
-				: null;
+		const is_dom_element = is_element_dom_element(element);
+		const element_name = get_element_identifier(element)?.name ?? null;
 		const child_namespace =
 			is_dom_element && element_name !== null
 				? determine_namespace_for_children(element_name, state.namespace)
 				: state.namespace;
 
-		const attributes = get_element_attributes(node).map((attr) => {
+		const attributes = get_element_attributes(element).map((attr) => {
 			if (attr.type === 'JSXAttribute') {
 				const name = visit(get_attribute_name_node(attr), state);
 				const attr_value = /** @type { AST.Expression & AST.NodeWithLocation | null} */ (
@@ -4662,7 +4674,7 @@ function transform_ts_child(node, context) {
 					prop_name = get_attribute_name(attr) || 'unknown';
 				}
 				const ref_target_type =
-					prop_name === 'ref' ? create_element_ref_target_type(node, state) : null;
+					prop_name === 'ref' ? create_element_ref_target_type(element, state) : null;
 				const value =
 					attr_value === null
 						? // <div attr>, not adding `name` for loc because `jsx_name` below
@@ -4725,12 +4737,12 @@ function transform_ts_child(node, context) {
 		});
 
 		if (
-			!is_self_closing(node) &&
-			!node.unclosed &&
+			!is_self_closing(element) &&
+			!element.unclosed &&
 			!has_children_props &&
-			node.children.length > 0
+			element.children.length > 0
 		) {
-			const component_scope = /** @type {ScopeInterface} */ (context.state.scopes.get(node));
+			const component_scope = /** @type {ScopeInterface} */ (context.state.scopes.get(element));
 			const child_context = {
 				...context,
 				state: {
@@ -4744,7 +4756,7 @@ function transform_ts_child(node, context) {
 			const thunk =
 				element_name === 'style' || is_dom_element
 					? null
-					: b.thunk(b.block(transform_body(node.children, child_context)));
+					: b.thunk(b.block(transform_body(element.children, child_context)));
 
 			if (element_name === 'style') {
 				// CSS children are TSRX stylesheet AST, not TSX children. Keep the
@@ -4752,7 +4764,7 @@ function transform_ts_child(node, context) {
 			} else if (is_dom_element) {
 				children.push(
 					...transform_tsrx_tsx_children(
-						/** @type {AST.Node[]} */ (node.children),
+						/** @type {AST.Node[]} */ (element.children),
 						/** @type {VisitorClientContext} */ (child_context),
 					),
 				);
@@ -4761,33 +4773,31 @@ function transform_ts_child(node, context) {
 			}
 		}
 
-		let element_source = /** @type {ESTreeJSX.JSXElement} */ (/** @type {unknown} */ (node));
+		let element_source = element;
 
-		if (get_element_id(node).type === 'MemberExpression') {
+		if (get_element_id(element).type === 'MemberExpression') {
 			const member = /** @type {AST.MemberExpression} */ (
-				visit(get_element_id(node), { ...state })
+				visit(get_element_id(element), { ...state })
 			);
 
-			set_element_id(node, member);
+			set_element_id(element, member);
 			// Plant the visited member tag on local copies for the printer — the
 			// source element is never mutated.
 			const opening = /** @type {ESTreeJSX.TSRXJSXOpeningElement} */ ({
-				...node.openingElement,
+				...element.openingElement,
 				name: member,
 			});
-			const closing = node.closingElement
+			const closing = element.closingElement
 				? /** @type {ESTreeJSX.TSRXJSXClosingElement} */ ({
-						...node.closingElement,
+						...element.closingElement,
 						name: setLocation(
 							{ ...member },
-							/** @type {AST.NodeWithLocation} */ (node.closingElement.name),
+							/** @type {AST.NodeWithLocation} */ (element.closingElement.name),
 							true,
 						),
 					})
 				: null;
-			element_source = /** @type {ESTreeJSX.JSXElement} */ (
-				/** @type {unknown} */ ({ ...node, openingElement: opening, closingElement: closing })
-			);
+			element_source = { ...element, openingElement: opening, closingElement: closing };
 		}
 
 		const jsxElement = b.jsx_element(element_source, attributes, children);
@@ -4801,7 +4811,7 @@ function transform_ts_child(node, context) {
 
 		// For unclosed elements, push the JSXElement directly without wrapping in ExpressionStatement
 		// This keeps it in the AST for mappings but avoids adding a semicolon
-		if (node.unclosed) {
+		if (element.unclosed) {
 			state.init?.push(/** @type {AST.Statement} */ (/** @type {unknown} */ (jsxElement)));
 		} else {
 			state.init?.push(b.stmt(jsxElement));
@@ -5008,28 +5018,20 @@ function transform_ts_child(node, context) {
 		}
 		state.init.push(/** @type {AST.Statement} */ (result));
 	} else if (is_template_fragment(node)) {
-		let result = build_tsrx_to_ts_expression(node, context);
+		// is_template_fragment stays a boolean predicate — narrow once.
+		const fragment = /** @type {AST.TSRXJSXFragment} */ (node);
+		let result = build_tsrx_to_ts_expression(fragment, context);
 		// Keep an AUTHORED `<> … </>` here too (a render-output / control-flow branch
 		// body, e.g. the `<>{[1,2,3]}</>` branch of an `@if`), so it is not unwrapped to
 		// a bare `[1,2,3]`. The fragment's contents (including any `<style>`) are already
 		// lowered by `build_tsrx_to_ts_expression`; this only re-adds the `<> … </>`.
-		if (is_authored_native_fragment(node)) {
-			result = wrap_to_ts_value_in_fragment(result, node);
+		if (is_authored_native_fragment(fragment)) {
+			result = wrap_to_ts_value_in_fragment(result, fragment);
 		}
 		if (!state.init) {
 			return result;
 		}
 		state.init.push(b.stmt(/** @type {AST.Expression} */ (result)));
-	} else if (node.type === 'JSXExpressionContainer') {
-		// JSX comments {/* ... */} are JSXExpressionContainer with JSXEmptyExpression
-		// These should be preserved in the output as-is for prettier to handle
-		const result = b.jsx_expression_container(
-			/** @type {AST.Expression} */ (visit(node.expression, state)),
-		);
-		if (!state.init) {
-			return result;
-		}
-		state.init.push(/** @type {AST.Statement} */ (/** @type {unknown} */ (result)));
 	} else if (node.type === 'ReturnStatement') {
 		const result = b.return(
 			node.argument ? /** @type {AST.Expression} */ (visit(node.argument, state)) : undefined,
@@ -5152,7 +5154,7 @@ function is_native_tsrx_value_position(path) {
  * An AUTHORED `<> … </>` fragment (not a compiler-generated wrapper around a
  * directive, nor a code-block-chain wrapper). These are kept verbatim in the
  * to_ts output instead of being unwrapped to their single child.
- * @param {any} node
+ * @param {AST.Node | null | undefined} node
  * @returns {boolean}
  */
 function is_authored_native_fragment(node) {
@@ -5200,9 +5202,9 @@ function is_combined_expression_position(path, node) {
  * `is_combined_expression_position`). A value that is already a fragment is left
  * as-is; a JSX element/text/container nests directly; any other expression goes in
  * a `{ … }` container.
- * @param {any} expression
+ * @param {TsrxTsViewNode} expression
  * @param {AST.Node} source
- * @returns {any}
+ * @returns {TsrxTsViewNode}
  */
 function wrap_to_ts_value_in_fragment(expression, source) {
 	if (expression?.type === 'JSXFragment') return expression;
@@ -5384,8 +5386,7 @@ function transform_children(children, context) {
 
 	const head_elements = /** @type {ESTreeJSX.JSXElement[]} */ (
 		children.filter(
-			(node) =>
-				is_template_element(node) && /** @type {any} */ (get_element_id(node)).name === 'head',
+			(node) => is_template_element(node) && get_element_identifier(node)?.name === 'head',
 		)
 	);
 
@@ -5410,7 +5411,10 @@ function transform_children(children, context) {
 			normalized.some(
 				(node) =>
 					is_template_expression(node) &&
-					is_children_template_expression(/** @type {any} */ (node).expression, state.scope),
+					is_children_template_expression(
+						/** @type {ESTreeJSX.JSXExpressionContainer} */ (node).expression,
+						state.scope,
+					),
 			)) ||
 		// At root level, non-literal expressions need a fragment template so the
 		// anchor has a parent node. Without a parent, expression()'s .before() call
@@ -5418,7 +5422,8 @@ function transform_children(children, context) {
 		(root &&
 			normalized.some(
 				(node) =>
-					is_template_expression(node) && /** @type {any} */ (node).expression.type !== 'Literal',
+					is_template_expression(node) &&
+					/** @type {ESTreeJSX.JSXExpressionContainer} */ (node).expression.type !== 'Literal',
 			)) ||
 		normalized.filter(
 			(node) =>
@@ -5451,9 +5456,9 @@ function transform_children(children, context) {
 			// __anchor too.
 			(is_template_element(single_output) &&
 				!is_dynamic_element(single_output) &&
-				get_element_id(single_output).type === 'Identifier' &&
-				!(/** @type {any} */ (get_element_id(single_output)).tracked) &&
-				/** @type {AST.Identifier} */ (get_element_id(single_output)).name !== 'children' &&
+				get_element_identifier(single_output) !== null &&
+				!get_element_identifier(single_output)?.tracked &&
+				get_element_identifier(single_output)?.name !== 'children' &&
 				!is_element_dom_element(single_output) &&
 				!is_ripple_fragment_element(single_output, context)));
 	if (root_controlled) {
@@ -5468,14 +5473,17 @@ function transform_children(children, context) {
 	// sentinel as the anchor; append() detects it (no nodeType) and appendChild()s
 	// the component's root, dropping the placeholder comment nodes from the template.
 	/** @param {AST.Node} n */
-	const is_static_component_child = (n) =>
-		is_template_element(n) &&
-		!is_dynamic_element(n) &&
-		get_element_id(n).type === 'Identifier' &&
-		!(/** @type {any} */ (get_element_id(n)).tracked) &&
-		/** @type {AST.Identifier} */ (get_element_id(n)).name !== 'children' &&
-		!is_element_dom_element(n) &&
-		!is_ripple_fragment_element(n, context);
+	const is_static_component_child = (n) => {
+		if (!is_template_element(n) || is_dynamic_element(n)) return false;
+		const id = get_element_identifier(n);
+		return (
+			id !== null &&
+			!id.tracked &&
+			id.name !== 'children' &&
+			!is_element_dom_element(n) &&
+			!is_ripple_fragment_element(n, context)
+		);
+	};
 	const all_component_append =
 		!root &&
 		!root_controlled &&
@@ -5504,7 +5512,7 @@ function transform_children(children, context) {
 							? state.scope.generate('expression')
 							: state.scope.generate('node'),
 			/** @type {AST.NodeWithLocation} */ (
-				is_template_element(node) ? /** @type {any} */ (node).openingElement : node
+				is_template_element(node) ? /** @type {AST.TSRXJSXElement} */ (node).openingElement : node
 			),
 		);
 	};
@@ -5515,7 +5523,9 @@ function transform_children(children, context) {
 			? b.id(
 					state.scope.generate('fragment'),
 					/** @type {AST.NodeWithLocation} */ (
-						is_template_element(node) ? /** @type {any} */ (node).openingElement : node
+						is_template_element(node)
+							? /** @type {AST.TSRXJSXElement} */ (node).openingElement
+							: node
 					),
 				)
 			: get_id(node);
@@ -5582,7 +5592,7 @@ function transform_children(children, context) {
 			if (is_template_text_or_expression(node)) {
 				metadata = { tracking: false };
 				expression = /** @type {AST.Expression} */ (
-					visit(get_template_expression(/** @type {any} */ (node), false), {
+					visit(get_template_expression(node, false), {
 						...state,
 						flush_node: null,
 						metadata,
@@ -5720,26 +5730,21 @@ function transform_children(children, context) {
 				// and component (non-DOM element) children. We need to ALSO add pop()
 				// when there are DOM element children, which the Element visitor doesn't cover.
 				const next_node = normalized[node_idx + 1];
-				if (
-					next_node &&
-					is_element_dom_element(node) &&
-					/** @type {AST.Node[]} */ (/** @type {any} */ (node).children).length > 0
-				) {
+				const element_children = is_template_element(node)
+					? /** @type {AST.TSRXJSXElement} */ (node).children
+					: [];
+				if (next_node && is_element_dom_element(node) && element_children.length > 0) {
 					// Check if any child is a DOM element - this causes navigation but
 					// the Element visitor doesn't add pop() for it
-					const has_dom_element_children = /** @type {AST.Node[]} */ (
-						/** @type {any} */ (node).children
-					).some(
+					const has_dom_element_children = element_children.some(
 						(child) =>
 							is_template_element(child) &&
-							get_element_id(child).type === 'Identifier' &&
+							get_element_identifier(child) !== null &&
 							is_element_dom_element(child),
 					);
 
 					// Check if the Element visitor already added pop()
-					const element_visitor_adds_pop = /** @type {AST.Node[]} */ (
-						/** @type {any} */ (node).children
-					).some(
+					const element_visitor_adds_pop = element_children.some(
 						(child) =>
 							is_template_directive(child) ||
 							child.type === 'IfStatement' ||
@@ -5790,9 +5795,13 @@ function transform_children(children, context) {
 					namespace: state.namespace,
 				});
 			} else if (is_template_expression(node)) {
+				// is_template_expression stays a boolean (its negative would lie
+				// about merged-text containers), so narrow the container once here.
+				const container = /** @type {ESTreeJSX.JSXExpressionContainer} */ (node);
+				const container_expression = /** @type {AST.Expression} */ (container.expression);
 				const expr = /** @type {AST.Expression} */ (expression);
 				const is_static_native_tsrx_call = is_static_native_tsrx_function_call(
-					/** @type {AST.Expression} */ (/** @type {any} */ (node).expression),
+					container_expression,
 					/** @type {VisitorClientContext} */ ({ ...context, state }),
 				);
 
@@ -5824,13 +5833,13 @@ function transform_children(children, context) {
 							: b.stmt(call),
 					);
 				} else if (
-					!is_children_template_expression(/** @type {any} */ (node).expression, state.scope) &&
-					is_stringish_expression(/** @type {any} */ (node).expression, state)
+					!is_children_template_expression(container_expression, state.scope) &&
+					is_stringish_expression(container_expression, state)
 				) {
-					render_text_expression(/** @type {any} */ (node).expression, expr);
+					render_text_expression(container_expression, expr);
 				} else if (
 					normalized.length === 1 &&
-					!is_children_template_expression(/** @type {any} */ (node).expression, state.scope)
+					!is_children_template_expression(container_expression, state.scope)
 				) {
 					skipped++;
 					state.template?.push(' ');
@@ -5854,7 +5863,10 @@ function transform_children(children, context) {
 				}
 			} else if (is_template_text(node)) {
 				render_text_expression(
-					get_template_expression(/** @type {any} */ (node), false),
+					get_template_expression(
+						/** @type {ESTreeJSX.JSXText | ESTreeJSX.JSXExpressionContainer} */ (node),
+						false,
+					),
 					/** @type {AST.Expression} */ (expression),
 				);
 			} else if (
@@ -5914,8 +5926,7 @@ function transform_children(children, context) {
 	if (context.state.inside_head) {
 		const title_element = /** @type {ESTreeJSX.JSXElement} */ (
 			children.find(
-				(node) =>
-					is_template_element(node) && /** @type {any} */ (get_element_id(node)).name === 'title',
+				(node) => is_template_element(node) && get_element_identifier(node)?.name === 'title',
 			)
 		);
 

--- a/packages/tsrx-ripple/src/transform/client/index.js
+++ b/packages/tsrx-ripple/src/transform/client/index.js
@@ -187,7 +187,7 @@ function add_type_only_style_anchor(node, context) {
 }
 
 /**
- * @param {ESTreeJSX.JSXElement} element
+ * @param {AST.TSRXJSXElement} element
  */
 function disable_style_anchor_verification(element) {
 	if (element.openingElement?.name) {
@@ -209,7 +209,7 @@ function disable_style_anchor_verification(element) {
  * mirrored onto the copies); untouched subtrees are shared with the input.
  * @param {AST.Node[]} body
  * @param {AST.Statement[]} setup
- * @param {Map<AST.Node | AST.Node[], any>} [scopes]
+ * @param {Map<AST.Node | AST.Node[], ScopeInterface>} [scopes]
  * @returns {AST.Node[]}
  */
 function insert_style_ref_setup_statements(body, setup, scopes) {
@@ -2021,19 +2021,6 @@ const visitors = {
 	},
 
 	CallExpression(node, context) {
-		const type_parameters = /** @type {any} */ (node).typeParameters;
-		if (type_parameters) {
-			// acorn-typescript quirk: call/new expressions carry their generics as
-			// `typeParameters`; the transforms (and the TSX printer) expect the
-			// standard `typeArguments`.
-			return context.visit(
-				/** @type {any} */ ({
-					...node,
-					typeArguments: type_parameters,
-					typeParameters: undefined,
-				}),
-			);
-		}
 		const callee = node.callee;
 		const parent = context.path.at(-1);
 
@@ -2202,19 +2189,6 @@ const visitors = {
 	},
 
 	NewExpression(node, context) {
-		const type_parameters = /** @type {any} */ (node).typeParameters;
-		if (type_parameters) {
-			// acorn-typescript quirk: call/new expressions carry their generics as
-			// `typeParameters`; the transforms (and the TSX printer) expect the
-			// standard `typeArguments`.
-			return context.visit(
-				/** @type {any} */ ({
-					...node,
-					typeArguments: type_parameters,
-					typeParameters: undefined,
-				}),
-			);
-		}
 		const callee = node.callee;
 
 		if (context.state.metadata?.tracking === false) {
@@ -3803,9 +3777,9 @@ function join_template(items) {
 }
 
 /**
- * @typedef {AST.Statement | ESTreeJSX.JSXElement | ESTreeJSX.JSXFragment} TsrxTsStatement
- * @typedef {AST.Expression | ESTreeJSX.JSXElement | ESTreeJSX.JSXFragment} TsrxTsExpression
- * @typedef {ESTreeJSX.JSXElement['children'][number]} TsrxTsxChild
+ * @typedef {AST.Statement | ESTreeJSX.JSXElement | AST.TSRXJSXFragment} TsrxTsStatement
+ * @typedef {AST.Expression | ESTreeJSX.JSXElement | AST.TSRXJSXFragment} TsrxTsExpression
+ * @typedef {ESTreeJSX.JSXText | ESTreeJSX.JSXExpressionContainer | ESTreeJSX.JSXElement | AST.TSRXJSXElement | AST.TSRXJSXFragment} TsrxTsxChild
  * @typedef {TsrxTsExpression | ESTreeJSX.JSXText | ESTreeJSX.JSXExpressionContainer} TsrxTsViewNode
  */
 
@@ -4657,7 +4631,7 @@ function transform_ts_child(node, context) {
 			node = lowered;
 		}
 
-		/** @type {ESTreeJSX.JSXElement['children']} */
+		/** @type {TsrxTsxChild[]} */
 		const children = [];
 		let has_children_props = false;
 		const is_dom_element = is_element_dom_element(node);
@@ -4816,7 +4790,6 @@ function transform_ts_child(node, context) {
 			);
 		}
 
-		/** @type {ESTreeJSX.JSXElement} */
 		const jsxElement = b.jsx_element(element_source, attributes, children);
 		if (element_name === 'style') {
 			disable_style_anchor_verification(jsxElement);
@@ -5197,14 +5170,14 @@ function is_authored_native_fragment(node) {
  * @returns {boolean}
  */
 function is_combined_expression_position(path, node) {
-	let parent = /** @type {any} */ (path.at(-1));
+	let parent = path.at(-1);
 	let slot_node = node;
 	// A generated value wrapper is visited FROM its directive's visitor, so the
 	// directive sits atop the path — the wrapper stands in the directive's
 	// slot, so judge the position against the directive's own parent.
 	if (parent?.metadata?.tsrx_value_wrapper === node) {
 		slot_node = parent;
-		parent = /** @type {any} */ (path.at(-2));
+		parent = path.at(-2);
 	}
 	if (!parent || !isTemplateValuePosition(parent, slot_node)) return false;
 	switch (parent.type) {
@@ -5215,7 +5188,7 @@ function is_combined_expression_position(path, node) {
 			return parent.right !== slot_node;
 		case 'CallExpression':
 		case 'NewExpression':
-			return !(Array.isArray(parent.arguments) && parent.arguments.includes(slot_node));
+			return !parent.arguments.some((argument) => argument === slot_node);
 		default:
 			return true;
 	}

--- a/packages/tsrx-ripple/src/transform/client/index.js
+++ b/packages/tsrx-ripple/src/transform/client/index.js
@@ -106,6 +106,7 @@ import {
 	rewrite_lazy_member_base,
 	strip_tsrx_style_elements,
 	wrap_code_block_in_iife,
+	visit_directive_wrapping_values,
 	get_code_block_render,
 	get_code_block_template_child,
 	lower_code_block_children,
@@ -2020,6 +2021,19 @@ const visitors = {
 	},
 
 	CallExpression(node, context) {
+		const type_parameters = /** @type {any} */ (node).typeParameters;
+		if (type_parameters) {
+			// acorn-typescript quirk: call/new expressions carry their generics as
+			// `typeParameters`; the transforms (and the TSX printer) expect the
+			// standard `typeArguments`.
+			return context.visit(
+				/** @type {any} */ ({
+					...node,
+					typeArguments: type_parameters,
+					typeParameters: undefined,
+				}),
+			);
+		}
 		const callee = node.callee;
 		const parent = context.path.at(-1);
 
@@ -2188,6 +2202,19 @@ const visitors = {
 	},
 
 	NewExpression(node, context) {
+		const type_parameters = /** @type {any} */ (node).typeParameters;
+		if (type_parameters) {
+			// acorn-typescript quirk: call/new expressions carry their generics as
+			// `typeParameters`; the transforms (and the TSX printer) expect the
+			// standard `typeArguments`.
+			return context.visit(
+				/** @type {any} */ ({
+					...node,
+					typeArguments: type_parameters,
+					typeParameters: undefined,
+				}),
+			);
+		}
 		const callee = node.callee;
 
 		if (context.state.metadata?.tracking === false) {
@@ -3494,17 +3521,23 @@ const visitors = {
 	// `@for` covers for-of / for-in / for(;;): non-for-of forms have no
 	// dedicated visitor and keep the default traversal, as before.
 	JSXForExpression(node, context) {
-		if (node.statementType === 'ForOfStatement') {
-			return visit_for_of_statement(node, context);
-		}
-		return context.next();
+		return visit_directive_wrapping_values(node, context, (node, context) => {
+			if (node.statementType === 'ForOfStatement') {
+				return visit_for_of_statement(node, context);
+			}
+			return context.next();
+		});
 	},
 
 	SwitchStatement: visit_switch_statement,
-	JSXSwitchExpression: visit_switch_statement,
+	JSXSwitchExpression(node, context) {
+		return visit_directive_wrapping_values(node, context, visit_switch_statement);
+	},
 
 	IfStatement: visit_if_statement,
-	JSXIfExpression: visit_if_statement,
+	JSXIfExpression(node, context) {
+		return visit_directive_wrapping_values(node, context, visit_if_statement);
+	},
 
 	ReturnStatement(node, context) {
 		if (
@@ -3598,7 +3631,9 @@ const visitors = {
 	},
 
 	TryStatement: visit_try_statement,
-	JSXTryExpression: visit_try_statement,
+	JSXTryExpression(node, context) {
+		return visit_directive_wrapping_values(node, context, visit_try_statement);
+	},
 
 	BinaryExpression(node, context) {
 		return b.binary(
@@ -5162,17 +5197,25 @@ function is_authored_native_fragment(node) {
  * @returns {boolean}
  */
 function is_combined_expression_position(path, node) {
-	const parent = /** @type {any} */ (path.at(-1));
-	if (!parent || !isTemplateValuePosition(parent, node)) return false;
+	let parent = /** @type {any} */ (path.at(-1));
+	let slot_node = node;
+	// A generated value wrapper is visited FROM its directive's visitor, so the
+	// directive sits atop the path — the wrapper stands in the directive's
+	// slot, so judge the position against the directive's own parent.
+	if (parent?.metadata?.tsrx_value_wrapper === node) {
+		slot_node = parent;
+		parent = /** @type {any} */ (path.at(-2));
+	}
+	if (!parent || !isTemplateValuePosition(parent, slot_node)) return false;
 	switch (parent.type) {
 		// Sole-value render-output slots: the collapse is invisible, keep it.
 		case 'VariableDeclarator':
-			return parent.init !== node;
+			return parent.init !== slot_node;
 		case 'AssignmentExpression':
-			return parent.right !== node;
+			return parent.right !== slot_node;
 		case 'CallExpression':
 		case 'NewExpression':
-			return !(Array.isArray(parent.arguments) && parent.arguments.includes(node));
+			return !(Array.isArray(parent.arguments) && parent.arguments.includes(slot_node));
 		default:
 			return true;
 	}

--- a/packages/tsrx-ripple/src/transform/client/index.js
+++ b/packages/tsrx-ripple/src/transform/client/index.js
@@ -107,7 +107,6 @@ import {
 	strip_tsrx_style_elements,
 	wrap_code_block_in_iife,
 	visit_directive_wrapping_values,
-	replace_with_statements,
 	get_code_block_render,
 	get_code_block_template_child,
 	lower_code_block_children,
@@ -1975,7 +1974,7 @@ const visitors = {
 		const { state } = context;
 
 		if (get_submodule_import_source_name(node) === 'server') {
-			return replace_with_statements(transform_server_module_import(node, state));
+			return transform_server_module_import(node, state);
 		}
 
 		if (!state.to_ts && node.importKind === 'type') {

--- a/packages/tsrx-ripple/src/transform/client/index.js
+++ b/packages/tsrx-ripple/src/transform/client/index.js
@@ -106,6 +106,9 @@ import {
 	rewrite_lazy_member_base,
 	strip_tsrx_style_elements,
 	wrap_code_block_in_iife,
+	get_code_block_render,
+	get_code_block_template_child,
+	lower_code_block_children,
 } from '../../utils.js';
 import {
 	get_attribute_name,
@@ -747,10 +750,13 @@ function get_native_tsrx_return_template_node(node, allow_direct_template = fals
 			/** @type {unknown} */ (node.argument)
 		);
 	}
-	if (node.type === 'JSXCodeBlock' && is_native_tsrx_template_node(node.render)) {
-		return /** @type {ESTreeJSX.JSXElement | ESTreeJSX.JSXFragment} */ (
-			/** @type {unknown} */ (node.render)
-		);
+	if (node.type === 'JSXCodeBlock') {
+		const render = get_code_block_render(node);
+		if (is_native_tsrx_template_node(render)) {
+			return /** @type {ESTreeJSX.JSXElement | ESTreeJSX.JSXFragment} */ (
+				/** @type {unknown} */ (render)
+			);
+		}
 	}
 	if (
 		node.type === 'FunctionDeclaration' ||
@@ -2443,18 +2449,19 @@ const visitors = {
 					body,
 				);
 			}
+			const render = get_code_block_render(node, context.state.scopes);
 			return {
 				...node,
 				body,
-				render: node.render
+				render: render
 					? transform_tsrx_ts_render_node(
-							/** @type {AST.Node} */ (node.render),
+							/** @type {AST.Node} */ (render),
 							/** @type {VisitorClientContext} */ (context),
 						)
 					: null,
 			};
 		}
-		if (node.render != null) {
+		if (get_code_block_render(node, context.state.scopes) != null) {
 			return context.next();
 		}
 		const body = node.body.map(
@@ -2499,7 +2506,10 @@ const visitors = {
 				: expression;
 		}
 
-		const children_filtered = /** @type {AST.Node[]} */ (node.children).filter((child) => {
+		const children_filtered = lower_code_block_children(
+			/** @type {AST.Node[]} */ (node.children),
+			state.scopes,
+		).filter((child) => {
 			return child != null && child.type !== 'EmptyStatement';
 		});
 
@@ -3061,7 +3071,9 @@ const visitors = {
 			if (!is_void) {
 				const element_name = /** @type {AST.Identifier} */ (element_id).name;
 				const render_children = /** @type {AST.Node[]} */ (
-					inner_html_attribute === null ? node.children : []
+					inner_html_attribute === null
+						? lower_code_block_children(node.children, state.scopes)
+						: []
 				);
 				// Special handling for <template> elements
 				if (element_name === 'template' && render_children.length > 0) {
@@ -3250,13 +3262,17 @@ const visitors = {
 				}
 			}
 
-			for (const child of /** @type {AST.Node[]} */ (node.children)) {
+			const element_children = lower_code_block_children(
+				/** @type {AST.Node[]} */ (node.children),
+				state.scopes,
+			);
+			for (const child of element_children) {
 				if (is_native_tsrx_function_node(child)) {
 					state.init?.push(/** @type {AST.Statement} */ (visit(child, state)));
 				}
 			}
 
-			const children_filtered = /** @type {AST.Node[]} */ (node.children).filter(
+			const children_filtered = element_children.filter(
 				(child) => child.type !== 'EmptyStatement' && !is_native_tsrx_function_node(child),
 			);
 
@@ -3818,7 +3834,7 @@ function transform_tsrx_ts_children(children, context) {
 	const init = [];
 	const ts_state = { ...state, init };
 
-	for (const child of children) {
+	for (const child of lower_code_block_children(children, state.scopes)) {
 		if (child == null || child.type === 'EmptyStatement') continue;
 		// Spread `context` (not just `visit`/`state`) so flags like `value_position`
 		// reach nested fragment/element children — see transform_tsrx_tsx_child.
@@ -3917,7 +3933,7 @@ function transform_tsrx_tsx_children(children, context) {
 		pending_statement_children = [];
 	};
 
-	for (const child of children) {
+	for (const child of lower_code_block_children(children, context.state.scopes)) {
 		const transformed = transform_tsrx_tsx_child(child, context);
 		if (transformed === undefined) {
 			pending_statement_children.push(child);
@@ -4058,7 +4074,7 @@ function transform_tsrx_ts_render_children(children, context) {
 	/** @type {AST.Statement[]} */
 	const body = [];
 
-	for (const child of children) {
+	for (const child of lower_code_block_children(children, context.state.scopes)) {
 		if (child == null || child.type === 'EmptyStatement') continue;
 
 		if (is_template_or_control_flow(child)) {
@@ -4365,7 +4381,7 @@ function build_tsrx_ts_directive_value(node, context) {
 		const setup = [];
 		/** @type {any[]} */
 		const renders = [];
-		for (const stmt of body) {
+		for (const stmt of lower_code_block_children(body, context.state.scopes)) {
 			if (stmt == null || stmt.type === 'EmptyStatement') continue;
 			if (is_template_directive(stmt)) {
 				// A nested directive is render content here — lower it to its own value.
@@ -5246,7 +5262,7 @@ function element_has_dynamic_content(element) {
 	}
 
 	// Check children for dynamic content
-	for (const child of /** @type {AST.Node[]} */ (element.children)) {
+	for (const child of lower_code_block_children(/** @type {AST.Node[]} */ (element.children))) {
 		if (
 			is_template_directive(child) ||
 			child.type === 'IfStatement' ||

--- a/packages/tsrx-ripple/src/transform/client/index.js
+++ b/packages/tsrx-ripple/src/transform/client/index.js
@@ -8,6 +8,7 @@
 	VisitorClientContext,
 	TransformClientState,
 	ScopeInterface,
+	Visitor,
 	Visitors,
 	Binding,
 }	from '../../../types/index';
@@ -119,6 +120,7 @@ import {
 	is_expression_attribute,
 	is_self_closing,
 	is_template_element,
+	is_template_directive,
 	is_template_expression,
 	is_template_fragment,
 	is_template_text,
@@ -1390,6 +1392,444 @@ function build_jsx_to_tsrx_element(node, context) {
 	);
 }
 
+/**
+ * Shared by the plain statement and the `@`-directive forms.
+ * @type {Visitor<AST.SwitchStatement | AST.JSXSwitchExpression, TransformClientState, AST.Node>}
+ */
+const visit_switch_statement = (node, context) => {
+	if (context.state.regular_js) {
+		return context.next();
+	}
+
+	if (!is_inside_component(context)) {
+		if (context.state.to_ts) {
+			return transform_ts_child(node, SetContextForOutsideComponent(context));
+		}
+
+		return context.next();
+	}
+
+	const root_controlled = /** @type {any} */ (node).root_controlled === true;
+	if (!root_controlled) {
+		context.state.template?.push('<!>');
+	}
+
+	const id = root_controlled ? b.id('__anchor') : context.state.flush_node?.();
+	const statements = [];
+	const cases = [];
+
+	let id_gen = 0;
+	let counter = 0;
+	for (const switch_case of node.cases) {
+		const case_body = [];
+		const consequent = switch_case.consequent;
+
+		if (consequent.length !== 0) {
+			const flattened_consequent = flatten_switch_consequent(consequent);
+			const consequent_scope = context.state.scopes.get(consequent) || context.state.scope;
+
+			const block = transform_body(flattened_consequent, {
+				...context,
+				state: { ...context.state, scope: consequent_scope, flush_node: null },
+			});
+			const is_default = switch_case.test == null;
+			const consequent_id = context.state.scope.generate(
+				'switch_case_' + (is_default ? 'default' : id_gen),
+			);
+
+			statements.push(b.var(b.id(consequent_id), b.arrow([b.id('__anchor')], b.block(block))));
+			case_body.push(
+				b.stmt(b.call(b.member(b.id('result'), b.id('push'), false), b.id(consequent_id))),
+			);
+			id_gen++;
+		}
+		case_body.push(b.return(b.id('result')));
+
+		counter++;
+
+		cases.push(
+			b.switch_case(
+				switch_case.test ? /** @type {AST.Expression} */ (context.visit(switch_case.test)) : null,
+				case_body,
+			),
+		);
+	}
+
+	statements.push(
+		b.stmt(
+			b.call(
+				'_$_.switch',
+				id,
+				b.thunk(
+					b.block([
+						b.var(b.id('result'), b.array([])),
+						b.switch(/** @type {AST.Expression} */ (context.visit(node.discriminant)), cases),
+					]),
+				),
+				root_controlled ? b.true : undefined,
+			),
+		),
+	);
+
+	context.state.init?.push(b.block(statements));
+};
+
+/**
+ * Shared by the plain statement and the `@`-directive forms.
+ * @type {Visitor<AST.IfStatement | AST.JSXIfExpression, TransformClientState, AST.Node>}
+ */
+const visit_if_statement = (node, context) => {
+	if (context.state.regular_js || node.metadata?.regular_js) {
+		return context.next({ ...context.state, regular_js: true });
+	}
+
+	if (context.state.to_ts) {
+		return transform_ts_child(node, context);
+	}
+
+	if (!is_inside_component(context)) {
+		return context.next();
+	}
+
+	if (
+		(node.metadata?.script_only || node.metadata?.has_continue) &&
+		!node.metadata?.has_template &&
+		!node.alternate
+	) {
+		const consequent_scope =
+			/** @type {ScopeInterface} */ (context.state.scopes.get(node.consequent)) ||
+			context.state.scope;
+		const consequent_body =
+			node.consequent.type === 'BlockStatement' ? node.consequent.body : [node.consequent];
+		const continue_index = find_top_level_continue_index(consequent_body);
+		const consequent_statements =
+			continue_index === -1
+				? transform_body(consequent_body, {
+						...context,
+						state: { ...context.state, flush_node: null, scope: consequent_scope },
+					})
+				: transform_continue_consequent_body(consequent_body, {
+						...context,
+						state: { ...context.state, flush_node: null, scope: consequent_scope },
+					});
+		const consequent = b.block(consequent_statements);
+
+		context.state.init?.push(
+			b.if(
+				/** @type {AST.Expression} */ (
+					context.visit(node.test, {
+						...context.state,
+						metadata: { ...context.state.metadata },
+					})
+				),
+				consequent,
+			),
+		);
+		return;
+	}
+
+	const root_controlled = /** @type {any} */ (node).root_controlled === true;
+	if (!root_controlled) {
+		context.state.template?.push('<!>');
+	}
+
+	const id = root_controlled ? b.id('__anchor') : context.state.flush_node?.();
+	const statements = [];
+
+	const consequent_scope =
+		/** @type {ScopeInterface} */ (context.state.scopes.get(node.consequent)) ||
+		context.state.scope;
+	const consequent_body =
+		node.consequent.type === 'BlockStatement' ? node.consequent.body : [node.consequent];
+	const consequent = b.block(
+		transform_body(consequent_body, {
+			...context,
+			state: { ...context.state, flush_node: null, scope: consequent_scope },
+		}),
+	);
+	const consequent_id = context.state.scope.generate('consequent');
+
+	statements.push(b.var(b.id(consequent_id), b.arrow([b.id('__anchor')], consequent)));
+
+	let alternate_id;
+
+	if (node.alternate !== null) {
+		const alternate = /** @type {AST.Statement} */ (node.alternate);
+		const alternate_scope = context.state.scopes.get(alternate) || context.state.scope;
+		/** @type {AST.Node[]} */
+		let alternate_body =
+			alternate.type === 'IfStatement'
+				? [alternate]
+				: alternate.type === 'BlockStatement'
+					? alternate.body
+					: [alternate];
+		const alternate_block = b.block(
+			transform_body(alternate_body, {
+				...context,
+				state: { ...context.state, flush_node: null, scope: alternate_scope },
+			}),
+		);
+		alternate_id = context.state.scope.generate('alternate');
+		statements.push(b.var(b.id(alternate_id), b.arrow([b.id('__anchor')], alternate_block)));
+	}
+
+	/** @type {AST.Statement[]} */
+	const callback_body = [];
+
+	callback_body.push(
+		b.if(
+			/** @type {AST.Expression} */ (
+				context.visit(node.test, {
+					...context.state,
+					metadata: { ...context.state.metadata },
+				})
+			),
+			b.stmt(b.call(b.id('__render'), b.id(consequent_id))),
+			alternate_id
+				? b.stmt(
+						b.call(
+							b.id('__render'),
+							b.id(alternate_id),
+							node.alternate ? b.literal(false) : undefined,
+						),
+					)
+				: undefined,
+		),
+	);
+
+	statements.push(
+		b.stmt(
+			b.call(
+				'_$_.if',
+				id,
+				b.arrow([b.id('__render')], b.block(callback_body)),
+				root_controlled ? b.true : undefined,
+			),
+		),
+	);
+
+	context.state.init?.push(b.block(statements));
+};
+
+/**
+ * Shared by the plain statement and the `@`-directive forms.
+ * @type {Visitor<AST.TryStatement | AST.JSXTryExpression, TransformClientState, AST.Node>}
+ */
+const visit_try_statement = (node, context) => {
+	if (context.state.regular_js) {
+		return context.next();
+	}
+
+	if (!is_inside_component(context)) {
+		if (context.state.to_ts) {
+			return transform_ts_child(node, SetContextForOutsideComponent(context));
+		}
+
+		return context.next();
+	}
+
+	if (context.state.to_ts) {
+		return transform_ts_child(node, context);
+	}
+	const root_controlled = /** @type {any} */ (node).root_controlled === true;
+	if (!root_controlled) {
+		context.state.template?.push('<!>');
+	}
+
+	const id = root_controlled ? b.id('__anchor') : context.state.flush_node?.();
+	const handler = /** @type {AST.CatchClause | null} */ (node.handler);
+	const pending = /** @type {AST.BlockStatement | null} */ (node.pending);
+	let body = transform_body(node.block.body, {
+		...context,
+		state: {
+			...context.state,
+			scope: /** @type {ScopeInterface} */ (context.state.scopes.get(node.block)),
+		},
+	});
+
+	if (handler?.param) {
+		delete handler.param.typeAnnotation;
+	}
+	if (handler?.resetParam) {
+		delete handler.resetParam.typeAnnotation;
+	}
+
+	const catch_arg =
+		handler === null
+			? b.literal(null)
+			: b.arrow(
+					[
+						b.id('__anchor'),
+						...(handler.param && handler.resetParam
+							? [handler.param, handler.resetParam]
+							: handler.param
+								? [handler.param]
+								: []),
+					],
+					b.block(
+						transform_body(handler.body.body, {
+							...context,
+							state: {
+								...context.state,
+								scope: /** @type {ScopeInterface} */ (context.state.scopes.get(handler.body)),
+							},
+						}),
+					),
+				);
+
+	const pending_arg =
+		pending === null
+			? null
+			: b.arrow(
+					[b.id('__anchor')],
+					b.block(
+						transform_body(pending.body, {
+							...context,
+							state: {
+								...context.state,
+								scope: /** @type {ScopeInterface} */ (context.state.scopes.get(pending)),
+							},
+						}),
+					),
+				);
+
+	const try_args = [id, b.arrow([b.id('__anchor')], b.block(body)), catch_arg];
+	if (root_controlled) {
+		// Keep pending_fn positioned (null when absent) so root_controlled lands
+		// in the 5th slot.
+		try_args.push(pending_arg ?? b.literal(null), b.true);
+	} else if (pending_arg !== null) {
+		try_args.push(pending_arg);
+	}
+
+	context.state.init?.push(b.stmt(b.call('_$_.try', ...try_args)));
+};
+
+/**
+ * Shared by the plain statement and the `@`-directive forms.
+ * @type {Visitor<AST.ForOfStatement | AST.JSXForExpression, TransformClientState, AST.Node>}
+ */
+const visit_for_of_statement = (node, context) => {
+	if (context.state.regular_js) {
+		return context.next();
+	}
+
+	if (!is_inside_component(context)) {
+		return context.next();
+	}
+	const is_controlled = node.is_controlled;
+	const root_controlled = /** @type {any} */ (node).root_controlled === true;
+	const index = node.index;
+	const key = node.key;
+	let flags = is_controlled ? IS_CONTROLLED : 0;
+
+	if (root_controlled) {
+		flags |= ROOT_CONTROLLED;
+	}
+
+	if (index != null) {
+		flags |= IS_INDEXED;
+	}
+
+	if (node.metadata?.script_only && !node.metadata?.has_template) {
+		const pattern = /** @type {AST.VariableDeclaration} */ (node.left).declarations[0].id;
+		const body_scope = /** @type {ScopeInterface} */ (context.state.scopes.get(node.body));
+		const body = transform_body(/** @type {AST.BlockStatement} */ (node.body).body, {
+			...context,
+			state: {
+				...context.state,
+				scope: body_scope,
+				namespace: context.state.namespace,
+				flush_node: null,
+			},
+		});
+
+		if (index) {
+			body.push(b.stmt(b.update('++', index)));
+			context.state.init?.push(b.var(index, b.literal(0)));
+		}
+
+		context.state.init?.push(
+			b.for_of(
+				/** @type {AST.VariableDeclaration} */ (context.visit(/** @type {AST.Node} */ (node.left))),
+				/** @type {AST.Expression} */ (context.visit(/** @type {AST.Node} */ (node.right))),
+				b.block(body),
+			),
+		);
+		return;
+	}
+
+	// do only if not controller
+	if (!is_controlled && !root_controlled) {
+		context.state.template?.push('<!>');
+	}
+
+	const id = root_controlled ? b.id('__anchor') : context.state.flush_node?.(false, is_controlled);
+	const pattern = /** @type {AST.VariableDeclaration} */ (node.left).declarations[0].id;
+	const body_scope = /** @type {ScopeInterface} */ (context.state.scopes.get(node.body));
+	const body_nodes = /** @type {AST.BlockStatement} */ (node.body).body;
+	/** @type {AST.Statement[]} */
+	const body = transform_body(body_nodes, {
+		...context,
+		state: {
+			...context.state,
+			scope: body_scope,
+			namespace: context.state.namespace,
+			flush_node: null,
+		},
+	});
+
+	const empty_scope = node.empty
+		? context.state.scopes.get(node.empty) || context.state.scope
+		: null;
+	const empty_renderer = node.empty
+		? b.arrow(
+				[b.id('__anchor')],
+				b.block(
+					transform_body(/** @type {AST.BlockStatement} */ (node.empty).body, {
+						...context,
+						state: {
+							...context.state,
+							scope: /** @type {ScopeInterface} */ (empty_scope),
+							namespace: context.state.namespace,
+							flush_node: null,
+						},
+					}),
+				),
+			)
+		: undefined;
+
+	const for_args = [
+		id,
+		b.thunk(/** @type {AST.Expression} */ (context.visit(/** @type {AST.Node} */ (node.right)))),
+		b.arrow(
+			index ? [b.id('__anchor'), pattern, index] : [b.id('__anchor'), pattern],
+			b.block(body),
+		),
+		b.literal(flags),
+	];
+	if (key != null) {
+		for_args.push(
+			b.arrow(
+				index ? [pattern, index] : [pattern],
+				/** @type {AST.Expression} */ (context.visit(key)),
+			),
+		);
+	}
+	if (empty_renderer) {
+		for_args.push(empty_renderer);
+	}
+
+	context.state.init?.push(
+		b.stmt(
+			b.call(
+				key != null ? '_$_.for_keyed' : '_$_.for',
+				.../** @type {AST.Expression[]} */ (for_args),
+			),
+		),
+	);
+};
+
 /** @type {Visitors<AST.Node, TransformClientState>} */
 const visitors = {
 	_(node, { next, state, path }) {
@@ -2558,6 +2998,7 @@ const visitors = {
 					element_name !== 'template' &&
 					render_children.some(
 						(child) =>
+							is_template_directive(child) ||
 							child.type === 'IfStatement' ||
 							child.type === 'TryStatement' ||
 							child.type === 'ForOfStatement' ||
@@ -2940,339 +3381,21 @@ const visitors = {
 		context.next();
 	},
 
-	ForOfStatement(node, context) {
-		if (context.state.regular_js) {
-			return context.next();
+	ForOfStatement: visit_for_of_statement,
+	// `@for` covers for-of / for-in / for(;;): non-for-of forms have no
+	// dedicated visitor and keep the default traversal, as before.
+	JSXForExpression(node, context) {
+		if (node.statementType === 'ForOfStatement') {
+			return visit_for_of_statement(node, context);
 		}
-
-		if (!is_inside_component(context)) {
-			return context.next();
-		}
-		const is_controlled = node.is_controlled;
-		const root_controlled = /** @type {any} */ (node).root_controlled === true;
-		const index = node.index;
-		const key = node.key;
-		let flags = is_controlled ? IS_CONTROLLED : 0;
-
-		if (root_controlled) {
-			flags |= ROOT_CONTROLLED;
-		}
-
-		if (index != null) {
-			flags |= IS_INDEXED;
-		}
-
-		if (node.metadata?.script_only && !node.metadata?.has_template) {
-			const pattern = /** @type {AST.VariableDeclaration} */ (node.left).declarations[0].id;
-			const body_scope = /** @type {ScopeInterface} */ (context.state.scopes.get(node.body));
-			const body = transform_body(/** @type {AST.BlockStatement} */ (node.body).body, {
-				...context,
-				state: {
-					...context.state,
-					scope: body_scope,
-					namespace: context.state.namespace,
-					flush_node: null,
-				},
-			});
-
-			if (index) {
-				body.push(b.stmt(b.update('++', index)));
-				context.state.init?.push(b.var(index, b.literal(0)));
-			}
-
-			context.state.init?.push(
-				b.for_of(
-					/** @type {AST.VariableDeclaration} */ (context.visit(node.left)),
-					/** @type {AST.Expression} */ (context.visit(node.right)),
-					b.block(body),
-				),
-			);
-			return;
-		}
-
-		// do only if not controller
-		if (!is_controlled && !root_controlled) {
-			context.state.template?.push('<!>');
-		}
-
-		const id = root_controlled
-			? b.id('__anchor')
-			: context.state.flush_node?.(false, is_controlled);
-		const pattern = /** @type {AST.VariableDeclaration} */ (node.left).declarations[0].id;
-		const body_scope = /** @type {ScopeInterface} */ (context.state.scopes.get(node.body));
-		const body_nodes = /** @type {AST.BlockStatement} */ (node.body).body;
-		/** @type {AST.Statement[]} */
-		const body = transform_body(body_nodes, {
-			...context,
-			state: {
-				...context.state,
-				scope: body_scope,
-				namespace: context.state.namespace,
-				flush_node: null,
-			},
-		});
-
-		const empty_scope = node.empty
-			? context.state.scopes.get(node.empty) || context.state.scope
-			: null;
-		const empty_renderer = node.empty
-			? b.arrow(
-					[b.id('__anchor')],
-					b.block(
-						transform_body(/** @type {AST.BlockStatement} */ (node.empty).body, {
-							...context,
-							state: {
-								...context.state,
-								scope: /** @type {ScopeInterface} */ (empty_scope),
-								namespace: context.state.namespace,
-								flush_node: null,
-							},
-						}),
-					),
-				)
-			: undefined;
-
-		const for_args = [
-			id,
-			b.thunk(/** @type {AST.Expression} */ (context.visit(node.right))),
-			b.arrow(
-				index ? [b.id('__anchor'), pattern, index] : [b.id('__anchor'), pattern],
-				b.block(body),
-			),
-			b.literal(flags),
-		];
-		if (key != null) {
-			for_args.push(
-				b.arrow(
-					index ? [pattern, index] : [pattern],
-					/** @type {AST.Expression} */ (context.visit(key)),
-				),
-			);
-		}
-		if (empty_renderer) {
-			for_args.push(empty_renderer);
-		}
-
-		context.state.init?.push(
-			b.stmt(
-				b.call(
-					key != null ? '_$_.for_keyed' : '_$_.for',
-					.../** @type {AST.Expression[]} */ (for_args),
-				),
-			),
-		);
+		return context.next();
 	},
 
-	SwitchStatement(node, context) {
-		if (context.state.regular_js) {
-			return context.next();
-		}
+	SwitchStatement: visit_switch_statement,
+	JSXSwitchExpression: visit_switch_statement,
 
-		if (!is_inside_component(context)) {
-			if (context.state.to_ts) {
-				return transform_ts_child(node, SetContextForOutsideComponent(context));
-			}
-
-			return context.next();
-		}
-
-		const root_controlled = /** @type {any} */ (node).root_controlled === true;
-		if (!root_controlled) {
-			context.state.template?.push('<!>');
-		}
-
-		const id = root_controlled ? b.id('__anchor') : context.state.flush_node?.();
-		const statements = [];
-		const cases = [];
-
-		let id_gen = 0;
-		let counter = 0;
-		for (const switch_case of node.cases) {
-			const case_body = [];
-			const consequent = switch_case.consequent;
-
-			if (consequent.length !== 0) {
-				const flattened_consequent = flatten_switch_consequent(consequent);
-				const consequent_scope = context.state.scopes.get(consequent) || context.state.scope;
-
-				const block = transform_body(flattened_consequent, {
-					...context,
-					state: { ...context.state, scope: consequent_scope, flush_node: null },
-				});
-				const is_default = switch_case.test == null;
-				const consequent_id = context.state.scope.generate(
-					'switch_case_' + (is_default ? 'default' : id_gen),
-				);
-
-				statements.push(b.var(b.id(consequent_id), b.arrow([b.id('__anchor')], b.block(block))));
-				case_body.push(
-					b.stmt(b.call(b.member(b.id('result'), b.id('push'), false), b.id(consequent_id))),
-				);
-				id_gen++;
-			}
-			case_body.push(b.return(b.id('result')));
-
-			counter++;
-
-			cases.push(
-				b.switch_case(
-					switch_case.test ? /** @type {AST.Expression} */ (context.visit(switch_case.test)) : null,
-					case_body,
-				),
-			);
-		}
-
-		statements.push(
-			b.stmt(
-				b.call(
-					'_$_.switch',
-					id,
-					b.thunk(
-						b.block([
-							b.var(b.id('result'), b.array([])),
-							b.switch(/** @type {AST.Expression} */ (context.visit(node.discriminant)), cases),
-						]),
-					),
-					root_controlled ? b.true : undefined,
-				),
-			),
-		);
-
-		context.state.init?.push(b.block(statements));
-	},
-
-	IfStatement(node, context) {
-		if (context.state.regular_js || node.metadata?.regular_js) {
-			return context.next({ ...context.state, regular_js: true });
-		}
-
-		if (context.state.to_ts) {
-			return transform_ts_child(node, context);
-		}
-
-		if (!is_inside_component(context)) {
-			return context.next();
-		}
-
-		if (
-			(node.metadata?.script_only || node.metadata?.has_continue) &&
-			!node.metadata?.has_template &&
-			!node.alternate
-		) {
-			const consequent_scope =
-				/** @type {ScopeInterface} */ (context.state.scopes.get(node.consequent)) ||
-				context.state.scope;
-			const consequent_body =
-				node.consequent.type === 'BlockStatement' ? node.consequent.body : [node.consequent];
-			const continue_index = find_top_level_continue_index(consequent_body);
-			const consequent_statements =
-				continue_index === -1
-					? transform_body(consequent_body, {
-							...context,
-							state: { ...context.state, flush_node: null, scope: consequent_scope },
-						})
-					: transform_continue_consequent_body(consequent_body, {
-							...context,
-							state: { ...context.state, flush_node: null, scope: consequent_scope },
-						});
-			const consequent = b.block(consequent_statements);
-
-			context.state.init?.push(
-				b.if(
-					/** @type {AST.Expression} */ (
-						context.visit(node.test, {
-							...context.state,
-							metadata: { ...context.state.metadata },
-						})
-					),
-					consequent,
-				),
-			);
-			return;
-		}
-
-		const root_controlled = /** @type {any} */ (node).root_controlled === true;
-		if (!root_controlled) {
-			context.state.template?.push('<!>');
-		}
-
-		const id = root_controlled ? b.id('__anchor') : context.state.flush_node?.();
-		const statements = [];
-
-		const consequent_scope =
-			/** @type {ScopeInterface} */ (context.state.scopes.get(node.consequent)) ||
-			context.state.scope;
-		const consequent_body =
-			node.consequent.type === 'BlockStatement' ? node.consequent.body : [node.consequent];
-		const consequent = b.block(
-			transform_body(consequent_body, {
-				...context,
-				state: { ...context.state, flush_node: null, scope: consequent_scope },
-			}),
-		);
-		const consequent_id = context.state.scope.generate('consequent');
-
-		statements.push(b.var(b.id(consequent_id), b.arrow([b.id('__anchor')], consequent)));
-
-		let alternate_id;
-
-		if (node.alternate !== null) {
-			const alternate = /** @type {AST.Statement} */ (node.alternate);
-			const alternate_scope = context.state.scopes.get(alternate) || context.state.scope;
-			/** @type {AST.Node[]} */
-			let alternate_body =
-				alternate.type === 'IfStatement'
-					? [alternate]
-					: alternate.type === 'BlockStatement'
-						? alternate.body
-						: [alternate];
-			const alternate_block = b.block(
-				transform_body(alternate_body, {
-					...context,
-					state: { ...context.state, flush_node: null, scope: alternate_scope },
-				}),
-			);
-			alternate_id = context.state.scope.generate('alternate');
-			statements.push(b.var(b.id(alternate_id), b.arrow([b.id('__anchor')], alternate_block)));
-		}
-
-		/** @type {AST.Statement[]} */
-		const callback_body = [];
-
-		callback_body.push(
-			b.if(
-				/** @type {AST.Expression} */ (
-					context.visit(node.test, {
-						...context.state,
-						metadata: { ...context.state.metadata },
-					})
-				),
-				b.stmt(b.call(b.id('__render'), b.id(consequent_id))),
-				alternate_id
-					? b.stmt(
-							b.call(
-								b.id('__render'),
-								b.id(alternate_id),
-								node.alternate ? b.literal(false) : undefined,
-							),
-						)
-					: undefined,
-			),
-		);
-
-		statements.push(
-			b.stmt(
-				b.call(
-					'_$_.if',
-					id,
-					b.arrow([b.id('__render')], b.block(callback_body)),
-					root_controlled ? b.true : undefined,
-				),
-			),
-		);
-
-		context.state.init?.push(b.block(statements));
-	},
+	IfStatement: visit_if_statement,
+	JSXIfExpression: visit_if_statement,
 
 	ReturnStatement(node, context) {
 		if (
@@ -3365,95 +3488,8 @@ const visitors = {
 		return context.next();
 	},
 
-	TryStatement(node, context) {
-		if (context.state.regular_js) {
-			return context.next();
-		}
-
-		if (!is_inside_component(context)) {
-			if (context.state.to_ts) {
-				return transform_ts_child(node, SetContextForOutsideComponent(context));
-			}
-
-			return context.next();
-		}
-
-		if (context.state.to_ts) {
-			return transform_ts_child(node, context);
-		}
-		const root_controlled = /** @type {any} */ (node).root_controlled === true;
-		if (!root_controlled) {
-			context.state.template?.push('<!>');
-		}
-
-		const id = root_controlled ? b.id('__anchor') : context.state.flush_node?.();
-		const handler = /** @type {AST.CatchClause | null} */ (node.handler);
-		const pending = /** @type {AST.BlockStatement | null} */ (node.pending);
-		let body = transform_body(node.block.body, {
-			...context,
-			state: {
-				...context.state,
-				scope: /** @type {ScopeInterface} */ (context.state.scopes.get(node.block)),
-			},
-		});
-
-		if (handler?.param) {
-			delete handler.param.typeAnnotation;
-		}
-		if (handler?.resetParam) {
-			delete handler.resetParam.typeAnnotation;
-		}
-
-		const catch_arg =
-			handler === null
-				? b.literal(null)
-				: b.arrow(
-						[
-							b.id('__anchor'),
-							...(handler.param && handler.resetParam
-								? [handler.param, handler.resetParam]
-								: handler.param
-									? [handler.param]
-									: []),
-						],
-						b.block(
-							transform_body(handler.body.body, {
-								...context,
-								state: {
-									...context.state,
-									scope: /** @type {ScopeInterface} */ (context.state.scopes.get(handler.body)),
-								},
-							}),
-						),
-					);
-
-		const pending_arg =
-			pending === null
-				? null
-				: b.arrow(
-						[b.id('__anchor')],
-						b.block(
-							transform_body(pending.body, {
-								...context,
-								state: {
-									...context.state,
-									scope: /** @type {ScopeInterface} */ (context.state.scopes.get(pending)),
-								},
-							}),
-						),
-					);
-
-		const try_args = [id, b.arrow([b.id('__anchor')], b.block(body)), catch_arg];
-		if (root_controlled) {
-			// Keep pending_fn positioned (null when absent) so root_controlled lands
-			// in the 5th slot.
-			try_args.push(pending_arg ?? b.literal(null), b.true);
-		} else if (pending_arg !== null) {
-			try_args.push(pending_arg);
-		}
-
-		context.state.init?.push(b.stmt(b.call('_$_.try', ...try_args)));
-	},
+	TryStatement: visit_try_statement,
+	JSXTryExpression: visit_try_statement,
 
 	BinaryExpression(node, context) {
 		return b.binary(
@@ -3719,11 +3755,13 @@ function build_tsrx_to_ts_expression(node, context, in_jsx_child = false) {
 	// emit. Render position never sets `tsrx_generated_wrapper`, so it is unaffected;
 	// authored `<> … </>` (no wrapper flag) keeps flowing through the normal path.
 	if (node.metadata?.tsrx_generated_wrapper === true) {
-		const only = (node.children || []).find(
-			(/** @type {any} */ child) => child && child.type !== 'EmptyStatement',
+		const only = /** @type {AST.Node | undefined} */ (
+			(node.children || []).find(
+				(/** @type {any} */ child) => child && child.type !== 'EmptyStatement',
+			)
 		);
-		if (only && /** @type {any} */ (only).metadata?.tsrxDirective) {
-			const value = build_tsrx_ts_directive_value(only, context);
+		if (only && is_template_directive(only)) {
+			const value = build_tsrx_ts_directive_value(/** @type {any} */ (only), context);
 			return in_jsx_child ? b.jsx_expression_container(value) : value;
 		}
 	}
@@ -3888,7 +3926,10 @@ function transform_tsrx_tsx_child(node, context) {
 	// as "Fallthrough case in switch" (7029). Its value form already returns from every case
 	// (with a trailing `return null`), so lower a `@switch` child to its value in render
 	// position too — it renders the matched case's output all the same.
-	if (node.metadata?.tsrxDirective && (context.value_position || node.type === 'SwitchStatement')) {
+	if (
+		is_template_directive(node) &&
+		(context.value_position || node.type === 'JSXSwitchExpression')
+	) {
 		return b.jsx_expression_container(build_tsrx_ts_directive_value(node, context));
 	}
 
@@ -3929,12 +3970,15 @@ function transform_tsrx_ts_render_children(children, context) {
 
 		if (is_template_or_control_flow(child)) {
 			if (
+				is_template_directive(child) ||
 				child.type === 'IfStatement' ||
 				child.type === 'ForOfStatement' ||
 				child.type === 'SwitchStatement' ||
 				child.type === 'TryStatement'
 			) {
-				body.push(transform_tsrx_ts_render_control_flow_statement(child, context));
+				body.push(
+					transform_tsrx_ts_render_control_flow_statement(/** @type {any} */ (child), context),
+				);
 			} else {
 				body.push(
 					...transform_tsrx_ts_statements_to_render_body(
@@ -3993,12 +4037,12 @@ function statement_definitely_returns(statement) {
 }
 
 /**
- * @param {AST.IfStatement | AST.ForOfStatement | AST.SwitchStatement | AST.TryStatement} node
+ * @param {AST.JSXIfExpression | AST.JSXForExpression | AST.JSXSwitchExpression | AST.JSXTryExpression | AST.IfStatement | AST.ForOfStatement | AST.SwitchStatement | AST.TryStatement} node
  * @param {VisitorClientContext} context
  * @returns {AST.Statement}
  */
 function transform_tsrx_ts_render_control_flow_statement(node, context) {
-	if (node.type === 'IfStatement') {
+	if (node.type === 'JSXIfExpression' || node.type === 'IfStatement') {
 		const consequent_scope =
 			/** @type {ScopeInterface} */ (context.state.scopes.get(node.consequent)) ||
 			context.state.scope;
@@ -4042,7 +4086,10 @@ function transform_tsrx_ts_render_control_flow_statement(node, context) {
 		);
 	}
 
-	if (node.type === 'ForOfStatement') {
+	if (
+		node.type === 'ForOfStatement' ||
+		(node.type === 'JSXForExpression' && node.statementType === 'ForOfStatement')
+	) {
 		const body_scope = /** @type {ScopeInterface} */ (context.state.scopes.get(node.body));
 		const block_body = transform_tsrx_ts_render_children(
 			/** @type {AST.BlockStatement} */ (node.body).body,
@@ -4074,8 +4121,8 @@ function transform_tsrx_ts_render_control_flow_statement(node, context) {
 				: null;
 
 		const result = b.for_of(
-			/** @type {AST.Pattern} */ (context.visit(node.left)),
-			/** @type {AST.Expression} */ (context.visit(node.right)),
+			/** @type {AST.Pattern} */ (context.visit(/** @type {AST.Node} */ (node.left))),
+			/** @type {AST.Expression} */ (context.visit(/** @type {AST.Node} */ (node.right))),
 			b.block(block_body),
 			node.await,
 			/** @type {AST.NodeWithLocation} */ (node),
@@ -4084,7 +4131,7 @@ function transform_tsrx_ts_render_control_flow_statement(node, context) {
 		return result;
 	}
 
-	if (node.type === 'SwitchStatement') {
+	if (node.type === 'SwitchStatement' || node.type === 'JSXSwitchExpression') {
 		const cases = node.cases.map((switch_case) => {
 			const consequent_scope =
 				context.state.scopes.get(switch_case.consequent) || context.state.scope;
@@ -4119,54 +4166,57 @@ function transform_tsrx_ts_render_control_flow_statement(node, context) {
 		);
 	}
 
-	const try_scope = /** @type {ScopeInterface} */ (context.state.scopes.get(node.block));
+	const try_node = /** @type {AST.TryStatement | AST.JSXTryExpression} */ (node);
+	const try_scope = /** @type {ScopeInterface} */ (context.state.scopes.get(try_node.block));
 	const try_body = b.block(
-		transform_tsrx_ts_render_children(node.block.body, {
+		transform_tsrx_ts_render_children(try_node.block.body, {
 			...context,
 			state: { ...context.state, scope: try_scope },
 		}),
-		/** @type {AST.NodeWithLocation} */ (node.block),
+		/** @type {AST.NodeWithLocation} */ (try_node.block),
 	);
 
 	let catch_handler = null;
-	if (node.handler) {
-		const catch_scope = /** @type {ScopeInterface} */ (context.state.scopes.get(node.handler.body));
+	if (try_node.handler) {
+		const catch_scope = /** @type {ScopeInterface} */ (
+			context.state.scopes.get(try_node.handler.body)
+		);
 		catch_handler = b.catch_clause(
-			node.handler.param || null,
-			node.handler.resetParam || null,
+			try_node.handler.param || null,
+			try_node.handler.resetParam || null,
 			b.block(
-				transform_tsrx_ts_render_children(node.handler.body.body, {
+				transform_tsrx_ts_render_children(try_node.handler.body.body, {
 					...context,
 					state: { ...context.state, scope: catch_scope },
 				}),
-				/** @type {AST.NodeWithLocation} */ (node.handler.body),
+				/** @type {AST.NodeWithLocation} */ (try_node.handler.body),
 			),
-			/** @type {AST.NodeWithLocation} */ (node.handler),
+			/** @type {AST.NodeWithLocation} */ (try_node.handler),
 		);
 	}
 
-	const pending = node.pending
+	const pending = try_node.pending
 		? b.block(
-				transform_tsrx_ts_render_children(node.pending.body, {
+				transform_tsrx_ts_render_children(try_node.pending.body, {
 					...context,
 					state: {
 						...context.state,
-						scope: /** @type {ScopeInterface} */ (context.state.scopes.get(node.pending)),
+						scope: /** @type {ScopeInterface} */ (context.state.scopes.get(try_node.pending)),
 					},
 				}),
-				/** @type {AST.NodeWithLocation} */ (node.pending),
+				/** @type {AST.NodeWithLocation} */ (try_node.pending),
 			)
 		: null;
-	const finalizer = node.finalizer
+	const finalizer = try_node.finalizer
 		? b.block(
-				transform_body(node.finalizer.body, {
+				transform_body(try_node.finalizer.body, {
 					...context,
 					state: {
 						...context.state,
-						scope: /** @type {ScopeInterface} */ (context.state.scopes.get(node.finalizer)),
+						scope: /** @type {ScopeInterface} */ (context.state.scopes.get(try_node.finalizer)),
 					},
 				}),
-				/** @type {AST.NodeWithLocation} */ (node.finalizer),
+				/** @type {AST.NodeWithLocation} */ (try_node.finalizer),
 			)
 		: null;
 
@@ -4224,7 +4274,7 @@ function build_tsrx_ts_directive_value(node, context) {
 		const renders = [];
 		for (const stmt of body) {
 			if (stmt == null || stmt.type === 'EmptyStatement') continue;
-			if (/** @type {any} */ (stmt).metadata?.tsrxDirective) {
+			if (is_template_directive(stmt)) {
 				// A nested directive is render content here — lower it to its own value.
 				renders.push(to_fragment_child(build_tsrx_ts_directive_value(stmt, scoped(stmt))));
 				continue;
@@ -4255,7 +4305,7 @@ function build_tsrx_ts_directive_value(node, context) {
 		return b.call(b.thunk(b.block(stmts)));
 	};
 
-	if (node.type === 'IfStatement') {
+	if (node.type === 'JSXIfExpression') {
 		const cons_body =
 			node.consequent.type === 'BlockStatement' ? node.consequent.body : [node.consequent];
 		const consequent = branch_value(cons_body, node.consequent);
@@ -4274,7 +4324,7 @@ function build_tsrx_ts_directive_value(node, context) {
 		);
 	}
 
-	if (node.type === 'ForOfStatement') {
+	if (node.type === 'JSXForExpression') {
 		// `@for await` iterates an AsyncIterable, which `Array.from` does NOT accept.
 		// Accumulate with a real `for await` loop instead (the runtime renders via
 		// `_$_.for`; this is the to_ts type view only). Await the async IIFE so the
@@ -4377,7 +4427,7 @@ function build_tsrx_ts_directive_value(node, context) {
 		return b.call(b.member(items(), b.id('map')), map_arrow);
 	}
 
-	if (node.type === 'SwitchStatement') {
+	if (node.type === 'JSXSwitchExpression') {
 		const cases = node.cases.map((/** @type {any} */ sc) =>
 			b.switch_case(
 				sc.test ? /** @type {AST.Expression} */ (context.visit(sc.test)) : null,
@@ -4628,7 +4678,7 @@ function transform_ts_child(node, context) {
 		} else {
 			state.init?.push(b.stmt(jsxElement));
 		}
-	} else if (node.type === 'IfStatement') {
+	} else if (node.type === 'IfStatement' || node.type === 'JSXIfExpression') {
 		const consequent_scope =
 			/** @type {ScopeInterface} */ (context.state.scopes.get(node.consequent)) ||
 			context.state.scope;
@@ -4672,7 +4722,7 @@ function transform_ts_child(node, context) {
 			return result;
 		}
 		state.init.push(result);
-	} else if (node.type === 'SwitchStatement') {
+	} else if (node.type === 'SwitchStatement' || node.type === 'JSXSwitchExpression') {
 		const cases = [];
 
 		for (const switch_case of node.cases) {
@@ -4708,7 +4758,10 @@ function transform_ts_child(node, context) {
 			return result;
 		}
 		state.init.push(result);
-	} else if (node.type === 'ForOfStatement') {
+	} else if (
+		node.type === 'ForOfStatement' ||
+		(node.type === 'JSXForExpression' && node.statementType === 'ForOfStatement')
+	) {
 		const body_scope = /** @type {ScopeInterface} */ (context.state.scopes.get(node.body));
 		const block_body = transform_body(/** @type {AST.BlockStatement} */ (node.body).body, {
 			...context,
@@ -4748,7 +4801,7 @@ function transform_ts_child(node, context) {
 			return result;
 		}
 		state.init.push(result);
-	} else if (node.type === 'TryStatement') {
+	} else if (node.type === 'TryStatement' || node.type === 'JSXTryExpression') {
 		const try_scope = /** @type {ScopeInterface} */ (context.state.scopes.get(node.block));
 		const try_body = b.block(
 			transform_body(node.block.body, {
@@ -4890,6 +4943,7 @@ function is_template_or_control_flow(node) {
 		node.type === 'JSXExpressionContainer' ||
 		node.type === 'JSXText' ||
 		is_template_fragment(node) ||
+		is_template_directive(node) ||
 		node.type === 'IfStatement' ||
 		node.type === 'ForOfStatement' ||
 		node.type === 'TryStatement' ||
@@ -4937,7 +4991,8 @@ function is_native_tsrx_statement_position(path) {
 		parent?.type === 'DoWhileStatement' ||
 		parent?.type === 'TryStatement' ||
 		parent?.type === 'SwitchStatement' ||
-		parent?.type === 'LabeledStatement'
+		parent?.type === 'LabeledStatement' ||
+		is_template_directive(parent)
 	);
 }
 
@@ -5089,6 +5144,7 @@ function element_has_dynamic_content(element) {
 	// Check children for dynamic content
 	for (const child of /** @type {AST.Node[]} */ (element.children)) {
 		if (
+			is_template_directive(child) ||
 			child.type === 'IfStatement' ||
 			child.type === 'TryStatement' ||
 			child.type === 'ForOfStatement' ||
@@ -5199,6 +5255,7 @@ function transform_children(children, context) {
 	const is_fragment =
 		normalized.some(
 			(node) =>
+				is_template_directive(node) ||
 				node.type === 'IfStatement' ||
 				node.type === 'TryStatement' ||
 				node.type === 'ForOfStatement' ||
@@ -5247,7 +5304,8 @@ function transform_children(children, context) {
 	const single_output = root_output.length === 1 ? root_output[0] : null;
 	const root_controlled =
 		single_output !== null &&
-		(single_output.type === 'IfStatement' ||
+		(is_template_directive(single_output) ||
+			single_output.type === 'IfStatement' ||
 			single_output.type === 'SwitchStatement' ||
 			single_output.type === 'ForOfStatement' ||
 			single_output.type === 'TryStatement' ||
@@ -5543,6 +5601,7 @@ function transform_children(children, context) {
 						/** @type {any} */ (node).children
 					).some(
 						(child) =>
+							is_template_directive(child) ||
 							child.type === 'IfStatement' ||
 							child.type === 'TryStatement' ||
 							child.type === 'ForOfStatement' ||
@@ -5658,7 +5717,10 @@ function transform_children(children, context) {
 					get_template_expression(/** @type {any} */ (node), false),
 					/** @type {AST.Expression} */ (expression),
 				);
-			} else if (node.type === 'ForOfStatement') {
+			} else if (
+				node.type === 'ForOfStatement' ||
+				(node.type === 'JSXForExpression' && node.statementType === 'ForOfStatement')
+			) {
 				skipped = 0;
 				node.is_controlled = is_controlled;
 				visit(node, {
@@ -5666,7 +5728,7 @@ function transform_children(children, context) {
 					flush_node: /** @type {TransformClientState['flush_node']} */ (flush_node),
 					namespace: state.namespace,
 				});
-			} else if (node.type === 'IfStatement') {
+			} else if (node.type === 'IfStatement' || node.type === 'JSXIfExpression') {
 				skipped = 0;
 				node.is_controlled = is_controlled;
 				visit(node, {
@@ -5674,7 +5736,7 @@ function transform_children(children, context) {
 					flush_node: /** @type {TransformClientState['flush_node']} */ (flush_node),
 					namespace: state.namespace,
 				});
-			} else if (node.type === 'TryStatement') {
+			} else if (node.type === 'TryStatement' || node.type === 'JSXTryExpression') {
 				skipped = 0;
 				node.is_controlled = is_controlled;
 				visit(node, {
@@ -5682,7 +5744,7 @@ function transform_children(children, context) {
 					flush_node: /** @type {TransformClientState['flush_node']} */ (flush_node),
 					namespace: state.namespace,
 				});
-			} else if (node.type === 'SwitchStatement') {
+			} else if (node.type === 'SwitchStatement' || node.type === 'JSXSwitchExpression') {
 				skipped = 0;
 				node.is_controlled = is_controlled;
 				visit(node, {

--- a/packages/tsrx-ripple/src/transform/client/index.js
+++ b/packages/tsrx-ripple/src/transform/client/index.js
@@ -115,6 +115,7 @@ import {
 	is_empty_expression_container,
 	is_expression_attribute,
 	is_template_expression,
+	is_template_fragment,
 	is_template_text,
 	is_template_text_or_expression,
 } from '../../template-ast.js';
@@ -784,18 +785,22 @@ function visit_function(node, context) {
 /**
  * @param {AST.Node | null | undefined} node
  * @param {boolean} [allow_direct_template]
- * @returns {AST.Element | AST.TsrxFragment | null}
+ * @returns {AST.Element | ESTreeJSX.JSXFragment | null}
  */
 function get_native_tsrx_return_template_node(node, allow_direct_template = false) {
 	if (!node) return null;
 	if (allow_direct_template && is_native_tsrx_template_node(node)) {
-		return /** @type {AST.Element | AST.TsrxFragment} */ (/** @type {unknown} */ (node));
+		return /** @type {AST.Element | ESTreeJSX.JSXFragment} */ (/** @type {unknown} */ (node));
 	}
 	if (node.type === 'ReturnStatement' && is_native_tsrx_template_node(node.argument)) {
-		return /** @type {AST.Element | AST.TsrxFragment} */ (/** @type {unknown} */ (node.argument));
+		return /** @type {AST.Element | ESTreeJSX.JSXFragment} */ (
+			/** @type {unknown} */ (node.argument)
+		);
 	}
 	if (node.type === 'JSXCodeBlock' && is_native_tsrx_template_node(node.render)) {
-		return /** @type {AST.Element | AST.TsrxFragment} */ (/** @type {unknown} */ (node.render));
+		return /** @type {AST.Element | ESTreeJSX.JSXFragment} */ (
+			/** @type {unknown} */ (node.render)
+		);
 	}
 	if (
 		node.type === 'FunctionDeclaration' ||
@@ -2029,27 +2034,19 @@ const visitors = {
 	},
 
 	JSXFragment(node, context) {
-		if (context.state.to_ts) {
-			return context.next();
-		}
-		if (context.state.jsx_to_tsrx_element || is_native_tsrx_value_position(context.path)) {
-			return build_jsx_to_tsrx_element(/** @type {AST.TSRXJSXFragment} */ (node), context);
-		}
-		return context.next();
-	},
-
-	JSXElement(node, context) {
-		if (context.state.to_ts) {
-			return context.next();
-		}
-		if (context.state.jsx_to_tsrx_element || is_native_tsrx_value_position(context.path)) {
-			return build_jsx_to_tsrx_element(/** @type {AST.TSRXJSXElement} */ (node), context);
-		}
-		return context.next();
-	},
-
-	TsrxFragment(node, context) {
 		const { state, visit } = context;
+
+		// A raw (non-template) fragment — an attribute value or other JSX that
+		// never entered the template traversal.
+		if (!is_template_fragment(node)) {
+			if (state.to_ts) {
+				return context.next();
+			}
+			if (state.jsx_to_tsrx_element || is_native_tsrx_value_position(context.path)) {
+				return build_jsx_to_tsrx_element(/** @type {AST.TSRXJSXFragment} */ (node), context);
+			}
+			return context.next();
+		}
 
 		// to_ts mode: produce a JSX fragment from native TSRX children.
 		if (state.to_ts) {
@@ -2111,6 +2108,16 @@ const visitors = {
 		return element;
 	},
 
+	JSXElement(node, context) {
+		if (context.state.to_ts) {
+			return context.next();
+		}
+		if (context.state.jsx_to_tsrx_element || is_native_tsrx_value_position(context.path)) {
+			return build_jsx_to_tsrx_element(/** @type {AST.TSRXJSXElement} */ (node), context);
+		}
+		return context.next();
+	},
+
 	Element(node, context) {
 		const { state, visit } = context;
 
@@ -2137,15 +2144,13 @@ const visitors = {
 		}
 
 		if (state.to_ts) {
-			const fragment = /** @type {AST.TsrxFragment} */ (
+			const fragment = /** @type {ESTreeJSX.JSXFragment} */ (
 				/** @type {unknown} */ ({
-					type: 'TsrxFragment',
+					type: 'JSXFragment',
 					children: [node],
-					openingElement: { type: 'JSXOpeningFragment', metadata: { path: [] } },
-					closingElement: { type: 'JSXClosingFragment', metadata: { path: [] } },
-					selfClosing: false,
-					attributes: [],
-					metadata: { path: [] },
+					openingFragment: { type: 'JSXOpeningFragment', metadata: { path: [] } },
+					closingFragment: { type: 'JSXClosingFragment', metadata: { path: [] } },
+					metadata: { path: [], tsrx_render_fragment: true },
 				})
 			);
 			return build_tsrx_to_ts_expression(fragment, context);
@@ -2622,7 +2627,7 @@ const visitors = {
 							child.type === 'TryStatement' ||
 							child.type === 'ForOfStatement' ||
 							child.type === 'SwitchStatement' ||
-							child.type === 'TsrxFragment' ||
+							is_template_fragment(child) ||
 							(child.type === 'Element' &&
 								(child.id.type !== 'Identifier' || !is_element_dom_element(child))) ||
 							// A JSXText child is always a literal; only a `{ … }` container
@@ -3767,7 +3772,7 @@ function transform_tsrx_ts_children(children, context) {
  * remain inline JSX; fragments with setup statements need an IIFE so declarations
  * stay in statement position.
  *
- * @param {AST.TsrxFragment} node
+ * @param {ESTreeJSX.JSXFragment} node
  * @param {VisitorClientContext} context
  * @param {boolean} [in_jsx_child]
  * @returns {TsrxTsViewNode}
@@ -3891,7 +3896,7 @@ function transform_tsrx_tsx_child(node, context) {
 		// targets and how the same fragment survives in an attribute value.
 		const expr = node.expression;
 		const is_empty_fragment =
-			expr?.type === 'TsrxFragment' &&
+			is_template_fragment(expr) &&
 			!(expr.children || []).some(
 				(/** @type {any} */ child) =>
 					child &&
@@ -3899,7 +3904,7 @@ function transform_tsrx_tsx_child(node, context) {
 					(child.type !== 'JSXText' || get_template_text_value(child, true) !== ''),
 			);
 		const expression = is_empty_fragment
-			? build_tsrx_to_ts_expression(/** @type {AST.TsrxFragment} */ (expr), context, true)
+			? build_tsrx_to_ts_expression(/** @type {ESTreeJSX.JSXFragment} */ (expr), context, true)
 			: /** @type {AST.Expression} */ (context.visit(node.expression, context.state));
 		return b.jsx_expression_container(
 			/** @type {AST.Expression} */ (expression),
@@ -3917,7 +3922,7 @@ function transform_tsrx_tsx_child(node, context) {
 			: undefined;
 	}
 
-	if (node.type === 'TsrxFragment') {
+	if (is_template_fragment(node)) {
 		// `in_jsx_child` mode already returns a valid JSX child (a fragment, or a
 		// `{expr}` container kept for type visibility), so use it as-is. Only a bare
 		// expression (which can happen in other positions) needs wrapping.
@@ -4861,7 +4866,7 @@ function transform_ts_child(node, context) {
 			return result;
 		}
 		state.init.push(/** @type {AST.Statement} */ (result));
-	} else if (node.type === 'TsrxFragment') {
+	} else if (is_template_fragment(node)) {
 		let result = build_tsrx_to_ts_expression(node, context);
 		// Keep an AUTHORED `<> … </>` here too (a render-output / control-flow branch
 		// body, e.g. the `<>{[1,2,3]}</>` branch of an `@if`), so it is not unwrapped to
@@ -4923,7 +4928,7 @@ function is_template_or_control_flow(node) {
 		node.type === 'Element' ||
 		node.type === 'JSXExpressionContainer' ||
 		node.type === 'JSXText' ||
-		node.type === 'TsrxFragment' ||
+		is_template_fragment(node) ||
 		node.type === 'IfStatement' ||
 		node.type === 'ForOfStatement' ||
 		node.type === 'TryStatement' ||
@@ -4984,7 +4989,7 @@ function is_native_tsrx_value_position(path) {
 	return !(
 		is_native_tsrx_statement_position(path) ||
 		parent?.type === 'Element' ||
-		parent?.type === 'TsrxFragment'
+		is_template_fragment(parent)
 	);
 }
 
@@ -5008,7 +5013,7 @@ function is_native_tsrx_value_position(path) {
  */
 function is_authored_native_fragment(node) {
 	return (
-		node?.type === 'TsrxFragment' &&
+		node?.type === 'JSXFragment' &&
 		node.metadata?.native_tsrx === true &&
 		node.metadata?.tsrx_generated_wrapper !== true &&
 		node.metadata?.tsrx_code_block_chain !== true
@@ -5128,7 +5133,7 @@ function element_has_dynamic_content(element) {
 			child.type === 'TryStatement' ||
 			child.type === 'ForOfStatement' ||
 			child.type === 'SwitchStatement' ||
-			child.type === 'TsrxFragment'
+			is_template_fragment(child)
 		) {
 			return true;
 		}
@@ -5234,7 +5239,7 @@ function transform_children(children, context) {
 				node.type === 'TryStatement' ||
 				node.type === 'ForOfStatement' ||
 				node.type === 'SwitchStatement' ||
-				node.type === 'TsrxFragment' ||
+				is_template_fragment(node) ||
 				(node.type === 'Element' &&
 					(node.id.type !== 'Identifier' || !is_element_dom_element(node))),
 		) ||
@@ -5565,7 +5570,7 @@ function transform_children(children, context) {
 							child.type === 'TryStatement' ||
 							child.type === 'ForOfStatement' ||
 							child.type === 'SwitchStatement' ||
-							child.type === 'TsrxFragment' ||
+							is_template_fragment(child) ||
 							(child.type === 'Element' &&
 								(child.id.type !== 'Identifier' || !is_element_dom_element(child))) ||
 							(child.type === 'JSXExpressionContainer' && child.expression.type !== 'Literal'),
@@ -5590,7 +5595,7 @@ function transform_children(children, context) {
 						state.init?.push(b.stmt(b.call('_$_.pop', id)));
 					}
 				}
-			} else if (node.type === 'TsrxFragment') {
+			} else if (is_template_fragment(node)) {
 				skipped = 0;
 
 				visit(node, {

--- a/packages/tsrx-ripple/src/transform/client/index.js
+++ b/packages/tsrx-ripple/src/transform/client/index.js
@@ -1289,7 +1289,7 @@ function ripple_namespace_requires_block(name) {
 }
 
 /**
- * @param {AST.Node} node
+ * @param {AST.TSRXJSXElement} node
  * @param {TransformClientContext | VisitorClientContext} context
  * @returns {boolean}
  */

--- a/packages/tsrx-ripple/src/transform/client/index.js
+++ b/packages/tsrx-ripple/src/transform/client/index.js
@@ -2065,7 +2065,7 @@ const visitors = {
 		// The TS view needs the `<TsrxDynamic is={expr}>` component shape for type
 		// checking; production codegen keeps `node.id` as the dynamic expression
 		// and renders it directly via `_$_.composite` in the component branch.
-		if (state.to_ts && lower_dynamic_element(/** @type {ESTreeJSX.JSXElement} */ (node))) {
+		if (state.to_ts && lower_dynamic_element(node)) {
 			state.imports.add(`import { Dynamic as ${dynamic_element_import_local} } from 'ripple'`);
 		}
 
@@ -5178,7 +5178,7 @@ function transform_children(children, context) {
 		for (const child of children) {
 			if (
 				is_template_element(child) &&
-				lower_dynamic_element(/** @type {ESTreeJSX.JSXElement} */ (child))
+				lower_dynamic_element(/** @type {AST.TSRXJSXElement} */ (child))
 			) {
 				state.imports.add(`import { Dynamic as ${dynamic_element_import_local} } from 'ripple'`);
 			}

--- a/packages/tsrx-ripple/src/transform/server/index.js
+++ b/packages/tsrx-ripple/src/transform/server/index.js
@@ -77,6 +77,8 @@ import {
 	is_code_block_function_body,
 } from '../../utils.js';
 import {
+	get_attribute_name,
+	get_attribute_value,
 	get_template_text_value,
 	is_droppable_template_text,
 	is_empty_expression_container,
@@ -944,15 +946,11 @@ function is_ripple_fragment_element(node, context) {
 
 /**
  * @param {AST.Element} node
- * @returns {AST.Attribute | null}
+ * @returns {ESTreeJSX.JSXAttribute | null}
  */
 function get_inner_html_attribute(node) {
 	for (const attr of node.attributes) {
-		if (
-			attr.type === 'Attribute' &&
-			attr.name.type === 'Identifier' &&
-			attr.name.name === 'innerHTML'
-		) {
+		if (attr.type === 'JSXAttribute' && get_attribute_name(attr) === 'innerHTML') {
 			return attr;
 		}
 	}
@@ -961,16 +959,17 @@ function get_inner_html_attribute(node) {
 }
 
 /**
- * @param {AST.Attribute} attr
+ * @param {ESTreeJSX.JSXAttribute} attr
  * @param {TransformServerContext} context
  * @returns {AST.Expression}
  */
 function get_attribute_value_expression(attr, context) {
-	if (attr.value === null) {
+	const value = get_attribute_value(attr);
+	if (value === null) {
 		return b.literal('');
 	}
 
-	return /** @type {AST.Expression} */ (context.visit(attr.value, context.state));
+	return /** @type {AST.Expression} */ (context.visit(value, context.state));
 }
 
 /**
@@ -1937,7 +1936,7 @@ const visitors = {
 		}
 
 		const is_dom_element = is_element_dom_element(node);
-		const is_spreading = node.attributes.some((attr) => attr.type === 'SpreadAttribute');
+		const is_spreading = node.attributes.some((attr) => attr.type === 'JSXSpreadAttribute');
 		/** @type {(AST.Property | AST.SpreadElement)[] | null} */
 		const spread_attributes = is_spreading ? [] : null;
 		const child_namespace = is_dom_element
@@ -1998,13 +1997,14 @@ const visitors = {
 			};
 
 			for (const attr of node.attributes) {
-				if (attr.type === 'Attribute') {
-					if (attr.name.type === 'Identifier') {
-						const name = attr.name.name;
+				if (attr.type === 'JSXAttribute') {
+					{
+						const name = get_attribute_name(attr);
+						const attr_value = get_attribute_value(attr);
 
 						if (name === 'innerHTML') {
 							const expression =
-								attr.value === null ? b.literal('') : get_attribute_value_expression(attr, context);
+								attr_value === null ? b.literal('') : get_attribute_value_expression(attr, context);
 							if (is_spreading) {
 								spread_attributes?.push(b.prop('init', b.literal('innerHTML'), expression));
 							} else {
@@ -2013,7 +2013,7 @@ const visitors = {
 							continue;
 						}
 
-						if (attr.value === null) {
+						if (attr_value === null) {
 							// omit a valueless event attr (analyze errored); `hidden` etc. still emit
 							if (!isEventAttribute(name)) {
 								handle_static_attr(name, true);
@@ -2025,8 +2025,8 @@ const visitors = {
 							continue;
 						}
 
-						if (attr.value.type === 'Literal' && name !== 'class') {
-							handle_static_attr(name, attr.value.value);
+						if (attr_value.type === 'Literal' && name !== 'class') {
+							handle_static_attr(name, attr_value.value);
 							continue;
 						}
 
@@ -2041,7 +2041,7 @@ const visitors = {
 						}
 						const metadata = { tracking: false };
 						const expression = /** @type {AST.Expression} */ (
-							visit(attr.value, { ...state, metadata })
+							visit(attr_value, { ...state, metadata })
 						);
 
 						state.init?.push(
@@ -2058,7 +2058,7 @@ const visitors = {
 							),
 						);
 					}
-				} else if (attr.type === 'SpreadAttribute') {
+				} else if (attr.type === 'JSXSpreadAttribute') {
 					spread_attributes?.push(
 						b.spread(/** @type {AST.Expression} */ (visit(attr.argument, state))),
 					);
@@ -2066,7 +2066,7 @@ const visitors = {
 			}
 
 			if (class_attribute !== null) {
-				const attr_value = /** @type {AST.Expression} */ (class_attribute.value);
+				const attr_value = /** @type {AST.Expression} */ (get_attribute_value(class_attribute));
 				if (attr_value.type === 'Literal') {
 					let value = attr_value.value;
 
@@ -2074,7 +2074,7 @@ const visitors = {
 						value = `${scoping_hash} ${value}`;
 					}
 
-					handle_static_attr(class_attribute.name.name, value);
+					handle_static_attr('class', value);
 				} else {
 					const metadata = { tracking: false };
 					let expression = /** @type {AST.Expression} */ (
@@ -2219,21 +2219,23 @@ const visitors = {
 			const apply_parent_css_scope = state.applyParentCssScope;
 
 			for (const attr of node.attributes) {
-				if (attr.type === 'Attribute') {
-					if (attr.name.type === 'Identifier') {
+				if (attr.type === 'JSXAttribute') {
+					{
+						const attr_name = get_attribute_name(attr);
+						const attr_value = get_attribute_value(attr);
 						const metadata = { tracking: false };
 						let property =
-							attr.value === null
+							attr_value === null
 								? b.literal(true)
 								: /** @type {AST.Expression} */ (
-										visit(/** @type {AST.Expression} */ (attr.value), {
+										visit(/** @type {AST.Expression} */ (attr_value), {
 											...state,
 											metadata,
 										})
 									);
 
 						const scoped_hash = get_component_css_hash(state);
-						if (attr.name.name === 'class' && node.metadata.scoped && scoped_hash) {
+						if (attr_name === 'class' && node.metadata.scoped && scoped_hash) {
 							if (property.type === 'Literal') {
 								property = b.literal(`${scoped_hash} ${property.value}`);
 							} else {
@@ -2241,7 +2243,7 @@ const visitors = {
 							}
 						}
 
-						if (attr.name.name === 'children') {
+						if (attr_name === 'children') {
 							children_prop = b.prop(
 								'init',
 								b.id('children'),
@@ -2251,9 +2253,9 @@ const visitors = {
 							continue;
 						}
 
-						props.push(b.prop('init', b.key(attr.name.name), property));
+						props.push(b.prop('init', b.key(attr_name), property));
 					}
-				} else if (attr.type === 'SpreadAttribute') {
+				} else if (attr.type === 'JSXSpreadAttribute') {
 					props.push(
 						b.spread(
 							/** @type {AST.Expression} */ (
@@ -2266,10 +2268,7 @@ const visitors = {
 
 			if (node.metadata.scoped && get_component_css(state)) {
 				const hasClassAttr = node.attributes.some(
-					(attr) =>
-						attr.type === 'Attribute' &&
-						attr.name.type === 'Identifier' &&
-						attr.name.name === 'class',
+					(attr) => attr.type === 'JSXAttribute' && get_attribute_name(attr) === 'class',
 				);
 				if (!hasClassAttr) {
 					const name = is_spreading ? '#class' : 'class';
@@ -2834,9 +2833,7 @@ const visitors = {
 					b.stmt(b.call(b.id('_$_.output_push'), b.literal(escape(expression.value)))),
 				);
 			} else {
-				state.init?.push(
-					b.stmt(b.call(b.id('_$_.output_push'), b.call('_$_.escape', expression))),
-				);
+				state.init?.push(b.stmt(b.call(b.id('_$_.output_push'), b.call('_$_.escape', expression))));
 			}
 			return;
 		}

--- a/packages/tsrx-ripple/src/transform/server/index.js
+++ b/packages/tsrx-ripple/src/transform/server/index.js
@@ -74,6 +74,7 @@ import {
 	strip_tsrx_style_elements,
 	unwrap_single_return_iife,
 	wrap_code_block_in_iife,
+	visit_directive_wrapping_values,
 	get_code_block_render,
 	get_code_block_template_child,
 	lower_code_block_children,
@@ -1759,6 +1760,19 @@ const visitors = {
 	},
 
 	CallExpression(node, context) {
+		const type_parameters = /** @type {any} */ (node).typeParameters;
+		if (type_parameters) {
+			// acorn-typescript quirk: call/new expressions carry their generics as
+			// `typeParameters`; the transforms (and the TSX printer) expect the
+			// standard `typeArguments`.
+			return context.visit(
+				/** @type {any} */ ({
+					...node,
+					typeArguments: type_parameters,
+					typeParameters: undefined,
+				}),
+			);
+		}
 		const { state } = context;
 
 		// When lowering to JS the call's type arguments are dropped; the rebuilt
@@ -1949,6 +1963,19 @@ const visitors = {
 	},
 
 	NewExpression(node, context) {
+		const type_parameters = /** @type {any} */ (node).typeParameters;
+		if (type_parameters) {
+			// acorn-typescript quirk: call/new expressions carry their generics as
+			// `typeParameters`; the transforms (and the TSX printer) expect the
+			// standard `typeArguments`.
+			return context.visit(
+				/** @type {any} */ ({
+					...node,
+					typeArguments: type_parameters,
+					typeParameters: undefined,
+				}),
+			);
+		}
 		const callee = node.callee;
 
 		// Transform `new RippleArray(...)`, `new RippleMap(...)`, etc. imported from 'ripple'
@@ -2714,20 +2741,26 @@ const visitors = {
 	},
 
 	SwitchStatement: visit_switch_statement,
-	JSXSwitchExpression: visit_switch_statement,
+	JSXSwitchExpression(node, context) {
+		return visit_directive_wrapping_values(node, context, visit_switch_statement);
+	},
 
 	ForOfStatement: visit_for_of_statement,
 	// `@for` covers for-of / for-in / for(;;): non-for-of forms have no
 	// dedicated visitor and keep the default traversal, as before.
 	JSXForExpression(node, context) {
-		if (node.statementType === 'ForOfStatement') {
-			return visit_for_of_statement(node, context);
-		}
-		return context.next();
+		return visit_directive_wrapping_values(node, context, (node, context) => {
+			if (node.statementType === 'ForOfStatement') {
+				return visit_for_of_statement(node, context);
+			}
+			return context.next();
+		});
 	},
 
 	IfStatement: visit_if_statement,
-	JSXIfExpression: visit_if_statement,
+	JSXIfExpression(node, context) {
+		return visit_directive_wrapping_values(node, context, visit_if_statement);
+	},
 
 	ReturnStatement(node, context) {
 		// A `return <markup>` produces a renderable value — lower it to a server
@@ -2899,7 +2932,9 @@ const visitors = {
 	},
 
 	TryStatement: visit_try_statement,
-	JSXTryExpression: visit_try_statement,
+	JSXTryExpression(node, context) {
+		return visit_directive_wrapping_values(node, context, visit_try_statement);
+	},
 
 	JSXExpressionContainer(node, context) {
 		const { visit, state } = context;

--- a/packages/tsrx-ripple/src/transform/server/index.js
+++ b/packages/tsrx-ripple/src/transform/server/index.js
@@ -428,6 +428,7 @@ function contains_template_value_node(node) {
 				node.type === 'Element' ||
 				node.type === 'JSXElement' ||
 				node.type === 'JSXFragment' ||
+				node.type === 'JSXStyleElement' ||
 				(node.type === 'CallExpression' &&
 					node.callee.type === 'Identifier' &&
 					node.callee.name === '_$_.tsrx_element')
@@ -565,6 +566,7 @@ function is_template_value_binding(expression, scope) {
 	return (
 		binding?.metadata?.is_template_value === true ||
 		initial?.type === 'Element' ||
+		initial?.type === 'JSXStyleElement' ||
 		is_template_fragment(initial)
 	);
 }
@@ -747,6 +749,7 @@ function is_template_or_control_flow(node) {
 
 	return (
 		node.type === 'Element' ||
+		node.type === 'JSXStyleElement' ||
 		node.type === 'JSXExpressionContainer' ||
 		node.type === 'JSXText' ||
 		is_template_fragment(node) ||
@@ -1958,16 +1961,13 @@ const visitors = {
 		return transform_variable_declaration(node, context);
 	},
 
-	Element(node, context) {
-		const { state, visit } = context;
-
-		lower_dynamic_element(node, b.member(b.id('_$_'), 'dynamic_element'));
+	JSXStyleElement(node, context) {
+		const { state } = context;
 
 		if (
-			is_style_element(node) &&
-			(state.regular_js ||
-				is_native_tsrx_value_position(context.path) ||
-				is_regular_js_statement_position(context.path))
+			state.regular_js ||
+			is_native_tsrx_value_position(context.path) ||
+			is_regular_js_statement_position(context.path)
 		) {
 			const expression = build_style_class_map_expression(node, context);
 			if (expression) {
@@ -1977,6 +1977,15 @@ const visitors = {
 				return expression;
 			}
 		}
+
+		// Component styles render nothing on the server — their CSS is extracted
+		// at analysis time and injected separately.
+	},
+
+	Element(node, context) {
+		const { state, visit } = context;
+
+		lower_dynamic_element(node, b.member(b.id('_$_'), 'dynamic_element'));
 
 		if (
 			state.regular_js ||

--- a/packages/tsrx-ripple/src/transform/server/index.js
+++ b/packages/tsrx-ripple/src/transform/server/index.js
@@ -79,9 +79,13 @@ import {
 import {
 	get_attribute_name,
 	get_attribute_value,
+	get_element_attributes,
+	get_element_id,
 	get_template_text_value,
 	is_droppable_template_text,
 	is_empty_expression_container,
+	is_self_closing,
+	is_template_element,
 	is_template_fragment,
 	is_template_text,
 	rendered_template_children,
@@ -425,7 +429,7 @@ function contains_template_value_node(node) {
 				return;
 			}
 			if (
-				node.type === 'Element' ||
+				is_template_element(node) ||
 				node.type === 'JSXElement' ||
 				node.type === 'JSXFragment' ||
 				node.type === 'JSXStyleElement' ||
@@ -565,7 +569,7 @@ function is_template_value_binding(expression, scope) {
 	const initial = /** @type {AST.Node | null | undefined} */ (binding?.initial);
 	return (
 		binding?.metadata?.is_template_value === true ||
-		initial?.type === 'Element' ||
+		is_template_element(initial) ||
 		initial?.type === 'JSXStyleElement' ||
 		is_template_fragment(initial)
 	);
@@ -748,7 +752,7 @@ function is_template_or_control_flow(node) {
 	}
 
 	return (
-		node.type === 'Element' ||
+		is_template_element(node) ||
 		node.type === 'JSXStyleElement' ||
 		node.type === 'JSXExpressionContainer' ||
 		node.type === 'JSXText' ||
@@ -907,7 +911,7 @@ function is_native_tsrx_value_position(path) {
 	const parent = path.at(-1);
 	return !(
 		is_native_tsrx_statement_position(path) ||
-		parent?.type === 'Element' ||
+		is_template_element(parent) ||
 		is_template_fragment(parent)
 	);
 }
@@ -925,7 +929,7 @@ function should_wrap_node_in_regular_block(node) {
  * @returns {boolean}
  */
 function is_head_element(node) {
-	return node.type === 'Element' && node.id.type === 'Identifier' && node.id.name === 'head';
+	return is_template_element(node) && /** @type {any} */ (get_element_id(node)).name === 'head';
 }
 
 /**
@@ -934,15 +938,16 @@ function is_head_element(node) {
  * @returns {boolean}
  */
 function is_ripple_fragment_element(node, context) {
-	if (node.id.type === 'Identifier') {
-		return node.id.name === 'Fragment' && is_ripple_import(node.id, context);
+	const id = get_element_id(node);
+	if (id.type === 'Identifier') {
+		return id.name === 'Fragment' && is_ripple_import(id, context);
 	}
 
 	return (
-		node.id.type === 'MemberExpression' &&
-		node.id.property.type === 'Identifier' &&
-		node.id.property.name === 'Fragment' &&
-		is_ripple_import(node.id, context)
+		id.type === 'MemberExpression' &&
+		id.property.type === 'Identifier' &&
+		id.property.name === 'Fragment' &&
+		is_ripple_import(id, context)
 	);
 }
 
@@ -951,7 +956,7 @@ function is_ripple_fragment_element(node, context) {
  * @returns {ESTreeJSX.JSXAttribute | null}
  */
 function get_inner_html_attribute(node) {
-	for (const attr of node.attributes) {
+	for (const attr of get_element_attributes(node)) {
 		if (attr.type === 'JSXAttribute' && get_attribute_name(attr) === 'innerHTML') {
 			return attr;
 		}
@@ -1987,6 +1992,9 @@ const visitors = {
 
 		lower_dynamic_element(node, b.member(b.id('_$_'), 'dynamic_element'));
 
+		const element_id = get_element_id(node);
+		const element_attributes = get_element_attributes(node);
+
 		if (
 			state.regular_js ||
 			(!state.template_child &&
@@ -2008,20 +2016,20 @@ const visitors = {
 		}
 
 		const is_dom_element = is_element_dom_element(node);
-		const is_spreading = node.attributes.some((attr) => attr.type === 'JSXSpreadAttribute');
+		const is_spreading = element_attributes.some((attr) => attr.type === 'JSXSpreadAttribute');
 		/** @type {(AST.Property | AST.SpreadElement)[] | null} */
 		const spread_attributes = is_spreading ? [] : null;
 		const child_namespace = is_dom_element
 			? determine_namespace_for_children(
-					/** @type {AST.Identifier} */ (node.id).name,
+					/** @type {AST.Identifier} */ (element_id).name,
 					state.namespace,
 				)
 			: state.namespace;
 
 		if (is_dom_element) {
-			const is_void = is_void_element(/** @type {AST.Identifier} */ (node.id).name);
-			const use_self_closing_syntax = node.selfClosing && is_void;
-			const tag_name = b.literal(/** @type {AST.Identifier} */ (node.id).name);
+			const is_void = is_void_element(/** @type {AST.Identifier} */ (element_id).name);
+			const use_self_closing_syntax = is_self_closing(node) && is_void;
+			const tag_name = b.literal(/** @type {AST.Identifier} */ (element_id).name);
 			/** @type {AST.CSS.StyleSheet['hash'] | null} */
 			const scoping_hash =
 				state.applyParentCssScope ?? (node.metadata.scoped ? get_component_css_hash(state) : null);
@@ -2068,7 +2076,7 @@ const visitors = {
 				}
 			};
 
-			for (const attr of node.attributes) {
+			for (const attr of element_attributes) {
 				if (attr.type === 'JSXAttribute') {
 					{
 						const name = get_attribute_name(attr);
@@ -2191,7 +2199,7 @@ const visitors = {
 
 			// In dev mode, emit push_element for runtime nesting validation
 			if (state.dev) {
-				const element_name = /** @type {AST.Identifier} */ (node.id).name;
+				const element_name = /** @type {AST.Identifier} */ (element_id).name;
 				const loc = node.loc;
 				state.init?.push(
 					b.stmt(
@@ -2290,7 +2298,7 @@ const visitors = {
 
 			const apply_parent_css_scope = state.applyParentCssScope;
 
-			for (const attr of node.attributes) {
+			for (const attr of element_attributes) {
 				if (attr.type === 'JSXAttribute') {
 					{
 						const attr_name = get_attribute_name(attr);
@@ -2339,7 +2347,7 @@ const visitors = {
 			}
 
 			if (node.metadata.scoped && get_component_css(state)) {
-				const hasClassAttr = node.attributes.some(
+				const hasClassAttr = element_attributes.some(
 					(attr) => attr.type === 'JSXAttribute' && get_attribute_name(attr) === 'class',
 				);
 				if (!hasClassAttr) {
@@ -2392,7 +2400,8 @@ const visitors = {
 			const args = [b.object(props)];
 
 			// Check if this is a locally defined component
-			const component_name = node.id.type === 'Identifier' ? node.id.name : null;
+			const component_name =
+				element_id.type === 'Identifier' ? /** @type {AST.Identifier} */ (element_id).name : null;
 			const local_metadata = component_name
 				? state.component_metadata.find((m) => m.id === component_name)
 				: null;
@@ -2401,7 +2410,7 @@ const visitors = {
 			const comp_call = b.call('_$_.render_component', comp_id, b.spread(args_id));
 			const comp_call_statement = b.stmt(comp_call);
 
-			const visited_id = /** @type {AST.Expression} */ (visit(node.id, state));
+			const visited_id = /** @type {AST.Expression} */ (visit(element_id, state));
 			/** @type {AST.Statement[]} */
 			const statements = [b.const(comp_id, visited_id), b.const(args_id, b.array(args))];
 

--- a/packages/tsrx-ripple/src/transform/server/index.js
+++ b/packages/tsrx-ripple/src/transform/server/index.js
@@ -76,6 +76,13 @@ import {
 	wrap_code_block_in_iife,
 	is_code_block_function_body,
 } from '../../utils.js';
+import {
+	get_template_text_value,
+	is_droppable_template_text,
+	is_empty_expression_container,
+	is_template_text,
+	rendered_template_children,
+} from '../../template-ast.js';
 
 /**
  * @param {unknown} value
@@ -739,8 +746,8 @@ function is_template_or_control_flow(node) {
 
 	return (
 		node.type === 'Element' ||
-		node.type === 'TSRXExpression' ||
-		node.type === 'Text' ||
+		node.type === 'JSXExpressionContainer' ||
+		node.type === 'JSXText' ||
 		node.type === 'TsrxFragment' ||
 		node.type === 'IfStatement' ||
 		node.type === 'ForOfStatement' ||
@@ -753,9 +760,9 @@ function is_template_or_control_flow(node) {
  * Whether a `{ … }` expression child is lowered to `_$_.render_expression(…)`,
  * which (unlike `render_tsrx_element` or plain text output) brackets its output
  * in a `<!--[-->`…`<!--]-->` hydration boundary. Mirrors the routing in the
- * `TSRXExpression` server visitor. A `@{ … }` block in template position reaches
- * here as a `TSRXExpression` wrapping its IIFE call.
- * @param {AST.TSRXExpression} node
+ * `JSXExpressionContainer` server visitor. A `@{ … }` block in template position
+ * reaches here as a `JSXExpressionContainer` wrapping its IIFE call.
+ * @param {ESTreeJSX.JSXExpressionContainer} node
  * @param {TransformServerContext} context
  * @returns {boolean}
  */
@@ -802,13 +809,25 @@ function node_leads_with_control_flow(node, context) {
 		case 'TryStatement':
 			return node.metadata?.regular_js ? null : true;
 		case 'Element':
-		case 'Text':
 			return false;
-		case 'TSRXExpression':
-			return tsrx_expression_emits_marker(/** @type {AST.TSRXExpression} */ (node), context);
+		case 'JSXText':
+			// Insignificant whitespace renders nothing — keep scanning.
+			return is_droppable_template_text(node, false) ? null : false;
+		case 'JSXExpressionContainer':
+			// Comment containers render nothing; merged text runs render as text.
+			if (is_empty_expression_container(node)) {
+				return null;
+			}
+			if (is_template_text(node)) {
+				return false;
+			}
+			return tsrx_expression_emits_marker(
+				/** @type {ESTreeJSX.JSXExpressionContainer} */ (node),
+				context,
+			);
 		case 'TsrxFragment':
 			return fragment_leads_with_control_flow(
-				node.children.filter((c) => c != null && c.type !== 'EmptyStatement'),
+				rendered_template_children(node.children, false),
 				context,
 			);
 		case 'JSXCodeBlock':
@@ -2797,8 +2816,31 @@ const visitors = {
 		context.state.init?.push(b.stmt(b.call('_$_.try_block', try_fn, catch_fn, pending_fn)));
 	},
 
-	TSRXExpression(node, context) {
+	JSXExpressionContainer(node, context) {
 		const { visit, state } = context;
+
+		// A `{/* comment */}` container renders nothing.
+		if (is_empty_expression_container(node)) {
+			return;
+		}
+
+		// A merged text run (adjacent text/expression children collapsed by
+		// `normalize_children`) renders through the plain text path.
+		if (is_template_text(node)) {
+			const expression = /** @type {AST.Expression} */ (visit(node.expression, state));
+
+			if (expression.type === 'Literal') {
+				state.init?.push(
+					b.stmt(b.call(b.id('_$_.output_push'), b.literal(escape(expression.value)))),
+				);
+			} else {
+				state.init?.push(
+					b.stmt(b.call(b.id('_$_.output_push'), b.call('_$_.escape', expression))),
+				);
+			}
+			return;
+		}
+
 		const is_static_native_tsrx_call = is_static_native_tsrx_function_call(
 			/** @type {AST.Expression} */ (node.expression),
 			context,
@@ -2836,16 +2878,15 @@ const visitors = {
 		}
 	},
 
-	Text(node, { visit, state }) {
-		let expression = /** @type {AST.Expression} */ (visit(node.expression, state));
+	JSXText(node, { state }) {
+		const value = get_template_text_value(node, false);
 
-		if (expression.type === 'Literal') {
-			state.init?.push(
-				b.stmt(b.call(b.id('_$_.output_push'), b.literal(escape(expression.value)))),
-			);
-		} else {
-			state.init?.push(b.stmt(b.call(b.id('_$_.output_push'), b.call('_$_.escape', expression))));
+		// Insignificant whitespace collapses to nothing.
+		if (value === '') {
+			return;
 		}
+
+		state.init?.push(b.stmt(b.call(b.id('_$_.output_push'), b.literal(escape(value)))));
 	},
 
 	TsrxFragment(node, context) {

--- a/packages/tsrx-ripple/src/transform/server/index.js
+++ b/packages/tsrx-ripple/src/transform/server/index.js
@@ -85,6 +85,7 @@ import {
 	get_attribute_value,
 	get_element_attributes,
 	get_element_id,
+	get_element_identifier,
 	get_template_text_value,
 	is_droppable_template_text,
 	is_empty_expression_container,
@@ -238,7 +239,7 @@ function insert_style_ref_setup_statements(body, setup, scopes) {
 			return rebuild(node, { cases });
 		}
 		if (node.type === 'TryStatement') {
-			/** @type {Partial<AST.TryStatement> & Record<string, any>} */
+			/** @type {Partial<AST.TryStatement>} */
 			const updates = {
 				block: /** @type {AST.BlockStatement} */ (insert_in_statement(node.block)),
 			};
@@ -862,7 +863,7 @@ function should_wrap_node_in_regular_block(node) {
  * @returns {boolean}
  */
 function is_head_element(node) {
-	return is_template_element(node) && /** @type {any} */ (get_element_id(node)).name === 'head';
+	return is_template_element(node) && get_element_identifier(node)?.name === 'head';
 }
 
 /**
@@ -2646,8 +2647,7 @@ const visitors = {
 			}
 
 			const children_filtered = element_children.filter(
-				(/** @type {any} */ child) =>
-					child.type !== 'EmptyStatement' && !is_native_tsrx_function_node(child),
+				(child) => child.type !== 'EmptyStatement' && !is_native_tsrx_function_node(child),
 			);
 
 			if (children_filtered.length > 0) {
@@ -3485,14 +3485,14 @@ function accumulate_output_pushes(program) {
 		// Guard against cycles: re-entry resolves to the original node.
 		cache.set(node, node);
 
-		/** @type {Record<string, any>} */
-		let result = node;
+		/** @type {AST.TraversableAstNode} */
+		let result = /** @type {AST.TraversableAstNode} */ (node);
 
 		if (isFunctionNode(node)) {
 			const body = /** @type {AST.Function} */ (node).body;
 			if (body && body.type === 'BlockStatement' && has_direct_output_push(body.body)) {
 				const out_id = fresh_accumulator_name(body.body);
-				result = {
+				result = /** @type {AST.TraversableAstNode} */ ({
 					...node,
 					body: {
 						...body,
@@ -3502,7 +3502,7 @@ function accumulate_output_pushes(program) {
 							b.stmt(b.call(b.id('_$_.output_push'), b.id(out_id))),
 						],
 					},
-				};
+				});
 			}
 		}
 
@@ -3519,7 +3519,7 @@ function accumulate_output_pushes(program) {
 			const child = result[key];
 			const next = recurse(child);
 			if (next !== child) {
-				if (result === node) result = { .../** @type {Record<string, any>} */ (node) };
+				if (result === node) result = /** @type {AST.TraversableAstNode} */ ({ ...node });
 				result[key] = next;
 			}
 		}

--- a/packages/tsrx-ripple/src/transform/server/index.js
+++ b/packages/tsrx-ripple/src/transform/server/index.js
@@ -74,6 +74,9 @@ import {
 	strip_tsrx_style_elements,
 	unwrap_single_return_iife,
 	wrap_code_block_in_iife,
+	get_code_block_render,
+	get_code_block_template_child,
+	lower_code_block_children,
 	is_code_block_function_body,
 } from '../../utils.js';
 import {
@@ -758,10 +761,15 @@ function node_leads_with_control_flow(node, context) {
 				rendered_template_children(/** @type {AST.Node[]} */ (node.children), false),
 				context,
 			);
-		case 'JSXCodeBlock':
-			// A `@{ … }` block renders only its `render` output (the body is setup);
-			// a code-only block (no render) contributes no DOM.
-			return node.render != null ? node_leads_with_control_flow(node.render, context) : null;
+		case 'JSXCodeBlock': {
+			// A `@{ … }` block renders only what its lowered template form emits
+			// (the body is setup); a code-only block contributes no DOM.
+			const child = get_code_block_template_child(
+				/** @type {AST.JSXCodeBlock} */ (node),
+				context.state.scopes,
+			);
+			return child != null && child !== node ? node_leads_with_control_flow(child, context) : null;
+		}
 		default:
 			// Non-renderable setup statement — keep scanning for the first node.
 			return null;
@@ -1217,10 +1225,13 @@ function get_native_tsrx_return_template_node(node, allow_direct_template = fals
 			/** @type {unknown} */ (node.argument)
 		);
 	}
-	if (node.type === 'JSXCodeBlock' && is_native_tsrx_template_node(node.render)) {
-		return /** @type {ESTreeJSX.JSXElement | ESTreeJSX.JSXFragment} */ (
-			/** @type {unknown} */ (node.render)
-		);
+	if (node.type === 'JSXCodeBlock') {
+		const render = get_code_block_render(node);
+		if (is_native_tsrx_template_node(render)) {
+			return /** @type {ESTreeJSX.JSXElement | ESTreeJSX.JSXFragment} */ (
+				/** @type {unknown} */ (render)
+			);
+		}
 	}
 	if (
 		node.type === 'FunctionDeclaration' ||
@@ -1856,7 +1867,7 @@ const visitors = {
 		// `transform_native_tsrx_function`. Everywhere else, lower it to a plain
 		// BlockStatement so the JS printer (which has no JSXCodeBlock visitor) can
 		// emit it.
-		if (node.render != null) {
+		if (get_code_block_render(node, context.state.scopes) != null) {
 			return context.next();
 		}
 		/** @type {AST.Statement[]} */
@@ -2624,13 +2635,17 @@ const visitors = {
 				}
 			}
 
-			for (const child of node.children) {
+			const element_children = lower_code_block_children(
+				/** @type {AST.Node[]} */ (node.children),
+				context.state.scopes,
+			);
+			for (const child of element_children) {
 				if (is_native_tsrx_function_node(child)) {
 					state.init?.push(/** @type {AST.Statement} */ (visit(child, state)));
 				}
 			}
 
-			const children_filtered = node.children.filter(
+			const children_filtered = element_children.filter(
 				(/** @type {any} */ child) =>
 					child.type !== 'EmptyStatement' && !is_native_tsrx_function_node(child),
 			);

--- a/packages/tsrx-ripple/src/transform/server/index.js
+++ b/packages/tsrx-ripple/src/transform/server/index.js
@@ -75,7 +75,6 @@ import {
 	unwrap_single_return_iife,
 	wrap_code_block_in_iife,
 	visit_directive_wrapping_values,
-	replace_with_statements,
 	get_code_block_render,
 	get_code_block_template_child,
 	lower_code_block_children,
@@ -2873,7 +2872,7 @@ const visitors = {
 		const { state } = context;
 
 		if (get_submodule_import_source_name(node) === 'server') {
-			return replace_with_statements(transform_server_module_import(node));
+			return transform_server_module_import(node);
 		}
 
 		if (!state.to_ts && node.importKind === 'type') {

--- a/packages/tsrx-ripple/src/transform/server/index.js
+++ b/packages/tsrx-ripple/src/transform/server/index.js
@@ -1760,19 +1760,6 @@ const visitors = {
 	},
 
 	CallExpression(node, context) {
-		const type_parameters = /** @type {any} */ (node).typeParameters;
-		if (type_parameters) {
-			// acorn-typescript quirk: call/new expressions carry their generics as
-			// `typeParameters`; the transforms (and the TSX printer) expect the
-			// standard `typeArguments`.
-			return context.visit(
-				/** @type {any} */ ({
-					...node,
-					typeArguments: type_parameters,
-					typeParameters: undefined,
-				}),
-			);
-		}
 		const { state } = context;
 
 		// When lowering to JS the call's type arguments are dropped; the rebuilt
@@ -1963,19 +1950,6 @@ const visitors = {
 	},
 
 	NewExpression(node, context) {
-		const type_parameters = /** @type {any} */ (node).typeParameters;
-		if (type_parameters) {
-			// acorn-typescript quirk: call/new expressions carry their generics as
-			// `typeParameters`; the transforms (and the TSX printer) expect the
-			// standard `typeArguments`.
-			return context.visit(
-				/** @type {any} */ ({
-					...node,
-					typeArguments: type_parameters,
-					typeParameters: undefined,
-				}),
-			);
-		}
 		const callee = node.callee;
 
 		// Transform `new RippleArray(...)`, `new RippleMap(...)`, etc. imported from 'ripple'

--- a/packages/tsrx-ripple/src/transform/server/index.js
+++ b/packages/tsrx-ripple/src/transform/server/index.js
@@ -82,6 +82,7 @@ import {
 	get_template_text_value,
 	is_droppable_template_text,
 	is_empty_expression_container,
+	is_template_fragment,
 	is_template_text,
 	rendered_template_children,
 } from '../../template-ast.js';
@@ -372,24 +373,23 @@ function build_jsx_to_tsrx_element(node, context) {
 }
 
 /**
- * @param {AST.Element | AST.TsrxFragment} node
+ * @param {AST.Element | ESTreeJSX.JSXFragment} node
  * @param {TransformServerContext} context
  * @returns {AST.CallExpression}
  */
 function build_template_node_to_tsrx_element(node, context) {
 	const { visit, state, path } = context;
-	const children =
-		node.type === 'TsrxFragment'
-			? node.children.filter((child) => child != null && child.type !== 'EmptyStatement')
-			: [
-					{
-						...node,
-						metadata: {
-							...node.metadata,
-							regular_js: undefined,
-						},
+	const children = is_template_fragment(node)
+		? node.children.filter((child) => child != null && child.type !== 'EmptyStatement')
+		: [
+				{
+					...node,
+					metadata: {
+						...node.metadata,
+						regular_js: undefined,
 					},
-				];
+				},
+			];
 
 	apply_tsrx_css_scoping(children, state);
 
@@ -428,7 +428,6 @@ function contains_template_value_node(node) {
 				node.type === 'Element' ||
 				node.type === 'JSXElement' ||
 				node.type === 'JSXFragment' ||
-				node.type === 'TsrxFragment' ||
 				(node.type === 'CallExpression' &&
 					node.callee.type === 'Identifier' &&
 					node.callee.name === '_$_.tsrx_element')
@@ -566,7 +565,7 @@ function is_template_value_binding(expression, scope) {
 	return (
 		binding?.metadata?.is_template_value === true ||
 		initial?.type === 'Element' ||
-		initial?.type === 'TsrxFragment'
+		is_template_fragment(initial)
 	);
 }
 
@@ -750,7 +749,7 @@ function is_template_or_control_flow(node) {
 		node.type === 'Element' ||
 		node.type === 'JSXExpressionContainer' ||
 		node.type === 'JSXText' ||
-		node.type === 'TsrxFragment' ||
+		is_template_fragment(node) ||
 		node.type === 'IfStatement' ||
 		node.type === 'ForOfStatement' ||
 		node.type === 'TryStatement' ||
@@ -827,7 +826,7 @@ function node_leads_with_control_flow(node, context) {
 				/** @type {ESTreeJSX.JSXExpressionContainer} */ (node),
 				context,
 			);
-		case 'TsrxFragment':
+		case 'JSXFragment':
 			return fragment_leads_with_control_flow(
 				rendered_template_children(node.children, false),
 				context,
@@ -906,7 +905,7 @@ function is_native_tsrx_value_position(path) {
 	return !(
 		is_native_tsrx_statement_position(path) ||
 		parent?.type === 'Element' ||
-		parent?.type === 'TsrxFragment'
+		is_template_fragment(parent)
 	);
 }
 
@@ -1084,14 +1083,13 @@ function transform_variable_declaration(node, context) {
 		}
 
 		const declarator_init = /** @type {AST.Node | null | undefined} */ (declarator.init);
-		const init =
-			declarator_init?.type === 'TsrxFragment'
-				? build_template_node_to_tsrx_element(declarator_init, context)
-				: declarator_init
-					? /** @type {AST.Expression} */ (
-							context.visit(declarator_init, { ...context.state, template_child: false })
-						)
-					: null;
+		const init = is_template_fragment(declarator_init)
+			? build_template_node_to_tsrx_element(declarator_init, context)
+			: declarator_init
+				? /** @type {AST.Expression} */ (
+						context.visit(declarator_init, { ...context.state, template_child: false })
+					)
+				: null;
 		transformed_inits.set(declarator, init);
 	}
 
@@ -1263,18 +1261,22 @@ function transform_body(body, context) {
 /**
  * @param {AST.Node | null | undefined} node
  * @param {boolean} [allow_direct_template]
- * @returns {AST.Element | AST.TsrxFragment | null}
+ * @returns {AST.Element | ESTreeJSX.JSXFragment | null}
  */
 function get_native_tsrx_return_template_node(node, allow_direct_template = false) {
 	if (!node) return null;
 	if (allow_direct_template && is_native_tsrx_template_node(node)) {
-		return /** @type {AST.Element | AST.TsrxFragment} */ (/** @type {unknown} */ (node));
+		return /** @type {AST.Element | ESTreeJSX.JSXFragment} */ (/** @type {unknown} */ (node));
 	}
 	if (node.type === 'ReturnStatement' && is_native_tsrx_template_node(node.argument)) {
-		return /** @type {AST.Element | AST.TsrxFragment} */ (/** @type {unknown} */ (node.argument));
+		return /** @type {AST.Element | ESTreeJSX.JSXFragment} */ (
+			/** @type {unknown} */ (node.argument)
+		);
 	}
 	if (node.type === 'JSXCodeBlock' && is_native_tsrx_template_node(node.render)) {
-		return /** @type {AST.Element | AST.TsrxFragment} */ (/** @type {unknown} */ (node.render));
+		return /** @type {AST.Element | ESTreeJSX.JSXFragment} */ (
+			/** @type {unknown} */ (node.render)
+		);
 	}
 	if (
 		node.type === 'FunctionDeclaration' ||
@@ -1575,10 +1577,71 @@ const visitors = {
 	},
 
 	JSXFragment(node, context) {
-		if (context.state.jsx_to_tsrx_element || is_native_tsrx_value_position(context.path)) {
-			return build_jsx_to_tsrx_element(/** @type {AST.TSRXJSXFragment} */ (node), context);
+		// A raw (non-template) fragment — an attribute value or other JSX that
+		// never entered the template traversal.
+		if (!is_template_fragment(node)) {
+			if (context.state.jsx_to_tsrx_element || is_native_tsrx_value_position(context.path)) {
+				return build_jsx_to_tsrx_element(/** @type {AST.TSRXJSXFragment} */ (node), context);
+			}
+			return context.next();
 		}
-		return context.next();
+
+		const { visit, state } = context;
+		const children = node.children.filter(
+			(child) => child != null && child.type !== 'EmptyStatement',
+		);
+		apply_tsrx_css_scoping(children, state);
+
+		/** @type {AST.Statement[]} */
+		const init = [];
+		transform_children(
+			children,
+			/** @type {TransformServerContext} */ ({
+				visit,
+				state: {
+					...state,
+					init,
+					regular_js: false,
+					jsx_to_tsrx_element: true,
+					// The fragment's own children are no longer the direct body of the
+					// enclosing control-flow branch, so they must not inherit the marker.
+					control_flow_branch_body: false,
+				},
+			}),
+		);
+
+		if (state.template_child) {
+			// In template position the client lowers `<>…</>` to a `<!>` placeholder +
+			// `_$_.expression(() => _$_.tsrx_element(…))`. During hydration that
+			// expression() needs a matching `<!--[-->`…`<!--]-->` boundary whenever it
+			// would otherwise borrow a nested control-flow's start marker as its own and
+			// advance the cursor past that child's content (desyncing hydration). That
+			// happens in two situations:
+			//   - the fragment is the direct body of a control-flow branch (or nested in
+			//     an element within one): the enclosing block already consumed its own
+			//     marker via hydrate_next before the branch body runs, leaving none for
+			//     the fragment — `control_flow_branch_body`;
+			//   - the fragment leads with control flow (e.g. a component body
+			//     `<> @for … </>`): its first child's marker would be mistaken for the
+			//     fragment's own.
+			// A fragment that leads with a component/element instead reuses its host
+			// boundary (or adopts real nodes) and must NOT be bracketed, or the extra
+			// markers desync the static-cursor (`next()` + skip_advance) client path.
+			const needs_boundary =
+				state.control_flow_branch_body || fragment_leads_with_control_flow(children, context);
+			if (needs_boundary && init.length > 0) {
+				state.init?.push(b.stmt(b.call(b.id('_$_.output_push'), b.literal(BLOCK_OPEN))));
+				state.init?.push(b.block(init));
+				state.init?.push(b.stmt(b.call(b.id('_$_.output_push'), b.literal(BLOCK_CLOSE))));
+			} else if (init.length > 0) {
+				// Template body: push children statements inline
+				state.init?.push(b.block(init));
+			}
+		} else {
+			// Expression context: return tsrx_element(render_fn)
+			const render_fn = b.arrow([], b.block(init));
+			return b.call('_$_.tsrx_element', render_fn);
+		}
 	},
 
 	NewExpression(node, context) {
@@ -2563,7 +2626,9 @@ const visitors = {
 		if (!context.state.to_ts && is_native_tsrx_template_node(node.argument)) {
 			return b.return(
 				build_template_node_to_tsrx_element(
-					/** @type {AST.Element | AST.TsrxFragment} */ (/** @type {unknown} */ (node.argument)),
+					/** @type {AST.Element | ESTreeJSX.JSXFragment} */ (
+						/** @type {unknown} */ (node.argument)
+					),
 					context,
 				),
 				/** @type {AST.NodeWithLocation} */ (node),
@@ -2884,65 +2949,6 @@ const visitors = {
 		}
 
 		state.init?.push(b.stmt(b.call(b.id('_$_.output_push'), b.literal(escape(value)))));
-	},
-
-	TsrxFragment(node, context) {
-		const { visit, state } = context;
-		const children = node.children.filter(
-			(child) => child != null && child.type !== 'EmptyStatement',
-		);
-		apply_tsrx_css_scoping(children, state);
-
-		/** @type {AST.Statement[]} */
-		const init = [];
-		transform_children(
-			children,
-			/** @type {TransformServerContext} */ ({
-				visit,
-				state: {
-					...state,
-					init,
-					regular_js: false,
-					jsx_to_tsrx_element: true,
-					// The fragment's own children are no longer the direct body of the
-					// enclosing control-flow branch, so they must not inherit the marker.
-					control_flow_branch_body: false,
-				},
-			}),
-		);
-
-		if (state.template_child) {
-			// In template position the client lowers `<>…</>` to a `<!>` placeholder +
-			// `_$_.expression(() => _$_.tsrx_element(…))`. During hydration that
-			// expression() needs a matching `<!--[-->`…`<!--]-->` boundary whenever it
-			// would otherwise borrow a nested control-flow's start marker as its own and
-			// advance the cursor past that child's content (desyncing hydration). That
-			// happens in two situations:
-			//   - the fragment is the direct body of a control-flow branch (or nested in
-			//     an element within one): the enclosing block already consumed its own
-			//     marker via hydrate_next before the branch body runs, leaving none for
-			//     the fragment — `control_flow_branch_body`;
-			//   - the fragment leads with control flow (e.g. a component body
-			//     `<> @for … </>`): its first child's marker would be mistaken for the
-			//     fragment's own.
-			// A fragment that leads with a component/element instead reuses its host
-			// boundary (or adopts real nodes) and must NOT be bracketed, or the extra
-			// markers desync the static-cursor (`next()` + skip_advance) client path.
-			const needs_boundary =
-				state.control_flow_branch_body || fragment_leads_with_control_flow(children, context);
-			if (needs_boundary && init.length > 0) {
-				state.init?.push(b.stmt(b.call(b.id('_$_.output_push'), b.literal(BLOCK_OPEN))));
-				state.init?.push(b.block(init));
-				state.init?.push(b.stmt(b.call(b.id('_$_.output_push'), b.literal(BLOCK_CLOSE))));
-			} else if (init.length > 0) {
-				// Template body: push children statements inline
-				state.init?.push(b.block(init));
-			}
-		} else {
-			// Expression context: return tsrx_element(render_fn)
-			const render_fn = b.arrow([], b.block(init));
-			return b.call('_$_.tsrx_element', render_fn);
-		}
 	},
 
 	TSModuleBlock(node, context) {

--- a/packages/tsrx-ripple/src/transform/server/index.js
+++ b/packages/tsrx-ripple/src/transform/server/index.js
@@ -64,7 +64,7 @@ import {
 	get_ripple_namespace_call_name,
 	strip_class_typescript_syntax,
 	strip_typescript_expression_wrappers,
-	jsx_to_ripple_node,
+	adopt_raw_template_jsx,
 	build_index_read,
 	build_index_write,
 	build_index_update,
@@ -170,14 +170,30 @@ function create_server_style_class_map_expression(stylesheet) {
 /**
  * @param {AST.Node[]} body
  * @param {AST.Statement[]} setup
+ * @param {Map<AST.Node[] | AST.Node, ScopeInterface>} [scopes]
  * @returns {AST.Node[]}
  */
-function insert_style_ref_setup_statements(body, setup) {
+function insert_style_ref_setup_statements(body, setup, scopes) {
 	if (setup.length === 0) {
 		return body;
 	}
 
 	let inserted = false;
+
+	/**
+	 * Copy-on-write helper: rebuilt spine nodes inherit the original's scope
+	 * mapping so transform-time lookups keep working.
+	 * @template {AST.Node} T
+	 * @param {T} original
+	 * @param {Partial<T>} updates
+	 * @returns {T}
+	 */
+	const rebuild = (original, updates) => {
+		const copy = { ...original, ...updates };
+		const scope = scopes?.get(original);
+		if (scope) scopes?.set(copy, scope);
+		return copy;
+	};
 
 	/** @param {AST.Node[]} nodes */
 	const insert_in_list = (nodes) => {
@@ -194,40 +210,44 @@ function insert_style_ref_setup_statements(body, setup) {
 		return nodes.map(insert_in_statement);
 	};
 
-	/** @param {AST.Node} node */
+	/** @param {AST.Node} node @returns {AST.Node} */
 	const insert_in_statement = (node) => {
 		if (node.type === 'FunctionDeclaration' || node.type === 'ClassDeclaration') {
 			return node;
 		}
 		if (node.type === 'BlockStatement') {
-			node.body = /** @type {AST.Statement[]} */ (insert_in_list(node.body || []));
-			return node;
+			const block_body = /** @type {AST.Statement[]} */ (insert_in_list(node.body || []));
+			return rebuild(node, { body: block_body });
 		}
 		if (node.type === 'IfStatement') {
-			node.consequent = /** @type {AST.Statement} */ (insert_in_statement(node.consequent));
-			if (node.alternate) {
-				node.alternate = /** @type {AST.Statement} */ (insert_in_statement(node.alternate));
-			}
-			return node;
+			const consequent = /** @type {AST.Statement} */ (insert_in_statement(node.consequent));
+			const alternate = node.alternate
+				? /** @type {AST.Statement} */ (insert_in_statement(node.alternate))
+				: node.alternate;
+			return rebuild(node, { consequent, alternate });
 		}
 		if (node.type === 'SwitchStatement') {
-			for (const switch_case of node.cases || []) {
-				switch_case.consequent = /** @type {AST.Statement[]} */ (
-					insert_in_list(switch_case.consequent || [])
-				);
-			}
-			return node;
+			const cases = (node.cases || []).map((switch_case) =>
+				rebuild(switch_case, {
+					consequent: /** @type {AST.Statement[]} */ (insert_in_list(switch_case.consequent || [])),
+				}),
+			);
+			return rebuild(node, { cases });
 		}
 		if (node.type === 'TryStatement') {
-			node.block = /** @type {AST.BlockStatement} */ (insert_in_statement(node.block));
+			/** @type {Partial<AST.TryStatement> & Record<string, any>} */
+			const updates = {
+				block: /** @type {AST.BlockStatement} */ (insert_in_statement(node.block)),
+			};
 			if (node.handler?.body) {
-				node.handler.body = /** @type {AST.BlockStatement} */ (
-					insert_in_statement(node.handler.body)
-				);
+				updates.handler = rebuild(node.handler, {
+					body: /** @type {AST.BlockStatement} */ (insert_in_statement(node.handler.body)),
+				});
 			}
 			if (node.finalizer) {
-				node.finalizer = /** @type {AST.BlockStatement} */ (insert_in_statement(node.finalizer));
+				updates.finalizer = /** @type {AST.BlockStatement} */ (insert_in_statement(node.finalizer));
 			}
+			return rebuild(node, updates);
 		}
 		return node;
 	};
@@ -246,7 +266,7 @@ function insert_style_ref_setup_statements(body, setup) {
  */
 function build_jsx_to_tsrx_element(node, context) {
 	const { visit, state, path } = context;
-	const result = jsx_to_ripple_node(/** @type {AST.Node} */ (node), path);
+	const result = adopt_raw_template_jsx(/** @type {AST.Node} */ (node));
 	const converted = Array.isArray(result) ? result : [result];
 	/** @type {AST.Node[]} */
 	const children = converted.filter((child) => child != null && child.type !== 'EmptyStatement');
@@ -981,19 +1001,23 @@ function is_dead_native_tsrx_expression_statement(node) {
 function transform_variable_declaration(node, context) {
 	/** @type {Map<AST.VariableDeclarator, AST.Expression | null>} */
 	const transformed_inits = new Map();
+	/** @type {Map<AST.VariableDeclarator, AST.Pattern>} */
+	const transformed_ids = new Map();
 
 	for (const declarator of node.declarations) {
+		let declarator_id = declarator.id;
 		if (!context.state.to_ts) {
-			delete declarator.id.typeAnnotation;
-
 			if (
-				(declarator.id.type === 'ObjectPattern' || declarator.id.type === 'ArrayPattern') &&
-				declarator.id.lazy &&
-				declarator.id.metadata?.lazy_id
+				(declarator_id.type === 'ObjectPattern' || declarator_id.type === 'ArrayPattern') &&
+				declarator_id.lazy &&
+				declarator_id.metadata?.lazy_id
 			) {
-				declarator.id = b.id(declarator.id.metadata.lazy_id);
+				declarator_id = b.id(declarator_id.metadata.lazy_id);
+			} else if (declarator_id.typeAnnotation) {
+				declarator_id = { ...declarator_id, typeAnnotation: undefined };
 			}
 		}
+		transformed_ids.set(declarator, declarator_id);
 
 		const declarator_init = /** @type {AST.Node | null | undefined} */ (declarator.init);
 		const init = is_template_fragment(declarator_init)
@@ -1013,7 +1037,9 @@ function transform_variable_declaration(node, context) {
 		...node,
 		declarations: node.declarations.map((declarator) => ({
 			...declarator,
-			id: /** @type {AST.Pattern} */ (context.visit(declarator.id)),
+			id: /** @type {AST.Pattern} */ (
+				context.visit(transformed_ids.get(declarator) ?? declarator.id)
+			),
 			init: transformed_inits.get(declarator) ?? null,
 		})),
 	};
@@ -1232,17 +1258,19 @@ function transform_native_tsrx_function(node, context) {
 	let props_param_output = null;
 
 	if (node.params.length > 0) {
-		let props_param = node.params[0];
+		const props_param = node.params[0];
 
 		if (props_param.type === 'Identifier') {
-			delete props_param.typeAnnotation;
-			props_param_output = props_param;
+			props_param_output = props_param.typeAnnotation
+				? { ...props_param, typeAnnotation: undefined }
+				: props_param;
 		} else if (props_param.type === 'ObjectPattern' || props_param.type === 'ArrayPattern') {
-			delete props_param.typeAnnotation;
 			if (props_param.lazy) {
 				props_param_output = b.id('__props');
 			} else {
-				props_param_output = replace_lazy_param_pattern(props_param);
+				props_param_output = replace_lazy_param_pattern(
+					props_param.typeAnnotation ? { ...props_param, typeAnnotation: undefined } : props_param,
+				);
 			}
 		} else {
 			props_param_output = props_param;
@@ -1259,7 +1287,7 @@ function transform_native_tsrx_function(node, context) {
 		body_statements.push(hash, b.stmt(b.call(b.id('_$_.output_register_css'), hash_id)));
 	}
 
-	const raw_render_body = get_native_tsrx_function_body(node);
+	const raw_render_body = get_native_tsrx_function_body(node, context.state.scopes);
 	const node_id = node.type !== 'ArrowFunctionExpression' ? (node.id ?? null) : null;
 	const render_scope_node = get_native_tsrx_return_template_node(
 		node.body,
@@ -1280,7 +1308,8 @@ function transform_native_tsrx_function(node, context) {
 			)
 		: [];
 	const render_body = strip_tsrx_style_elements(
-		insert_style_ref_setup_statements(raw_render_body, style_ref_setup),
+		insert_style_ref_setup_statements(raw_render_body, style_ref_setup, context.state.scopes),
+		context.state.scopes,
 	);
 	body_statements.push(
 		...transform_body(render_body, {
@@ -1323,6 +1352,32 @@ function transform_native_tsrx_function(node, context) {
 	const fn = b.function(node_id, component_params, component_body);
 	fn.metadata.native_tsrx_function = true;
 	return fn;
+}
+
+/**
+ * Returns the function's params with TypeScript annotations stripped and lazy
+ * destructuring patterns replaced by their generated identifiers, without
+ * mutating the original nodes.
+ * @param {AST.Pattern[]} params
+ * @returns {AST.Pattern[]}
+ */
+function strip_function_params(params) {
+	return params.map((param) => {
+		let stripped = param.typeAnnotation ? { ...param, typeAnnotation: undefined } : param;
+		// Handle AssignmentPattern (parameters with default values)
+		if (stripped.type === 'AssignmentPattern' && stripped.left?.typeAnnotation) {
+			stripped = { ...stripped, left: { ...stripped.left, typeAnnotation: undefined } };
+		}
+		// Replace lazy destructuring params with generated identifiers
+		const pattern = stripped.type === 'AssignmentPattern' ? stripped.left : stripped;
+		if (pattern.type === 'ObjectPattern' || pattern.type === 'ArrayPattern') {
+			const transformed_pattern = replace_lazy_param_pattern(pattern);
+			return stripped.type === 'AssignmentPattern'
+				? /** @type {AST.AssignmentPattern} */ ({ ...stripped, left: transformed_pattern })
+				: transformed_pattern;
+		}
+		return stripped;
+	});
 }
 
 /**
@@ -1501,15 +1556,17 @@ const visit_try_statement = (node, context) => {
 
 	const handler = node.handler;
 	if (handler) {
-		if (handler.param) {
-			delete handler.param.typeAnnotation;
-		}
+		const handler_param = handler.param
+			? handler.param.typeAnnotation
+				? /** @type {AST.Pattern} */ ({ ...handler.param, typeAnnotation: undefined })
+				: handler.param
+			: null;
 
 		/** @type {AST.Statement | null} */
 		let reset = null;
 		if (handler.resetParam) {
-			delete handler.resetParam.typeAnnotation;
-
+			// `resetParam` never reaches the output (only its name is read below),
+			// so its type annotation needs no stripping.
 			reset = b.const(
 				handler.resetParam.type === 'AssignmentPattern'
 					? /** @type {AST.Identifier} */ (handler.resetParam.left).name
@@ -1519,7 +1576,7 @@ const visit_try_statement = (node, context) => {
 		}
 
 		catch_fn = b.arrow(
-			[handler.param || b.id('error')],
+			[handler_param || b.id('error')],
 			b.block([
 				b.stmt(b.call(b.id('_$_.output_push'), b.literal(BLOCK_OPEN))),
 				...(reset ? [reset] : []),
@@ -1693,9 +1750,9 @@ const visitors = {
 	CallExpression(node, context) {
 		const { state } = context;
 
-		if (!state.to_ts) {
-			delete node.typeArguments;
-		}
+		// When lowering to JS the call's type arguments are dropped; the rebuilt
+		// nodes below override `typeArguments` instead of mutating `node`.
+		const type_arguments = state.to_ts ? node.typeArguments : undefined;
 
 		const callee = node.callee;
 
@@ -1713,6 +1770,7 @@ const visitors = {
 			if (ripple_runtime_method !== null) {
 				return {
 					...node,
+					typeArguments: type_arguments,
 					callee: b.member(b.id('_$_'), b.id(ripple_runtime_method)),
 					arguments: /** @type {(AST.Expression | AST.SpreadElement)[]} */ ([
 						...node.arguments.map((arg) => context.visit(arg)),
@@ -1727,12 +1785,10 @@ const visitors = {
 
 			/** @type {AST.BaseCallExpression['arguments']} */
 			const call_args = [];
-			if (node.arguments.length === 0) {
-				node.arguments.push(b.void0);
-			}
+			const track_args = node.arguments.length === 0 ? [b.void0] : node.arguments;
 
-			for (let i = 0; i < node.arguments.length; i++) {
-				const arg = node.arguments[i];
+			for (let i = 0; i < track_args.length; i++) {
+				const arg = track_args[i];
 				call_args.push(/** @type {(AST.Expression | AST.SpreadElement)} */ (context.visit(arg)));
 				if (i === 0) {
 					call_args.push(b.literal(node.metadata.hash));
@@ -1741,6 +1797,7 @@ const visitors = {
 
 			return {
 				...node,
+				typeArguments: type_arguments,
 				callee: b.member(b.id('_$_'), b.id(track_method_name)),
 				arguments: call_args,
 			};
@@ -1772,7 +1829,12 @@ const visitors = {
 			}
 		}
 
-		return context.next();
+		const walked = /** @type {AST.CallExpression | undefined} */ (context.next());
+		const result = walked ?? node;
+		if (!state.to_ts && result.typeArguments) {
+			return { ...result, typeArguments: undefined };
+		}
+		return walked;
 	},
 
 	JSXCodeBlock(node, context) {
@@ -1878,10 +1940,6 @@ const visitors = {
 	NewExpression(node, context) {
 		const callee = node.callee;
 
-		if (!context.state.to_ts) {
-			delete node.typeArguments;
-		}
-
 		// Transform `new RippleArray(...)`, `new RippleMap(...)`, etc. imported from 'ripple'
 		if (callee.type === 'Identifier' && is_ripple_import(callee, context)) {
 			const ripple_runtime_method = get_ripple_namespace_call_name(callee.name);
@@ -1895,26 +1953,37 @@ const visitors = {
 			}
 		}
 
-		return context.next();
+		const walked = /** @type {AST.NewExpression | undefined} */ (context.next());
+		const result = walked ?? node;
+		if (!context.state.to_ts && result.typeArguments) {
+			return { ...result, typeArguments: undefined };
+		}
+		return walked;
 	},
 
 	PropertyDefinition(node, context) {
-		if (!context.state.to_ts) {
-			delete node.typeAnnotation;
+		const walked = /** @type {AST.PropertyDefinition | undefined} */ (context.next());
+		const result = walked ?? node;
+		if (!context.state.to_ts && result.typeAnnotation) {
+			return { ...result, typeAnnotation: undefined };
 		}
-		return context.next();
+		return walked;
 	},
 
 	ClassDeclaration(node, context) {
 		if (!context.state.to_ts) {
-			strip_class_typescript_syntax(node, context);
+			// Returns a stripped copy with visited children — the source node is
+			// never mutated.
+			return strip_class_typescript_syntax(node, context);
 		}
 		return context.next();
 	},
 
 	ClassExpression(node, context) {
 		if (!context.state.to_ts) {
-			strip_class_typescript_syntax(node, context);
+			// Returns a stripped copy with visited children — the source node is
+			// never mutated.
+			return strip_class_typescript_syntax(node, context);
 		}
 		return context.next();
 	},
@@ -1933,25 +2002,15 @@ const visitors = {
 			return transform_native_tsrx_function(node, context);
 		}
 		if (!context.state.to_ts) {
-			delete node.returnType;
-			delete node.typeParameters;
-			for (let i = 0; i < node.params.length; i++) {
-				const param = node.params[i];
-				delete param.typeAnnotation;
-				// Handle AssignmentPattern (parameters with default values)
-				if (param.type === 'AssignmentPattern' && param.left) {
-					delete param.left.typeAnnotation;
-				}
-				// Replace lazy destructuring params with generated identifiers
-				const pattern = param.type === 'AssignmentPattern' ? param.left : param;
-				if (pattern.type === 'ObjectPattern' || pattern.type === 'ArrayPattern') {
-					const transformed_pattern = replace_lazy_param_pattern(pattern);
-					node.params[i] =
-						param.type === 'AssignmentPattern'
-							? /** @type {AST.AssignmentPattern} */ ({ ...param, left: transformed_pattern })
-							: transformed_pattern;
-				}
-			}
+			const params = strip_function_params(node.params);
+			return {
+				...node,
+				returnType: undefined,
+				typeParameters: undefined,
+				id: node.id ? /** @type {AST.Identifier} */ (context.visit(node.id)) : node.id,
+				params: params.map((param) => /** @type {AST.Pattern} */ (context.visit(param))),
+				body: /** @type {AST.BlockStatement} */ (context.visit(node.body)),
+			};
 		}
 		return context.next();
 	},
@@ -1961,25 +2020,15 @@ const visitors = {
 			return transform_native_tsrx_function(node, context);
 		}
 		if (!context.state.to_ts) {
-			delete node.returnType;
-			delete node.typeParameters;
-			for (let i = 0; i < node.params.length; i++) {
-				const param = node.params[i];
-				delete param.typeAnnotation;
-				// Handle AssignmentPattern (parameters with default values)
-				if (param.type === 'AssignmentPattern' && param.left) {
-					delete param.left.typeAnnotation;
-				}
-				// Replace lazy destructuring params with generated identifiers
-				const pattern = param.type === 'AssignmentPattern' ? param.left : param;
-				if (pattern.type === 'ObjectPattern' || pattern.type === 'ArrayPattern') {
-					const transformed_pattern = replace_lazy_param_pattern(pattern);
-					node.params[i] =
-						param.type === 'AssignmentPattern'
-							? /** @type {AST.AssignmentPattern} */ ({ ...param, left: transformed_pattern })
-							: transformed_pattern;
-				}
-			}
+			const params = strip_function_params(node.params);
+			return {
+				...node,
+				returnType: undefined,
+				typeParameters: undefined,
+				id: node.id ? /** @type {AST.Identifier} */ (context.visit(node.id)) : node.id,
+				params: params.map((param) => /** @type {AST.Pattern} */ (context.visit(param))),
+				body: /** @type {AST.BlockStatement} */ (context.visit(node.body)),
+			};
 		}
 		return context.next();
 	},
@@ -2002,27 +2051,12 @@ const visitors = {
 		if (is_tsrx_component_function(node)) {
 			return transform_native_tsrx_function(node, context);
 		}
-		delete node.returnType;
-		delete node.typeParameters;
-		const params = node.params.map((param) => {
-			delete param.typeAnnotation;
-			// Handle AssignmentPattern (parameters with default values)
-			if (param.type === 'AssignmentPattern' && param.left) {
-				delete param.left.typeAnnotation;
-			}
-			// Replace lazy destructuring params with generated identifiers
-			const pattern = param.type === 'AssignmentPattern' ? param.left : param;
-			if (pattern.type === 'ObjectPattern' || pattern.type === 'ArrayPattern') {
-				const transformed_pattern = replace_lazy_param_pattern(pattern);
-				return param.type === 'AssignmentPattern'
-					? /** @type {AST.AssignmentPattern} */ ({ ...param, left: transformed_pattern })
-					: transformed_pattern;
-			}
-			return param;
-		});
+		const params = strip_function_params(node.params);
 
 		return {
 			...node,
+			returnType: undefined,
+			typeParameters: undefined,
 			params: params.map((param) => /** @type {AST.Pattern} */ (context.visit(param))),
 			body:
 				node.body.type === 'BlockStatement'
@@ -2222,7 +2256,8 @@ const visitors = {
 			return context.next();
 		}
 
-		lower_dynamic_element(node, b.member(b.id('_$_'), 'dynamic_element'));
+		node =
+			lower_dynamic_element(node, b.member(b.id('_$_'), 'dynamic_element'), state.scopes) ?? node;
 
 		const element_id = get_element_id(node);
 		const element_attributes = get_element_attributes(node);
@@ -2830,13 +2865,13 @@ const visitors = {
 
 			/** @type {AST.VariableDeclaration[]} */
 			const locals = state.server_block_locals;
-			for (const spec of node.specifiers) {
+			const specifiers = node.specifiers.map((spec) => {
 				const original_name = spec.local.name;
 				const name = obfuscateIdentifier(original_name);
-				spec.local = b.id(name);
 				locals.push(b.const(original_name, b.id(name)));
-			}
-			state.imports.add(node);
+				return { ...spec, local: b.id(name) };
+			});
+			state.imports.add(/** @type {AST.ImportDeclaration} */ ({ ...node, specifiers }));
 			return b.empty;
 		}
 
@@ -3249,8 +3284,7 @@ function thread_statement_list(list, out_id) {
 			pending.push(arg);
 		} else if (CONTAINER_TYPES.has(stmt.type) && !container_header_branches(stmt)) {
 			commit();
-			thread_container(stmt, out_id);
-			out.push(stmt);
+			out.push(thread_container(stmt, out_id));
 		} else if (stmt.type === 'ReturnStatement' || contains_branching_call(stmt)) {
 			flush();
 			out.push(stmt);
@@ -3266,47 +3300,63 @@ function thread_statement_list(list, out_id) {
 }
 
 /**
- * Threads the accumulator into a container's body slot(s), in place.
+ * Threads the accumulator into a container's body slot(s), copy-on-write:
+ * returns a rebuilt statement instead of mutating the original.
  * @param {AST.Statement} stmt
  * @param {string} out_id
- * @returns {void}
+ * @returns {AST.Statement}
  */
 function thread_container(stmt, out_id) {
 	/** @param {AST.Statement} node @returns {AST.Statement} */
 	const body_slot = (node) => {
 		if (node.type === 'BlockStatement') {
-			node.body = thread_statement_list(node.body, out_id);
-			return node;
+			return { ...node, body: thread_statement_list(node.body, out_id) };
 		}
 		return b.block(thread_statement_list([node], out_id));
 	};
 	switch (stmt.type) {
 		case 'BlockStatement':
-			stmt.body = thread_statement_list(stmt.body, out_id);
-			break;
+			return { ...stmt, body: thread_statement_list(stmt.body, out_id) };
 		case 'IfStatement':
-			stmt.consequent = body_slot(stmt.consequent);
-			if (stmt.alternate) stmt.alternate = body_slot(stmt.alternate);
-			break;
+			return {
+				...stmt,
+				consequent: body_slot(stmt.consequent),
+				alternate: stmt.alternate ? body_slot(stmt.alternate) : stmt.alternate,
+			};
 		case 'ForStatement':
 		case 'ForInStatement':
 		case 'ForOfStatement':
 		case 'WhileStatement':
 		case 'DoWhileStatement':
 		case 'LabeledStatement':
-			stmt.body = body_slot(stmt.body);
-			break;
+			return { ...stmt, body: body_slot(stmt.body) };
 		case 'SwitchStatement':
-			for (const switch_case of stmt.cases) {
-				switch_case.consequent = thread_statement_list(switch_case.consequent, out_id);
-			}
-			break;
+			return {
+				...stmt,
+				cases: stmt.cases.map((switch_case) => ({
+					...switch_case,
+					consequent: thread_statement_list(switch_case.consequent, out_id),
+				})),
+			};
 		case 'TryStatement':
-			stmt.block.body = thread_statement_list(stmt.block.body, out_id);
-			if (stmt.handler)
-				stmt.handler.body.body = thread_statement_list(stmt.handler.body.body, out_id);
-			if (stmt.finalizer) stmt.finalizer.body = thread_statement_list(stmt.finalizer.body, out_id);
-			break;
+			return {
+				...stmt,
+				block: { ...stmt.block, body: thread_statement_list(stmt.block.body, out_id) },
+				handler: stmt.handler
+					? {
+							...stmt.handler,
+							body: {
+								...stmt.handler.body,
+								body: thread_statement_list(stmt.handler.body.body, out_id),
+							},
+						}
+					: stmt.handler,
+				finalizer: stmt.finalizer
+					? { ...stmt.finalizer, body: thread_statement_list(stmt.finalizer.body, out_id) }
+					: stmt.finalizer,
+			};
+		default:
+			return stmt;
 	}
 }
 
@@ -3382,34 +3432,58 @@ function fresh_accumulator_name(body) {
  * and flush before every branching statement and at block end. So a child block's
  * slot always follows what the parent already flushed: we never accumulate across
  * a block boundary.
+ *
+ * Copy-on-write: the input tree is never mutated — changed spines are rebuilt
+ * and the rebuilt program is returned. A shared subtree is rewritten once and
+ * every occurrence points at the same rewritten copy (mirroring the old
+ * in-place semantics).
  * @param {AST.Program} program
- * @returns {void}
+ * @returns {AST.Program}
  */
 function accumulate_output_pushes(program) {
-	const seen = new WeakSet();
-	/** @param {unknown} node */
+	/** @type {WeakMap<object, unknown>} */
+	const cache = new WeakMap();
+	/** @param {unknown} node @returns {unknown} */
 	const recurse = (node) => {
 		if (Array.isArray(node)) {
-			for (const child of node) recurse(child);
-			return;
+			/** @type {unknown[] | null} */
+			let copy = null;
+			for (let i = 0; i < node.length; i++) {
+				const next = recurse(node[i]);
+				if (next !== node[i]) {
+					copy ??= node.slice();
+					copy[i] = next;
+				}
+			}
+			return copy ?? node;
 		}
-		if (!is_traversable_ast_node(node)) return;
-		if (seen.has(node)) return;
-		seen.add(node);
+		if (!is_traversable_ast_node(node)) return node;
+		if (cache.has(node)) return cache.get(node);
+		// Guard against cycles: re-entry resolves to the original node.
+		cache.set(node, node);
+
+		/** @type {Record<string, any>} */
+		let result = node;
 
 		if (isFunctionNode(node)) {
 			const body = /** @type {AST.Function} */ (node).body;
 			if (body && body.type === 'BlockStatement' && has_direct_output_push(body.body)) {
 				const out_id = fresh_accumulator_name(body.body);
-				body.body = [
-					b.let(b.id(out_id), b.literal('')),
-					...thread_statement_list(body.body, out_id),
-					b.stmt(b.call(b.id('_$_.output_push'), b.id(out_id))),
-				];
+				result = {
+					...node,
+					body: {
+						...body,
+						body: [
+							b.let(b.id(out_id), b.literal('')),
+							...thread_statement_list(body.body, out_id),
+							b.stmt(b.call(b.id('_$_.output_push'), b.id(out_id))),
+						],
+					},
+				};
 			}
 		}
 
-		for (const key in node) {
+		for (const key in result) {
 			if (
 				key === 'metadata' ||
 				key === 'loc' ||
@@ -3419,10 +3493,18 @@ function accumulate_output_pushes(program) {
 			) {
 				continue;
 			}
-			recurse(node[key]);
+			const child = result[key];
+			const next = recurse(child);
+			if (next !== child) {
+				if (result === node) result = { .../** @type {Record<string, any>} */ (node) };
+				result[key] = next;
+			}
 		}
+
+		cache.set(node, result);
+		return result;
 	};
-	recurse(program);
+	return /** @type {AST.Program} */ (recurse(program));
 }
 
 /**
@@ -3462,18 +3544,6 @@ export function transform_server(filename, source, analysis, minify_css, dev = f
 
 	const { css, cssHash } = renderCssResult(state.stylesheets, minify_css);
 
-	// Register each stylesheet's CSS so the runtime can serialize it
-	if (css) {
-		for (const stylesheet of state.stylesheets) {
-			const css_for_component = renderStylesheets([stylesheet]);
-			/** @type {AST.Program} */ (program).body.push(
-				b.stmt(
-					b.call('_$_.register_css', b.literal(stylesheet.hash), b.literal(css_for_component)),
-				),
-			);
-		}
-	}
-
 	/** @type {AST.Program['body']} */
 	let body = [];
 
@@ -3487,13 +3557,25 @@ export function transform_server(filename, source, analysis, minify_css, dev = f
 
 	body.push(...program.body);
 
-	program.body = body;
+	// Register each stylesheet's CSS so the runtime can serialize it
+	if (css) {
+		for (const stylesheet of state.stylesheets) {
+			const css_for_component = renderStylesheets([stylesheet]);
+			body.push(
+				b.stmt(
+					b.call('_$_.register_css', b.literal(stylesheet.hash), b.literal(css_for_component)),
+				),
+			);
+		}
+	}
+
+	program = /** @type {AST.Program} */ ({ ...program, body });
 
 	// Accumulate each runtime block's output into a single `__out` string and
 	// push it once per block (flushing only before a child block) so the whole
 	// `@for` feed lands in one push. Stays within block boundaries by
 	// construction (see accumulate_output_pushes).
-	accumulate_output_pushes(/** @type {AST.Program} */ (program));
+	program = accumulate_output_pushes(/** @type {AST.Program} */ (program));
 
 	const { code, map } = print(
 		program,

--- a/packages/tsrx-ripple/src/transform/server/index.js
+++ b/packages/tsrx-ripple/src/transform/server/index.js
@@ -268,7 +268,7 @@ function build_jsx_to_tsrx_element(node, context) {
 }
 
 /**
- * @param {ESTreeJSX.JSXElement | ESTreeJSX.JSXFragment} node
+ * @param {AST.TSRXJSXElement | AST.TSRXJSXFragment} node
  * @param {TransformServerContext} context
  * @returns {AST.CallExpression}
  */
@@ -825,7 +825,7 @@ function is_head_element(node) {
 }
 
 /**
- * @param {ESTreeJSX.JSXElement} node
+ * @param {AST.TSRXJSXElement} node
  * @param {TransformServerContext} context
  * @returns {boolean}
  */
@@ -844,7 +844,7 @@ function is_ripple_fragment_element(node, context) {
 }
 
 /**
- * @param {ESTreeJSX.JSXElement} node
+ * @param {AST.TSRXJSXElement} node
  * @returns {ESTreeJSX.JSXAttribute | null}
  */
 function get_inner_html_attribute(node) {
@@ -934,7 +934,7 @@ function push_inner_html_expression(expression, state) {
 }
 
 /**
- * @param {ESTreeJSX.JSXElement} node
+ * @param {AST.TSRXJSXElement} node
  * @param {TransformServerContext} context
  * @returns {void}
  */
@@ -985,7 +985,7 @@ function transform_variable_declaration(node, context) {
 		const declarator_init = /** @type {AST.Node | null | undefined} */ (declarator.init);
 		const init = is_template_fragment(declarator_init)
 			? build_template_node_to_tsrx_element(
-					/** @type {ESTreeJSX.JSXFragment} */ (declarator_init),
+					/** @type {AST.TSRXJSXFragment} */ (declarator_init),
 					context,
 				)
 			: declarator_init
@@ -1876,10 +1876,6 @@ const visitors = {
 		// at analysis time and injected separately.
 	},
 
-	/**
-	 * @param {any} node
-	 * @param {TransformServerContext} context
-	 */
 	JSXElement(node, context) {
 		const { state, visit } = context;
 
@@ -2547,7 +2543,7 @@ const visitors = {
 		if (!context.state.to_ts && is_native_tsrx_template_node(node.argument)) {
 			return b.return(
 				build_template_node_to_tsrx_element(
-					/** @type {ESTreeJSX.JSXElement | ESTreeJSX.JSXFragment} */ (
+					/** @type {AST.TSRXJSXElement | AST.TSRXJSXFragment} */ (
 						/** @type {unknown} */ (node.argument)
 					),
 					context,

--- a/packages/tsrx-ripple/src/transform/server/index.js
+++ b/packages/tsrx-ripple/src/transform/server/index.js
@@ -19,7 +19,6 @@ import {
 	renderCssResult,
 	renderStylesheets,
 	prepareStylesheetForRender,
-	pruneCss,
 	collectStyleRefAttributes,
 	createStyleClassMap,
 	createStyleClassMapFromStylesheet,
@@ -106,50 +105,6 @@ function is_traversable_ast_node(value) {
 }
 
 /**
- * Re-run CSS pruning on JSX converted into Ripple template nodes so server
- * output applies the same scoped metadata as regular Ripple template elements.
- *
- * @param {AST.Node[]} nodes
- * @param {TransformServerState} state
- * @returns {void}
- */
-function apply_tsrx_css_scoping(nodes, state) {
-	const component = state.component;
-	const css = get_component_css(state);
-	if (!component || !css) {
-		return;
-	}
-	const stylesheet = /** @type {AST.CSS.StyleSheet} */ (css);
-
-	const style_classes = /** @type {any} */ (component.metadata).styleClasses ?? new Map();
-	const top_scoped_classes = /** @type {any} */ (component.metadata).topScopedClasses ?? new Map();
-
-	/**
-	 * @param {AST.Node} node
-	 * @returns {void}
-	 */
-	function visit_node(node) {
-		if (node.type === 'Element') {
-			pruneCss(stylesheet, node, style_classes, top_scoped_classes);
-			for (const child of node.children) {
-				visit_node(child);
-			}
-			return;
-		}
-
-		if ('children' in node && Array.isArray(node.children)) {
-			for (const child of node.children) {
-				visit_node(/** @type {AST.Node} */ (child));
-			}
-		}
-	}
-
-	for (const node of nodes) {
-		visit_node(node);
-	}
-}
-
-/**
  * @param {TransformServerState} state
  * @returns {AST.CSS.StyleSheet | null}
  */
@@ -167,7 +122,7 @@ function get_component_css_hash(state) {
 }
 
 /**
- * @param {AST.Element} node
+ * @param {AST.JSXStyleElement} node
  * @param {TransformServerContext} context
  * @returns {AST.ObjectExpression | null}
  */
@@ -294,8 +249,6 @@ function build_jsx_to_tsrx_element(node, context) {
 	/** @type {AST.Node[]} */
 	const children = converted.filter((child) => child != null && child.type !== 'EmptyStatement');
 
-	apply_tsrx_css_scoping(children, state);
-
 	/** @type {AST.Statement[]} */
 	const init = [];
 	transform_children(
@@ -315,14 +268,16 @@ function build_jsx_to_tsrx_element(node, context) {
 }
 
 /**
- * @param {AST.Element | ESTreeJSX.JSXFragment} node
+ * @param {ESTreeJSX.JSXElement | ESTreeJSX.JSXFragment} node
  * @param {TransformServerContext} context
  * @returns {AST.CallExpression}
  */
 function build_template_node_to_tsrx_element(node, context) {
 	const { visit, state, path } = context;
 	const children = is_template_fragment(node)
-		? node.children.filter((child) => child != null && child.type !== 'EmptyStatement')
+		? /** @type {AST.Node[]} */ (node.children).filter(
+				(child) => child != null && child.type !== 'EmptyStatement',
+			)
 		: [
 				{
 					...node,
@@ -332,8 +287,6 @@ function build_template_node_to_tsrx_element(node, context) {
 					},
 				},
 			];
-
-	apply_tsrx_css_scoping(children, state);
 
 	/** @type {AST.Statement[]} */
 	const init = [];
@@ -774,7 +727,7 @@ function node_leads_with_control_flow(node, context) {
 			);
 		case 'JSXFragment':
 			return fragment_leads_with_control_flow(
-				rendered_template_children(node.children, false),
+				rendered_template_children(/** @type {AST.Node[]} */ (node.children), false),
 				context,
 			);
 		case 'JSXCodeBlock':
@@ -872,7 +825,7 @@ function is_head_element(node) {
 }
 
 /**
- * @param {AST.Element} node
+ * @param {ESTreeJSX.JSXElement} node
  * @param {TransformServerContext} context
  * @returns {boolean}
  */
@@ -891,7 +844,7 @@ function is_ripple_fragment_element(node, context) {
 }
 
 /**
- * @param {AST.Element} node
+ * @param {ESTreeJSX.JSXElement} node
  * @returns {ESTreeJSX.JSXAttribute | null}
  */
 function get_inner_html_attribute(node) {
@@ -981,7 +934,7 @@ function push_inner_html_expression(expression, state) {
 }
 
 /**
- * @param {AST.Element} node
+ * @param {ESTreeJSX.JSXElement} node
  * @param {TransformServerContext} context
  * @returns {void}
  */
@@ -993,7 +946,7 @@ function visit_ripple_fragment_element(node, context) {
 		return;
 	}
 
-	transform_children(node.children, context);
+	transform_children(/** @type {AST.Node[]} */ (node.children), context);
 }
 
 /**
@@ -1031,7 +984,10 @@ function transform_variable_declaration(node, context) {
 
 		const declarator_init = /** @type {AST.Node | null | undefined} */ (declarator.init);
 		const init = is_template_fragment(declarator_init)
-			? build_template_node_to_tsrx_element(declarator_init, context)
+			? build_template_node_to_tsrx_element(
+					/** @type {ESTreeJSX.JSXFragment} */ (declarator_init),
+					context,
+				)
 			: declarator_init
 				? /** @type {AST.Expression} */ (
 						context.visit(declarator_init, { ...context.state, template_child: false })
@@ -1158,7 +1114,7 @@ function transform_children(children, context) {
 		}
 	}
 
-	const head_elements = /** @type {AST.Element[]} */ (
+	const head_elements = /** @type {ESTreeJSX.JSXElement[]} */ (
 		children.filter((node) => is_head_element(node))
 	);
 
@@ -1174,7 +1130,7 @@ function transform_children(children, context) {
 			// Emit hydration marker comment with hash
 			state.init?.push(b.stmt(b.call(b.id('_$_.output_push'), b.literal(`<!--${hash_value}-->`))));
 
-			transform_children(head_element.children, {
+			transform_children(/** @type {AST.Node[]} */ (head_element.children), {
 				...context,
 				state: { ...state, skip_regular_blocks: true },
 			});
@@ -1208,20 +1164,22 @@ function transform_body(body, context) {
 /**
  * @param {AST.Node | null | undefined} node
  * @param {boolean} [allow_direct_template]
- * @returns {AST.Element | ESTreeJSX.JSXFragment | null}
+ * @returns {ESTreeJSX.JSXElement | ESTreeJSX.JSXFragment | null}
  */
 function get_native_tsrx_return_template_node(node, allow_direct_template = false) {
 	if (!node) return null;
 	if (allow_direct_template && is_native_tsrx_template_node(node)) {
-		return /** @type {AST.Element | ESTreeJSX.JSXFragment} */ (/** @type {unknown} */ (node));
+		return /** @type {ESTreeJSX.JSXElement | ESTreeJSX.JSXFragment} */ (
+			/** @type {unknown} */ (node)
+		);
 	}
 	if (node.type === 'ReturnStatement' && is_native_tsrx_template_node(node.argument)) {
-		return /** @type {AST.Element | ESTreeJSX.JSXFragment} */ (
+		return /** @type {ESTreeJSX.JSXElement | ESTreeJSX.JSXFragment} */ (
 			/** @type {unknown} */ (node.argument)
 		);
 	}
 	if (node.type === 'JSXCodeBlock' && is_native_tsrx_template_node(node.render)) {
-		return /** @type {AST.Element | ESTreeJSX.JSXFragment} */ (
+		return /** @type {ESTreeJSX.JSXElement | ESTreeJSX.JSXFragment} */ (
 			/** @type {unknown} */ (node.render)
 		);
 	}
@@ -1527,10 +1485,9 @@ const visitors = {
 		}
 
 		const { visit, state } = context;
-		const children = node.children.filter(
+		const children = /** @type {AST.Node[]} */ (node.children).filter(
 			(child) => child != null && child.type !== 'EmptyStatement',
 		);
-		apply_tsrx_css_scoping(children, state);
 
 		/** @type {AST.Statement[]} */
 		const init = [];
@@ -1919,6 +1876,10 @@ const visitors = {
 		// at analysis time and injected separately.
 	},
 
+	/**
+	 * @param {any} node
+	 * @param {TransformServerContext} context
+	 */
 	JSXElement(node, context) {
 		const { state, visit } = context;
 
@@ -2305,7 +2266,8 @@ const visitors = {
 			}
 
 			const children_filtered = node.children.filter(
-				(child) => child.type !== 'EmptyStatement' && !is_native_tsrx_function_node(child),
+				(/** @type {any} */ child) =>
+					child.type !== 'EmptyStatement' && !is_native_tsrx_function_node(child),
 			);
 
 			if (children_filtered.length > 0) {
@@ -2585,7 +2547,7 @@ const visitors = {
 		if (!context.state.to_ts && is_native_tsrx_template_node(node.argument)) {
 			return b.return(
 				build_template_node_to_tsrx_element(
-					/** @type {AST.Element | ESTreeJSX.JSXFragment} */ (
+					/** @type {ESTreeJSX.JSXElement | ESTreeJSX.JSXFragment} */ (
 						/** @type {unknown} */ (node.argument)
 					),
 					context,

--- a/packages/tsrx-ripple/src/transform/server/index.js
+++ b/packages/tsrx-ripple/src/transform/server/index.js
@@ -75,6 +75,7 @@ import {
 	unwrap_single_return_iife,
 	wrap_code_block_in_iife,
 	visit_directive_wrapping_values,
+	replace_with_statements,
 	get_code_block_render,
 	get_code_block_template_child,
 	lower_code_block_children,
@@ -115,8 +116,7 @@ function is_traversable_ast_node(value) {
  * @returns {AST.CSS.StyleSheet | null}
  */
 function get_component_css(state) {
-	const component = /** @type {any} */ (state.component);
-	return component?.css ?? component?.metadata?.css ?? null;
+	return state.component?.metadata.component_css ?? null;
 }
 
 /**
@@ -1632,7 +1632,7 @@ const visit_try_statement = (node, context) => {
 
 /**
  * Shared by the plain statement and the `@`-directive forms.
- * @type {Visitor<AST.ForOfStatement | AST.JSXForExpression, TransformServerState, AST.Node>}
+ * @type {Visitor<AST.ForOfStatement | AST.JSXForOfExpression, TransformServerState, AST.Node>}
  */
 const visit_for_of_statement = (node, context) => {
 	if (context.state.regular_js) {
@@ -2873,7 +2873,7 @@ const visitors = {
 		const { state } = context;
 
 		if (get_submodule_import_source_name(node) === 'server') {
-			return /** @type {any} */ (transform_server_module_import(node));
+			return replace_with_statements(transform_server_module_import(node));
 		}
 
 		if (!state.to_ts && node.importKind === 'type') {

--- a/packages/tsrx-ripple/src/transform/server/index.js
+++ b/packages/tsrx-ripple/src/transform/server/index.js
@@ -5,6 +5,7 @@
 @import {
 	TransformServerContext,
 	TransformServerState,
+	Visitor,
 	Visitors,
 	AnalysisResult,
 	ScopeInterface,
@@ -85,6 +86,7 @@ import {
 	is_empty_expression_container,
 	is_self_closing,
 	is_template_element,
+	is_template_directive,
 	is_template_fragment,
 	is_template_text,
 	rendered_template_children,
@@ -648,6 +650,7 @@ function is_template_or_control_flow(node) {
 		node.type === 'JSXExpressionContainer' ||
 		node.type === 'JSXText' ||
 		is_template_fragment(node) ||
+		is_template_directive(node) ||
 		node.type === 'IfStatement' ||
 		node.type === 'ForOfStatement' ||
 		node.type === 'TryStatement' ||
@@ -702,6 +705,11 @@ function tsrx_expression_emits_marker(node, context) {
  */
 function node_leads_with_control_flow(node, context) {
 	switch (node.type) {
+		case 'JSXIfExpression':
+		case 'JSXForExpression':
+		case 'JSXSwitchExpression':
+		case 'JSXTryExpression':
+			return true;
 		case 'IfStatement':
 		case 'ForOfStatement':
 		case 'SwitchStatement':
@@ -791,7 +799,8 @@ function is_native_tsrx_statement_position(path) {
 		parent?.type === 'DoWhileStatement' ||
 		parent?.type === 'TryStatement' ||
 		parent?.type === 'SwitchStatement' ||
-		parent?.type === 'LabeledStatement'
+		parent?.type === 'LabeledStatement' ||
+		is_template_directive(parent)
 	);
 }
 
@@ -813,7 +822,11 @@ function is_native_tsrx_value_position(path) {
  * @returns {boolean}
  */
 function should_wrap_node_in_regular_block(node) {
-	return is_template_or_control_flow(node) && node.type !== 'TryStatement';
+	return (
+		is_template_or_control_flow(node) &&
+		node.type !== 'TryStatement' &&
+		node.type !== 'JSXTryExpression'
+	);
 }
 
 /**
@@ -1311,6 +1324,327 @@ function transform_native_tsrx_function(node, context) {
 	fn.metadata.native_tsrx_function = true;
 	return fn;
 }
+
+/**
+ * Shared by the plain statement and the `@`-directive forms.
+ * @type {Visitor<AST.SwitchStatement | AST.JSXSwitchExpression, TransformServerState, AST.Node>}
+ */
+const visit_switch_statement = (node, context) => {
+	if (context.state.regular_js) {
+		return context.next();
+	}
+
+	if (!is_inside_component(context)) {
+		return context.next();
+	}
+
+	const cases = [];
+
+	for (const switch_case of node.cases) {
+		const case_body = [];
+
+		if (switch_case.consequent.length !== 0) {
+			const flattened_consequent = flatten_switch_consequent(switch_case.consequent);
+			const consequent_scope =
+				context.state.scopes.get(switch_case.consequent) || context.state.scope;
+			const consequent = b.block(
+				transform_body(flattened_consequent, {
+					...context,
+					state: {
+						...context.state,
+						scope: consequent_scope,
+						control_flow_branch_body: true,
+					},
+				}),
+			);
+			case_body.push(...consequent.body);
+		}
+		case_body.push(b.break);
+
+		cases.push(
+			b.switch_case(
+				switch_case.test ? /** @type {AST.Expression} */ (context.visit(switch_case.test)) : null,
+				case_body,
+			),
+		);
+	}
+
+	context.state.init?.push(b.stmt(b.call(b.id('_$_.output_push'), b.literal(BLOCK_OPEN))));
+
+	context.state.init?.push(
+		b.switch(/** @type {AST.Expression} */ (context.visit(node.discriminant)), cases),
+	);
+
+	context.state.init?.push(b.stmt(b.call(b.id('_$_.output_push'), b.literal(BLOCK_CLOSE))));
+};
+
+/**
+ * Shared by the plain statement and the `@`-directive forms.
+ * @type {Visitor<AST.IfStatement | AST.JSXIfExpression, TransformServerState, AST.Node>}
+ */
+const visit_if_statement = (node, context) => {
+	if (context.state.regular_js || node.metadata?.regular_js) {
+		return context.next({ ...context.state, regular_js: true });
+	}
+
+	if (!is_inside_component(context)) {
+		context.next();
+		return;
+	}
+
+	const consequent_body =
+		node.consequent.type === 'BlockStatement' ? node.consequent.body : [node.consequent];
+	const consequent_scope = context.state.scopes.get(node.consequent) || context.state.scope;
+
+	if (
+		(node.metadata?.script_only || node.metadata?.has_continue) &&
+		!node.metadata?.has_template &&
+		!node.alternate
+	) {
+		context.state.init?.push(
+			b.if(
+				/** @type {AST.Expression} */ (context.visit(node.test)),
+				b.block(
+					transform_body(consequent_body, {
+						...context,
+						state: { ...context.state, scope: consequent_scope },
+					}),
+				),
+			),
+		);
+		return;
+	}
+
+	const consequent = b.block(
+		transform_body(consequent_body, {
+			...context,
+			state: {
+				...context.state,
+				scope: /** @type {ScopeInterface} */ (consequent_scope),
+				control_flow_branch_body: true,
+			},
+		}),
+	);
+
+	context.state.init?.push(b.stmt(b.call(b.id('_$_.output_push'), b.literal(BLOCK_OPEN))));
+
+	/** @type {AST.BlockStatement | AST.IfStatement | null} */
+	let alternate = null;
+	if (node.alternate) {
+		const alternate_scope = context.state.scopes.get(node.alternate) || context.state.scope;
+		const alternate_body_nodes =
+			node.alternate.type === 'IfStatement'
+				? [node.alternate]
+				: node.alternate.type === 'BlockStatement'
+					? node.alternate.body
+					: [node.alternate];
+
+		alternate = b.block(
+			transform_body(alternate_body_nodes, {
+				...context,
+				state: {
+					...context.state,
+					scope: alternate_scope,
+					control_flow_branch_body: node.alternate.type !== 'IfStatement',
+				},
+			}),
+		);
+	}
+
+	context.state.init?.push(
+		b.if(/** @type {AST.Expression} */ (context.visit(node.test)), consequent, alternate),
+	);
+
+	context.state.init?.push(b.stmt(b.call(b.id('_$_.output_push'), b.literal(BLOCK_CLOSE))));
+};
+
+/**
+ * Shared by the plain statement and the `@`-directive forms.
+ * @type {Visitor<AST.TryStatement | AST.JSXTryExpression, TransformServerState, AST.Node>}
+ */
+const visit_try_statement = (node, context) => {
+	if (context.state.regular_js) {
+		return context.next();
+	}
+
+	if (!is_inside_component(context)) {
+		return context.next();
+	}
+
+	const has_pending = node.pending !== null;
+	const has_catch = node.handler !== null;
+
+	const body = transform_body(node.block.body, {
+		...context,
+		state: {
+			...context.state,
+			scope: /** @type {ScopeInterface} */ (context.state.scopes.get(node.block)),
+		},
+	});
+
+	// Wrap try_fn body with hydration markers when pending or catch is present
+	const try_fn = b.arrow(
+		[],
+		b.block(
+			has_pending || has_catch
+				? [
+						b.stmt(b.call(b.id('_$_.output_push'), b.literal(BLOCK_OPEN))),
+						...body,
+						b.stmt(b.call(b.id('_$_.output_push'), b.literal(BLOCK_CLOSE))),
+					]
+				: body,
+		),
+	);
+
+	/** @type {AST.Expression} */
+	let catch_fn = b.literal(null);
+
+	const handler = node.handler;
+	if (handler) {
+		if (handler.param) {
+			delete handler.param.typeAnnotation;
+		}
+
+		/** @type {AST.Statement | null} */
+		let reset = null;
+		if (handler.resetParam) {
+			delete handler.resetParam.typeAnnotation;
+
+			reset = b.const(
+				handler.resetParam.type === 'AssignmentPattern'
+					? /** @type {AST.Identifier} */ (handler.resetParam.left).name
+					: /** @type {AST.Identifier} */ (handler.resetParam).name,
+				b.id('_$_.noop'),
+			);
+		}
+
+		catch_fn = b.arrow(
+			[handler.param || b.id('error')],
+			b.block([
+				b.stmt(b.call(b.id('_$_.output_push'), b.literal(BLOCK_OPEN))),
+				...(reset ? [reset] : []),
+				...transform_body(handler.body.body, {
+					...context,
+					state: {
+						...context.state,
+						scope: /** @type {ScopeInterface} */ (context.state.scopes.get(handler.body)),
+					},
+				}),
+				b.stmt(b.call(b.id('_$_.output_push'), b.literal(BLOCK_CLOSE))),
+			]),
+		);
+	}
+
+	const pending_body = node.pending
+		? transform_body(node.pending.body, {
+				...context,
+				state: {
+					...context.state,
+					scope: /** @type {ScopeInterface} */ (context.state.scopes.get(node.pending)),
+				},
+			})
+		: null;
+
+	// Wrap pending_fn body with hydration markers
+	const pending_fn =
+		pending_body !== null
+			? b.arrow(
+					[],
+					b.block([
+						b.stmt(b.call(b.id('_$_.output_push'), b.literal(BLOCK_OPEN))),
+						...pending_body,
+						b.stmt(b.call(b.id('_$_.output_push'), b.literal(BLOCK_CLOSE))),
+					]),
+				)
+			: b.literal(null);
+
+	context.state.init?.push(b.stmt(b.call('_$_.try_block', try_fn, catch_fn, pending_fn)));
+};
+
+/**
+ * Shared by the plain statement and the `@`-directive forms.
+ * @type {Visitor<AST.ForOfStatement | AST.JSXForExpression, TransformServerState, AST.Node>}
+ */
+const visit_for_of_statement = (node, context) => {
+	if (context.state.regular_js) {
+		return context.next();
+	}
+
+	if (!is_inside_component(context)) {
+		context.next();
+		return;
+	}
+	const body_scope = context.state.scopes.get(node.body);
+
+	if (node.metadata?.script_only && !node.metadata?.has_template) {
+		const body = transform_body(/** @type {AST.BlockStatement} */ (node.body).body, {
+			...context,
+			state: { ...context.state, scope: /** @type {ScopeInterface} */ (body_scope) },
+		});
+
+		if (node.index) {
+			context.state.init?.push(b.var(node.index, b.literal(0)));
+			body.push(b.stmt(b.update('++', node.index)));
+		}
+
+		context.state.init?.push(
+			b.for_of(
+				/** @type {AST.VariableDeclaration} */ (context.visit(/** @type {AST.Node} */ (node.left))),
+				/** @type {AST.Expression} */
+				(context.visit(/** @type {AST.Node} */ (node.right))),
+				b.block(body),
+			),
+		);
+		return;
+	}
+
+	context.state.init?.push(b.stmt(b.call(b.id('_$_.output_push'), b.literal(BLOCK_OPEN))));
+
+	const body = transform_body(/** @type {AST.BlockStatement} */ (node.body).body, {
+		...context,
+		state: {
+			...context.state,
+			scope: /** @type {ScopeInterface} */ (body_scope),
+			control_flow_branch_body: true,
+		},
+	});
+	const empty_id = node.empty ? b.id(context.state.scope.generate('for_empty')) : null;
+
+	if (node.index) {
+		context.state.init?.push(b.var(node.index, b.literal(0)));
+		body.push(b.stmt(b.update('++', node.index)));
+	}
+	if (empty_id) {
+		context.state.init?.push(b.var(empty_id, b.true));
+		body.unshift(b.stmt(b.assignment('=', empty_id, b.false)));
+	}
+
+	context.state.init?.push(
+		b.for_of(
+			/** @type {AST.VariableDeclaration} */ (context.visit(/** @type {AST.Node} */ (node.left))),
+			/** @type {AST.Expression} */
+			(context.visit(/** @type {AST.Node} */ (node.right))),
+			b.block(body),
+		),
+	);
+
+	if (empty_id && node.empty) {
+		const empty_scope = context.state.scopes.get(node.empty) || context.state.scope;
+		context.state.init?.push(
+			b.if(
+				empty_id,
+				b.block(
+					transform_body(/** @type {AST.BlockStatement} */ (node.empty).body, {
+						...context,
+						state: { ...context.state, scope: /** @type {ScopeInterface} */ (empty_scope) },
+					}),
+				),
+			),
+		);
+	}
+
+	context.state.init?.push(b.stmt(b.call(b.id('_$_.output_push'), b.literal(BLOCK_CLOSE))));
+};
 
 /** @type {Visitors<AST.Node, TransformServerState>} */
 const visitors = {
@@ -2329,211 +2663,21 @@ const visitors = {
 		}
 	},
 
-	SwitchStatement(node, context) {
-		if (context.state.regular_js) {
-			return context.next();
+	SwitchStatement: visit_switch_statement,
+	JSXSwitchExpression: visit_switch_statement,
+
+	ForOfStatement: visit_for_of_statement,
+	// `@for` covers for-of / for-in / for(;;): non-for-of forms have no
+	// dedicated visitor and keep the default traversal, as before.
+	JSXForExpression(node, context) {
+		if (node.statementType === 'ForOfStatement') {
+			return visit_for_of_statement(node, context);
 		}
-
-		if (!is_inside_component(context)) {
-			return context.next();
-		}
-
-		const cases = [];
-
-		for (const switch_case of node.cases) {
-			const case_body = [];
-
-			if (switch_case.consequent.length !== 0) {
-				const flattened_consequent = flatten_switch_consequent(switch_case.consequent);
-				const consequent_scope =
-					context.state.scopes.get(switch_case.consequent) || context.state.scope;
-				const consequent = b.block(
-					transform_body(flattened_consequent, {
-						...context,
-						state: {
-							...context.state,
-							scope: consequent_scope,
-							control_flow_branch_body: true,
-						},
-					}),
-				);
-				case_body.push(...consequent.body);
-			}
-			case_body.push(b.break);
-
-			cases.push(
-				b.switch_case(
-					switch_case.test ? /** @type {AST.Expression} */ (context.visit(switch_case.test)) : null,
-					case_body,
-				),
-			);
-		}
-
-		context.state.init?.push(b.stmt(b.call(b.id('_$_.output_push'), b.literal(BLOCK_OPEN))));
-
-		context.state.init?.push(
-			b.switch(/** @type {AST.Expression} */ (context.visit(node.discriminant)), cases),
-		);
-
-		context.state.init?.push(b.stmt(b.call(b.id('_$_.output_push'), b.literal(BLOCK_CLOSE))));
+		return context.next();
 	},
 
-	ForOfStatement(node, context) {
-		if (context.state.regular_js) {
-			return context.next();
-		}
-
-		if (!is_inside_component(context)) {
-			context.next();
-			return;
-		}
-		const body_scope = context.state.scopes.get(node.body);
-
-		if (node.metadata?.script_only && !node.metadata?.has_template) {
-			const body = transform_body(/** @type {AST.BlockStatement} */ (node.body).body, {
-				...context,
-				state: { ...context.state, scope: /** @type {ScopeInterface} */ (body_scope) },
-			});
-
-			if (node.index) {
-				context.state.init?.push(b.var(node.index, b.literal(0)));
-				body.push(b.stmt(b.update('++', node.index)));
-			}
-
-			context.state.init?.push(
-				b.for_of(
-					/** @type {AST.VariableDeclaration} */ (context.visit(node.left)),
-					/** @type {AST.Expression} */
-					(context.visit(node.right)),
-					b.block(body),
-				),
-			);
-			return;
-		}
-
-		context.state.init?.push(b.stmt(b.call(b.id('_$_.output_push'), b.literal(BLOCK_OPEN))));
-
-		const body = transform_body(/** @type {AST.BlockStatement} */ (node.body).body, {
-			...context,
-			state: {
-				...context.state,
-				scope: /** @type {ScopeInterface} */ (body_scope),
-				control_flow_branch_body: true,
-			},
-		});
-		const empty_id = node.empty ? b.id(context.state.scope.generate('for_empty')) : null;
-
-		if (node.index) {
-			context.state.init?.push(b.var(node.index, b.literal(0)));
-			body.push(b.stmt(b.update('++', node.index)));
-		}
-		if (empty_id) {
-			context.state.init?.push(b.var(empty_id, b.true));
-			body.unshift(b.stmt(b.assignment('=', empty_id, b.false)));
-		}
-
-		context.state.init?.push(
-			b.for_of(
-				/** @type {AST.VariableDeclaration} */ (context.visit(node.left)),
-				/** @type {AST.Expression} */
-				(context.visit(node.right)),
-				b.block(body),
-			),
-		);
-
-		if (empty_id && node.empty) {
-			const empty_scope = context.state.scopes.get(node.empty) || context.state.scope;
-			context.state.init?.push(
-				b.if(
-					empty_id,
-					b.block(
-						transform_body(/** @type {AST.BlockStatement} */ (node.empty).body, {
-							...context,
-							state: { ...context.state, scope: /** @type {ScopeInterface} */ (empty_scope) },
-						}),
-					),
-				),
-			);
-		}
-
-		context.state.init?.push(b.stmt(b.call(b.id('_$_.output_push'), b.literal(BLOCK_CLOSE))));
-	},
-
-	IfStatement(node, context) {
-		if (context.state.regular_js || node.metadata?.regular_js) {
-			return context.next({ ...context.state, regular_js: true });
-		}
-
-		if (!is_inside_component(context)) {
-			context.next();
-			return;
-		}
-
-		const consequent_body =
-			node.consequent.type === 'BlockStatement' ? node.consequent.body : [node.consequent];
-		const consequent_scope = context.state.scopes.get(node.consequent) || context.state.scope;
-
-		if (
-			(node.metadata?.script_only || node.metadata?.has_continue) &&
-			!node.metadata?.has_template &&
-			!node.alternate
-		) {
-			context.state.init?.push(
-				b.if(
-					/** @type {AST.Expression} */ (context.visit(node.test)),
-					b.block(
-						transform_body(consequent_body, {
-							...context,
-							state: { ...context.state, scope: consequent_scope },
-						}),
-					),
-				),
-			);
-			return;
-		}
-
-		const consequent = b.block(
-			transform_body(consequent_body, {
-				...context,
-				state: {
-					...context.state,
-					scope: /** @type {ScopeInterface} */ (consequent_scope),
-					control_flow_branch_body: true,
-				},
-			}),
-		);
-
-		context.state.init?.push(b.stmt(b.call(b.id('_$_.output_push'), b.literal(BLOCK_OPEN))));
-
-		/** @type {AST.BlockStatement | AST.IfStatement | null} */
-		let alternate = null;
-		if (node.alternate) {
-			const alternate_scope = context.state.scopes.get(node.alternate) || context.state.scope;
-			const alternate_body_nodes =
-				node.alternate.type === 'IfStatement'
-					? [node.alternate]
-					: node.alternate.type === 'BlockStatement'
-						? node.alternate.body
-						: [node.alternate];
-
-			alternate = b.block(
-				transform_body(alternate_body_nodes, {
-					...context,
-					state: {
-						...context.state,
-						scope: alternate_scope,
-						control_flow_branch_body: node.alternate.type !== 'IfStatement',
-					},
-				}),
-			);
-		}
-
-		context.state.init?.push(
-			b.if(/** @type {AST.Expression} */ (context.visit(node.test)), consequent, alternate),
-		);
-
-		context.state.init?.push(b.stmt(b.call(b.id('_$_.output_push'), b.literal(BLOCK_CLOSE))));
-	},
+	IfStatement: visit_if_statement,
+	JSXIfExpression: visit_if_statement,
 
 	ReturnStatement(node, context) {
 		// A `return <markup>` produces a renderable value — lower it to a server
@@ -2575,7 +2719,9 @@ const visitors = {
 		if (left.type === 'MemberExpression') {
 			const target = get_indexed_reactive_target(left, context);
 			if (target !== null) {
-				const right = /** @type {AST.Expression} */ (context.visit(node.right));
+				const right = /** @type {AST.Expression} */ (
+					context.visit(/** @type {AST.Node} */ (node.right))
+				);
 				let value = right;
 				if (node.operator !== '=') {
 					const operator = /** @type {AST.BinaryOperator} */ (node.operator.slice(0, -1));
@@ -2600,7 +2746,9 @@ const visitors = {
 							context,
 						)
 					),
-					right: /** @type {AST.Expression} */ (context.visit(node.right)),
+					right: /** @type {AST.Expression} */ (
+						context.visit(/** @type {AST.Node} */ (node.right))
+					),
 				};
 			}
 		}
@@ -2609,7 +2757,9 @@ const visitors = {
 		if (left.type === 'Identifier') {
 			const binding = context.state.scope?.get(left.name);
 			if (binding?.transform?.assign && binding.node !== left) {
-				let value = /** @type {AST.Expression} */ (context.visit(node.right));
+				let value = /** @type {AST.Expression} */ (
+					context.visit(/** @type {AST.Node} */ (node.right))
+				);
 
 				// For compound operators (+=, -=, *=, /=), expand to read + operation
 				if (node.operator !== '=') {
@@ -2625,7 +2775,7 @@ const visitors = {
 		return {
 			...node,
 			left: /** @type {AST.Pattern} */ (strip_typescript_expression_wrappers(node.left, context)),
-			right: /** @type {AST.Expression} */ (context.visit(node.right)),
+			right: /** @type {AST.Expression} */ (context.visit(/** @type {AST.Node} */ (node.right))),
 		};
 	},
 
@@ -2698,104 +2848,8 @@ const visitors = {
 		});
 	},
 
-	TryStatement(node, context) {
-		if (context.state.regular_js) {
-			return context.next();
-		}
-
-		if (!is_inside_component(context)) {
-			return context.next();
-		}
-
-		const has_pending = node.pending !== null;
-		const has_catch = node.handler !== null;
-
-		const body = transform_body(node.block.body, {
-			...context,
-			state: {
-				...context.state,
-				scope: /** @type {ScopeInterface} */ (context.state.scopes.get(node.block)),
-			},
-		});
-
-		// Wrap try_fn body with hydration markers when pending or catch is present
-		const try_fn = b.arrow(
-			[],
-			b.block(
-				has_pending || has_catch
-					? [
-							b.stmt(b.call(b.id('_$_.output_push'), b.literal(BLOCK_OPEN))),
-							...body,
-							b.stmt(b.call(b.id('_$_.output_push'), b.literal(BLOCK_CLOSE))),
-						]
-					: body,
-			),
-		);
-
-		/** @type {AST.Expression} */
-		let catch_fn = b.literal(null);
-
-		const handler = node.handler;
-		if (handler) {
-			if (handler.param) {
-				delete handler.param.typeAnnotation;
-			}
-
-			/** @type {AST.Statement | null} */
-			let reset = null;
-			if (handler.resetParam) {
-				delete handler.resetParam.typeAnnotation;
-
-				reset = b.const(
-					handler.resetParam.type === 'AssignmentPattern'
-						? /** @type {AST.Identifier} */ (handler.resetParam.left).name
-						: /** @type {AST.Identifier} */ (handler.resetParam).name,
-					b.id('_$_.noop'),
-				);
-			}
-
-			catch_fn = b.arrow(
-				[handler.param || b.id('error')],
-				b.block([
-					b.stmt(b.call(b.id('_$_.output_push'), b.literal(BLOCK_OPEN))),
-					...(reset ? [reset] : []),
-					...transform_body(handler.body.body, {
-						...context,
-						state: {
-							...context.state,
-							scope: /** @type {ScopeInterface} */ (context.state.scopes.get(handler.body)),
-						},
-					}),
-					b.stmt(b.call(b.id('_$_.output_push'), b.literal(BLOCK_CLOSE))),
-				]),
-			);
-		}
-
-		const pending_body = node.pending
-			? transform_body(node.pending.body, {
-					...context,
-					state: {
-						...context.state,
-						scope: /** @type {ScopeInterface} */ (context.state.scopes.get(node.pending)),
-					},
-				})
-			: null;
-
-		// Wrap pending_fn body with hydration markers
-		const pending_fn =
-			pending_body !== null
-				? b.arrow(
-						[],
-						b.block([
-							b.stmt(b.call(b.id('_$_.output_push'), b.literal(BLOCK_OPEN))),
-							...pending_body,
-							b.stmt(b.call(b.id('_$_.output_push'), b.literal(BLOCK_CLOSE))),
-						]),
-					)
-				: b.literal(null);
-
-		context.state.init?.push(b.stmt(b.call('_$_.try_block', try_fn, catch_fn, pending_fn)));
-	},
+	TryStatement: visit_try_statement,
+	JSXTryExpression: visit_try_statement,
 
 	JSXExpressionContainer(node, context) {
 		const { visit, state } = context;

--- a/packages/tsrx-ripple/src/transform/server/index.js
+++ b/packages/tsrx-ripple/src/transform/server/index.js
@@ -124,8 +124,6 @@ function apply_tsrx_css_scoping(nodes, state) {
 	const style_classes = /** @type {any} */ (component.metadata).styleClasses ?? new Map();
 	const top_scoped_classes = /** @type {any} */ (component.metadata).topScopedClasses ?? new Map();
 
-	const restore_nodes = prepare_legacy_nodes_for_css_pruning(nodes);
-
 	/**
 	 * @param {AST.Node} node
 	 * @returns {void}
@@ -146,69 +144,9 @@ function apply_tsrx_css_scoping(nodes, state) {
 		}
 	}
 
-	try {
-		for (const node of nodes) {
-			visit_node(node);
-		}
-	} finally {
-		restore_nodes();
-	}
-}
-
-/**
- * Ripple still lowers JSX-shaped TSRX into internal Element nodes before its
- * renderer runs. Keep that compatibility local by presenting those nodes to the
- * shared CSS pruner as native JSX only during pruning.
- *
- * @param {AST.Node[]} nodes
- * @returns {() => void}
- */
-function prepare_legacy_nodes_for_css_pruning(nodes) {
-	/** @type {{ node: any, type: string, native_tsrx: unknown, had_native_tsrx: boolean }[]} */
-	const changed = [];
-	const seen = new Set();
-
-	/** @param {any} node */
-	function visit(node) {
-		if (!node || typeof node !== 'object' || seen.has(node)) {
-			return;
-		}
-		seen.add(node);
-
-		if (node.type === 'Element') {
-			node.metadata ??= { path: [] };
-			changed.push({
-				node,
-				type: node.type,
-				native_tsrx: node.metadata.native_tsrx,
-				had_native_tsrx: Object.prototype.hasOwnProperty.call(node.metadata, 'native_tsrx'),
-			});
-			node.type = 'JSXElement';
-			node.metadata.native_tsrx = true;
-		}
-
-		if (Array.isArray(node.children)) {
-			for (const child of node.children) {
-				visit(child);
-			}
-		}
-	}
-
 	for (const node of nodes) {
-		visit(node);
+		visit_node(node);
 	}
-
-	return () => {
-		for (let i = changed.length - 1; i >= 0; i--) {
-			const entry = changed[i];
-			entry.node.type = entry.type;
-			if (entry.had_native_tsrx) {
-				entry.node.metadata.native_tsrx = entry.native_tsrx;
-			} else {
-				delete entry.node.metadata.native_tsrx;
-			}
-		}
-	};
 }
 
 /**
@@ -816,7 +754,8 @@ function node_leads_with_control_flow(node, context) {
 		case 'SwitchStatement':
 		case 'TryStatement':
 			return node.metadata?.regular_js ? null : true;
-		case 'Element':
+		case 'JSXElement':
+		case 'JSXStyleElement':
 			return false;
 		case 'JSXText':
 			// Insignificant whitespace renders nothing — keep scanning.
@@ -1577,13 +1516,6 @@ const visitors = {
 		return b.block(statements);
 	},
 
-	JSXElement(node, context) {
-		if (context.state.jsx_to_tsrx_element || is_native_tsrx_value_position(context.path)) {
-			return build_jsx_to_tsrx_element(/** @type {AST.TSRXJSXElement} */ (node), context);
-		}
-		return context.next();
-	},
-
 	JSXFragment(node, context) {
 		// A raw (non-template) fragment — an attribute value or other JSX that
 		// never entered the template traversal.
@@ -1987,8 +1919,17 @@ const visitors = {
 		// at analysis time and injected separately.
 	},
 
-	Element(node, context) {
+	JSXElement(node, context) {
 		const { state, visit } = context;
+
+		// A raw (non-template) element — an attribute value or other JSX that
+		// never entered the template traversal.
+		if (!is_template_element(node)) {
+			if (state.jsx_to_tsrx_element || is_native_tsrx_value_position(context.path)) {
+				return build_jsx_to_tsrx_element(/** @type {AST.TSRXJSXElement} */ (node), context);
+			}
+			return context.next();
+		}
 
 		lower_dynamic_element(node, b.member(b.id('_$_'), 'dynamic_element'));
 

--- a/packages/tsrx-ripple/src/utils.js
+++ b/packages/tsrx-ripple/src/utils.js
@@ -21,9 +21,12 @@ import {
 	strongHash,
 } from '@tsrx/core';
 import {
+	get_element_id,
 	get_template_expression,
 	is_droppable_template_text,
 	is_empty_expression_container,
+	is_dynamic_element,
+	is_template_element,
 	is_template_expression,
 	is_template_fragment,
 	is_template_text,
@@ -1080,9 +1083,9 @@ function collect_style_elements(node, styles, inside_head) {
 	const node_any = /** @type {any} */ (node);
 	const next_inside_head =
 		inside_head ||
-		(node_any.type === 'Element' &&
-			node_any.id?.type === 'Identifier' &&
-			node_any.id.name === 'head');
+		(is_template_element(node_any) &&
+			/** @type {any} */ (get_element_id(node_any))?.type === 'Identifier' &&
+			/** @type {any} */ (get_element_id(node_any)).name === 'head');
 	if ('children' in node && Array.isArray(node.children)) {
 		collect_style_elements(/** @type {AST.Node[]} */ (node.children), styles, next_inside_head);
 	}
@@ -1124,9 +1127,9 @@ function strip_style_element_children(node, inside_head) {
 	const node_any = /** @type {any} */ (node);
 	const next_inside_head =
 		inside_head ||
-		(node_any.type === 'Element' &&
-			node_any.id?.type === 'Identifier' &&
-			node_any.id.name === 'head');
+		(is_template_element(node_any) &&
+			/** @type {any} */ (get_element_id(node_any))?.type === 'Identifier' &&
+			/** @type {any} */ (get_element_id(node_any)).name === 'head');
 	if ('children' in node && Array.isArray(node.children)) {
 		node.children = strip_style_elements(
 			/** @type {AST.Node[]} */ (node.children),
@@ -1891,10 +1894,10 @@ export function escape_html(value, is_attr = false) {
 export function is_element_dom_element(node) {
 	// A dynamic tag's id is an arbitrary expression (possibly a lowercase
 	// identifier) and resolves at runtime, never statically to a DOM element.
-	if (/** @type {AST.Element} */ (node).isDynamic === true) {
+	if (is_dynamic_element(node)) {
 		return false;
 	}
-	const id = /** @type {AST.Element} */ (node).id;
+	const id = /** @type {AST.Identifier} */ (get_element_id(node));
 	return (
 		id.type === 'Identifier' &&
 		id.name[0].toLowerCase() === id.name[0] &&
@@ -2266,9 +2269,11 @@ function normalize_child(node, normalized, context) {
 		// Component styles render nothing — their CSS is extracted at analysis.
 		return;
 	} else if (
-		node.type === 'Element' &&
-		node.id.type === 'Identifier' &&
-		(node.id.name === 'head' || (node.id.name === 'title' && context.state.inside_head))
+		is_template_element(node) &&
+		get_element_id(node).type === 'Identifier' &&
+		/** @type {AST.Identifier} */ ((get_element_id(node)).name === 'head' ||
+			/** @type {AST.Identifier} */ ((get_element_id(node)).name === 'title' &&
+				context.state.inside_head))
 	) {
 		return;
 	} else {

--- a/packages/tsrx-ripple/src/utils.js
+++ b/packages/tsrx-ripple/src/utils.js
@@ -28,7 +28,6 @@ import {
 	is_empty_expression_container,
 	is_dynamic_element,
 	is_template_element,
-	set_element_id,
 	is_template_directive,
 	is_template_else_if,
 	is_template_expression,
@@ -2002,6 +2001,14 @@ export function lower_dynamic_element(node, component_id, scopes) {
 		})
 	);
 
+	// The component reference becomes the copy's tag: the default `TsrxDynamic`
+	// local as a plain JSX identifier, or the caller's reference (the server's
+	// `_$_.dynamic_element` member) planted directly in the name slot —
+	// get_element_id derives the id from either.
+	const name =
+		component_id && component_id.type === 'MemberExpression'
+			? component_id
+			: b.jsx_id(dynamic_element_import_local);
 	const opening = node.openingElement;
 	const copy = /** @type {AST.TSRXJSXElement} */ ({
 		...node,
@@ -2011,17 +2018,14 @@ export function lower_dynamic_element(node, component_id, scopes) {
 		openingElement: {
 			...opening,
 			isDynamic: false,
-			name: opening?.name ? b.jsx_id(dynamic_element_import_local) : opening?.name,
+			name,
 			attributes: [is_attribute, ...(opening?.attributes ?? [])],
 		},
 		closingElement: node.closingElement?.name
 			? { ...node.closingElement, name: b.jsx_id(dynamic_element_import_local) }
 			: node.closingElement,
-		// Fork the metadata so the id memo can point at the component reference
-		// without polluting the source element's memoized dynamic expression.
 		metadata: { ...node.metadata },
 	});
-	set_element_id(copy, component_id ?? b.id(dynamic_element_import_local));
 
 	const scope = scopes?.get(node);
 	if (scope) scopes?.set(copy, scope);

--- a/packages/tsrx-ripple/src/utils.js
+++ b/packages/tsrx-ripple/src/utils.js
@@ -27,6 +27,7 @@ import {
 	is_empty_expression_container,
 	is_dynamic_element,
 	is_template_element,
+	set_element_id,
 	is_template_expression,
 	is_template_fragment,
 	is_template_text,
@@ -181,8 +182,7 @@ export function is_tsrx_component_function(node) {
 export function is_native_tsrx_template_node(node) {
 	return !!(
 		node &&
-		(node.type === 'Element' ||
-			node.type === 'JSXElement' ||
+		(node.type === 'JSXElement' ||
 			node.type === 'JSXFragment' ||
 			node.type === 'JSXIfExpression' ||
 			node.type === 'JSXForExpression' ||
@@ -1909,29 +1909,29 @@ export function is_element_dom_element(node) {
 export const dynamic_element_import_local = 'TsrxDynamic';
 
 /**
- * @param {AST.Element} node
+ * @param {ESTreeJSX.JSXElement} node
  * @param {AST.Expression} [component_id] - Override for the lowered component
  * reference; defaults to the `TsrxDynamic` local used by type-only output.
  * @returns {boolean}
  */
 export function lower_dynamic_element(node, component_id) {
-	if (node.isDynamic !== true) {
+	if (!is_dynamic_element(node)) {
 		return false;
 	}
 
-	const expression = /** @type {AST.Expression} */ (node.id);
+	const expression = /** @type {AST.Expression} */ (get_element_id(node));
 	const closing_name = /** @type {any} */ (node.closingElement?.name);
 	const closing_expression =
 		closing_name?.expression && clone_expression_node(closing_name.expression);
 	add_extra_source_mappings_from_matching_expression(expression, closing_expression);
-	node.id = component_id ?? b.id(dynamic_element_import_local);
+	set_element_id(node, component_id ?? b.id(dynamic_element_import_local));
 	if (node.openingElement?.name) {
 		node.openingElement.name = b.jsx_id(dynamic_element_import_local);
 	}
 	if (node.closingElement?.name) {
 		node.closingElement.name = b.jsx_id(dynamic_element_import_local);
 	}
-	node.attributes = [
+	node.openingElement.attributes = [
 		// A synthetic `is={expr}` JSXAttribute; the container value marks it as
 		// an authored-expression attribute for the accessors.
 		/** @type {ESTreeJSX.JSXAttribute} */ (
@@ -1951,9 +1951,14 @@ export function lower_dynamic_element(node, component_id) {
 				loc: expression.loc,
 			})
 		),
-		...node.attributes,
+		...node.openingElement.attributes,
 	];
+	// The tag is no longer dynamic — clear the parser's markers (the name
+	// container was already replaced above).
 	node.isDynamic = false;
+	if (node.openingElement) {
+		node.openingElement.isDynamic = false;
+	}
 	return true;
 }
 
@@ -2271,9 +2276,12 @@ function normalize_child(node, normalized, context) {
 	} else if (
 		is_template_element(node) &&
 		get_element_id(node).type === 'Identifier' &&
-		/** @type {AST.Identifier} */ ((get_element_id(node)).name === 'head' ||
-			/** @type {AST.Identifier} */ ((get_element_id(node)).name === 'title' &&
-				context.state.inside_head))
+		/** @type {AST.Identifier} */ (
+			get_element_id(node).name === 'head' ||
+				/** @type {AST.Identifier} */ (
+					get_element_id(node).name === 'title' && context.state.inside_head
+				)
+		)
 	) {
 		return;
 	} else {
@@ -2546,7 +2554,7 @@ export function is_inside_left_side_assignment(node) {
 			case 'MethodDefinition':
 			case 'PropertyDefinition':
 			case 'StaticBlock':
-			case 'Element':
+			case 'JSXElement':
 				return false;
 
 			default:
@@ -2613,45 +2621,6 @@ export function strip_class_typescript_syntax(node, context) {
 }
 
 /**
- * Converts a JSXMemberExpression to an AST MemberExpression.
- * e.g., <Foo.Bar.Baz> → MemberExpression(MemberExpression(Foo, Bar), Baz)
- * @param {import('estree-jsx').JSXMemberExpression} jsx_member
- * @returns {AST.MemberExpression}
- */
-function jsx_member_expression_to_member_expression(jsx_member) {
-	/** @type {AST.Expression} */
-	let object;
-
-	if (jsx_member.object.type === 'JSXMemberExpression') {
-		// Recursively convert nested member expressions
-		object = jsx_member_expression_to_member_expression(jsx_member.object);
-	} else {
-		// Base case: JSXIdentifier
-		object = /** @type {AST.Identifier} */ ({
-			type: 'Identifier',
-			name: jsx_member.object.name,
-			start: jsx_member.object.start,
-			end: jsx_member.object.end,
-		});
-	}
-
-	return /** @type {AST.MemberExpression} */ ({
-		type: 'MemberExpression',
-		object,
-		property: /** @type {AST.Identifier} */ ({
-			type: 'Identifier',
-			name: jsx_member.property.name,
-			start: jsx_member.property.start,
-			end: jsx_member.property.end,
-		}),
-		computed: false,
-		optional: false,
-		start: jsx_member.start,
-		end: jsx_member.end,
-	});
-}
-
-/**
  * Fragments stay raw `JSXFragment` nodes; normalization only lowers their
  * template children (code blocks, nested elements) in place.
  * @param {ESTreeJSX.JSXFragment} node
@@ -2662,7 +2631,10 @@ function jsx_to_ripple_fragment(node, inherited_path = []) {
 	node.children = /** @type {any} */ (
 		normalize_jsx_tsrx_template_children(node.children || [], inherited_path)
 	);
-	node.metadata = { ...(node.metadata ?? {}), path: inherited_path };
+	// Marking `native_tsrx` pulls raw JSX fragments (attribute values entering
+	// `build_jsx_to_tsrx_element`) into the template paths; authored template
+	// fragments already carry the flag from the parser.
+	node.metadata = { ...(node.metadata ?? {}), native_tsrx: true, path: inherited_path };
 	return node;
 }
 
@@ -2987,73 +2959,20 @@ function normalize_jsx_tsrx_node(node, inherited_path = []) {
  */
 export function jsx_to_ripple_node(node, inherited_path = []) {
 	if (node.type === 'JSXElement') {
-		const opening = node.openingElement;
-		const name = opening.name;
+		// Elements stay raw JSXElement nodes; only their template children are
+		// lowered in place. Marking `native_tsrx` pulls raw JSX (attribute
+		// values entering `build_jsx_to_tsrx_element`) into the template paths;
+		// authored template elements already carry the flag from the parser.
+		node.metadata = { ...(node.metadata ?? {}), native_tsrx: true, path: inherited_path };
 
-		/** @type {AST.Identifier | AST.MemberExpression | AST.Expression} */
-		let id;
-
-		if (name.type === 'JSXIdentifier') {
-			id = /** @type {AST.Identifier} */ ({
-				type: 'Identifier',
-				name: name.name,
-				start: name.start,
-				end: name.end,
-			});
-		} else if (name.type === 'JSXMemberExpression') {
-			// Convert JSXMemberExpression to MemberExpression
-			// e.g., <Foo.Bar.Baz> → MemberExpression(MemberExpression(Foo, Bar), Baz)
-			id = jsx_member_expression_to_member_expression(name);
-		} else if (name.type === 'JSXNamespacedName') {
-			// For JSXNamespacedName like <namespace:element>, create an identifier with the full name
-			id = /** @type {AST.Identifier} */ ({
-				type: 'Identifier',
-				name: name.namespace.name + ':' + name.name.name,
-				start: name.start,
-				end: name.end,
-			});
-		} else if (name.type === 'JSXExpressionContainer' && name.isDynamic === true) {
-			id = name.expression;
-		} else {
-			// Fallback - should not reach here
-			id = /** @type {AST.Identifier} */ ({
-				type: 'Identifier',
-				name: 'unknown',
-				start: /** @type {AST.Node} */ (name).start,
-				end: /** @type {AST.Node} */ (name).end,
-			});
-		}
-
-		// Attributes stay raw JSXAttribute/JSXSpreadAttribute nodes — consumers
-		// unwrap them via the template-ast.js accessors.
-		const attributes = opening.attributes;
-
-		const element = /** @type {AST.Element} */ (
-			/** @type {unknown} */ ({
-				type: 'Element',
-				id,
-				attributes,
-				children: [],
-				openingElement: opening,
-				closingElement: node.closingElement,
-				selfClosing: opening.selfClosing,
-				metadata: { scoped: false, path: inherited_path },
-				start: node.start,
-				end: node.end,
-			})
-		);
-		if (node.isDynamic === true || opening.isDynamic === true || name.isDynamic === true) {
-			element.isDynamic = true;
-		}
-
-		element.children = /** @type {AST.Node[]} */ (
+		node.children = /** @type {AST.Node[]} */ (
 			normalize_jsx_tsrx_template_children(/** @type {AST.Node[]} */ (node.children), [
 				...inherited_path,
-				element,
+				node,
 			]).filter(Boolean)
 		);
 
-		return element;
+		return node;
 	}
 
 	if (

--- a/packages/tsrx-ripple/src/utils.js
+++ b/packages/tsrx-ripple/src/utils.js
@@ -22,6 +22,7 @@ import {
 } from '@tsrx/core';
 import {
 	get_element_id,
+	get_element_identifier,
 	get_template_expression,
 	is_droppable_template_text,
 	is_empty_expression_container,
@@ -377,7 +378,7 @@ export function is_code_block_function_body(node, parent) {
 		(parent?.type === 'ArrowFunctionExpression' ||
 			parent?.type === 'FunctionDeclaration' ||
 			parent?.type === 'FunctionExpression') &&
-		/** @type {any} */ (parent).body === node
+		parent.body === node
 	);
 }
 
@@ -501,7 +502,7 @@ function node_contains_native_tsrx_template(node, root = false) {
 			continue;
 		}
 
-		const value = /** @type {any} */ (node)[key];
+		const value = /** @type {AST.TraversableAstNode} */ (node)[key];
 		if (Array.isArray(value)) {
 			if (value.some((child) => node_contains_native_tsrx_template(child, false))) {
 				return true;
@@ -509,7 +510,7 @@ function node_contains_native_tsrx_template(node, root = false) {
 		} else if (
 			value &&
 			typeof value === 'object' &&
-			node_contains_native_tsrx_template(value, false)
+			node_contains_native_tsrx_template(/** @type {AST.Node} */ (value), false)
 		) {
 			return true;
 		}
@@ -641,7 +642,7 @@ function statements_contain_native_tsrx_return(statements) {
 }
 
 /**
- * @param {any} statement
+ * @param {AST.Node | null | undefined} statement
  * @returns {boolean}
  */
 function statement_contains_native_tsrx_return(statement) {
@@ -673,7 +674,7 @@ function statement_contains_native_tsrx_return(statement) {
 	}
 
 	if (statement.type === 'SwitchStatement') {
-		return (statement.cases || []).some((/** @type {any} */ c) =>
+		return (statement.cases || []).some((c) =>
 			statements_contain_native_tsrx_return(c.consequent || []),
 		);
 	}
@@ -834,10 +835,8 @@ function node_contains_component_return(node) {
 	}
 
 	if (node.type === 'SwitchStatement') {
-		return (node.cases || []).some((/** @type {any} */ switch_case) =>
-			/** @type {AST.Statement[]} */ (switch_case.consequent || []).some((statement) =>
-				node_contains_component_return(statement),
-			),
+		return (node.cases || []).some((switch_case) =>
+			(switch_case.consequent || []).some((statement) => node_contains_component_return(statement)),
 		);
 	}
 
@@ -1101,11 +1100,9 @@ function collect_style_elements(node, styles, inside_head) {
 	}
 	if (is_style_element(node)) {
 		if (!inside_head) {
-			const stylesheet = node.children?.find(
-				(/** @type {any} */ child) => child.type === 'StyleSheet',
-			);
+			const stylesheet = node.children?.find((child) => child.type === 'StyleSheet');
 			if (stylesheet) {
-				styles.push(/** @type {AST.CSS.StyleSheet} */ (/** @type {unknown} */ (stylesheet)));
+				styles.push(stylesheet);
 			}
 		}
 		return;
@@ -1117,12 +1114,8 @@ function collect_style_elements(node, styles, inside_head) {
 	) {
 		return;
 	}
-	const node_any = /** @type {any} */ (node);
 	const next_inside_head =
-		inside_head ||
-		(is_template_element(node_any) &&
-			/** @type {any} */ (get_element_id(node_any))?.type === 'Identifier' &&
-			/** @type {any} */ (get_element_id(node_any)).name === 'head');
+		inside_head || (is_template_element(node) && get_element_identifier(node)?.name === 'head');
 	if ('children' in node && Array.isArray(node.children)) {
 		collect_style_elements(/** @type {AST.Node[]} */ (node.children), styles, next_inside_head);
 	}
@@ -1177,12 +1170,8 @@ function strip_style_elements(nodes, inside_head, scopes) {
  * @returns {AST.Node}
  */
 function strip_style_element_children(node, inside_head, scopes) {
-	const node_any = /** @type {any} */ (node);
 	const next_inside_head =
-		inside_head ||
-		(is_template_element(node_any) &&
-			/** @type {any} */ (get_element_id(node_any))?.type === 'Identifier' &&
-			/** @type {any} */ (get_element_id(node_any)).name === 'head');
+		inside_head || (is_template_element(node) && get_element_identifier(node)?.name === 'head');
 	/** @type {Record<string, any> | null} */
 	let updates = null;
 	if ('children' in node && Array.isArray(node.children)) {
@@ -1236,10 +1225,7 @@ export function create_native_tsrx_render_function(params, children, source_node
 	);
 	const fn = b.arrow(
 		params,
-		b.block(
-			[b.return(/** @type {any} */ (fragment))],
-			/** @type {AST.NodeWithLocation | undefined} */ (source_node),
-		),
+		b.block([b.return(fragment)], /** @type {AST.NodeWithLocation | undefined} */ (source_node)),
 		false,
 		undefined,
 		/** @type {AST.NodeWithLocation | undefined} */ (source_node),
@@ -1990,9 +1976,10 @@ export function lower_dynamic_element(node, component_id, scopes) {
 	}
 
 	const expression = /** @type {AST.Expression} */ (get_element_id(node));
-	const closing_name = /** @type {any} */ (node.closingElement?.name);
+	const closing_name = node.closingElement?.name;
 	const closing_expression =
-		closing_name?.expression && clone_expression_node(closing_name.expression);
+		closing_name?.type === 'JSXExpressionContainer' &&
+		clone_expression_node(closing_name.expression);
 	add_extra_source_mappings_from_matching_expression(expression, closing_expression);
 
 	const is_attribute = /** @type {ESTreeJSX.JSXAttribute} */ (
@@ -2032,7 +2019,7 @@ export function lower_dynamic_element(node, component_id, scopes) {
 			: node.closingElement,
 		// Fork the metadata so the id memo can point at the component reference
 		// without polluting the source element's memoized dynamic expression.
-		metadata: { .../** @type {any} */ (node.metadata) },
+		metadata: { ...node.metadata },
 	});
 	set_element_id(copy, component_id ?? b.id(dynamic_element_import_local));
 
@@ -2065,8 +2052,8 @@ export function normalize_children(children, context) {
 			prev_child != null &&
 			is_template_text_or_expression(prev_child)
 		) {
-			const child_expression = get_template_expression(/** @type {any} */ (child), to_ts);
-			const prev_expression = get_template_expression(/** @type {any} */ (prev_child), to_ts);
+			const child_expression = get_template_expression(child, to_ts);
+			const prev_expression = get_template_expression(prev_child, to_ts);
 			if (
 				(is_template_expression(child) &&
 					is_children_template_expression(child_expression, context.state.scope)) ||
@@ -2365,13 +2352,8 @@ function normalize_child(node, normalized, context) {
 		return;
 	} else if (
 		is_template_element(node) &&
-		get_element_id(node).type === 'Identifier' &&
-		/** @type {any} */ (
-			/** @type {any} */ (get_element_id(node)).name === 'head' ||
-				/** @type {any} */ (
-					/** @type {any} */ (get_element_id(node)).name === 'title' && context.state.inside_head
-				)
-		)
+		(get_element_identifier(node)?.name === 'head' ||
+			(get_element_identifier(node)?.name === 'title' && context.state.inside_head))
 	) {
 		return;
 	} else {
@@ -2725,9 +2707,9 @@ export function visit_children_without(node, context, cleared_fields) {
 			}
 		}
 	}
-	const scopes = /** @type {any} */ (context.state)?.scopes;
+	const scopes = context.state.scopes;
 	const scope = scopes?.get(node);
-	if (scope) scopes.set(copy, scope);
+	if (scope) scopes.set(/** @type {AST.Node} */ (copy), scope);
 	return /** @type {T} */ (/** @type {unknown} */ (copy));
 }
 
@@ -2751,7 +2733,7 @@ export function strip_class_typescript_syntax(node, context) {
 	let source = node;
 	if (superClass !== node.superClass) {
 		source = { ...node, superClass };
-		const scopes = /** @type {any} */ (context.state)?.scopes;
+		const scopes = context.state.scopes;
 		const scope = scopes?.get(node);
 		if (scope) scopes.set(source, scope);
 	}
@@ -2986,7 +2968,7 @@ export function is_template_child_position(path, node) {
  * Mark every element/fragment in a raw JSX subtree `native_tsrx` so the
  * transforms route it through the template paths rather than the raw-JSX
  * value lowering.
- * @param {any} node
+ * @param {AST.Node | AST.Node[] | null | undefined} node
  * @returns {void}
  */
 function mark_raw_template_jsx(node) {
@@ -3011,8 +2993,8 @@ function mark_raw_template_jsx(node) {
  * the `native_tsrx` marking that routes the visitors down the template paths,
  * plus flattening a fragment root to its children.
  *
- * @param {any} node
- * @returns {any}
+ * @param {AST.Node} node
+ * @returns {AST.Node | AST.Node[]}
  */
 export function adopt_raw_template_jsx(node) {
 	mark_raw_template_jsx(node);

--- a/packages/tsrx-ripple/src/utils.js
+++ b/packages/tsrx-ripple/src/utils.js
@@ -199,7 +199,12 @@ export function is_native_tsrx_template_node(node) {
  */
 export function is_directive_render_position(parent, node) {
 	if (!parent) return true;
-	const container = /** @type {any} */ (parent);
+	// A structural view over the slots that can hold a directive — no single
+	// estree interface carries them all.
+	const container =
+		/** @type {{ type: AST.Node['type']; body?: AST.Node | AST.Node[]; children?: AST.Node[]; render?: AST.Node | null; expression?: AST.Node; consequent?: AST.Node | AST.Node[]; alternate?: AST.Node | null }} */ (
+			/** @type {unknown} */ (parent)
+		);
 	// Block/program/loop/function bodies are statement lists (or a lone body
 	// statement) — but a CONCISE (non-block) arrow body is an expression
 	// position, not a statement, and a directive is never a BlockStatement.
@@ -214,7 +219,13 @@ export function is_directive_render_position(parent, node) {
 	// `{ … }` containers lower their expression through the render machinery.
 	if (container.type === 'JSXExpressionContainer' && container.expression === node) return true;
 	// Switch-case statement lists.
-	if (container.type === 'SwitchCase' && container.consequent?.includes?.(node)) return true;
+	if (
+		container.type === 'SwitchCase' &&
+		Array.isArray(container.consequent) &&
+		container.consequent.includes(node)
+	) {
+		return true;
+	}
 	// An if-node's branches, and the `@else if` chain (another directive) that
 	// lives in `alternate`.
 	if (
@@ -240,15 +251,15 @@ export function is_directive_render_position(parent, node) {
  *
  * Memoized on the directive so the analyzer and the transforms share one
  * wrapper identity.
- * @param {any} directive
- * @returns {any}
+ * @param {AST.JSXTemplateDirective} directive
+ * @returns {AST.TSRXJSXFragment}
  */
 export function get_directive_value_wrapper(directive) {
 	directive.metadata ??= { path: [] };
 	if (directive.metadata.tsrx_value_wrapper) {
 		return directive.metadata.tsrx_value_wrapper;
 	}
-	const fragment = /** @type {any} */ (b.jsx_fragment([directive]));
+	const fragment = b.jsx_fragment([directive]);
 	// Mark as a GENERATED wrapper (not an authored `<> … </>`) so the to_ts
 	// single-child collapse keeps unwrapping it to the directive's lowered value,
 	// unlike an authored fragment which is kept verbatim.
@@ -257,9 +268,7 @@ export function get_directive_value_wrapper(directive) {
 		native_tsrx: true,
 		tsrx_generated_wrapper: true,
 	};
-	fragment.start = directive.start;
-	fragment.end = directive.end;
-	fragment.loc = directive.loc;
+	setLocation(fragment, /** @type {AST.NodeWithLocation} */ (directive));
 	directive.metadata.tsrx_value_wrapper = fragment;
 	return fragment;
 }
@@ -273,11 +282,12 @@ export function get_directive_value_wrapper(directive) {
  * their paths cannot be trusted for slot checks) and communicated via the
  * memoized wrapper on the directive's metadata. The wrapper-in-path guard
  * stops the detour once the wrapper's own visit re-reaches the directive.
+ * @template {AST.JSXTemplateDirective} T
  * @template {{ path: AST.Node[]; visit: (node: AST.Node) => AST.Node }} C
- * @param {any} node
+ * @param {T} node
  * @param {C} context
- * @param {(node: any, context: C) => any} visit
- * @returns {any}
+ * @param {(node: T, context: C) => AST.Node | void} visit
+ * @returns {AST.Node | void}
  */
 export function visit_directive_wrapping_values(node, context, visit) {
 	const wrapper = node.metadata?.tsrx_value_wrapper;
@@ -294,11 +304,12 @@ export function visit_directive_wrapping_values(node, context, visit) {
  * its `<> … </>` wrapper memoized (for the transforms to follow) and is
  * analyzed through it; the wrapper's re-visit of the directive lands in
  * render position and proceeds normally.
+ * @template {AST.JSXTemplateDirective} T
  * @template {{ path: AST.Node[]; visit: (node: AST.Node) => AST.Node }} C
- * @param {any} node
+ * @param {T} node
  * @param {C} context
- * @param {(node: any, context: C) => any} visit
- * @returns {any}
+ * @param {(node: T, context: C) => AST.Node | void} visit
+ * @returns {AST.Node | void}
  */
 export function analyze_directive_wrapping_values(node, context, visit) {
 	const wrapper = node.metadata?.tsrx_value_wrapper;
@@ -680,7 +691,7 @@ function statement_contains_native_tsrx_return(statement) {
 
 /**
  * @param {ESTreeJSX.JSXElement | ESTreeJSX.JSXFragment} node
- * @param {Map<AST.Node | AST.Node[], any>} [scopes]
+ * @param {Map<AST.Node | AST.Node[], ScopeInterface>} [scopes]
  * @returns {AST.Node[]}
  */
 export function get_native_tsrx_template_children(node, scopes) {
@@ -691,7 +702,7 @@ export function get_native_tsrx_template_children(node, scopes) {
 
 /**
  * @param {AST.Function} node
- * @param {Map<AST.Node | AST.Node[], any>} [scopes]
+ * @param {Map<AST.Node | AST.Node[], ScopeInterface>} [scopes]
  * @returns {AST.Node[]}
  */
 export function get_native_tsrx_function_body(node, scopes) {
@@ -742,7 +753,7 @@ export function get_native_tsrx_function_body(node, scopes) {
 /**
  * @param {AST.Statement[]} statements
  * @param {boolean} [omit_final_control_return]
- * @param {Map<AST.Node | AST.Node[], any>} [scopes]
+ * @param {Map<AST.Node | AST.Node[], ScopeInterface>} [scopes]
  * @returns {AST.Node[]}
  */
 export function expand_native_tsrx_return_statements(
@@ -885,7 +896,7 @@ function create_return_argument_child(argument, statement) {
 /**
  * @param {AST.Statement} statement
  * @param {boolean} [omit_control_return]
- * @param {Map<AST.Node | AST.Node[], any>} [scopes]
+ * @param {Map<AST.Node | AST.Node[], ScopeInterface>} [scopes]
  * @returns {AST.Node[]}
  */
 function expand_native_tsrx_return_statement(statement, omit_control_return = false, scopes) {
@@ -1035,7 +1046,7 @@ function expand_native_tsrx_return_statement(statement, omit_control_return = fa
 
 /**
  * @param {AST.Statement} statement
- * @param {Map<AST.Node | AST.Node[], any>} [scopes]
+ * @param {Map<AST.Node | AST.Node[], ScopeInterface>} [scopes]
  * @returns {AST.Statement}
  */
 function expand_embedded_native_tsrx_return_statement(statement, scopes) {
@@ -1128,7 +1139,7 @@ function collect_style_elements(node, styles, inside_head) {
  * Copy-on-write: rebuilt spine nodes inherit the original's scope mapping when
  * a `scopes` map is provided, so transform-time lookups keep working.
  * @param {AST.Node[]} nodes
- * @param {Map<AST.Node | AST.Node[], any>} [scopes]
+ * @param {Map<AST.Node | AST.Node[], ScopeInterface>} [scopes]
  * @returns {AST.Node[]}
  */
 export function strip_tsrx_style_elements(nodes, scopes) {
@@ -1138,7 +1149,7 @@ export function strip_tsrx_style_elements(nodes, scopes) {
 /**
  * @param {AST.Node[]} nodes
  * @param {boolean} inside_head
- * @param {Map<AST.Node | AST.Node[], any>} [scopes]
+ * @param {Map<AST.Node | AST.Node[], ScopeInterface>} [scopes]
  * @returns {AST.Node[]}
  */
 function strip_style_elements(nodes, inside_head, scopes) {
@@ -1162,7 +1173,7 @@ function strip_style_elements(nodes, inside_head, scopes) {
 /**
  * @param {AST.Node} node
  * @param {boolean} inside_head
- * @param {Map<AST.Node | AST.Node[], any>} [scopes]
+ * @param {Map<AST.Node | AST.Node[], ScopeInterface>} [scopes]
  * @returns {AST.Node}
  */
 function strip_style_element_children(node, inside_head, scopes) {
@@ -1970,7 +1981,7 @@ export const dynamic_element_import_local = 'TsrxDynamic';
  * @param {AST.TSRXJSXElement} node
  * @param {AST.Expression} [component_id] - Override for the lowered component
  * reference; defaults to the `TsrxDynamic` local used by type-only output.
- * @param {Map<AST.Node | AST.Node[], any>} [scopes]
+ * @param {Map<AST.Node | AST.Node[], ScopeInterface>} [scopes]
  * @returns {AST.TSRXJSXElement | null}
  */
 export function lower_dynamic_element(node, component_id, scopes) {
@@ -2760,12 +2771,12 @@ export function strip_class_typescript_syntax(node, context) {
  * consumers treat it like any other template output. Memoized on the node so
  * the analyzer and the transforms share one lowered identity.
  * @param {AST.JSXCodeBlock} block
- * @param {Map<AST.Node | AST.Node[], any>} [scopes]
+ * @param {Map<AST.Node | AST.Node[], ScopeInterface>} [scopes]
  * @returns {AST.Node | null}
  */
 export function get_code_block_render(block, scopes) {
 	block.metadata ??= { path: [] };
-	const memo = /** @type {{ tsrx_render_slot?: { render: AST.Node | null } }} */ (block.metadata);
+	const memo = block.metadata;
 	if (memo.tsrx_render_slot) {
 		return memo.tsrx_render_slot.render;
 	}
@@ -2786,7 +2797,7 @@ export function get_code_block_render(block, scopes) {
 			// wrapper fragment.
 			render = inner_child;
 		} else {
-			const fragment = /** @type {any} */ (b.jsx_fragment([/** @type {any} */ (inner_child)]));
+			const fragment = b.jsx_fragment([inner_child]);
 			setLocation(fragment, /** @type {AST.NodeWithLocation} */ (block.render));
 			// native_tsrx so the template paths treat the wrapper like any other
 			// template fragment; tsrx_code_block_chain so template-children
@@ -2826,12 +2837,12 @@ export function get_code_block_render(block, scopes) {
  * scope IIFEs mirror the code block's scope so binding lookups keep working
  * (mirroring is idempotent, so it also applies on memoized hits).
  * @param {AST.JSXCodeBlock} block
- * @param {Map<AST.Node | AST.Node[], any>} [scopes]
+ * @param {Map<AST.Node | AST.Node[], ScopeInterface>} [scopes]
  * @returns {AST.Node | null}
  */
 export function get_code_block_template_child(block, scopes) {
 	block.metadata ??= { path: [] };
-	const memo = /** @type {{ tsrx_template_child?: { child: AST.Node | null } }} */ (block.metadata);
+	const memo = block.metadata;
 	if (memo.tsrx_template_child) {
 		mirror_code_block_scope(block, memo.tsrx_template_child.child, scopes);
 		return memo.tsrx_template_child.child;
@@ -2847,7 +2858,7 @@ export function get_code_block_template_child(block, scopes) {
 		// for render-slot consumers (function bodies, value positions). As a
 		// template child, unwrap it instead of stacking an inline component per
 		// nesting level.
-		const inner_child = /** @type {any} */ (render.children[0]);
+		const inner_child = /** @type {AST.Node} */ (render.children[0]);
 		if (body.length === 0) {
 			child = inner_child;
 		} else if (inner_child.type === 'BlockStatement') {
@@ -2900,7 +2911,7 @@ export function get_code_block_template_child(block, scopes) {
  * it needs no mirroring — the scope map already keys off the block itself.
  * @param {AST.JSXCodeBlock} block
  * @param {AST.Node | null} child
- * @param {Map<AST.Node | AST.Node[], any>} [scopes]
+ * @param {Map<AST.Node | AST.Node[], ScopeInterface>} [scopes]
  * @returns {void}
  */
 function mirror_code_block_scope(block, child, scopes) {
@@ -2909,14 +2920,14 @@ function mirror_code_block_scope(block, child, scopes) {
 	if (!scope) return;
 	if (child.type === 'BlockStatement') {
 		scopes.set(child, scope);
-	} else if (
-		child.type === 'JSXExpressionContainer' &&
-		/** @type {any} */ (child).expression?.metadata?.tsrx_code_block_scope
-	) {
-		const arrow = /** @type {any} */ (child).expression.callee;
-		if (arrow) {
-			scopes.set(arrow, scope);
-			if (arrow.body) scopes.set(arrow.body, scope);
+	} else if (child.type === 'JSXExpressionContainer') {
+		const expression = child.expression;
+		if (expression.type === 'CallExpression' && expression.metadata?.tsrx_code_block_scope) {
+			const arrow = expression.callee;
+			if (arrow.type === 'ArrowFunctionExpression') {
+				scopes.set(arrow, scope);
+				scopes.set(arrow.body, scope);
+			}
 		}
 	}
 }
@@ -2926,7 +2937,7 @@ function mirror_code_block_scope(block, child, scopes) {
  * template forms (dropping blocks that render nothing). Returns the input
  * list unchanged when it holds no code blocks.
  * @param {AST.Node[]} children
- * @param {Map<AST.Node | AST.Node[], any>} [scopes]
+ * @param {Map<AST.Node | AST.Node[], ScopeInterface>} [scopes]
  * @returns {AST.Node[]}
  */
 export function lower_code_block_children(children, scopes) {
@@ -2952,7 +2963,7 @@ export function is_template_child_position(path, node) {
 	if (!parent) return false;
 	if (
 		(parent.type === 'JSXElement' || parent.type === 'JSXFragment') &&
-		/** @type {any} */ (parent).children?.includes(node)
+		parent.children.some((child) => child === node)
 	) {
 		return true;
 	}

--- a/packages/tsrx-ripple/src/utils.js
+++ b/packages/tsrx-ripple/src/utils.js
@@ -1920,11 +1920,10 @@ export function lower_dynamic_element(node, component_id) {
 		return false;
 	}
 
-	const expression = /** @type {AST.Expression & { was_expression?: boolean }} */ (node.id);
+	const expression = /** @type {AST.Expression} */ (node.id);
 	const closing_name = /** @type {any} */ (node.closingElement?.name);
 	const closing_expression =
 		closing_name?.expression && clone_expression_node(closing_name.expression);
-	expression.was_expression = true;
 	add_extra_source_mappings_from_matching_expression(expression, closing_expression);
 	node.id = component_id ?? b.id(dynamic_element_import_local);
 	if (node.openingElement?.name) {
@@ -1934,22 +1933,25 @@ export function lower_dynamic_element(node, component_id) {
 		node.closingElement.name = b.jsx_id(dynamic_element_import_local);
 	}
 	node.attributes = [
-		/** @type {AST.Attribute} */ ({
-			type: 'Attribute',
-			name: {
-				type: 'Identifier',
-				name: 'is',
-				tracked: false,
+		// A synthetic `is={expr}` JSXAttribute; the container value marks it as
+		// an authored-expression attribute for the accessors.
+		/** @type {ESTreeJSX.JSXAttribute} */ (
+			/** @type {unknown} */ ({
+				type: 'JSXAttribute',
+				name: b.jsx_id(
+					'is',
+					/** @type {AST.NodeWithLocation} */ (/** @type {unknown} */ (expression)),
+				),
+				value: b.jsx_expression_container(
+					expression,
+					/** @type {AST.NodeWithLocation} */ (/** @type {unknown} */ (expression)),
+				),
+				shorthand: false,
 				start: expression.start,
 				end: expression.end,
 				loc: expression.loc,
-			},
-			value: expression,
-			shorthand: false,
-			start: expression.start,
-			end: expression.end,
-			loc: expression.loc,
-		}),
+			})
+		),
 		...node.attributes,
 	];
 	node.isDynamic = false;
@@ -3058,66 +3060,9 @@ export function jsx_to_ripple_node(node, inherited_path = []) {
 			});
 		}
 
-		const attributes = opening.attributes
-			.map((/** @type {any} */ attr) => {
-				if (attr.type === 'JSXAttribute') {
-					const name =
-						attr.name.type === 'JSXIdentifier'
-							? attr.name.name
-							: attr.name.namespace.name + ':' + attr.name.name.name;
-					const shorthand_end_loc =
-						attr.loc?.end && attr.loc.end.column > 0
-							? { ...attr.loc.end, column: attr.loc.end.column - 1 }
-							: attr.loc?.end;
-					const value = attr.shorthand
-						? {
-								type: 'Identifier',
-								name,
-								start: attr.name.start,
-								end:
-									attr.name.end && attr.name.end > attr.name.start ? attr.name.end : attr.end - 1,
-								loc: {
-									start: attr.name.loc?.start ?? attr.loc?.start,
-									end: attr.name.loc?.end ?? shorthand_end_loc,
-								},
-							}
-						: attr.value
-							? attr.value.type === 'JSXExpressionContainer'
-								? attr.value.expression
-								: attr.value
-							: null;
-					if (attr.value?.type === 'JSXExpressionContainer' && value) {
-						value.was_expression = true;
-					}
-					return /** @type {AST.Node} */ ({
-						type: 'Attribute',
-						name: {
-							type: 'Identifier',
-							name,
-							tracked: false,
-							start: attr.name.start,
-							end: attr.name.end && attr.name.end > attr.name.start ? attr.name.end : attr.end - 1,
-							loc: {
-								start: attr.name.loc?.start ?? attr.loc?.start,
-								end: attr.name.loc?.end ?? shorthand_end_loc,
-							},
-						},
-						value,
-						shorthand: attr.shorthand === true,
-						start: attr.start,
-						end: attr.end,
-					});
-				} else if (attr.type === 'JSXSpreadAttribute') {
-					return /** @type {AST.Node} */ ({
-						type: 'SpreadAttribute',
-						argument: attr.argument,
-						start: attr.start,
-						end: attr.end,
-					});
-				}
-				return null;
-			})
-			.filter(Boolean);
+		// Attributes stay raw JSXAttribute/JSXSpreadAttribute nodes — consumers
+		// unwrap them via the template-ast.js accessors.
+		const attributes = opening.attributes;
 
 		const element = /** @type {AST.Element} */ (
 			/** @type {unknown} */ ({

--- a/packages/tsrx-ripple/src/utils.js
+++ b/packages/tsrx-ripple/src/utils.js
@@ -186,69 +186,40 @@ export function is_native_tsrx_template_node(node) {
 }
 
 /**
- * Pre-pass: wrap `@if`/`@for`/`@switch`/`@try` directives used in value
- * positions in a `<> … </>` fragment so they lower as values. Directives keep
- * their parser forms (`JSXIfExpression`, …) — the analyzer and transforms
- * dispatch on those directly.
- *
- * Copy-on-write: the input tree is never mutated — changed spines are rebuilt
- * (unchanged subtrees are shared), so the parse result stays pristine.
- * @template {AST.Node} T
- * @param {T} ast
- * @returns {T}
- */
-export function prepare_template_control_flow(ast) {
-	return /** @type {T} */ (wrap_directives_combined_into_expressions(/** @type {any} */ (ast)));
-}
-
-/**
- * A `@if`/`@for`/`@switch`/`@try` control-flow directive. (A `@{ … }` code
- * block is deliberately NOT included: it self-lowers to an IIFE in every
- * position, so it never needs wrapping and wrapping it would add a redundant
- * fragment.)
- * @param {AST.Node} node
- * @returns {boolean}
- */
-function is_control_flow_directive(node) {
-	return is_template_directive(node);
-}
-
-/**
  * Slots where a control-flow directive is a render child / statement and is
  * lowered correctly as-is — so it must NOT be wrapped. Every OTHER slot is a
  * value position (an operator operand, a variable initializer, a `@for` iterable,
  * an `@if`/`@switch` test, a concise arrow body, a `return` argument, a member
  * object, …), where a bare directive would leak as an `if (…) { … }` statement
- * and is wrapped instead. Enumerating the render positions (rather than the value
- * ones) is robust: it covers every value slot, and the pre- and post-normalization
- * node shapes alike.
- * @param {AST.Node} parent
- * @param {string} key
- * @param {AST.Node} child
+ * and is wrapped in a `<> … </>` instead. Enumerating the render positions
+ * (rather than the value ones) is robust: it covers every value slot.
+ * @param {AST.Node | undefined} parent
+ * @param {AST.Node} node
  * @returns {boolean}
  */
-function is_render_child_or_statement_slot(parent, key, child) {
-	// JSX children.
-	if (key === 'children') return true;
-	// Block/program/loop/function bodies are statement lists — but a CONCISE
-	// (non-block) arrow body is an expression position, not a statement.
-	if (key === 'body') {
-		return !(
-			parent?.type === 'ArrowFunctionExpression' &&
-			/** @type {any} */ (child)?.type !== 'BlockStatement'
-		);
+export function is_directive_render_position(parent, node) {
+	if (!parent) return true;
+	const container = /** @type {any} */ (parent);
+	// Block/program/loop/function bodies are statement lists (or a lone body
+	// statement) — but a CONCISE (non-block) arrow body is an expression
+	// position, not a statement, and a directive is never a BlockStatement.
+	if (container.body === node) {
+		return container.type !== 'ArrowFunctionExpression';
 	}
+	if (Array.isArray(container.body) && container.body.includes(node)) return true;
+	// JSX children.
+	if (Array.isArray(container.children) && container.children.includes(node)) return true;
 	// A `@{ … }` code block's trailing render output.
-	if (parent?.type === 'JSXCodeBlock' && key === 'render') return true;
+	if (container.type === 'JSXCodeBlock' && container.render === node) return true;
 	// `{ … }` containers lower their expression through the render machinery.
-	if (parent?.type === 'JSXExpressionContainer' && key === 'expression') return true;
+	if (container.type === 'JSXExpressionContainer' && container.expression === node) return true;
 	// Switch-case statement lists.
-	if (parent?.type === 'SwitchCase' && key === 'consequent') return true;
+	if (container.type === 'SwitchCase' && container.consequent?.includes?.(node)) return true;
 	// An if-node's branches, and the `@else if` chain (another directive) that
 	// lives in `alternate`.
 	if (
-		(parent?.type === 'IfStatement' || parent?.type === 'JSXIfExpression') &&
-		(key === 'consequent' || key === 'alternate')
+		(container.type === 'IfStatement' || container.type === 'JSXIfExpression') &&
+		(container.consequent === node || container.alternate === node)
 	) {
 		return true;
 	}
@@ -256,13 +227,27 @@ function is_render_child_or_statement_slot(parent, key, child) {
 }
 
 /**
- * Wrap a directive in a `<> … </>` — the same shape an authored `<>@if … </>`
- * produces — so it flows through the render machinery (a `tsrx_element` on the
- * client/server, a `<> … </>` in to_ts).
+ * The generated `<> … </>` wrapper for a `@if`/`@for`/`@switch`/`@try`
+ * directive used in a VALUE position — the sole value of a slot
+ * (`let cd = @if (…) { … }`), an operator operand, a conditional branch, an
+ * array element, a `@for` iterable, an `@if`/`@switch` test, a concise arrow
+ * body (`xs.map((x) => @if (…) { … })`), a `return` argument, a member
+ * object. Wrapped, the directive flows through the render machinery as a
+ * valid value (a `tsrx_element` render on the client/server, a `<> … </>` in
+ * to_ts) instead of leaking a bare `if (…) { … }` statement into expression
+ * position (or a raw `JSX…Expression` crashing the printer). A `@{ … }` code
+ * block self-lowers to an IIFE in every position and is never wrapped.
+ *
+ * Memoized on the directive so the analyzer and the transforms share one
+ * wrapper identity.
  * @param {any} directive
  * @returns {any}
  */
-function wrap_directive_in_jsx_fragment(directive) {
+export function get_directive_value_wrapper(directive) {
+	directive.metadata ??= { path: [] };
+	if (directive.metadata.tsrx_value_wrapper) {
+		return directive.metadata.tsrx_value_wrapper;
+	}
 	const fragment = /** @type {any} */ (b.jsx_fragment([directive]));
 	// Mark as a GENERATED wrapper (not an authored `<> … </>`) so the to_ts
 	// single-child collapse keeps unwrapping it to the directive's lowered value,
@@ -275,83 +260,55 @@ function wrap_directive_in_jsx_fragment(directive) {
 	fragment.start = directive.start;
 	fragment.end = directive.end;
 	fragment.loc = directive.loc;
+	directive.metadata.tsrx_value_wrapper = fragment;
 	return fragment;
 }
 
 /**
- * Pre-normalization pass: a `@if`/`@for`/`@switch`/`@try` directive used in ANY
- * value position — the sole value of a slot (`let cd = @if (…) { … }`), an
- * operator operand, a conditional branch, an array element, a `@for` iterable, an
- * `@if`/`@switch` test, a concise arrow body (`xs.map((x) => @if (…) { … })`), a
- * `return` argument, a member object — is wrapped in a `<> … </>` so it becomes a
- * valid value (a `tsrx_element` render, or a `<> … </>` in to_ts) instead of a
- * bare `if (…) { … }` statement leaking into expression position (or a raw
- * `JSX…Expression` crashing the printer). The render positions where a directive
- * is already lowered correctly are enumerated in `is_render_child_or_statement_slot`;
- * everything else is wrapped. A `@{ … }` code block self-lowers to an IIFE in
- * every position and is never wrapped.
- * @param {any} ast
+ * The transform-side dissolution of the old wrap pre-pass: dispatch a template
+ * control-flow directive through `visit`, detouring VALUE-position directives
+ * through their generated `<> … </>` wrapper first. Whether a directive is a
+ * value is decided during ANALYSIS (where traversal is generic and visitor
+ * paths mirror the real tree — the transforms' helper funnels skip levels, so
+ * their paths cannot be trusted for slot checks) and communicated via the
+ * memoized wrapper on the directive's metadata. The wrapper-in-path guard
+ * stops the detour once the wrapper's own visit re-reaches the directive.
+ * @template {{ path: AST.Node[]; visit: (node: AST.Node) => AST.Node }} C
+ * @param {any} node
+ * @param {C} context
+ * @param {(node: any, context: C) => any} visit
+ * @returns {any}
  */
-function wrap_directives_combined_into_expressions(ast) {
-	/**
-	 * @param {any} parent
-	 * @param {string} key
-	 * @param {any} value
-	 * @returns {any}
-	 */
-	const visit_slot = (parent, key, value) => {
-		if (
-			is_control_flow_directive(value) &&
-			!is_render_child_or_statement_slot(parent, key, value)
-		) {
-			return wrap_directive_in_jsx_fragment(visit(value));
-		}
-		return visit(value);
-	};
-	/**
-	 * @param {any} node
-	 * @returns {any}
-	 */
-	const visit = (node) => {
-		if (!node || typeof node !== 'object') return node;
-		/** @type {Record<string, any> | null} */
-		let updates = null;
-		// acorn-typescript quirk: call/new expressions carry their generics as
-		// `typeParameters`; the transforms (and the TSX printer) expect the
-		// standard `typeArguments`.
-		if ((node.type === 'CallExpression' || node.type === 'NewExpression') && node.typeParameters) {
-			updates = { typeArguments: node.typeParameters, typeParameters: undefined };
-		}
-		for (const key of Object.keys(node)) {
-			if (
-				key === 'loc' ||
-				key === 'start' ||
-				key === 'end' ||
-				key === 'metadata' ||
-				key === 'parent'
-			) {
-				continue;
-			}
-			const value = node[key];
-			if (Array.isArray(value)) {
-				/** @type {any[] | null} */
-				let out = null;
-				for (let i = 0; i < value.length; i++) {
-					const next = visit_slot(node, key, value[i]);
-					if (next !== value[i]) {
-						out ??= value.slice();
-						out[i] = next;
-					}
-				}
-				if (out) (updates ??= {})[key] = out;
-			} else if (value && typeof value === 'object') {
-				const next = visit_slot(node, key, value);
-				if (next !== value) (updates ??= {})[key] = next;
-			}
-		}
-		return updates ? { ...node, ...updates } : node;
-	};
-	return visit(ast);
+export function visit_directive_wrapping_values(node, context, visit) {
+	const wrapper = node.metadata?.tsrx_value_wrapper;
+	if (wrapper && !context.path.includes(wrapper)) {
+		return context.visit(wrapper);
+	}
+	return visit(node, context);
+}
+
+/**
+ * The analyzer-side counterpart of {@link visit_directive_wrapping_values}:
+ * the analyzer's traversal is generic, so its visitor path mirrors the real
+ * tree and the slot check is decidable here. A VALUE-position directive gets
+ * its `<> … </>` wrapper memoized (for the transforms to follow) and is
+ * analyzed through it; the wrapper's re-visit of the directive lands in
+ * render position and proceeds normally.
+ * @template {{ path: AST.Node[]; visit: (node: AST.Node) => AST.Node }} C
+ * @param {any} node
+ * @param {C} context
+ * @param {(node: any, context: C) => any} visit
+ * @returns {any}
+ */
+export function analyze_directive_wrapping_values(node, context, visit) {
+	const wrapper = node.metadata?.tsrx_value_wrapper;
+	if (
+		(!wrapper || !context.path.includes(wrapper)) &&
+		!is_directive_render_position(context.path.at(-1), node)
+	) {
+		return context.visit(get_directive_value_wrapper(node));
+	}
+	return visit(node, context);
 }
 
 /**
@@ -2874,9 +2831,7 @@ export function get_code_block_render(block, scopes) {
  */
 export function get_code_block_template_child(block, scopes) {
 	block.metadata ??= { path: [] };
-	const memo = /** @type {{ tsrx_template_child?: { child: AST.Node | null } }} */ (
-		block.metadata
-	);
+	const memo = /** @type {{ tsrx_template_child?: { child: AST.Node | null } }} */ (block.metadata);
 	if (memo.tsrx_template_child) {
 		mirror_code_block_scope(block, memo.tsrx_template_child.child, scopes);
 		return memo.tsrx_template_child.child;

--- a/packages/tsrx-ripple/src/utils.js
+++ b/packages/tsrx-ripple/src/utils.js
@@ -16,6 +16,7 @@ import {
 	isNonDelegated,
 	isVoidElement,
 	normalizeEventName,
+	setLocation,
 	simpleHash,
 	strongHash,
 } from '@tsrx/core';
@@ -24,6 +25,7 @@ import {
 	is_droppable_template_text,
 	is_empty_expression_container,
 	is_template_expression,
+	is_template_fragment,
 	is_template_text,
 	is_template_text_or_expression,
 } from './template-ast.js';
@@ -177,7 +179,6 @@ export function is_native_tsrx_template_node(node) {
 	return !!(
 		node &&
 		(node.type === 'Element' ||
-			node.type === 'TsrxFragment' ||
 			node.type === 'JSXElement' ||
 			node.type === 'JSXFragment' ||
 			node.type === 'JSXIfExpression' ||
@@ -717,11 +718,11 @@ function statement_contains_native_tsrx_return(statement) {
 }
 
 /**
- * @param {AST.Element | AST.TsrxFragment} node
+ * @param {AST.Element | ESTreeJSX.JSXFragment} node
  * @returns {AST.Node[]}
  */
 export function get_native_tsrx_template_children(node) {
-	return node.type === 'TsrxFragment' ? node.children || [] : [node];
+	return is_template_fragment(node) ? node.children || [] : [node];
 }
 
 /**
@@ -743,7 +744,7 @@ export function get_native_tsrx_function_body(node) {
 		return is_native_tsrx_template_node(node.body)
 			? [
 					...get_native_tsrx_template_children(
-						/** @type {AST.Element | AST.TsrxFragment} */ (/** @type {unknown} */ (node.body)),
+						/** @type {AST.Element | ESTreeJSX.JSXFragment} */ (/** @type {unknown} */ (node.body)),
 					).map((child) => mark_returned_template_child(child)),
 				]
 			: [b.return(/** @type {AST.Expression} */ (node.body))];
@@ -916,7 +917,9 @@ function expand_native_tsrx_return_statement(statement, omit_control_return = fa
 
 	if (statement.type === 'ReturnStatement' && is_native_tsrx_template_node(statement.argument)) {
 		const template_children = get_native_tsrx_template_children(
-			/** @type {AST.Element | AST.TsrxFragment} */ (/** @type {unknown} */ (statement.argument)),
+			/** @type {AST.Element | ESTreeJSX.JSXFragment} */ (
+				/** @type {unknown} */ (statement.argument)
+			),
 		);
 		const children = omit_control_return
 			? template_children.flatMap((child) =>
@@ -1158,15 +1161,13 @@ function strip_style_element_children(node, inside_head) {
  * @returns {AST.ArrowFunctionExpression}
  */
 export function create_native_tsrx_render_function(params, children, source_node) {
-	const fragment = /** @type {AST.TsrxFragment} */ (
+	const fragment = /** @type {ESTreeJSX.JSXFragment} */ (
 		/** @type {unknown} */ ({
-			type: 'TsrxFragment',
+			type: 'JSXFragment',
 			children,
-			openingElement: { type: 'JSXOpeningFragment', metadata: { path: [] } },
-			closingElement: { type: 'JSXClosingFragment', metadata: { path: [] } },
-			selfClosing: false,
-			attributes: [],
-			metadata: { path: [] },
+			openingFragment: { type: 'JSXOpeningFragment', metadata: { path: [] } },
+			closingFragment: { type: 'JSXClosingFragment', metadata: { path: [] } },
+			metadata: { path: [], tsrx_render_fragment: true },
 		})
 	);
 	const fn = b.arrow(
@@ -2215,7 +2216,7 @@ export function is_children_template_expression(expression, scope, component_sco
  * @returns {boolean}
  */
 function is_template_fragment_node(node) {
-	return node?.type === 'TsrxFragment';
+	return is_template_fragment(node);
 }
 
 /**
@@ -2648,27 +2649,18 @@ function jsx_member_expression_to_member_expression(jsx_member) {
 }
 
 /**
+ * Fragments stay raw `JSXFragment` nodes; normalization only lowers their
+ * template children (code blocks, nested elements) in place.
  * @param {ESTreeJSX.JSXFragment} node
  * @param {AST.Node[]} [inherited_path]
- * @returns {AST.TsrxFragment}
+ * @returns {ESTreeJSX.JSXFragment}
  */
 function jsx_to_ripple_fragment(node, inherited_path = []) {
-	const fragment = /** @type {AST.TsrxFragment} */ (
-		/** @type {unknown} */ ({
-			type: 'TsrxFragment',
-			children: normalize_jsx_tsrx_template_children(node.children || [], inherited_path),
-			openingElement: node.openingFragment,
-			closingElement: node.closingFragment,
-			selfClosing: false,
-			attributes: [],
-			metadata: { ...(node.metadata ?? {}), path: inherited_path },
-			start: node.start,
-			end: node.end,
-			loc: node.loc,
-		})
+	node.children = /** @type {any} */ (
+		normalize_jsx_tsrx_template_children(node.children || [], inherited_path)
 	);
-
-	return fragment;
+	node.metadata = { ...(node.metadata ?? {}), path: inherited_path };
+	return node;
 }
 
 /**
@@ -2847,7 +2839,7 @@ function code_block_to_template_child(block, inherited_path) {
 	// synthetic fragment for render-slot consumers (function bodies, value
 	// positions). As a template child, unwrap it instead of stacking an
 	// inline component per nesting level.
-	if (render?.type === 'TsrxFragment' && render.metadata.tsrx_code_block_chain) {
+	if (render?.type === 'JSXFragment' && render.metadata?.tsrx_code_block_chain) {
 		const inner_child = render.children[0];
 		if (body.length === 0) {
 			return inner_child;
@@ -2974,13 +2966,14 @@ function normalize_jsx_tsrx_node(node, inherited_path = []) {
 				// with no wrapper fragment.
 				node.render = inner_child;
 			} else {
-				const fragment = b.tsrx_fragment(
-					[inner_child],
-					/** @type {AST.NodeWithLocation} */ (inner),
-				);
+				const fragment = /** @type {any} */ (b.jsx_fragment([/** @type {any} */ (inner_child)]));
+				setLocation(fragment, /** @type {AST.NodeWithLocation} */ (inner));
 				fragment.metadata.path = path;
-				// Mark the wrapper so template-children lowering can unwrap it
-				// instead of stacking an inline component per nesting level.
+				// native_tsrx so core scope creation treats the wrapper like any
+				// other template fragment; tsrx_code_block_chain so
+				// template-children lowering can unwrap it instead of stacking an
+				// inline component per nesting level.
+				fragment.metadata.native_tsrx = true;
 				fragment.metadata.tsrx_code_block_chain = true;
 				node.render = fragment;
 			}

--- a/packages/tsrx-ripple/src/utils.js
+++ b/packages/tsrx-ripple/src/utils.js
@@ -358,9 +358,9 @@ function is_render_child_or_statement_slot(parent, key, child) {
 }
 
 /**
- * Wrap a directive in a `<> … </>` so it normalizes to a `TsrxFragment` — the
- * same shape an authored `<>@if … </>` produces — and flows through the render
- * machinery (a `tsrx_element` on the client/server, a `<> … </>` in to_ts).
+ * Wrap a directive in a `<> … </>` — the same shape an authored `<>@if … </>`
+ * produces — so it flows through the render machinery (a `tsrx_element` on the
+ * client/server, a `<> … </>` in to_ts).
  * @param {any} directive
  * @returns {any}
  */
@@ -803,11 +803,11 @@ function statement_contains_native_tsrx_return(statement) {
 }
 
 /**
- * @param {AST.Element | ESTreeJSX.JSXFragment} node
+ * @param {ESTreeJSX.JSXElement | ESTreeJSX.JSXFragment} node
  * @returns {AST.Node[]}
  */
 export function get_native_tsrx_template_children(node) {
-	return is_template_fragment(node) ? node.children || [] : [node];
+	return is_template_fragment(node) ? /** @type {AST.Node[]} */ (node.children || []) : [node];
 }
 
 /**
@@ -829,7 +829,9 @@ export function get_native_tsrx_function_body(node) {
 		return is_native_tsrx_template_node(node.body)
 			? [
 					...get_native_tsrx_template_children(
-						/** @type {AST.Element | ESTreeJSX.JSXFragment} */ (/** @type {unknown} */ (node.body)),
+						/** @type {ESTreeJSX.JSXElement | ESTreeJSX.JSXFragment} */ (
+							/** @type {unknown} */ (node.body)
+						),
 					).map((child) => mark_returned_template_child(child)),
 				]
 			: [b.return(/** @type {AST.Expression} */ (node.body))];
@@ -1002,7 +1004,7 @@ function expand_native_tsrx_return_statement(statement, omit_control_return = fa
 
 	if (statement.type === 'ReturnStatement' && is_native_tsrx_template_node(statement.argument)) {
 		const template_children = get_native_tsrx_template_children(
-			/** @type {AST.Element | ESTreeJSX.JSXFragment} */ (
+			/** @type {ESTreeJSX.JSXElement | ESTreeJSX.JSXFragment} */ (
 				/** @type {unknown} */ (statement.argument)
 			),
 		);
@@ -1213,9 +1215,8 @@ function strip_style_element_children(node, inside_head) {
 			/** @type {any} */ (get_element_id(node_any))?.type === 'Identifier' &&
 			/** @type {any} */ (get_element_id(node_any)).name === 'head');
 	if ('children' in node && Array.isArray(node.children)) {
-		node.children = strip_style_elements(
-			/** @type {AST.Node[]} */ (node.children),
-			next_inside_head,
+		node.children = /** @type {any} */ (
+			strip_style_elements(/** @type {AST.Node[]} */ (node.children), next_inside_head)
 		);
 	}
 	if (node.type === 'BlockStatement') {
@@ -2037,9 +2038,9 @@ export function lower_dynamic_element(node, component_id) {
 	];
 	// The tag is no longer dynamic — clear the parser's markers (the name
 	// container was already replaced above).
-	node.isDynamic = false;
+	/** @type {any} */ (node).isDynamic = false;
 	if (node.openingElement) {
-		node.openingElement.isDynamic = false;
+		/** @type {any} */ (node.openingElement).isDynamic = false;
 	}
 	return true;
 }
@@ -2358,10 +2359,10 @@ function normalize_child(node, normalized, context) {
 	} else if (
 		is_template_element(node) &&
 		get_element_id(node).type === 'Identifier' &&
-		/** @type {AST.Identifier} */ (
-			get_element_id(node).name === 'head' ||
-				/** @type {AST.Identifier} */ (
-					get_element_id(node).name === 'title' && context.state.inside_head
+		/** @type {any} */ (
+			/** @type {any} */ (get_element_id(node)).name === 'head' ||
+				/** @type {any} */ (
+					/** @type {any} */ (get_element_id(node)).name === 'title' && context.state.inside_head
 				)
 		)
 	) {
@@ -2920,7 +2921,7 @@ function code_block_to_template_child(block, inherited_path) {
 	// positions). As a template child, unwrap it instead of stacking an
 	// inline component per nesting level.
 	if (render?.type === 'JSXFragment' && render.metadata?.tsrx_code_block_chain) {
-		const inner_child = render.children[0];
+		const inner_child = /** @type {any} */ (render.children[0]);
 		if (body.length === 0) {
 			return inner_child;
 		}

--- a/packages/tsrx-ripple/src/utils.js
+++ b/packages/tsrx-ripple/src/utils.js
@@ -29,6 +29,7 @@ import {
 	is_template_element,
 	set_element_id,
 	is_template_directive,
+	is_template_else_if,
 	is_template_expression,
 	is_template_fragment,
 	is_template_text,
@@ -427,7 +428,7 @@ export function function_has_native_tsrx_return(node) {
 	}
 
 	if (node.body?.type === 'JSXCodeBlock') {
-		return is_native_tsrx_template_node(node.body.render);
+		return is_native_tsrx_template_node(get_code_block_render(node.body));
 	}
 
 	if (node.type === 'ArrowFunctionExpression' && node.body?.type !== 'BlockStatement') {
@@ -453,7 +454,7 @@ export function function_contains_native_tsrx_template(node) {
 	}
 
 	if (node.body?.type === 'JSXCodeBlock') {
-		return is_native_tsrx_template_node(node.body.render);
+		return is_native_tsrx_template_node(get_code_block_render(node.body));
 	}
 
 	return node_contains_native_tsrx_template(node.body, true);
@@ -722,10 +723,13 @@ function statement_contains_native_tsrx_return(statement) {
 
 /**
  * @param {ESTreeJSX.JSXElement | ESTreeJSX.JSXFragment} node
+ * @param {Map<AST.Node | AST.Node[], any>} [scopes]
  * @returns {AST.Node[]}
  */
-export function get_native_tsrx_template_children(node) {
-	return is_template_fragment(node) ? /** @type {AST.Node[]} */ (node.children || []) : [node];
+export function get_native_tsrx_template_children(node, scopes) {
+	return is_template_fragment(node)
+		? lower_code_block_children(/** @type {AST.Node[]} */ (node.children || []), scopes)
+		: [node];
 }
 
 /**
@@ -747,10 +751,15 @@ export function get_native_tsrx_function_body(node, scopes) {
 	let result;
 	if (node.body?.type === 'JSXCodeBlock') {
 		const block = node.body;
+		const render = get_code_block_render(block, scopes);
 		result = [
-			...expand_native_tsrx_return_statements(block.body || [], true, scopes),
-			...(is_native_tsrx_template_node(block.render)
-				? [mark_returned_template_child(/** @type {AST.Node} */ (block.render))]
+			...expand_native_tsrx_return_statements(
+				(block.body || []).filter((statement) => statement.type !== 'EmptyStatement'),
+				true,
+				scopes,
+			),
+			...(is_native_tsrx_template_node(render)
+				? [mark_returned_template_child(/** @type {AST.Node} */ (render))]
 				: []),
 		];
 	} else if (node.type === 'ArrowFunctionExpression' && node.body?.type !== 'BlockStatement') {
@@ -760,6 +769,7 @@ export function get_native_tsrx_function_body(node, scopes) {
 						/** @type {ESTreeJSX.JSXElement | ESTreeJSX.JSXFragment} */ (
 							/** @type {unknown} */ (node.body)
 						),
+						scopes,
 					).map((child) => mark_returned_template_child(child)),
 				]
 			: [b.return(/** @type {AST.Expression} */ (node.body))];
@@ -957,6 +967,7 @@ function expand_native_tsrx_return_statement(statement, omit_control_return = fa
 			/** @type {ESTreeJSX.JSXElement | ESTreeJSX.JSXFragment} */ (
 				/** @type {unknown} */ (statement.argument)
 			),
+			scopes,
 		);
 		const children = omit_control_return
 			? template_children.flatMap((child) =>
@@ -2359,6 +2370,17 @@ function is_template_fragment_binding(binding, scope, visited = new Set()) {
 function normalize_child(node, normalized, context) {
 	if (node.type === 'EmptyStatement') {
 		return;
+	} else if (node.type === 'JSXCodeBlock') {
+		// A `@{ … }` template child renders as its lowered template form (or
+		// nothing at all) — lowered lazily here, at the point of use.
+		const child = get_code_block_template_child(
+			/** @type {AST.JSXCodeBlock} */ (node),
+			context.state.scopes,
+		);
+		if (child != null) {
+			normalize_child(child, normalized, context);
+		}
+		return;
 	} else if (
 		// Insignificant whitespace text renders nothing, and a `{/* comment */}`
 		// container is a comment — both are dropped from the rendered children.
@@ -2774,336 +2796,224 @@ export function strip_class_typescript_syntax(node, context) {
 }
 
 /**
- * Lower the `@{ … }` code blocks that appear as template children throughout
- * the AST: element/fragment children lists and the branch bodies of template
- * directives. Statement-position code blocks (function bodies,
- * code-block bodies) are left alone — they stay lexical blocks and are lowered
- * by the transforms. Also drops `EmptyStatement` separators from the lists it
- * touches, matching the old normalizer.
- *
- * Copy-on-write: the input tree is never mutated — changed spines are rebuilt
- * (unchanged subtrees are shared), so the parse result stays pristine.
- * @template {AST.Node} T
- * @param {T} ast
- * @returns {T}
+ * Resolve the render slot of a `@{ … }` code block, folding nested
+ * code-block chains: each level is its own scope, so the inner chain
+ * lowers like a template child and — unless it collapsed to a plain template
+ * node — rides in a synthetic `tsrx_code_block_chain` fragment so render-slot
+ * consumers treat it like any other template output. Memoized on the node so
+ * the analyzer and the transforms share one lowered identity.
+ * @param {AST.JSXCodeBlock} block
+ * @param {Map<AST.Node | AST.Node[], any>} [scopes]
+ * @returns {AST.Node | null}
  */
-export function lower_template_code_blocks(ast) {
-	return /** @type {T} */ (lower_node(/** @type {any} */ (ast), []));
-}
-
-/**
- * @param {any[]} children
- * @param {AST.Node[]} inherited_path
- * @returns {any[]}
- */
-function lower_template_children(children, inherited_path = []) {
-	/** @type {any[] | null} */
-	let out = null;
-	for (let i = 0; i < children.length; i++) {
-		let next = lower_node(children[i], inherited_path);
-		if (next?.type === 'JSXCodeBlock') {
-			next = code_block_to_template_child(next, inherited_path);
-		}
-		if (next !== children[i]) {
-			out ??= children.slice();
-			out[i] = next;
-		}
-	}
-	const result = out ?? children;
-	return result.some((/** @type {any} */ child) => child == null || child.type === 'EmptyStatement')
-		? result.filter((/** @type {any} */ child) => child != null && child.type !== 'EmptyStatement')
-		: result;
-}
-
-/**
- * @param {any[]} statements
- * @param {AST.Node[]} inherited_path
- * @returns {any[]}
- */
-function lower_statement_children(statements, inherited_path) {
-	/** @type {any[] | null} */
-	let out = null;
-	for (let i = 0; i < statements.length; i++) {
-		const next = lower_node(statements[i], inherited_path);
-		if (next !== statements[i]) {
-			out ??= statements.slice();
-			out[i] = next;
-		}
-	}
-	const result = out ?? statements;
-	return result.some((/** @type {any} */ child) => child == null || child.type === 'EmptyStatement')
-		? result.filter((/** @type {any} */ child) => child != null && child.type !== 'EmptyStatement')
-		: result;
-}
-
-/**
- * Rebuild a `BlockStatement`-valued slot with lowered template children,
- * reusing the original when nothing changed.
- * @param {any} block
- * @param {AST.Node[]} path
- * @returns {any}
- */
-function lower_block_slot(block, path) {
-	const body = lower_template_children(block.body || [], path);
-	return body === (block.body || []) ? block : { ...block, body };
-}
-
-/**
- * @param {any} statement — a template directive (`JSX…Expression`)
- * @param {AST.Node[]} inherited_path
- * @returns {any}
- */
-function lower_directive_template_slots(statement, inherited_path) {
-	const path = [...inherited_path, statement];
-	/** @type {Record<string, any> | null} */
-	let updates = null;
-	/** @param {string} key @param {any} next @param {any} prev */
-	const update = (key, next, prev) => {
-		if (next !== prev) (updates ??= {})[key] = next;
-	};
-
-	for (const key of ['consequent', 'alternate']) {
-		const value = statement[key];
-		if (value?.type === 'BlockStatement') {
-			update(key, lower_block_slot(value, path), value);
-		} else if (value) {
-			update(key, lower_node(value, path), value);
-		}
-	}
-	for (const key of ['body', 'empty', 'block', 'pending', 'finalizer']) {
-		const value = statement[key];
-		if (value?.type === 'BlockStatement') {
-			update(key, lower_block_slot(value, path), value);
-		}
-	}
-	if (statement.handler?.body?.type === 'BlockStatement') {
-		const body = lower_block_slot(statement.handler.body, path);
-		if (body !== statement.handler.body) {
-			update('handler', { ...statement.handler, body }, statement.handler);
-		}
-	}
-	if (Array.isArray(statement.cases)) {
-		/** @type {any[] | null} */
-		let cases = null;
-		for (let i = 0; i < statement.cases.length; i++) {
-			const switch_case = statement.cases[i];
-			const consequent = lower_template_children(switch_case.consequent || [], path);
-			if (consequent !== (switch_case.consequent || [])) {
-				cases ??= /** @type {any[]} */ (statement.cases.slice());
-				cases[i] = { ...switch_case, consequent };
-			}
-		}
-		if (cases) update('cases', cases, statement.cases);
-	}
-	// Test/discriminant/iterable expressions are not template slots — raw JSX
-	// there lowers through the transforms' value paths — but they may still
-	// contain nested templates, so keep walking them.
-	for (const key of ['test', 'discriminant', 'right']) {
-		const value = statement[key];
-		if (value) update(key, lower_node(value, path), value);
+export function get_code_block_render(block, scopes) {
+	block.metadata ??= { path: [] };
+	const memo = /** @type {{ tsrx_render_slot?: { render: AST.Node | null } }} */ (block.metadata);
+	if (memo.tsrx_render_slot) {
+		return memo.tsrx_render_slot.render;
 	}
 
-	if (!updates) return statement;
-	return { ...statement, .../** @type {Record<string, any>} */ (updates) };
-}
-
-/**
- * The recursive worker for {@link lower_template_code_blocks}: dispatches on
- * the node shapes that own template-children lists and walks everything else
- * generically, rebuilding only the spines that change.
- * @param {any} node
- * @param {AST.Node[]} inherited_path
- * @returns {any}
- */
-function lower_node(node, inherited_path = []) {
-	if (!node || typeof node !== 'object') return node;
-	if (Array.isArray(node)) {
-		return lower_statement_children(node, inherited_path);
-	}
-
-	if (node.type === 'JSXFragment' || node.type === 'JSXElement') {
-		/** @type {Record<string, any> | null} */
-		let updates = null;
-		const children = lower_template_children(node.children || [], [...inherited_path, node]);
-		if (children !== (node.children || [])) (updates ??= {}).children = children;
-		if (node.type === 'JSXElement' && node.openingElement?.attributes) {
-			// Attribute values may hold raw JSX with nested templates.
-			const attributes = lower_statement_children(node.openingElement.attributes, [
-				...inherited_path,
-				node,
-			]);
-			if (attributes !== node.openingElement.attributes) {
-				(updates ??= {}).openingElement = { ...node.openingElement, attributes };
-			}
-		}
-		return updates ? { ...node, ...updates } : node;
-	}
-	if (
-		node.type === 'JSXStyleElement' ||
-		node.type === 'JSXText' ||
-		node.type === 'StyleSheet' ||
-		node.type === 'JSXOpeningElement' ||
-		node.type === 'JSXClosingElement'
-	) {
-		return node;
-	}
-	if (node.type === 'JSXCodeBlock') {
-		// Each `@{ … }` is its own lexical scope, so nested blocks never merge
-		// into their parent. A block whose render output is itself a code block
-		// (`@{ @{ … } }`) keeps the nesting: the inner block is lowered like a
-		// template child inside a synthetic fragment so it gets its own scope.
-		const path = [...inherited_path, node];
-		/** @type {Record<string, any> | null} */
-		let updates = null;
-		const body = lower_statement_children(node.body || [], path);
-		if (body !== (node.body || [])) (updates ??= {}).body = body;
-		if (node.render?.type === 'JSXCodeBlock') {
-			const inner = lower_node(node.render, path);
-			const inner_child = code_block_to_template_child(inner, path);
+	let render = /** @type {AST.Node | null} */ (block.render ?? null);
+	if (render?.type === 'JSXCodeBlock') {
+		const inner_child = get_code_block_template_child(
+			/** @type {AST.JSXCodeBlock} */ (render),
+			scopes,
+		);
+		if (inner_child == null) {
 			// An inner block that is empty all the way down renders nothing —
-			// drop it so the outer block becomes code-only (and prunable too).
-			if (inner_child == null) {
-				(updates ??= {}).render = null;
-			} else if (is_native_tsrx_template_node(inner_child)) {
-				// The inner chain collapsed to a plain template node (its scope
-				// was unobservable) — it becomes this block's render directly,
-				// with no wrapper fragment.
-				(updates ??= {}).render = inner_child;
-			} else {
-				const fragment = /** @type {any} */ (b.jsx_fragment([/** @type {any} */ (inner_child)]));
-				setLocation(fragment, /** @type {AST.NodeWithLocation} */ (inner));
-				fragment.metadata.path = path;
-				// native_tsrx so core scope creation treats the wrapper like any
-				// other template fragment; tsrx_code_block_chain so
-				// template-children lowering can unwrap it instead of stacking an
-				// inline component per nesting level.
-				fragment.metadata.native_tsrx = true;
-				fragment.metadata.tsrx_code_block_chain = true;
-				(updates ??= {}).render = fragment;
-			}
-		} else if (node.render) {
-			const render = lower_node(node.render, path);
-			if (render !== node.render) (updates ??= {}).render = render;
-		}
-		return updates ? { ...node, ...updates } : node;
-	}
-	if (is_template_directive(node)) {
-		return lower_directive_template_slots(node, inherited_path);
-	}
-
-	/** @type {Record<string, any> | null} */
-	let updates = null;
-	for (const key in node) {
-		if (
-			key === 'metadata' ||
-			key === 'parent' ||
-			key === 'loc' ||
-			key === 'start' ||
-			key === 'end' ||
-			key === 'type'
-		) {
-			continue;
-		}
-
-		const value = node[key];
-		if (Array.isArray(value)) {
-			const next = lower_statement_children(value, [...inherited_path, node]);
-			if (next !== value) (updates ??= {})[key] = next;
-		} else if (value && typeof value === 'object') {
-			const next = lower_node(value, [...inherited_path, node]);
-			if (next !== value) (updates ??= {})[key] = next;
+			// dropping it makes the outer block code-only (and prunable too).
+			render = null;
+		} else if (is_native_tsrx_template_node(inner_child)) {
+			// The inner chain collapsed to a plain template node (its scope was
+			// unobservable) — it becomes this block's render directly, with no
+			// wrapper fragment.
+			render = inner_child;
+		} else {
+			const fragment = /** @type {any} */ (b.jsx_fragment([/** @type {any} */ (inner_child)]));
+			setLocation(fragment, /** @type {AST.NodeWithLocation} */ (block.render));
+			// native_tsrx so the template paths treat the wrapper like any other
+			// template fragment; tsrx_code_block_chain so template-children
+			// lowering can unwrap it instead of stacking an inline component per
+			// nesting level.
+			fragment.metadata.native_tsrx = true;
+			fragment.metadata.tsrx_code_block_chain = true;
+			render = fragment;
 		}
 	}
 
-	return updates ? { ...node, ...updates } : node;
+	memo.tsrx_render_slot = { render };
+	return render;
 }
 
 /**
- * Lower a `@{ … }` code block that appears in a template children list. Each
- * code block is its own lexical scope, so it never flattens into the
- * surrounding scope, but the lowering only pays for what the block uses:
+ * Lower a `@{ … }` code block for a template-children position. Each code
+ * block is its own lexical scope, so it never flattens into the surrounding
+ * scope, but the lowering only pays for what the block uses:
  *
  * - no setup code: the scope is unobservable, so the render output merges
  *   statically into the parent template — no `_$_.expression`, no inline
  *   component, no anchor;
  * - code-only: a plain `BlockStatement` — statements run in source order,
- *   scoped, render nothing;
+ *   scoped, render nothing (`null` when the block is empty all the way down);
  * - setup code + render output: an inline anonymous component expression
  *   (`(() =>@{ … })()`, the same lowering as value-position code blocks),
  *   since the setup may feed the output — `_$_.expression` is the right tool
  *   for a dynamic child value;
- * - nested chains (a code block directly inside another): intermediate levels with statements merge
- *   into one IIFE as nested plain `{ … }` blocks (one closure, not one per
- *   level), and only the innermost render-bearing level becomes the inline
- *   component.
- * @param {AST.JSXCodeBlock} block — internals already normalized
- * @param {AST.Node[]} inherited_path
+ * - nested chains (a code block directly inside another): intermediate levels
+ *   with statements merge into one IIFE as nested plain `{ … }` blocks (one
+ *   closure, not one per level), and only the innermost render-bearing level
+ *   becomes the inline component.
+ *
+ * Memoized on the node so the analyzer and the transforms share one lowered
+ * identity. When a `scopes` map is provided, synthesized statement blocks and
+ * scope IIFEs mirror the code block's scope so binding lookups keep working
+ * (mirroring is idempotent, so it also applies on memoized hits).
+ * @param {AST.JSXCodeBlock} block
+ * @param {Map<AST.Node | AST.Node[], any>} [scopes]
  * @returns {AST.Node | null}
  */
-function code_block_to_template_child(block, inherited_path) {
-	const body = block.body || [];
-	const render = block.render;
+export function get_code_block_template_child(block, scopes) {
+	block.metadata ??= { path: [] };
+	const memo = /** @type {{ tsrx_template_child?: { child: AST.Node | null } }} */ (
+		block.metadata
+	);
+	if (memo.tsrx_template_child) {
+		mirror_code_block_scope(block, memo.tsrx_template_child.child, scopes);
+		return memo.tsrx_template_child.child;
+	}
 
-	// `@{ @{ … } }` — normalize wrapped the already-lowered inner chain in a
-	// synthetic fragment for render-slot consumers (function bodies, value
-	// positions). As a template child, unwrap it instead of stacking an
-	// inline component per nesting level.
+	const body = (block.body || []).filter((statement) => statement.type !== 'EmptyStatement');
+	const render = get_code_block_render(block, scopes);
+	/** @type {AST.Node | null} */
+	let child;
+
 	if (render?.type === 'JSXFragment' && render.metadata?.tsrx_code_block_chain) {
+		// `@{ @{ … } }` — the folded inner chain rides in a synthetic fragment
+		// for render-slot consumers (function bodies, value positions). As a
+		// template child, unwrap it instead of stacking an inline component per
+		// nesting level.
 		const inner_child = /** @type {any} */ (render.children[0]);
 		if (body.length === 0) {
-			return inner_child;
-		}
-		if (inner_child.type === 'BlockStatement') {
-			const statement = b.block(
-				[...body, inner_child],
-				/** @type {AST.NodeWithLocation} */ (block),
-			);
-			statement.metadata = { path: inherited_path };
-			return statement;
-		}
-		if (inner_child.type !== 'JSXExpressionContainer') {
+			child = inner_child;
+		} else if (inner_child.type === 'BlockStatement') {
+			child = b.block([...body, inner_child], /** @type {AST.NodeWithLocation} */ (block));
+		} else if (inner_child.type !== 'JSXExpressionContainer') {
 			// Unreachable by construction — the chain wrapper only ever holds
 			// a statement block or an expression child.
-			return inner_child;
+			child = inner_child;
+		} else {
+			// The inner level is either one of our scope IIFEs (fold its body in
+			// as a nested plain block instead of a nested closure, so a whole
+			// chain shares a single function) or the inline component (return its
+			// value from this level's scope).
+			const inner_expression = inner_child.expression;
+			const scope_body =
+				inner_expression.type === 'CallExpression' &&
+				inner_expression.metadata?.tsrx_code_block_scope &&
+				inner_expression.callee.type === 'ArrowFunctionExpression' &&
+				inner_expression.callee.body.type === 'BlockStatement'
+					? [...body, inner_expression.callee.body]
+					: [...body, b.return(inner_expression)];
+			const scope_call = /** @type {AST.SimpleCallExpression} */ (
+				b.call(b.arrow([], b.block(scope_body, /** @type {AST.NodeWithLocation} */ (block))))
+			);
+			scope_call.metadata = { ...scope_call.metadata, tsrx_code_block_scope: true };
+			child = b.jsx_expression_container(scope_call, /** @type {AST.NodeWithLocation} */ (block));
 		}
-		// The inner level is either one of our scope IIFEs (fold its body in
-		// as a nested plain block instead of a nested closure, so a whole
-		// chain shares a single function) or the inline component (return its
-		// value from this level's scope).
-		const inner_expression = inner_child.expression;
-		const scope_body =
-			inner_expression.type === 'CallExpression' &&
-			inner_expression.metadata?.tsrx_code_block_scope &&
-			inner_expression.callee.type === 'ArrowFunctionExpression' &&
-			inner_expression.callee.body.type === 'BlockStatement'
-				? [...body, inner_expression.callee.body]
-				: [...body, b.return(inner_expression)];
-		const scope_call = /** @type {AST.SimpleCallExpression} */ (
-			b.call(b.arrow([], b.block(scope_body, /** @type {AST.NodeWithLocation} */ (block))))
-		);
-		scope_call.metadata = { ...scope_call.metadata, tsrx_code_block_scope: true };
-		return b.jsx_expression_container(scope_call, /** @type {AST.NodeWithLocation} */ (block));
-	}
-
-	if (render == null) {
-		if (body.length === 0) {
-			return null;
-		}
-		const statement = b.block(body, /** @type {AST.NodeWithLocation} */ (block));
-		statement.metadata = { path: inherited_path };
-		return statement;
-	}
-
-	if (body.length === 0) {
+	} else if (render == null) {
+		child = body.length === 0 ? null : b.block(body, /** @type {AST.NodeWithLocation} */ (block));
+	} else if (body.length === 0) {
 		// No setup code — the block's scope is unobservable, so the render
 		// output merges statically into the parent template.
-		return render;
+		child = render;
+	} else {
+		child = b.jsx_expression_container(
+			wrap_code_block_in_iife(block),
+			/** @type {AST.NodeWithLocation} */ (block),
+		);
 	}
 
-	return b.jsx_expression_container(
-		wrap_code_block_in_iife(block),
-		/** @type {AST.NodeWithLocation} */ (block),
-	);
+	memo.tsrx_template_child = { child };
+	mirror_code_block_scope(block, child, scopes);
+	return child;
+}
+
+/**
+ * Mirror a code block's scope onto the statement blocks / scope IIFEs its
+ * lowering synthesized, so binding lookups during the walks keep working. The
+ * plain-IIFE lowering keeps the original `JSXCodeBlock` as the arrow body, so
+ * it needs no mirroring — the scope map already keys off the block itself.
+ * @param {AST.JSXCodeBlock} block
+ * @param {AST.Node | null} child
+ * @param {Map<AST.Node | AST.Node[], any>} [scopes]
+ * @returns {void}
+ */
+function mirror_code_block_scope(block, child, scopes) {
+	if (!scopes || child == null) return;
+	const scope = scopes.get(block);
+	if (!scope) return;
+	if (child.type === 'BlockStatement') {
+		scopes.set(child, scope);
+	} else if (
+		child.type === 'JSXExpressionContainer' &&
+		/** @type {any} */ (child).expression?.metadata?.tsrx_code_block_scope
+	) {
+		const arrow = /** @type {any} */ (child).expression.callee;
+		if (arrow) {
+			scopes.set(arrow, scope);
+			if (arrow.body) scopes.set(arrow.body, scope);
+		}
+	}
+}
+
+/**
+ * Lower any raw `@{ … }` entries in a template-children list to their
+ * template forms (dropping blocks that render nothing). Returns the input
+ * list unchanged when it holds no code blocks.
+ * @param {AST.Node[]} children
+ * @param {Map<AST.Node | AST.Node[], any>} [scopes]
+ * @returns {AST.Node[]}
+ */
+export function lower_code_block_children(children, scopes) {
+	return children.some((child) => child?.type === 'JSXCodeBlock')
+		? children.flatMap((child) =>
+				child?.type === 'JSXCodeBlock'
+					? (get_code_block_template_child(/** @type {AST.JSXCodeBlock} */ (child), scopes) ?? [])
+					: [child],
+			)
+		: children;
+}
+
+/**
+ * Whether `node` sits in a template-children slot: a JSX element/fragment
+ * children list, or a branch body of a template control-flow directive
+ * (including positional `@else if` chain links and `@try` catch handlers).
+ * @param {AST.Node[]} path — ancestor chain, innermost last
+ * @param {AST.Node} node
+ * @returns {boolean}
+ */
+export function is_template_child_position(path, node) {
+	const parent = path.at(-1);
+	if (!parent) return false;
+	if (
+		(parent.type === 'JSXElement' || parent.type === 'JSXFragment') &&
+		/** @type {any} */ (parent).children?.includes(node)
+	) {
+		return true;
+	}
+	if (parent.type === 'BlockStatement' || parent.type === 'SwitchCase') {
+		const grand = path.at(-2);
+		if (!grand) return false;
+		if (is_template_directive(grand)) return true;
+		if (grand.type === 'CatchClause' && is_template_directive(path.at(-3))) return true;
+		if (
+			grand.type === 'IfStatement' &&
+			is_template_else_if(grand, /** @type {AST.Node[]} */ (path.slice(0, -2)))
+		) {
+			return true;
+		}
+	}
+	return false;
 }
 
 /**

--- a/packages/tsrx-ripple/src/utils.js
+++ b/packages/tsrx-ripple/src/utils.js
@@ -286,8 +286,8 @@ export function get_directive_value_wrapper(directive) {
  * @template {{ path: AST.Node[]; visit: (node: AST.Node) => AST.Node }} C
  * @param {T} node
  * @param {C} context
- * @param {(node: T, context: C) => AST.Node | void} visit
- * @returns {AST.Node | void}
+ * @param {(node: T, context: C) => AST.Node | AST.Node[] | void} visit
+ * @returns {AST.Node | AST.Node[] | void}
  */
 export function visit_directive_wrapping_values(node, context, visit) {
 	const wrapper = node.metadata?.tsrx_value_wrapper;
@@ -308,8 +308,8 @@ export function visit_directive_wrapping_values(node, context, visit) {
  * @template {{ path: AST.Node[]; visit: (node: AST.Node) => AST.Node }} C
  * @param {T} node
  * @param {C} context
- * @param {(node: T, context: C) => AST.Node | void} visit
- * @returns {AST.Node | void}
+ * @param {(node: T, context: C) => AST.Node | AST.Node[] | void} visit
+ * @returns {AST.Node | AST.Node[] | void}
  */
 export function analyze_directive_wrapping_values(node, context, visit) {
 	const wrapper = node.metadata?.tsrx_value_wrapper;
@@ -320,18 +320,6 @@ export function analyze_directive_wrapping_values(node, context, visit) {
 		return context.visit(get_directive_value_wrapper(node));
 	}
 	return visit(node, context);
-}
-
-/**
- * Replace a single statement with several from a visitor: zimmerframe stores
- * the array verbatim in the parent's statement list and the printer flattens
- * nested statement arrays, so this is a supported — if untyped — replacement
- * shape. This helper is the one sanctioned boundary for it.
- * @param {AST.Statement[]} statements
- * @returns {AST.Node}
- */
-export function replace_with_statements(statements) {
-	return /** @type {AST.Node} */ (/** @type {unknown} */ (statements));
 }
 
 /**

--- a/packages/tsrx-ripple/src/utils.js
+++ b/packages/tsrx-ripple/src/utils.js
@@ -196,18 +196,100 @@ export function is_native_tsrx_template_node(node) {
 }
 
 /**
- * Normalize native JSX-shaped TSRX parser nodes into Ripple's current internal
- * template node shape. Ripple's renderer still consumes Element/TsrxFragment,
- * while the shared parser now emits JSXElement/JSXFragment plus custom JSX
- * control-flow expressions.
- * @template T
- * @param {T} node
- * @param {{ to_ts?: boolean }} [options]
- * @returns {T}
+ * Pre-pass: make template control flow consumable by the analyzer and
+ * transforms. Wraps `@if`/`@for`/`@switch`/`@try` directives used in value
+ * positions in a `<> … </>` fragment, then retypes every expression-position
+ * `JSX…Expression` directive into its standard ESTree statement form tagged
+ * with `metadata.tsrxDirective`.
+ * @param {AST.Node} ast
+ * @returns {void}
  */
-export function normalize_jsx_tsrx_templates(node, options = {}) {
-	wrap_directives_combined_into_expressions(/** @type {any} */ (node));
-	return /** @type {T} */ (normalize_jsx_tsrx_node(/** @type {any} */ (node), []));
+export function prepare_template_control_flow(ast) {
+	wrap_directives_combined_into_expressions(/** @type {any} */ (ast));
+	retype_directive_expressions(/** @type {any} */ (ast));
+}
+
+/**
+ * @param {any} node
+ * @returns {any}
+ */
+function retype_directive_expression(node) {
+	const statement = /** @type {any} */ ({ ...node, type: node.statementType });
+	delete statement.statementType;
+	const directive =
+		node.type === 'JSXIfExpression'
+			? 'if'
+			: node.type === 'JSXForExpression'
+				? 'for'
+				: node.type === 'JSXSwitchExpression'
+					? 'switch'
+					: 'try';
+	statement.metadata = {
+		...(statement.metadata ?? {}),
+		tsrxDirective: directive,
+		// Marks a RETYPED directive: its branch bodies are template children
+		// (lowered by `lower_template_code_blocks`), unlike a plain `@else if`
+		// IfStatement that only carries `tsrxDirective` for the transforms.
+		tsrx_template_directive: true,
+	};
+	// `@else if` parses as a plain IfStatement in the alternate — tag it so the
+	// transforms lower it as template control flow (one level, matching the old
+	// normalizer).
+	if (directive === 'if' && statement.alternate?.type === 'IfStatement') {
+		statement.alternate.metadata = {
+			...(statement.alternate.metadata ?? {}),
+			tsrxDirective: 'if',
+		};
+	}
+	return statement;
+}
+
+/**
+ * @param {any} node
+ * @returns {boolean}
+ */
+function is_directive_expression(node) {
+	return (
+		node?.type === 'JSXIfExpression' ||
+		node?.type === 'JSXForExpression' ||
+		node?.type === 'JSXSwitchExpression' ||
+		node?.type === 'JSXTryExpression'
+	);
+}
+
+/**
+ * @param {any} ast
+ * @returns {void}
+ */
+function retype_directive_expressions(ast) {
+	const seen = new Set();
+	/** @param {any} node */
+	const visit = (node) => {
+		if (!node || typeof node !== 'object' || seen.has(node)) return;
+		seen.add(node);
+		if (Array.isArray(node)) {
+			for (const item of node) visit(item);
+			return;
+		}
+		for (const key of Object.keys(node)) {
+			if (key === 'loc' || key === 'start' || key === 'end' || key === 'metadata') continue;
+			const value = node[key];
+			if (Array.isArray(value)) {
+				for (let i = 0; i < value.length; i++) {
+					if (is_directive_expression(value[i])) {
+						value[i] = retype_directive_expression(value[i]);
+					}
+					visit(value[i]);
+				}
+			} else if (is_directive_expression(value)) {
+				node[key] = retype_directive_expression(value);
+				visit(node[key]);
+			} else {
+				visit(value);
+			}
+		}
+	};
+	visit(ast);
 }
 
 /**
@@ -2621,132 +2703,190 @@ export function strip_class_typescript_syntax(node, context) {
 }
 
 /**
- * Fragments stay raw `JSXFragment` nodes; normalization only lowers their
- * template children (code blocks, nested elements) in place.
- * @param {ESTreeJSX.JSXFragment} node
- * @param {AST.Node[]} [inherited_path]
- * @returns {ESTreeJSX.JSXFragment}
+ * Lower the `@{ … }` code blocks that appear as template children throughout
+ * the AST: element/fragment children lists and the branch bodies of retyped
+ * template directives. Statement-position code blocks (function bodies,
+ * code-block bodies) are left alone — they stay lexical blocks and are lowered
+ * by the transforms. Also drops `EmptyStatement` separators from the lists it
+ * touches, matching the old normalizer.
+ * @param {AST.Node} ast
+ * @returns {void}
  */
-function jsx_to_ripple_fragment(node, inherited_path = []) {
-	node.children = /** @type {any} */ (
-		normalize_jsx_tsrx_template_children(node.children || [], inherited_path)
-	);
-	// Marking `native_tsrx` pulls raw JSX fragments (attribute values entering
-	// `build_jsx_to_tsrx_element`) into the template paths; authored template
-	// fragments already carry the flag from the parser.
-	node.metadata = { ...(node.metadata ?? {}), native_tsrx: true, path: inherited_path };
-	return node;
-}
-
-/**
- * @param {any} node
- * @param {AST.Node[]} [inherited_path]
- * @returns {any}
- */
-function jsx_control_expression_to_statement(node, inherited_path = []) {
-	const statement = /** @type {any} */ ({ ...node, type: node.statementType });
-	delete statement.statementType;
-	const directive =
-		node.type === 'JSXIfExpression'
-			? 'if'
-			: node.type === 'JSXForExpression'
-				? 'for'
-				: node.type === 'JSXSwitchExpression'
-					? 'switch'
-					: node.type === 'JSXTryExpression'
-						? 'try'
-						: null;
-	statement.metadata = { ...(statement.metadata ?? {}), path: inherited_path };
-	if (directive) {
-		statement.metadata.tsrxDirective = directive;
-	}
-
-	if (statement.consequent?.type === 'BlockStatement') {
-		statement.consequent.body = normalize_jsx_tsrx_template_children(
-			statement.consequent.body || [],
-			[...inherited_path, statement],
-		);
-	} else if (statement.consequent) {
-		statement.consequent = normalize_jsx_tsrx_node(statement.consequent, [
-			...inherited_path,
-			statement,
-		]);
-	}
-	if (statement.alternate?.type === 'BlockStatement') {
-		statement.alternate.body = normalize_jsx_tsrx_template_children(
-			statement.alternate.body || [],
-			[...inherited_path, statement],
-		);
-	} else if (statement.alternate) {
-		statement.alternate = normalize_jsx_tsrx_node(statement.alternate, [
-			...inherited_path,
-			statement,
-		]);
-		if (directive === 'if' && statement.alternate?.type === 'IfStatement') {
-			statement.alternate.metadata = {
-				...(statement.alternate.metadata ?? {}),
-				tsrxDirective: 'if',
-			};
-		}
-	}
-	if (statement.body?.type === 'BlockStatement') {
-		statement.body.body = normalize_jsx_tsrx_template_children(statement.body.body || [], [
-			...inherited_path,
-			statement,
-		]);
-	}
-	if (statement.empty?.type === 'BlockStatement') {
-		statement.empty.body = normalize_jsx_tsrx_template_children(statement.empty.body || [], [
-			...inherited_path,
-			statement,
-		]);
-	}
-	if (statement.block?.type === 'BlockStatement') {
-		statement.block.body = normalize_jsx_tsrx_template_children(statement.block.body || [], [
-			...inherited_path,
-			statement,
-		]);
-	}
-	if (statement.pending?.type === 'BlockStatement') {
-		statement.pending.body = normalize_jsx_tsrx_template_children(statement.pending.body || [], [
-			...inherited_path,
-			statement,
-		]);
-	}
-	if (statement.handler?.body?.type === 'BlockStatement') {
-		statement.handler.body.body = normalize_jsx_tsrx_template_children(
-			statement.handler.body.body || [],
-			[...inherited_path, statement],
-		);
-	}
-	if (statement.finalizer?.type === 'BlockStatement') {
-		statement.finalizer.body = normalize_jsx_tsrx_template_children(
-			statement.finalizer.body || [],
-			[...inherited_path, statement],
-		);
-	}
-	if (Array.isArray(statement.cases)) {
-		for (const switch_case of statement.cases) {
-			switch_case.consequent = normalize_jsx_tsrx_template_children(switch_case.consequent || [], [
-				...inherited_path,
-				statement,
-			]);
-		}
-	}
-
-	return statement;
+export function lower_template_code_blocks(ast) {
+	lower_node(/** @type {any} */ (ast), []);
 }
 
 /**
  * @param {any[]} children
- * @param {AST.Node[]} [inherited_path]
- * @returns {AST.Node[]}
+ * @param {AST.Node[]} inherited_path
+ * @returns {any[]}
  */
-function normalize_jsx_tsrx_children(children, inherited_path = []) {
+function lower_template_children(children, inherited_path = []) {
 	return children
-		.map((/** @type {any} */ child) => normalize_jsx_tsrx_node(child, inherited_path))
-		.flat()
+		.map((/** @type {any} */ child) => {
+			lower_node(child, inherited_path);
+			return child?.type === 'JSXCodeBlock'
+				? code_block_to_template_child(child, inherited_path)
+				: child;
+		})
 		.filter((/** @type {any} */ child) => child != null && child.type !== 'EmptyStatement');
+}
+
+/**
+ * @param {any[]} statements
+ * @param {AST.Node[]} inherited_path
+ * @returns {any[]}
+ */
+function lower_statement_children(statements, inherited_path) {
+	for (const statement of statements) {
+		lower_node(statement, inherited_path);
+	}
+	return statements.filter(
+		(/** @type {any} */ child) => child != null && child.type !== 'EmptyStatement',
+	);
+}
+
+/**
+ * @param {any} statement — a retyped template directive
+ * @param {AST.Node[]} inherited_path
+ * @returns {void}
+ */
+function lower_directive_template_slots(statement, inherited_path) {
+	const path = [...inherited_path, statement];
+	if (statement.consequent?.type === 'BlockStatement') {
+		statement.consequent.body = lower_template_children(statement.consequent.body || [], path);
+	} else if (statement.consequent) {
+		lower_node(statement.consequent, path);
+	}
+	if (statement.alternate?.type === 'BlockStatement') {
+		statement.alternate.body = lower_template_children(statement.alternate.body || [], path);
+	} else if (statement.alternate) {
+		lower_node(statement.alternate, path);
+	}
+	if (statement.body?.type === 'BlockStatement') {
+		statement.body.body = lower_template_children(statement.body.body || [], path);
+	}
+	if (statement.empty?.type === 'BlockStatement') {
+		statement.empty.body = lower_template_children(statement.empty.body || [], path);
+	}
+	if (statement.block?.type === 'BlockStatement') {
+		statement.block.body = lower_template_children(statement.block.body || [], path);
+	}
+	if (statement.pending?.type === 'BlockStatement') {
+		statement.pending.body = lower_template_children(statement.pending.body || [], path);
+	}
+	if (statement.handler?.body?.type === 'BlockStatement') {
+		statement.handler.body.body = lower_template_children(statement.handler.body.body || [], path);
+	}
+	if (statement.finalizer?.type === 'BlockStatement') {
+		statement.finalizer.body = lower_template_children(statement.finalizer.body || [], path);
+	}
+	if (Array.isArray(statement.cases)) {
+		for (const switch_case of statement.cases) {
+			switch_case.consequent = lower_template_children(switch_case.consequent || [], path);
+		}
+	}
+	// Test/discriminant/iterable expressions are not template slots — raw JSX
+	// there lowers through the transforms' value paths — but they may still
+	// contain nested templates, so keep walking them.
+	if (statement.test) lower_node(statement.test, path);
+	if (statement.discriminant) lower_node(statement.discriminant, path);
+	if (statement.right) lower_node(statement.right, path);
+}
+
+/**
+ * The recursive worker for {@link lower_template_code_blocks}: dispatches on
+ * the node shapes that own template-children lists and walks everything else
+ * generically.
+ * @param {any} node
+ * @param {AST.Node[]} inherited_path
+ * @returns {void}
+ */
+function lower_node(node, inherited_path = []) {
+	if (!node || typeof node !== 'object') return;
+	if (Array.isArray(node)) {
+		for (const item of node) lower_node(item, inherited_path);
+		return;
+	}
+
+	if (node.type === 'JSXFragment' || node.type === 'JSXElement') {
+		node.children = lower_template_children(node.children || [], [...inherited_path, node]);
+		if (node.type === 'JSXElement') {
+			// Attribute values may hold raw JSX with nested templates.
+			lower_node(node.openingElement?.attributes, [...inherited_path, node]);
+		}
+		return;
+	}
+	if (
+		node.type === 'JSXStyleElement' ||
+		node.type === 'JSXText' ||
+		node.type === 'StyleSheet' ||
+		node.type === 'JSXOpeningElement' ||
+		node.type === 'JSXClosingElement'
+	) {
+		return;
+	}
+	if (node.type === 'JSXCodeBlock') {
+		// Each `@{ … }` is its own lexical scope, so nested blocks never merge
+		// into their parent. A block whose render output is itself a code block
+		// (`@{ @{ … } }`) keeps the nesting: the inner block is lowered like a
+		// template child inside a synthetic fragment so it gets its own scope.
+		const path = [...inherited_path, node];
+		node.body = lower_statement_children(node.body || [], path);
+		if (node.render?.type === 'JSXCodeBlock') {
+			const inner = node.render;
+			lower_node(inner, path);
+			const inner_child = code_block_to_template_child(inner, path);
+			// An inner block that is empty all the way down renders nothing —
+			// drop it so the outer block becomes code-only (and prunable too).
+			if (inner_child == null) {
+				node.render = null;
+			} else if (is_native_tsrx_template_node(inner_child)) {
+				// The inner chain collapsed to a plain template node (its scope
+				// was unobservable) — it becomes this block's render directly,
+				// with no wrapper fragment.
+				node.render = inner_child;
+			} else {
+				const fragment = /** @type {any} */ (b.jsx_fragment([/** @type {any} */ (inner_child)]));
+				setLocation(fragment, /** @type {AST.NodeWithLocation} */ (inner));
+				fragment.metadata.path = path;
+				// native_tsrx so core scope creation treats the wrapper like any
+				// other template fragment; tsrx_code_block_chain so
+				// template-children lowering can unwrap it instead of stacking an
+				// inline component per nesting level.
+				fragment.metadata.native_tsrx = true;
+				fragment.metadata.tsrx_code_block_chain = true;
+				node.render = fragment;
+			}
+		} else if (node.render) {
+			lower_node(node.render, path);
+		}
+		return;
+	}
+	if (node.metadata?.tsrx_template_directive) {
+		lower_directive_template_slots(node, inherited_path);
+		return;
+	}
+
+	for (const key in node) {
+		if (
+			key === 'metadata' ||
+			key === 'parent' ||
+			key === 'loc' ||
+			key === 'start' ||
+			key === 'end' ||
+			key === 'type'
+		) {
+			continue;
+		}
+
+		const value = node[key];
+		if (Array.isArray(value)) {
+			node[key] = lower_statement_children(value, [...inherited_path, node]);
+		} else if (value && typeof value === 'object') {
+			lower_node(value, [...inherited_path, node]);
+		}
+	}
 }
 
 /**
@@ -2838,170 +2978,44 @@ function code_block_to_template_child(block, inherited_path) {
 }
 
 /**
- * Normalize a template children list (fragment/element children, control-flow
- * branch bodies), lowering `@{ … }` code-block children into their scoped
- * template-child form. Statement arrays that are not template children
- * (function bodies, program body) must keep using
- * `normalize_jsx_tsrx_children` so statement-position code blocks stay
- * lexical blocks.
- * @param {any[]} children
- * @param {AST.Node[]} [inherited_path]
- * @returns {AST.Node[]}
- */
-function normalize_jsx_tsrx_template_children(children, inherited_path = []) {
-	return normalize_jsx_tsrx_children(children, inherited_path)
-		.map((child) =>
-			child.type === 'JSXCodeBlock' ? code_block_to_template_child(child, inherited_path) : child,
-		)
-		.filter((child) => child != null);
-}
-
-/**
+ * Mark every element/fragment in a raw JSX subtree `native_tsrx` so the
+ * transforms route it through the template paths rather than the raw-JSX
+ * value lowering.
  * @param {any} node
- * @param {AST.Node[]} [inherited_path]
- * @returns {any}
+ * @returns {void}
  */
-function normalize_jsx_tsrx_node(node, inherited_path = []) {
-	if (!node || typeof node !== 'object') return node;
-	if (Array.isArray(node)) return normalize_jsx_tsrx_children(node, inherited_path);
-
-	if (node.type === 'JSXFragment') {
-		return jsx_to_ripple_fragment(node, inherited_path);
+function mark_raw_template_jsx(node) {
+	if (!node || typeof node !== 'object') return;
+	if (Array.isArray(node)) {
+		for (const item of node) mark_raw_template_jsx(item);
+		return;
 	}
-	if (node.type === 'JSXElement') {
-		return jsx_to_ripple_node(node, inherited_path);
+	// Only children chains: raw JSX inside `{ … }` containers or attribute
+	// values keeps lowering lazily through the value path.
+	if (node.type === 'JSXElement' || node.type === 'JSXFragment') {
+		node.metadata = { ...(node.metadata ?? {}), native_tsrx: true };
+		mark_raw_template_jsx(node.children);
 	}
-	if (node.type === 'JSXStyleElement') {
-		// Consumed directly from the parser AST — its children are stylesheet
-		// AST, nothing to normalize.
-		node.metadata = { ...(node.metadata ?? {}), path: inherited_path };
-		return node;
-	}
-	if (
-		node.type === 'JSXIfExpression' ||
-		node.type === 'JSXForExpression' ||
-		node.type === 'JSXSwitchExpression' ||
-		node.type === 'JSXTryExpression'
-	) {
-		return jsx_control_expression_to_statement(node, inherited_path);
-	}
-	if (node.type === 'JSXText') {
-		// Consumed directly from the parser AST (see template-ast.js).
-		return node;
-	}
-	if (node.type === 'JSXCodeBlock') {
-		// Each `@{ … }` is its own lexical scope, so nested blocks never merge
-		// into their parent. A block whose render output is itself a code block
-		// (`@{ @{ … } }`) keeps the nesting: the inner block is lowered like a
-		// template child inside a synthetic fragment so it gets its own scope.
-		const path = [...inherited_path, node];
-		node.body = normalize_jsx_tsrx_children(node.body || [], path);
-		if (node.render?.type === 'JSXCodeBlock') {
-			const inner = normalize_jsx_tsrx_node(node.render, path);
-			const inner_child = code_block_to_template_child(inner, path);
-			// An inner block that is empty all the way down renders nothing —
-			// drop it so the outer block becomes code-only (and prunable too).
-			if (inner_child == null) {
-				node.render = null;
-			} else if (is_native_tsrx_template_node(inner_child)) {
-				// The inner chain collapsed to a plain template node (its scope
-				// was unobservable) — it becomes this block's render directly,
-				// with no wrapper fragment.
-				node.render = inner_child;
-			} else {
-				const fragment = /** @type {any} */ (b.jsx_fragment([/** @type {any} */ (inner_child)]));
-				setLocation(fragment, /** @type {AST.NodeWithLocation} */ (inner));
-				fragment.metadata.path = path;
-				// native_tsrx so core scope creation treats the wrapper like any
-				// other template fragment; tsrx_code_block_chain so
-				// template-children lowering can unwrap it instead of stacking an
-				// inline component per nesting level.
-				fragment.metadata.native_tsrx = true;
-				fragment.metadata.tsrx_code_block_chain = true;
-				node.render = fragment;
-			}
-		} else if (node.render) {
-			node.render = normalize_jsx_tsrx_node(node.render, path);
-		}
-		return node;
-	}
-
-	for (const key in node) {
-		if (
-			key === 'metadata' ||
-			key === 'parent' ||
-			key === 'loc' ||
-			key === 'start' ||
-			key === 'end' ||
-			key === 'type'
-		) {
-			continue;
-		}
-
-		const value = node[key];
-		if (Array.isArray(value)) {
-			node[key] = normalize_jsx_tsrx_children(value, [...inherited_path, node]);
-		} else if (value && typeof value === 'object') {
-			node[key] = normalize_jsx_tsrx_node(value, [...inherited_path, node]);
-		}
-	}
-
-	return node;
 }
 
 /**
- * Converts a JSX AST node (JSXElement, JSXText, etc.) to a Ripple AST node
- * (Element, Text, TSRXExpression) for JSX-to-template lowering.
+ * Adopt a raw JSX subtree (an attribute value or other JSX that never entered
+ * the template traversal) into the template machinery at transform time:
+ * marks its elements/fragments `native_tsrx`, retypes any nested directives,
+ * and lowers its `@{ … }` code-block template children. Returns the template
+ * children — a fragment root flattens to its children list.
  *
  * @param {any} node
  * @param {AST.Node[]} [inherited_path]
  * @returns {any}
  */
 export function jsx_to_ripple_node(node, inherited_path = []) {
-	if (node.type === 'JSXElement') {
-		// Elements stay raw JSXElement nodes; only their template children are
-		// lowered in place. Marking `native_tsrx` pulls raw JSX (attribute
-		// values entering `build_jsx_to_tsrx_element`) into the template paths;
-		// authored template elements already carry the flag from the parser.
-		node.metadata = { ...(node.metadata ?? {}), native_tsrx: true, path: inherited_path };
-
-		node.children = /** @type {AST.Node[]} */ (
-			normalize_jsx_tsrx_template_children(/** @type {AST.Node[]} */ (node.children), [
-				...inherited_path,
-				node,
-			]).filter(Boolean)
-		);
-
-		return node;
-	}
-
-	if (
-		node.type === 'JSXStyleElement' ||
-		node.type === 'JSXText' ||
-		node.type === 'JSXExpressionContainer'
-	) {
-		// Consumed directly from the parser AST (see template-ast.js). Elements
-		// nested inside a container's expression still normalize via the
-		// recursive pass; this helper only sees already-normalized subtrees.
-		return node;
-	}
+	mark_raw_template_jsx(node);
+	prepare_template_control_flow(node);
+	lower_node(node, inherited_path);
 
 	if (node.type === 'JSXFragment') {
-		return /** @type {AST.Node[]} */ (
-			normalize_jsx_tsrx_template_children(
-				/** @type {AST.Node[]} */ (node.children),
-				inherited_path,
-			).filter(Boolean)
-		);
-	}
-
-	if (
-		node.type === 'JSXIfExpression' ||
-		node.type === 'JSXForExpression' ||
-		node.type === 'JSXSwitchExpression' ||
-		node.type === 'JSXTryExpression'
-	) {
-		return jsx_control_expression_to_statement(node, inherited_path);
+		return node.children;
 	}
 
 	return node;

--- a/packages/tsrx-ripple/src/utils.js
+++ b/packages/tsrx-ripple/src/utils.js
@@ -1023,15 +1023,10 @@ function expand_embedded_native_tsrx_return_statement(statement) {
 
 /**
  * @param {AST.Node | null | undefined} node
- * @returns {node is AST.Element}
+ * @returns {node is AST.JSXStyleElement}
  */
 export function is_style_element(node) {
-	return !!(
-		node &&
-		node.type === 'Element' &&
-		node.id?.type === 'Identifier' &&
-		node.id.name === 'style'
-	);
+	return !!(node && node.type === 'JSXStyleElement');
 }
 
 /**
@@ -2264,13 +2259,16 @@ function normalize_child(node, normalized, context) {
 	) {
 		return;
 	} else if (
+		node.type === 'JSXStyleElement' &&
+		!context.state.inside_head &&
+		!context.state.keep_component_style
+	) {
+		// Component styles render nothing — their CSS is extracted at analysis.
+		return;
+	} else if (
 		node.type === 'Element' &&
 		node.id.type === 'Identifier' &&
-		((node.id.name === 'style' &&
-			!context.state.inside_head &&
-			!context.state.keep_component_style) ||
-			node.id.name === 'head' ||
-			(node.id.name === 'title' && context.state.inside_head))
+		(node.id.name === 'head' || (node.id.name === 'title' && context.state.inside_head))
 	) {
 		return;
 	} else {
@@ -2763,41 +2761,6 @@ function jsx_control_expression_to_statement(node, inherited_path = []) {
 }
 
 /**
- * @param {AST.JSXStyleElement} node
- * @param {AST.Node[]} [inherited_path]
- * @returns {AST.Element}
- */
-function jsx_style_to_ripple_element(node, inherited_path = []) {
-	const id = /** @type {AST.Identifier} */ ({
-		type: 'Identifier',
-		name: 'style',
-		start: node.openingElement?.name?.start ?? node.start,
-		end: node.openingElement?.name?.end ?? node.start,
-		loc: node.openingElement?.name?.loc,
-	});
-	const stylesheet = node.children?.find(
-		(/** @type {any} */ child) => child?.type === 'StyleSheet',
-	);
-
-	return /** @type {AST.Element} */ (
-		/** @type {unknown} */ ({
-			type: 'Element',
-			id,
-			attributes: [],
-			children: node.children || [],
-			openingElement: node.openingElement,
-			closingElement: node.closingElement,
-			selfClosing: false,
-			css: stylesheet?.source ?? '',
-			metadata: { ...(node.metadata ?? {}), scoped: false, path: inherited_path },
-			start: node.start,
-			end: node.end,
-			loc: node.loc,
-		})
-	);
-}
-
-/**
  * @param {any[]} children
  * @param {AST.Node[]} [inherited_path]
  * @returns {AST.Node[]}
@@ -2932,7 +2895,10 @@ function normalize_jsx_tsrx_node(node, inherited_path = []) {
 		return jsx_to_ripple_node(node, inherited_path);
 	}
 	if (node.type === 'JSXStyleElement') {
-		return jsx_style_to_ripple_element(node, inherited_path);
+		// Consumed directly from the parser AST — its children are stylesheet
+		// AST, nothing to normalize.
+		node.metadata = { ...(node.metadata ?? {}), path: inherited_path };
+		return node;
 	}
 	if (
 		node.type === 'JSXIfExpression' ||
@@ -3085,11 +3051,11 @@ export function jsx_to_ripple_node(node, inherited_path = []) {
 		return element;
 	}
 
-	if (node.type === 'JSXStyleElement') {
-		return jsx_style_to_ripple_element(node, inherited_path);
-	}
-
-	if (node.type === 'JSXText' || node.type === 'JSXExpressionContainer') {
+	if (
+		node.type === 'JSXStyleElement' ||
+		node.type === 'JSXText' ||
+		node.type === 'JSXExpressionContainer'
+	) {
 		// Consumed directly from the parser AST (see template-ast.js). Elements
 		// nested inside a container's expression still normalize via the
 		// recursive pass; this helper only sees already-normalized subtrees.

--- a/packages/tsrx-ripple/src/utils.js
+++ b/packages/tsrx-ripple/src/utils.js
@@ -1940,7 +1940,7 @@ export function escape_html(value, is_attr = false) {
 
 /**
  * Returns true if node is a DOM element (not a component)
- * @param {AST.Node} node
+ * @param {AST.TSRXJSXElement | AST.JSXStyleElement} node
  * @returns {boolean}
  */
 export function is_element_dom_element(node) {

--- a/packages/tsrx-ripple/src/utils.js
+++ b/packages/tsrx-ripple/src/utils.js
@@ -189,11 +189,15 @@ export function is_native_tsrx_template_node(node) {
  * positions in a `<> … </>` fragment so they lower as values. Directives keep
  * their parser forms (`JSXIfExpression`, …) — the analyzer and transforms
  * dispatch on those directly.
- * @param {AST.Node} ast
- * @returns {void}
+ *
+ * Copy-on-write: the input tree is never mutated — changed spines are rebuilt
+ * (unchanged subtrees are shared), so the parse result stays pristine.
+ * @template {AST.Node} T
+ * @param {T} ast
+ * @returns {T}
  */
 export function prepare_template_control_flow(ast) {
-	wrap_directives_combined_into_expressions(/** @type {any} */ (ast));
+	return /** @type {T} */ (wrap_directives_combined_into_expressions(/** @type {any} */ (ast)));
 }
 
 /**
@@ -288,49 +292,70 @@ function wrap_directive_in_jsx_fragment(directive) {
  * @param {any} ast
  */
 function wrap_directives_combined_into_expressions(ast) {
-	const seen = new Set();
 	/**
 	 * @param {any} parent
 	 * @param {string} key
-	 * @param {any} child
-	 * @returns {boolean}
+	 * @param {any} value
+	 * @returns {any}
 	 */
-	const is_flagged = (parent, key, child) =>
-		is_control_flow_directive(child) && !is_render_child_or_statement_slot(parent, key, child);
+	const visit_slot = (parent, key, value) => {
+		if (
+			is_control_flow_directive(value) &&
+			!is_render_child_or_statement_slot(parent, key, value)
+		) {
+			return wrap_directive_in_jsx_fragment(visit(value));
+		}
+		return visit(value);
+	};
 	/**
 	 * @param {any} node
+	 * @returns {any}
 	 */
 	const visit = (node) => {
-		if (!node || typeof node !== 'object' || seen.has(node)) return;
-		seen.add(node);
-		if (Array.isArray(node)) {
-			for (const item of node) visit(item);
-			return;
+		if (!node || typeof node !== 'object') return node;
+		/** @type {Record<string, any> | null} */
+		let updates = null;
+		// acorn-typescript quirk: call/new expressions carry their generics as
+		// `typeParameters`; the transforms (and the TSX printer) expect the
+		// standard `typeArguments`.
+		if ((node.type === 'CallExpression' || node.type === 'NewExpression') && node.typeParameters) {
+			updates = { typeArguments: node.typeParameters, typeParameters: undefined };
 		}
 		for (const key of Object.keys(node)) {
-			if (key === 'loc' || key === 'start' || key === 'end' || key === 'metadata') continue;
+			if (
+				key === 'loc' ||
+				key === 'start' ||
+				key === 'end' ||
+				key === 'metadata' ||
+				key === 'parent'
+			) {
+				continue;
+			}
 			const value = node[key];
 			if (Array.isArray(value)) {
+				/** @type {any[] | null} */
+				let out = null;
 				for (let i = 0; i < value.length; i++) {
-					if (is_flagged(node, key, value[i])) {
-						value[i] = wrap_directive_in_jsx_fragment(value[i]);
+					const next = visit_slot(node, key, value[i]);
+					if (next !== value[i]) {
+						out ??= value.slice();
+						out[i] = next;
 					}
-					visit(value[i]);
 				}
-			} else if (is_flagged(node, key, value)) {
-				node[key] = wrap_directive_in_jsx_fragment(value);
-				visit(node[key]);
-			} else {
-				visit(value);
+				if (out) (updates ??= {})[key] = out;
+			} else if (value && typeof value === 'object') {
+				const next = visit_slot(node, key, value);
+				if (next !== value) (updates ??= {})[key] = next;
 			}
 		}
+		return updates ? { ...node, ...updates } : node;
 	};
-	visit(ast);
+	return visit(ast);
 }
 
 /**
  * Wrap a `@{ … }` code block in an immediately-invoked arrow
- * (`(() => @{ … })()`). Ripple only lowers a code block when it is a function body
+ * (`(() =>@{ … })()`). Ripple only lowers a code block when it is a function body
  * @param {AST.JSXCodeBlock} code_block
  * @returns {AST.CallExpression}
  */
@@ -705,21 +730,31 @@ export function get_native_tsrx_template_children(node) {
 
 /**
  * @param {AST.Function} node
+ * @param {Map<AST.Node | AST.Node[], any>} [scopes]
  * @returns {AST.Node[]}
  */
-export function get_native_tsrx_function_body(node) {
+export function get_native_tsrx_function_body(node, scopes) {
+	// Memoized: the expansion is computed once (during analysis) and shared
+	// with the transforms, so the expanded statements keep one identity across
+	// stages — metadata written on them by the analyzer stays visible.
+	node.metadata ??= { path: [] };
+	const metadata = /** @type {{ tsrx_render_body?: AST.Node[] }} */ (node.metadata);
+	if (metadata.tsrx_render_body) {
+		return metadata.tsrx_render_body;
+	}
+
+	/** @type {AST.Node[]} */
+	let result;
 	if (node.body?.type === 'JSXCodeBlock') {
 		const block = node.body;
-		return [
-			...expand_native_tsrx_return_statements(block.body || [], true),
+		result = [
+			...expand_native_tsrx_return_statements(block.body || [], true, scopes),
 			...(is_native_tsrx_template_node(block.render)
 				? [mark_returned_template_child(/** @type {AST.Node} */ (block.render))]
 				: []),
 		];
-	}
-
-	if (node.type === 'ArrowFunctionExpression' && node.body?.type !== 'BlockStatement') {
-		return is_native_tsrx_template_node(node.body)
+	} else if (node.type === 'ArrowFunctionExpression' && node.body?.type !== 'BlockStatement') {
+		result = is_native_tsrx_template_node(node.body)
 			? [
 					...get_native_tsrx_template_children(
 						/** @type {ESTreeJSX.JSXElement | ESTreeJSX.JSXFragment} */ (
@@ -728,20 +763,25 @@ export function get_native_tsrx_function_body(node) {
 					).map((child) => mark_returned_template_child(child)),
 				]
 			: [b.return(/** @type {AST.Expression} */ (node.body))];
+	} else {
+		const body = node.body?.type === 'BlockStatement' ? node.body.body : [];
+		result = expand_native_tsrx_return_statements(body, true, scopes);
 	}
 
-	const body = node.body?.type === 'BlockStatement' ? node.body.body : [];
-	return expand_native_tsrx_return_statements(body, true);
+	metadata.tsrx_render_body = result;
+	return result;
 }
 
 /**
  * @param {AST.Statement[]} statements
  * @param {boolean} [omit_final_control_return]
+ * @param {Map<AST.Node | AST.Node[], any>} [scopes]
  * @returns {AST.Node[]}
  */
 export function expand_native_tsrx_return_statements(
 	statements,
 	omit_final_control_return = false,
+	scopes,
 ) {
 	return statements.flatMap((statement, index) =>
 		expand_native_tsrx_return_statement(
@@ -749,6 +789,7 @@ export function expand_native_tsrx_return_statements(
 			omit_final_control_return &&
 				index === statements.length - 1 &&
 				statement.type === 'ReturnStatement',
+			scopes,
 		),
 	);
 }
@@ -877,9 +918,25 @@ function create_return_argument_child(argument, statement) {
 /**
  * @param {AST.Statement} statement
  * @param {boolean} [omit_control_return]
+ * @param {Map<AST.Node | AST.Node[], any>} [scopes]
  * @returns {AST.Node[]}
  */
-function expand_native_tsrx_return_statement(statement, omit_control_return = false) {
+function expand_native_tsrx_return_statement(statement, omit_control_return = false, scopes) {
+	/**
+	 * Copy-on-write helper: rebuilt spine nodes inherit the original's scope
+	 * mapping so transform-time lookups keep working.
+	 * @template {AST.Node} T
+	 * @param {T} original
+	 * @param {Partial<T>} updates
+	 * @returns {T}
+	 */
+	const rebuild = (original, updates) => {
+		const copy = { ...original, ...updates };
+		const scope = scopes?.get(original);
+		if (scope) scopes?.set(copy, scope);
+		return copy;
+	};
+
 	if (statement.metadata?.returned_tsrx_child) {
 		return [statement];
 	}
@@ -904,7 +961,11 @@ function expand_native_tsrx_return_statement(statement, omit_control_return = fa
 		const children = omit_control_return
 			? template_children.flatMap((child) =>
 					node_contains_component_return(child)
-						? expand_native_tsrx_return_statement(/** @type {AST.Statement} */ (child))
+						? expand_native_tsrx_return_statement(
+								/** @type {AST.Statement} */ (child),
+								false,
+								scopes,
+							)
 						: [child],
 				)
 			: template_children;
@@ -944,44 +1005,61 @@ function expand_native_tsrx_return_statement(statement, omit_control_return = fa
 	}
 
 	if (statement.type === 'BlockStatement') {
-		statement.body = /** @type {AST.Statement[]} */ (
-			expand_native_tsrx_return_statements(statement.body || [])
+		const body = /** @type {AST.Statement[]} */ (
+			expand_native_tsrx_return_statements(statement.body || [], false, scopes)
 		);
-		return [statement];
+		return [body === (statement.body || []) ? statement : rebuild(statement, { body })];
 	}
 
 	if (statement.type === 'IfStatement') {
-		statement.consequent = expand_embedded_native_tsrx_return_statement(statement.consequent);
-		if (statement.alternate) {
-			statement.alternate = expand_embedded_native_tsrx_return_statement(statement.alternate);
-		}
-		return [statement];
+		const consequent = expand_embedded_native_tsrx_return_statement(statement.consequent, scopes);
+		const alternate = statement.alternate
+			? expand_embedded_native_tsrx_return_statement(statement.alternate, scopes)
+			: statement.alternate;
+		return [
+			consequent === statement.consequent && alternate === statement.alternate
+				? statement
+				: rebuild(statement, { consequent, alternate }),
+		];
 	}
 
 	if (statement.type === 'SwitchStatement') {
-		for (const switch_case of statement.cases || []) {
-			switch_case.consequent = /** @type {AST.Statement[]} */ (
-				expand_native_tsrx_return_statements(switch_case.consequent || [])
+		/** @type {AST.SwitchCase[] | null} */
+		let cases = null;
+		(statement.cases || []).forEach((switch_case, i) => {
+			const consequent = /** @type {AST.Statement[]} */ (
+				expand_native_tsrx_return_statements(switch_case.consequent || [], false, scopes)
 			);
-		}
-		return [statement];
+			if (consequent !== (switch_case.consequent || [])) {
+				cases ??= statement.cases.slice();
+				cases[i] = rebuild(switch_case, { consequent });
+			}
+		});
+		return [cases ? rebuild(statement, { cases }) : statement];
 	}
 
 	if (statement.type === 'TryStatement') {
-		statement.block = /** @type {AST.BlockStatement} */ (
-			expand_embedded_native_tsrx_return_statement(statement.block)
+		/** @type {Partial<AST.TryStatement> & Record<string, any>} */
+		const updates = {};
+		const block = /** @type {AST.BlockStatement} */ (
+			expand_embedded_native_tsrx_return_statement(statement.block, scopes)
 		);
+		if (block !== statement.block) updates.block = block;
 		if (statement.handler?.body) {
-			statement.handler.body = /** @type {AST.BlockStatement} */ (
-				expand_embedded_native_tsrx_return_statement(statement.handler.body)
+			const body = /** @type {AST.BlockStatement} */ (
+				expand_embedded_native_tsrx_return_statement(statement.handler.body, scopes)
 			);
+			if (body !== statement.handler.body) {
+				updates.handler = rebuild(statement.handler, { body });
+			}
 		}
 		if (statement.finalizer) {
-			statement.finalizer = /** @type {AST.BlockStatement} */ (
-				expand_embedded_native_tsrx_return_statement(statement.finalizer)
+			const finalizer = /** @type {AST.BlockStatement} */ (
+				expand_embedded_native_tsrx_return_statement(statement.finalizer, scopes)
 			);
+			if (finalizer !== statement.finalizer) updates.finalizer = finalizer;
 		}
-		return [statement];
+		return [Object.keys(updates).length > 0 ? rebuild(statement, updates) : statement];
 	}
 
 	return [statement];
@@ -989,16 +1067,19 @@ function expand_native_tsrx_return_statement(statement, omit_control_return = fa
 
 /**
  * @param {AST.Statement} statement
+ * @param {Map<AST.Node | AST.Node[], any>} [scopes]
  * @returns {AST.Statement}
  */
-function expand_embedded_native_tsrx_return_statement(statement) {
-	const expanded = expand_native_tsrx_return_statement(statement);
-	return expanded.length === 1
-		? /** @type {AST.Statement} */ (expanded[0])
-		: b.block(
-				/** @type {AST.Statement[]} */ (expanded),
-				/** @type {AST.NodeWithLocation} */ (statement),
-			);
+function expand_embedded_native_tsrx_return_statement(statement, scopes) {
+	const expanded = expand_native_tsrx_return_statement(statement, false, scopes);
+	return expanded.length === 1 && expanded[0] === statement
+		? statement
+		: expanded.length === 1
+			? /** @type {AST.Statement} */ (expanded[0])
+			: b.block(
+					/** @type {AST.Statement[]} */ (expanded),
+					/** @type {AST.NodeWithLocation} */ (statement),
+				);
 }
 
 /**
@@ -1076,56 +1157,86 @@ function collect_style_elements(node, styles, inside_head) {
 }
 
 /**
+ * Copy-on-write: rebuilt spine nodes inherit the original's scope mapping when
+ * a `scopes` map is provided, so transform-time lookups keep working.
  * @param {AST.Node[]} nodes
+ * @param {Map<AST.Node | AST.Node[], any>} [scopes]
  * @returns {AST.Node[]}
  */
-export function strip_tsrx_style_elements(nodes) {
-	return strip_style_elements(nodes, false);
+export function strip_tsrx_style_elements(nodes, scopes) {
+	return strip_style_elements(nodes, false, scopes);
 }
 
 /**
  * @param {AST.Node[]} nodes
  * @param {boolean} inside_head
+ * @param {Map<AST.Node | AST.Node[], any>} [scopes]
  * @returns {AST.Node[]}
  */
-function strip_style_elements(nodes, inside_head) {
-	return nodes
-		.filter((node) => !(is_style_element(node) && !inside_head))
-		.map((node) => strip_style_element_children(node, inside_head))
-		.filter(Boolean);
+function strip_style_elements(nodes, inside_head, scopes) {
+	/** @type {AST.Node[] | null} */
+	let out = null;
+	for (let i = 0; i < nodes.length; i++) {
+		const node = nodes[i];
+		const next =
+			is_style_element(node) && !inside_head
+				? null
+				: strip_style_element_children(node, inside_head, scopes);
+		if (next !== node) {
+			out ??= nodes.slice();
+			out[i] = /** @type {AST.Node} */ (next);
+		}
+	}
+	const result = out ?? nodes;
+	return result.some((node) => node == null) ? result.filter(Boolean) : result;
 }
 
 /**
  * @param {AST.Node} node
  * @param {boolean} inside_head
+ * @param {Map<AST.Node | AST.Node[], any>} [scopes]
  * @returns {AST.Node}
  */
-function strip_style_element_children(node, inside_head) {
+function strip_style_element_children(node, inside_head, scopes) {
 	const node_any = /** @type {any} */ (node);
 	const next_inside_head =
 		inside_head ||
 		(is_template_element(node_any) &&
 			/** @type {any} */ (get_element_id(node_any))?.type === 'Identifier' &&
 			/** @type {any} */ (get_element_id(node_any)).name === 'head');
+	/** @type {Record<string, any> | null} */
+	let updates = null;
 	if ('children' in node && Array.isArray(node.children)) {
-		node.children = /** @type {any} */ (
-			strip_style_elements(/** @type {AST.Node[]} */ (node.children), next_inside_head)
+		const children = strip_style_elements(
+			/** @type {AST.Node[]} */ (node.children),
+			next_inside_head,
+			scopes,
 		);
+		if (children !== node.children) (updates ??= {}).children = children;
 	}
 	if (node.type === 'BlockStatement') {
-		node.body = /** @type {AST.Statement[]} */ (strip_style_elements(node.body, next_inside_head));
+		const body = /** @type {AST.Statement[]} */ (
+			strip_style_elements(node.body, next_inside_head, scopes)
+		);
+		if (body !== node.body) (updates ??= {}).body = body;
 	}
 	if (node.type === 'IfStatement') {
-		node.consequent = /** @type {AST.Statement} */ (
-			strip_style_element_children(node.consequent, next_inside_head)
+		const consequent = /** @type {AST.Statement} */ (
+			strip_style_element_children(node.consequent, next_inside_head, scopes)
 		);
+		if (consequent !== node.consequent) (updates ??= {}).consequent = consequent;
 		if (node.alternate) {
-			node.alternate = /** @type {AST.Statement} */ (
-				strip_style_element_children(node.alternate, next_inside_head)
+			const alternate = /** @type {AST.Statement} */ (
+				strip_style_element_children(node.alternate, next_inside_head, scopes)
 			);
+			if (alternate !== node.alternate) (updates ??= {}).alternate = alternate;
 		}
 	}
-	return node;
+	if (!updates) return node;
+	const copy = { ...node, ...updates };
+	const scope = scopes?.get(node);
+	if (scope) scopes?.set(copy, scope);
+	return copy;
 }
 
 /**
@@ -1885,14 +1996,18 @@ export function is_element_dom_element(node) {
 export const dynamic_element_import_local = 'TsrxDynamic';
 
 /**
+ * Lower a dynamic `<{expr}>` element to the `TsrxDynamic` component shape on a
+ * copy — the source element is never mutated. Returns the lowered copy, or
+ * `null` when the element is not dynamic.
  * @param {AST.TSRXJSXElement} node
  * @param {AST.Expression} [component_id] - Override for the lowered component
  * reference; defaults to the `TsrxDynamic` local used by type-only output.
- * @returns {boolean}
+ * @param {Map<AST.Node | AST.Node[], any>} [scopes]
+ * @returns {AST.TSRXJSXElement | null}
  */
-export function lower_dynamic_element(node, component_id) {
+export function lower_dynamic_element(node, component_id, scopes) {
 	if (!is_dynamic_element(node)) {
-		return false;
+		return null;
 	}
 
 	const expression = /** @type {AST.Expression} */ (get_element_id(node));
@@ -1900,42 +2015,51 @@ export function lower_dynamic_element(node, component_id) {
 	const closing_expression =
 		closing_name?.expression && clone_expression_node(closing_name.expression);
 	add_extra_source_mappings_from_matching_expression(expression, closing_expression);
-	set_element_id(node, component_id ?? b.id(dynamic_element_import_local));
-	if (node.openingElement?.name) {
-		node.openingElement.name = b.jsx_id(dynamic_element_import_local);
-	}
-	if (node.closingElement?.name) {
-		node.closingElement.name = b.jsx_id(dynamic_element_import_local);
-	}
-	node.openingElement.attributes = [
+
+	const is_attribute = /** @type {ESTreeJSX.JSXAttribute} */ (
 		// A synthetic `is={expr}` JSXAttribute; the container value marks it as
 		// an authored-expression attribute for the accessors.
-		/** @type {ESTreeJSX.JSXAttribute} */ (
-			/** @type {unknown} */ ({
-				type: 'JSXAttribute',
-				name: b.jsx_id(
-					'is',
-					/** @type {AST.NodeWithLocation} */ (/** @type {unknown} */ (expression)),
-				),
-				value: b.jsx_expression_container(
-					expression,
-					/** @type {AST.NodeWithLocation} */ (/** @type {unknown} */ (expression)),
-				),
-				shorthand: false,
-				start: expression.start,
-				end: expression.end,
-				loc: expression.loc,
-			})
-		),
-		...node.openingElement.attributes,
-	];
-	// The tag is no longer dynamic — clear the parser's markers (the name
-	// container was already replaced above).
-	/** @type {any} */ (node).isDynamic = false;
-	if (node.openingElement) {
-		/** @type {any} */ (node.openingElement).isDynamic = false;
-	}
-	return true;
+		/** @type {unknown} */ ({
+			type: 'JSXAttribute',
+			name: b.jsx_id(
+				'is',
+				/** @type {AST.NodeWithLocation} */ (/** @type {unknown} */ (expression)),
+			),
+			value: b.jsx_expression_container(
+				expression,
+				/** @type {AST.NodeWithLocation} */ (/** @type {unknown} */ (expression)),
+			),
+			shorthand: false,
+			start: expression.start,
+			end: expression.end,
+			loc: expression.loc,
+		})
+	);
+
+	const opening = node.openingElement;
+	const copy = /** @type {AST.TSRXJSXElement} */ ({
+		...node,
+		// The tag is no longer dynamic — the copy drops the parser's markers and
+		// the dynamic name container.
+		isDynamic: false,
+		openingElement: {
+			...opening,
+			isDynamic: false,
+			name: opening?.name ? b.jsx_id(dynamic_element_import_local) : opening?.name,
+			attributes: [is_attribute, ...(opening?.attributes ?? [])],
+		},
+		closingElement: node.closingElement?.name
+			? { ...node.closingElement, name: b.jsx_id(dynamic_element_import_local) }
+			: node.closingElement,
+		// Fork the metadata so the id memo can point at the component reference
+		// without polluting the source element's memoized dynamic expression.
+		metadata: { .../** @type {any} */ (node.metadata) },
+	});
+	set_element_id(copy, component_id ?? b.id(dynamic_element_import_local));
+
+	const scope = scopes?.get(node);
+	if (scope) scopes?.set(copy, scope);
+	return copy;
 }
 
 /**
@@ -2350,17 +2474,20 @@ export function build_getter(node, context) {
 
 	if (!context.path) return node;
 
-	for (let i = context.path.length - 1; i >= 0; i -= 1) {
-		const binding = state.scope.get(node.name);
-		const transform = binding?.transform;
+	// don't transform the declaration itself — checked structurally because the
+	// declarator id may be a copy of the binding's node (copy-on-write rewrites)
+	const parent = context.path.at(-1);
+	if (parent?.type === 'VariableDeclarator' && parent.id === node) {
+		return node;
+	}
 
-		// don't transform the declaration itself
-		if (node !== binding?.node) {
-			const read_fn = transform?.read;
+	const binding = state.scope.get(node.name);
 
-			if (read_fn) {
-				return read_fn(node);
-			}
+	if (node !== binding?.node) {
+		const read_fn = binding?.transform?.read;
+
+		if (read_fn) {
+			return read_fn(node);
 		}
 	}
 
@@ -2580,20 +2707,70 @@ export function ripple_import_requires_block(name) {
 }
 
 /**
+ * Visit a node's children the way zimmerframe's `context.next()` would, but on
+ * a shallow copy with the given fields cleared, so the cleared subtrees are
+ * neither visited nor emitted. The source node is left untouched; the copy
+ * mirrors the source's scope mapping when one exists.
+ * @template {AST.Node} T
+ * @param {T} node
+ * @param {CommonContext} context
+ * @param {string[]} cleared_fields
+ * @returns {T}
+ */
+export function visit_children_without(node, context, cleared_fields) {
+	const copy = /** @type {Record<string, any>} */ ({ ...node });
+	for (const field of cleared_fields) {
+		copy[field] = undefined;
+	}
+	for (const key in copy) {
+		if (key === 'type') continue;
+		const child = copy[key];
+		if (child && typeof child === 'object') {
+			if (Array.isArray(child)) {
+				copy[key] = child.map((item) =>
+					item && typeof item === 'object' ? context.visit(item) : item,
+				);
+			} else {
+				copy[key] = context.visit(child);
+			}
+		}
+	}
+	const scopes = /** @type {any} */ (context.state)?.scopes;
+	const scope = scopes?.get(node);
+	if (scope) scopes.set(copy, scope);
+	return /** @type {T} */ (/** @type {unknown} */ (copy));
+}
+
+/**
+ * Strips TypeScript-only class syntax and visits the remaining children,
+ * returning the transformed copy — the source node is never mutated.
  * @param {AST.ClassDeclaration | AST.ClassExpression} node
  * @param {CommonContext} context
- * @returns {void}
+ * @returns {AST.ClassDeclaration | AST.ClassExpression}
  */
 export function strip_class_typescript_syntax(node, context) {
-	delete node.typeParameters;
-	delete node.superTypeParameters;
-	delete node.implements;
+	let superClass = node.superClass;
 
-	if (node.superClass?.type === 'TSInstantiationExpression') {
-		node.superClass = /** @type {AST.Expression} */ (context.visit(node.superClass.expression));
-	} else if (node.superClass && 'typeArguments' in node.superClass) {
-		delete node.superClass.typeArguments;
+	if (superClass?.type === 'TSInstantiationExpression') {
+		superClass = /** @type {AST.Expression} */ (context.visit(superClass.expression));
+	} else if (superClass && 'typeArguments' in superClass) {
+		superClass = /** @type {AST.Expression} */ ({ ...superClass, typeArguments: undefined });
 	}
+
+	/** @type {AST.ClassDeclaration | AST.ClassExpression} */
+	let source = node;
+	if (superClass !== node.superClass) {
+		source = { ...node, superClass };
+		const scopes = /** @type {any} */ (context.state)?.scopes;
+		const scope = scopes?.get(node);
+		if (scope) scopes.set(source, scope);
+	}
+
+	return visit_children_without(source, context, [
+		'typeParameters',
+		'superTypeParameters',
+		'implements',
+	]);
 }
 
 /**
@@ -2603,11 +2780,15 @@ export function strip_class_typescript_syntax(node, context) {
  * code-block bodies) are left alone — they stay lexical blocks and are lowered
  * by the transforms. Also drops `EmptyStatement` separators from the lists it
  * touches, matching the old normalizer.
- * @param {AST.Node} ast
- * @returns {void}
+ *
+ * Copy-on-write: the input tree is never mutated — changed spines are rebuilt
+ * (unchanged subtrees are shared), so the parse result stays pristine.
+ * @template {AST.Node} T
+ * @param {T} ast
+ * @returns {T}
  */
 export function lower_template_code_blocks(ast) {
-	lower_node(/** @type {any} */ (ast), []);
+	return /** @type {T} */ (lower_node(/** @type {any} */ (ast), []));
 }
 
 /**
@@ -2616,14 +2797,22 @@ export function lower_template_code_blocks(ast) {
  * @returns {any[]}
  */
 function lower_template_children(children, inherited_path = []) {
-	return children
-		.map((/** @type {any} */ child) => {
-			lower_node(child, inherited_path);
-			return child?.type === 'JSXCodeBlock'
-				? code_block_to_template_child(child, inherited_path)
-				: child;
-		})
-		.filter((/** @type {any} */ child) => child != null && child.type !== 'EmptyStatement');
+	/** @type {any[] | null} */
+	let out = null;
+	for (let i = 0; i < children.length; i++) {
+		let next = lower_node(children[i], inherited_path);
+		if (next?.type === 'JSXCodeBlock') {
+			next = code_block_to_template_child(next, inherited_path);
+		}
+		if (next !== children[i]) {
+			out ??= children.slice();
+			out[i] = next;
+		}
+	}
+	const result = out ?? children;
+	return result.some((/** @type {any} */ child) => child == null || child.type === 'EmptyStatement')
+		? result.filter((/** @type {any} */ child) => child != null && child.type !== 'EmptyStatement')
+		: result;
 }
 
 /**
@@ -2632,84 +2821,122 @@ function lower_template_children(children, inherited_path = []) {
  * @returns {any[]}
  */
 function lower_statement_children(statements, inherited_path) {
-	for (const statement of statements) {
-		lower_node(statement, inherited_path);
+	/** @type {any[] | null} */
+	let out = null;
+	for (let i = 0; i < statements.length; i++) {
+		const next = lower_node(statements[i], inherited_path);
+		if (next !== statements[i]) {
+			out ??= statements.slice();
+			out[i] = next;
+		}
 	}
-	return statements.filter(
-		(/** @type {any} */ child) => child != null && child.type !== 'EmptyStatement',
-	);
+	const result = out ?? statements;
+	return result.some((/** @type {any} */ child) => child == null || child.type === 'EmptyStatement')
+		? result.filter((/** @type {any} */ child) => child != null && child.type !== 'EmptyStatement')
+		: result;
+}
+
+/**
+ * Rebuild a `BlockStatement`-valued slot with lowered template children,
+ * reusing the original when nothing changed.
+ * @param {any} block
+ * @param {AST.Node[]} path
+ * @returns {any}
+ */
+function lower_block_slot(block, path) {
+	const body = lower_template_children(block.body || [], path);
+	return body === (block.body || []) ? block : { ...block, body };
 }
 
 /**
  * @param {any} statement — a template directive (`JSX…Expression`)
  * @param {AST.Node[]} inherited_path
- * @returns {void}
+ * @returns {any}
  */
 function lower_directive_template_slots(statement, inherited_path) {
 	const path = [...inherited_path, statement];
-	if (statement.consequent?.type === 'BlockStatement') {
-		statement.consequent.body = lower_template_children(statement.consequent.body || [], path);
-	} else if (statement.consequent) {
-		lower_node(statement.consequent, path);
+	/** @type {Record<string, any> | null} */
+	let updates = null;
+	/** @param {string} key @param {any} next @param {any} prev */
+	const update = (key, next, prev) => {
+		if (next !== prev) (updates ??= {})[key] = next;
+	};
+
+	for (const key of ['consequent', 'alternate']) {
+		const value = statement[key];
+		if (value?.type === 'BlockStatement') {
+			update(key, lower_block_slot(value, path), value);
+		} else if (value) {
+			update(key, lower_node(value, path), value);
+		}
 	}
-	if (statement.alternate?.type === 'BlockStatement') {
-		statement.alternate.body = lower_template_children(statement.alternate.body || [], path);
-	} else if (statement.alternate) {
-		lower_node(statement.alternate, path);
-	}
-	if (statement.body?.type === 'BlockStatement') {
-		statement.body.body = lower_template_children(statement.body.body || [], path);
-	}
-	if (statement.empty?.type === 'BlockStatement') {
-		statement.empty.body = lower_template_children(statement.empty.body || [], path);
-	}
-	if (statement.block?.type === 'BlockStatement') {
-		statement.block.body = lower_template_children(statement.block.body || [], path);
-	}
-	if (statement.pending?.type === 'BlockStatement') {
-		statement.pending.body = lower_template_children(statement.pending.body || [], path);
+	for (const key of ['body', 'empty', 'block', 'pending', 'finalizer']) {
+		const value = statement[key];
+		if (value?.type === 'BlockStatement') {
+			update(key, lower_block_slot(value, path), value);
+		}
 	}
 	if (statement.handler?.body?.type === 'BlockStatement') {
-		statement.handler.body.body = lower_template_children(statement.handler.body.body || [], path);
-	}
-	if (statement.finalizer?.type === 'BlockStatement') {
-		statement.finalizer.body = lower_template_children(statement.finalizer.body || [], path);
+		const body = lower_block_slot(statement.handler.body, path);
+		if (body !== statement.handler.body) {
+			update('handler', { ...statement.handler, body }, statement.handler);
+		}
 	}
 	if (Array.isArray(statement.cases)) {
-		for (const switch_case of statement.cases) {
-			switch_case.consequent = lower_template_children(switch_case.consequent || [], path);
+		/** @type {any[] | null} */
+		let cases = null;
+		for (let i = 0; i < statement.cases.length; i++) {
+			const switch_case = statement.cases[i];
+			const consequent = lower_template_children(switch_case.consequent || [], path);
+			if (consequent !== (switch_case.consequent || [])) {
+				cases ??= /** @type {any[]} */ (statement.cases.slice());
+				cases[i] = { ...switch_case, consequent };
+			}
 		}
+		if (cases) update('cases', cases, statement.cases);
 	}
 	// Test/discriminant/iterable expressions are not template slots — raw JSX
 	// there lowers through the transforms' value paths — but they may still
 	// contain nested templates, so keep walking them.
-	if (statement.test) lower_node(statement.test, path);
-	if (statement.discriminant) lower_node(statement.discriminant, path);
-	if (statement.right) lower_node(statement.right, path);
+	for (const key of ['test', 'discriminant', 'right']) {
+		const value = statement[key];
+		if (value) update(key, lower_node(value, path), value);
+	}
+
+	if (!updates) return statement;
+	return { ...statement, .../** @type {Record<string, any>} */ (updates) };
 }
 
 /**
  * The recursive worker for {@link lower_template_code_blocks}: dispatches on
  * the node shapes that own template-children lists and walks everything else
- * generically.
+ * generically, rebuilding only the spines that change.
  * @param {any} node
  * @param {AST.Node[]} inherited_path
- * @returns {void}
+ * @returns {any}
  */
 function lower_node(node, inherited_path = []) {
-	if (!node || typeof node !== 'object') return;
+	if (!node || typeof node !== 'object') return node;
 	if (Array.isArray(node)) {
-		for (const item of node) lower_node(item, inherited_path);
-		return;
+		return lower_statement_children(node, inherited_path);
 	}
 
 	if (node.type === 'JSXFragment' || node.type === 'JSXElement') {
-		node.children = lower_template_children(node.children || [], [...inherited_path, node]);
-		if (node.type === 'JSXElement') {
+		/** @type {Record<string, any> | null} */
+		let updates = null;
+		const children = lower_template_children(node.children || [], [...inherited_path, node]);
+		if (children !== (node.children || [])) (updates ??= {}).children = children;
+		if (node.type === 'JSXElement' && node.openingElement?.attributes) {
 			// Attribute values may hold raw JSX with nested templates.
-			lower_node(node.openingElement?.attributes, [...inherited_path, node]);
+			const attributes = lower_statement_children(node.openingElement.attributes, [
+				...inherited_path,
+				node,
+			]);
+			if (attributes !== node.openingElement.attributes) {
+				(updates ??= {}).openingElement = { ...node.openingElement, attributes };
+			}
 		}
-		return;
+		return updates ? { ...node, ...updates } : node;
 	}
 	if (
 		node.type === 'JSXStyleElement' ||
@@ -2718,7 +2945,7 @@ function lower_node(node, inherited_path = []) {
 		node.type === 'JSXOpeningElement' ||
 		node.type === 'JSXClosingElement'
 	) {
-		return;
+		return node;
 	}
 	if (node.type === 'JSXCodeBlock') {
 		// Each `@{ … }` is its own lexical scope, so nested blocks never merge
@@ -2726,20 +2953,22 @@ function lower_node(node, inherited_path = []) {
 		// (`@{ @{ … } }`) keeps the nesting: the inner block is lowered like a
 		// template child inside a synthetic fragment so it gets its own scope.
 		const path = [...inherited_path, node];
-		node.body = lower_statement_children(node.body || [], path);
+		/** @type {Record<string, any> | null} */
+		let updates = null;
+		const body = lower_statement_children(node.body || [], path);
+		if (body !== (node.body || [])) (updates ??= {}).body = body;
 		if (node.render?.type === 'JSXCodeBlock') {
-			const inner = node.render;
-			lower_node(inner, path);
+			const inner = lower_node(node.render, path);
 			const inner_child = code_block_to_template_child(inner, path);
 			// An inner block that is empty all the way down renders nothing —
 			// drop it so the outer block becomes code-only (and prunable too).
 			if (inner_child == null) {
-				node.render = null;
+				(updates ??= {}).render = null;
 			} else if (is_native_tsrx_template_node(inner_child)) {
 				// The inner chain collapsed to a plain template node (its scope
 				// was unobservable) — it becomes this block's render directly,
 				// with no wrapper fragment.
-				node.render = inner_child;
+				(updates ??= {}).render = inner_child;
 			} else {
 				const fragment = /** @type {any} */ (b.jsx_fragment([/** @type {any} */ (inner_child)]));
 				setLocation(fragment, /** @type {AST.NodeWithLocation} */ (inner));
@@ -2750,18 +2979,20 @@ function lower_node(node, inherited_path = []) {
 				// inline component per nesting level.
 				fragment.metadata.native_tsrx = true;
 				fragment.metadata.tsrx_code_block_chain = true;
-				node.render = fragment;
+				(updates ??= {}).render = fragment;
 			}
 		} else if (node.render) {
-			lower_node(node.render, path);
+			const render = lower_node(node.render, path);
+			if (render !== node.render) (updates ??= {}).render = render;
 		}
-		return;
+		return updates ? { ...node, ...updates } : node;
 	}
 	if (is_template_directive(node)) {
-		lower_directive_template_slots(node, inherited_path);
-		return;
+		return lower_directive_template_slots(node, inherited_path);
 	}
 
+	/** @type {Record<string, any> | null} */
+	let updates = null;
 	for (const key in node) {
 		if (
 			key === 'metadata' ||
@@ -2776,11 +3007,15 @@ function lower_node(node, inherited_path = []) {
 
 		const value = node[key];
 		if (Array.isArray(value)) {
-			node[key] = lower_statement_children(value, [...inherited_path, node]);
+			const next = lower_statement_children(value, [...inherited_path, node]);
+			if (next !== value) (updates ??= {})[key] = next;
 		} else if (value && typeof value === 'object') {
-			lower_node(value, [...inherited_path, node]);
+			const next = lower_node(value, [...inherited_path, node]);
+			if (next !== value) (updates ??= {})[key] = next;
 		}
 	}
+
+	return updates ? { ...node, ...updates } : node;
 }
 
 /**
@@ -2794,10 +3029,10 @@ function lower_node(node, inherited_path = []) {
  * - code-only: a plain `BlockStatement` — statements run in source order,
  *   scoped, render nothing;
  * - setup code + render output: an inline anonymous component expression
- *   (`(() => @{ … })()`, the same lowering as value-position code blocks),
+ *   (`(() =>@{ … })()`, the same lowering as value-position code blocks),
  *   since the setup may feed the output — `_$_.expression` is the right tool
  *   for a dynamic child value;
- * - nested chains (`@{ @{ … } }`): intermediate levels with statements merge
+ * - nested chains (a code block directly inside another): intermediate levels with statements merge
  *   into one IIFE as nested plain `{ … }` blocks (one closure, not one per
  *   level), and only the innermost render-bearing level becomes the inline
  *   component.
@@ -2893,24 +3128,17 @@ function mark_raw_template_jsx(node) {
 }
 
 /**
- * Adopt a raw JSX subtree (an attribute value or other JSX that never entered
- * the template traversal) into the template machinery at transform time:
- * marks its elements/fragments `native_tsrx`, retypes any nested directives,
- * and lowers its `@{ … }` code-block template children. Returns the template
- * children — a fragment root flattens to its children list.
+ * Adopt a raw JSX subtree (an attribute value or other JSX the parser did not
+ * stamp `native_tsrx`) into the template machinery. The analyze-time
+ * pre-passes already traversed it (they walk attribute values too), so its
+ * code blocks and value-position directives are lowered — adoption is just
+ * the `native_tsrx` marking that routes the visitors down the template paths,
+ * plus flattening a fragment root to its children.
  *
  * @param {any} node
- * @param {AST.Node[]} [inherited_path]
  * @returns {any}
  */
-export function jsx_to_ripple_node(node, inherited_path = []) {
+export function adopt_raw_template_jsx(node) {
 	mark_raw_template_jsx(node);
-	prepare_template_control_flow(node);
-	lower_node(node, inherited_path);
-
-	if (node.type === 'JSXFragment') {
-		return node.children;
-	}
-
-	return node;
+	return node.type === 'JSXFragment' ? node.children : node;
 }

--- a/packages/tsrx-ripple/src/utils.js
+++ b/packages/tsrx-ripple/src/utils.js
@@ -1992,7 +1992,7 @@ export function is_element_dom_element(node) {
 export const dynamic_element_import_local = 'TsrxDynamic';
 
 /**
- * @param {ESTreeJSX.JSXElement} node
+ * @param {AST.TSRXJSXElement} node
  * @param {AST.Expression} [component_id] - Override for the lowered component
  * reference; defaults to the `TsrxDynamic` local used by type-only output.
  * @returns {boolean}

--- a/packages/tsrx-ripple/src/utils.js
+++ b/packages/tsrx-ripple/src/utils.js
@@ -28,6 +28,7 @@ import {
 	is_dynamic_element,
 	is_template_element,
 	set_element_id,
+	is_template_directive,
 	is_template_expression,
 	is_template_fragment,
 	is_template_text,
@@ -71,17 +72,14 @@ export function should_guard_regular_js_statement(statement) {
 }
 
 /**
- * Plain JS control flow (`if`/`for`/`while`/`switch`/`try`, etc.) that is NOT an
- * `@if`/`@for`/`@switch`/`@try` template directive. Only directives carry
- * `metadata.tsrxDirective`; everything else is ordinary JavaScript that may
- * return JSX, and must lower exactly like control flow in a regular function.
+ * Plain JS control flow (`if`/`for`/`while`/`switch`/`try`, etc.). Template
+ * directives keep their own parser node types (`JSXIfExpression`, …), so any
+ * standard statement form here is ordinary JavaScript that may return JSX and
+ * must lower exactly like control flow in a regular function.
  * @param {AST.Node} node
  * @returns {boolean}
  */
 export function is_plain_js_control_flow(node) {
-	if (node.metadata?.tsrxDirective) {
-		return false;
-	}
 	return (
 		node.type === 'IfStatement' ||
 		node.type === 'SwitchStatement' ||
@@ -182,137 +180,32 @@ export function is_tsrx_component_function(node) {
 export function is_native_tsrx_template_node(node) {
 	return !!(
 		node &&
-		(node.type === 'JSXElement' ||
-			node.type === 'JSXFragment' ||
-			node.type === 'JSXIfExpression' ||
-			node.type === 'JSXForExpression' ||
-			node.type === 'JSXSwitchExpression' ||
-			node.type === 'JSXTryExpression' ||
-			node.metadata?.tsrxDirective === 'if' ||
-			node.metadata?.tsrxDirective === 'for' ||
-			node.metadata?.tsrxDirective === 'switch' ||
-			node.metadata?.tsrxDirective === 'try')
+		(node.type === 'JSXElement' || node.type === 'JSXFragment' || is_template_directive(node))
 	);
 }
 
 /**
- * Pre-pass: make template control flow consumable by the analyzer and
- * transforms. Wraps `@if`/`@for`/`@switch`/`@try` directives used in value
- * positions in a `<> … </>` fragment, then retypes every expression-position
- * `JSX…Expression` directive into its standard ESTree statement form tagged
- * with `metadata.tsrxDirective`.
+ * Pre-pass: wrap `@if`/`@for`/`@switch`/`@try` directives used in value
+ * positions in a `<> … </>` fragment so they lower as values. Directives keep
+ * their parser forms (`JSXIfExpression`, …) — the analyzer and transforms
+ * dispatch on those directly.
  * @param {AST.Node} ast
  * @returns {void}
  */
 export function prepare_template_control_flow(ast) {
 	wrap_directives_combined_into_expressions(/** @type {any} */ (ast));
-	retype_directive_expressions(/** @type {any} */ (ast));
 }
 
 /**
- * @param {any} node
- * @returns {any}
- */
-function retype_directive_expression(node) {
-	const statement = /** @type {any} */ ({ ...node, type: node.statementType });
-	delete statement.statementType;
-	const directive =
-		node.type === 'JSXIfExpression'
-			? 'if'
-			: node.type === 'JSXForExpression'
-				? 'for'
-				: node.type === 'JSXSwitchExpression'
-					? 'switch'
-					: 'try';
-	statement.metadata = {
-		...(statement.metadata ?? {}),
-		tsrxDirective: directive,
-		// Marks a RETYPED directive: its branch bodies are template children
-		// (lowered by `lower_template_code_blocks`), unlike a plain `@else if`
-		// IfStatement that only carries `tsrxDirective` for the transforms.
-		tsrx_template_directive: true,
-	};
-	// `@else if` parses as a plain IfStatement in the alternate — tag it so the
-	// transforms lower it as template control flow (one level, matching the old
-	// normalizer).
-	if (directive === 'if' && statement.alternate?.type === 'IfStatement') {
-		statement.alternate.metadata = {
-			...(statement.alternate.metadata ?? {}),
-			tsrxDirective: 'if',
-		};
-	}
-	return statement;
-}
-
-/**
- * @param {any} node
- * @returns {boolean}
- */
-function is_directive_expression(node) {
-	return (
-		node?.type === 'JSXIfExpression' ||
-		node?.type === 'JSXForExpression' ||
-		node?.type === 'JSXSwitchExpression' ||
-		node?.type === 'JSXTryExpression'
-	);
-}
-
-/**
- * @param {any} ast
- * @returns {void}
- */
-function retype_directive_expressions(ast) {
-	const seen = new Set();
-	/** @param {any} node */
-	const visit = (node) => {
-		if (!node || typeof node !== 'object' || seen.has(node)) return;
-		seen.add(node);
-		if (Array.isArray(node)) {
-			for (const item of node) visit(item);
-			return;
-		}
-		for (const key of Object.keys(node)) {
-			if (key === 'loc' || key === 'start' || key === 'end' || key === 'metadata') continue;
-			const value = node[key];
-			if (Array.isArray(value)) {
-				for (let i = 0; i < value.length; i++) {
-					if (is_directive_expression(value[i])) {
-						value[i] = retype_directive_expression(value[i]);
-					}
-					visit(value[i]);
-				}
-			} else if (is_directive_expression(value)) {
-				node[key] = retype_directive_expression(value);
-				visit(node[key]);
-			} else {
-				visit(value);
-			}
-		}
-	};
-	visit(ast);
-}
-
-/**
- * A `@if`/`@for`/`@switch`/`@try` control-flow directive — a raw `JSX…Expression`
- * before normalization, or a statement carrying `metadata.tsrxDirective` after.
- * (A `@{ … }` code block is deliberately NOT included: it self-lowers to an IIFE
- * in every position, so it never needs wrapping and wrapping it would add a
- * redundant fragment.)
+ * A `@if`/`@for`/`@switch`/`@try` control-flow directive. (A `@{ … }` code
+ * block is deliberately NOT included: it self-lowers to an IIFE in every
+ * position, so it never needs wrapping and wrapping it would add a redundant
+ * fragment.)
  * @param {AST.Node} node
  * @returns {boolean}
  */
 function is_control_flow_directive(node) {
-	const directive = node?.metadata?.tsrxDirective;
-	return (
-		directive === 'if' ||
-		directive === 'for' ||
-		directive === 'switch' ||
-		directive === 'try' ||
-		node?.type === 'JSXIfExpression' ||
-		node?.type === 'JSXForExpression' ||
-		node?.type === 'JSXSwitchExpression' ||
-		node?.type === 'JSXTryExpression'
-	);
+	return is_template_directive(node);
 }
 
 /**
@@ -2705,8 +2598,8 @@ export function strip_class_typescript_syntax(node, context) {
 
 /**
  * Lower the `@{ … }` code blocks that appear as template children throughout
- * the AST: element/fragment children lists and the branch bodies of retyped
- * template directives. Statement-position code blocks (function bodies,
+ * the AST: element/fragment children lists and the branch bodies of template
+ * directives. Statement-position code blocks (function bodies,
  * code-block bodies) are left alone — they stay lexical blocks and are lowered
  * by the transforms. Also drops `EmptyStatement` separators from the lists it
  * touches, matching the old normalizer.
@@ -2748,7 +2641,7 @@ function lower_statement_children(statements, inherited_path) {
 }
 
 /**
- * @param {any} statement — a retyped template directive
+ * @param {any} statement — a template directive (`JSX…Expression`)
  * @param {AST.Node[]} inherited_path
  * @returns {void}
  */
@@ -2864,7 +2757,7 @@ function lower_node(node, inherited_path = []) {
 		}
 		return;
 	}
-	if (node.metadata?.tsrx_template_directive) {
+	if (is_template_directive(node)) {
 		lower_directive_template_slots(node, inherited_path);
 		return;
 	}

--- a/packages/tsrx-ripple/src/utils.js
+++ b/packages/tsrx-ripple/src/utils.js
@@ -323,6 +323,18 @@ export function analyze_directive_wrapping_values(node, context, visit) {
 }
 
 /**
+ * Replace a single statement with several from a visitor: zimmerframe stores
+ * the array verbatim in the parent's statement list and the printer flattens
+ * nested statement arrays, so this is a supported — if untyped — replacement
+ * shape. This helper is the one sanctioned boundary for it.
+ * @param {AST.Statement[]} statements
+ * @returns {AST.Node}
+ */
+export function replace_with_statements(statements) {
+	return /** @type {AST.Node} */ (/** @type {unknown} */ (statements));
+}
+
+/**
  * Wrap a `@{ … }` code block in an immediately-invoked arrow
  * (`(() =>@{ … })()`). Ripple only lowers a code block when it is a function body
  * @param {AST.JSXCodeBlock} code_block

--- a/packages/tsrx-ripple/src/utils.js
+++ b/packages/tsrx-ripple/src/utils.js
@@ -19,6 +19,14 @@ import {
 	simpleHash,
 	strongHash,
 } from '@tsrx/core';
+import {
+	get_template_expression,
+	is_droppable_template_text,
+	is_empty_expression_container,
+	is_template_expression,
+	is_template_text,
+	is_template_text_or_expression,
+} from './template-ast.js';
 const b = builders;
 
 // Re-export under the framework's snake_case internal convention.
@@ -194,14 +202,8 @@ export function is_native_tsrx_template_node(node) {
  * @returns {T}
  */
 export function normalize_jsx_tsrx_templates(node, options = {}) {
-	const previous_to_ts = normalize_output_to_ts;
-	normalize_output_to_ts = !!options.to_ts;
-	try {
-		wrap_directives_combined_into_expressions(/** @type {any} */ (node));
-		return /** @type {T} */ (normalize_jsx_tsrx_node(/** @type {any} */ (node), []));
-	} finally {
-		normalize_output_to_ts = previous_to_ts;
-	}
+	wrap_directives_combined_into_expressions(/** @type {any} */ (node));
+	return /** @type {T} */ (normalize_jsx_tsrx_node(/** @type {any} */ (node), []));
 }
 
 /**
@@ -875,11 +877,11 @@ function should_render_return_argument(argument) {
 /**
  * @param {AST.Expression} argument
  * @param {AST.ReturnStatement} statement
- * @returns {AST.TSRXExpression}
+ * @returns {ESTreeJSX.JSXExpressionContainer}
  */
 function create_return_argument_child(argument, statement) {
-	return /** @type {AST.TSRXExpression} */ ({
-		type: 'TSRXExpression',
+	return /** @type {ESTreeJSX.JSXExpressionContainer} */ ({
+		type: 'JSXExpressionContainer',
 		expression: argument,
 		metadata: {
 			path: statement.metadata?.path ?? [],
@@ -1961,6 +1963,7 @@ export function lower_dynamic_element(node, component_id) {
  * @returns {AST.Node[]}
  */
 export function normalize_children(children, context) {
+	const to_ts = !!context.state.to_ts;
 	/** @type {AST.Node[]} */
 	const normalized = [];
 
@@ -1973,34 +1976,42 @@ export function normalize_children(children, context) {
 		const prev_child = normalized[i - 1];
 
 		if (
-			(child.type === 'TSRXExpression' || child.type === 'Text') &&
-			(prev_child?.type === 'TSRXExpression' || prev_child?.type === 'Text')
+			is_template_text_or_expression(child) &&
+			prev_child != null &&
+			is_template_text_or_expression(prev_child)
 		) {
+			const child_expression = get_template_expression(/** @type {any} */ (child), to_ts);
+			const prev_expression = get_template_expression(/** @type {any} */ (prev_child), to_ts);
 			if (
-				(child.type === 'TSRXExpression' &&
-					is_children_template_expression(child.expression, context.state.scope)) ||
-				(prev_child.type === 'TSRXExpression' &&
-					is_children_template_expression(prev_child.expression, context.state.scope)) ||
-				expression_contains_call(child.expression) ||
-				expression_contains_call(prev_child.expression)
+				(is_template_expression(child) &&
+					is_children_template_expression(child_expression, context.state.scope)) ||
+				(is_template_expression(prev_child) &&
+					is_children_template_expression(prev_expression, context.state.scope)) ||
+				expression_contains_call(child_expression) ||
+				expression_contains_call(prev_expression)
 			) {
 				continue;
 			}
 
-			if (prev_child.type === 'Text' || child.type === 'Text') {
-				prev_child.type = 'Text';
-			}
-			if (child.expression.type === 'Literal' && prev_child.expression.type === 'Literal') {
-				prev_child.expression = b.literal(
-					prev_child.expression.value + String(child.expression.value),
-				);
-			} else {
-				prev_child.expression = b.binary(
-					'+',
-					prev_child.expression,
-					b.call('String', b.logical('??', child.expression, b.literal(''))),
-				);
-			}
+			const merged_expression =
+				child_expression.type === 'Literal' && prev_expression.type === 'Literal'
+					? b.literal(prev_expression.value + String(child_expression.value))
+					: b.binary(
+							'+',
+							prev_expression,
+							b.call('String', b.logical('??', child_expression, b.literal(''))),
+						);
+			const merged = b.jsx_expression_container(
+				merged_expression,
+				/** @type {AST.NodeWithLocation} */ (prev_child),
+			);
+			merged.metadata = {
+				...(prev_child.metadata ?? {}),
+				// A run containing any text renders through the text path
+				// (`_$_.text`/`set_text`) — the analogue of the old merged `Text` node.
+				tsrx_text: is_template_text(prev_child) || is_template_text(child),
+			};
+			normalized[i - 1] = merged;
 			normalized.splice(i, 1);
 		}
 	}
@@ -2241,6 +2252,13 @@ function is_template_fragment_binding(binding, scope, visited = new Set()) {
  */
 function normalize_child(node, normalized, context) {
 	if (node.type === 'EmptyStatement') {
+		return;
+	} else if (
+		// Insignificant whitespace text renders nothing, and a `{/* comment */}`
+		// container is a comment — both are dropped from the rendered children.
+		is_droppable_template_text(node, !!context.state.to_ts) ||
+		is_empty_expression_container(node)
+	) {
 		return;
 	} else if (
 		node.type === 'Element' &&
@@ -2628,56 +2646,6 @@ function jsx_member_expression_to_member_expression(jsx_member) {
 }
 
 /**
- * @param {string} value
- * @returns {string}
- */
-function decode_jsx_text_entities(value) {
-	return value.replace(
-		/&(#x[0-9a-fA-F]+|#[0-9]+|amp|quot|apos|lt|gt);/g,
-		(/** @type {string} */ match, /** @type {string} */ entity) => {
-			if (entity === 'amp') return '&';
-			if (entity === 'quot') return '"';
-			if (entity === 'apos') return "'";
-			if (entity === 'lt') return '<';
-			if (entity === 'gt') return '>';
-			if (entity.startsWith('#x')) {
-				const code_point = Number.parseInt(entity.slice(2), 16);
-				return Number.isNaN(code_point) ? match : String.fromCodePoint(code_point);
-			}
-			if (entity.startsWith('#')) {
-				const code_point = Number.parseInt(entity.slice(1), 10);
-				return Number.isNaN(code_point) ? match : String.fromCodePoint(code_point);
-			}
-			return match;
-		},
-	);
-}
-
-/**
- * Whether normalization is producing the type-only (editor) view. In that mode text
- * is kept verbatim so it stays faithful to the source and its location; whitespace
- * collapse is a runtime-only concern (see {@link normalize_jsx_text_value}).
- * @type {boolean}
- */
-let normalize_output_to_ts = false;
-
-/**
- * @param {string} value
- * @returns {string}
- */
-function normalize_jsx_text_value(value) {
-	// The whitespace collapse is a runtime-only concern: Ripple lowers text to explicit
-	// `_$_.text(...)` calls, so insignificant JSX whitespace (newlines/indentation between
-	// elements) must be trimmed or it would render as literal text. The type-only view
-	// keeps the JSX shape — like the other targets — so it stays faithful to the source and
-	// its location. Trimming there would leave the node lying about its size (e.g. a lone
-	// `@` with a 1-char value but a multi-char location), producing a mismatched-length
-	// source mapping the editor can't use for completions.
-	const normalized = normalize_output_to_ts ? value : /[\r\n]/.test(value) ? value.trim() : value;
-	return decode_jsx_text_entities(normalized);
-}
-
-/**
  * @param {ESTreeJSX.JSXFragment} node
  * @param {AST.Node[]} [inherited_path]
  * @returns {AST.TsrxFragment}
@@ -2890,7 +2858,7 @@ function code_block_to_template_child(block, inherited_path) {
 			statement.metadata = { path: inherited_path };
 			return statement;
 		}
-		if (inner_child.type !== 'TSRXExpression') {
+		if (inner_child.type !== 'JSXExpressionContainer') {
 			// Unreachable by construction — the chain wrapper only ever holds
 			// a statement block or an expression child.
 			return inner_child;
@@ -2911,7 +2879,7 @@ function code_block_to_template_child(block, inherited_path) {
 			b.call(b.arrow([], b.block(scope_body, /** @type {AST.NodeWithLocation} */ (block))))
 		);
 		scope_call.metadata = { ...scope_call.metadata, tsrx_code_block_scope: true };
-		return b.tsrx_expression(scope_call, /** @type {AST.NodeWithLocation} */ (block));
+		return b.jsx_expression_container(scope_call, /** @type {AST.NodeWithLocation} */ (block));
 	}
 
 	if (render == null) {
@@ -2929,7 +2897,7 @@ function code_block_to_template_child(block, inherited_path) {
 		return render;
 	}
 
-	return b.tsrx_expression(
+	return b.jsx_expression_container(
 		wrap_code_block_in_iife(block),
 		/** @type {AST.NodeWithLocation} */ (block),
 	);
@@ -2981,10 +2949,8 @@ function normalize_jsx_tsrx_node(node, inherited_path = []) {
 		return jsx_control_expression_to_statement(node, inherited_path);
 	}
 	if (node.type === 'JSXText') {
-		return jsx_to_ripple_node(node, inherited_path);
-	}
-	if (node.type === 'JSXExpressionContainer') {
-		return jsx_to_ripple_node(node, inherited_path);
+		// Consumed directly from the parser AST (see template-ast.js).
+		return node;
 	}
 	if (node.type === 'JSXCodeBlock') {
 		// Each `@{ … }` is its own lexical scope, so nested blocks never merge
@@ -3185,28 +3151,11 @@ export function jsx_to_ripple_node(node, inherited_path = []) {
 		return jsx_style_to_ripple_element(node, inherited_path);
 	}
 
-	if (node.type === 'JSXText') {
-		const value = normalize_jsx_text_value(node.value);
-		// Runtime collapses insignificant newline whitespace to '' (dropped here) while
-		// keeping significant single spaces. to_ts keeps text verbatim, so a newline-only run
-		// stays non-empty and is preserved — matching the other targets' JSX view.
-		if (value === '') {
-			return null;
-		}
-		return /** @type {AST.Node} */ (
-			b.text(value, /** @type {AST.NodeWithLocation} */ (/** @type {unknown} */ (node)))
-		);
-	}
-
-	if (node.type === 'JSXExpressionContainer') {
-		if (node.expression.type === 'JSXEmptyExpression') return null;
-		return /** @type {AST.Node} */ ({
-			type: 'TSRXExpression',
-			expression: normalize_jsx_tsrx_node(node.expression, inherited_path),
-			metadata: {},
-			start: node.start,
-			end: node.end,
-		});
+	if (node.type === 'JSXText' || node.type === 'JSXExpressionContainer') {
+		// Consumed directly from the parser AST (see template-ast.js). Elements
+		// nested inside a container's expression still normalize via the
+		// recursive pass; this helper only sees already-normalized subtrees.
+		return node;
 	}
 
 	if (node.type === 'JSXFragment') {

--- a/packages/tsrx-ripple/tests/basic.test.js
+++ b/packages/tsrx-ripple/tests/basic.test.js
@@ -832,10 +832,7 @@ describe('@tsrx/ripple Volar mappings style anchors', () => {
 		const collect_style_nodes = (node) => {
 			if (!node || typeof node !== 'object' || seen.has(node)) return;
 			seen.add(node);
-			if (
-				node.type === 'JSXStyleElement' ||
-				(node.type === 'Element' && node.id?.name === 'style')
-			) {
+			if (node.type === 'JSXStyleElement') {
 				source_style_nodes.push(node.type);
 			}
 			for (const key in node) {

--- a/packages/tsrx-ripple/tests/basic.test.js
+++ b/packages/tsrx-ripple/tests/basic.test.js
@@ -1487,7 +1487,7 @@ describe('@tsrx/ripple <> expression values', () => {
 		const { code } = compile(`const App = () => <button>Hello</button>;`, 'App.tsrx');
 
 		expect(code).toContain('template(`<button>Hello</button>`');
-		expect(code).toContain('_$_.append(__anchor, button_1)');
+		expect(code).toContain('_$_.append(__anchor, button)');
 		expect(code).not.toContain('template(``');
 	});
 
@@ -1500,7 +1500,7 @@ describe('@tsrx/ripple <> expression values', () => {
 		);
 
 		expect(code).toContain('template(`<div>Commented</div>`');
-		expect(code).toContain('_$_.append(__anchor, div_1)');
+		expect(code).toContain('_$_.append(__anchor, div)');
 	});
 
 	it('keeps directly called PascalCase numeric helpers as ordinary functions', () => {

--- a/packages/tsrx-ripple/tests/basic.test.js
+++ b/packages/tsrx-ripple/tests/basic.test.js
@@ -504,6 +504,20 @@ describe('@tsrx/ripple lowers control flow combined into an expression', () => {
 		expect(code).not.toMatch(/const ad = if\b/);
 	});
 
+	it('lowers a value-position @else if chain to a ternary chain in to_ts output', () => {
+		const source = `function App({ x }: { x: number }) {
+	const v = @if (x > 1) { <div>a</div> } @else if (x > 0) { <div>b</div> } @else { <div>c</div> }
+	return <div>{v}</div>;
+}`;
+		// Each `@else if` link recurses into build_tsrx_ts_directive_value as a plain
+		// IfStatement — it must lower like the rooting `@if` (the ternary's next arm),
+		// not fall through to the `@try` lowering (which used to crash on the missing
+		// `block`).
+		const { code, errors } = compile_to_volar_mappings(source, 'App.tsrx', { loose: true });
+		expect(errors).toEqual([]);
+		expect(code).toContain('x > 1 ? <div>a</div> : x > 0 ? <div>b</div> : <div>c</div>');
+	});
+
 	it('wraps a @{ … } code block operand and a ternary branch', () => {
 		const code_block = `function App() @{
 			const ad = (@{ const x = 1; <span>{x}</span> }) || 'd';

--- a/packages/tsrx-ripple/tests/code-block-children.test.js
+++ b/packages/tsrx-ripple/tests/code-block-children.test.js
@@ -99,6 +99,21 @@ describe('@tsrx/ripple code blocks in template children position', () => {
 		expect(code).toContain('<span class="sum">{x + y}</span>');
 	});
 
+	it('collapses a whole-body nested chain to a bare IIFE in the TS view', () => {
+		// The chain wrapper fragment is compiler-generated (tsrx_code_block_chain)
+		// — is_authored_native_fragment must not treat it as an authored `<> … </>`
+		// or the returned value keeps a spurious fragment around the IIFE.
+		const source = `function Comp(props) @{
+	@{
+		const { Item } = props;
+		<Item></Item>
+	}
+}`;
+		const { code } = compile_to_volar_mappings(source, 'App.tsrx');
+		expect(code).toContain('return (() => {');
+		expect(code).not.toContain('return <>{(() => {');
+	});
+
 	const empty_nested = `function App() @{
 	<>
 		<span>{'a'}</span>

--- a/packages/tsrx-solid/src/transform.js
+++ b/packages/tsrx-solid/src/transform.js
@@ -1487,7 +1487,7 @@ function lower_solid_component_control_statement(statement, rest) {
 	// left untouched. The exceptions, which still lower into Solid's reactive
 	// render forms, are:
 	//   - `@`-directives (`@if`/`@for`/`@switch`/`@try`), which carry
-	//     `statementType` / `tsrxDirective` (see `is_template_*_node`); and
+	//     `statementType` (see `is_template_*_node`); and
 	//   - control flow that `throw`s, so a `@try` boundary keeps re-catching when
 	//     the throwing condition changes (a setup-once throw could never re-fire).
 	if (!is_solid_render_control(statement) && !control_flow_has_render_throw(statement)) {

--- a/packages/tsrx/src/scope.js
+++ b/packages/tsrx/src/scope.js
@@ -63,10 +63,9 @@ export function create_scopes(ast, root, parent, error_options) {
 		const scope = state.scope.child(true);
 		scopes.set(node, scope);
 
-		if (node.type === 'ForOfStatement') {
-			if (node.index) {
-				state.scope.declare(node.index, 'normal', 'let');
-			}
+		// Only a `@for` directive can declare an `index` binding.
+		if (node.type === 'JSXForExpression' && node.index) {
+			state.scope.declare(node.index, 'normal', 'let');
 		}
 
 		next({ scope });

--- a/packages/tsrx/src/scope.js
+++ b/packages/tsrx/src/scope.js
@@ -180,6 +180,21 @@ export function create_scopes(ast, root, parent, error_options) {
 		SwitchStatement: create_block_scope,
 		JSXForExpression: create_block_scope,
 		JSXSwitchExpression: create_block_scope,
+		// Each `@{ … }` code block is its own lexical scope, whether it is a
+		// function body or a template child — its bindings never leak out.
+		JSXCodeBlock(node, context) {
+			const parent = context.path.at(-1);
+			if (
+				parent?.type === 'FunctionDeclaration' ||
+				parent?.type === 'FunctionExpression' ||
+				parent?.type === 'ArrowFunctionExpression'
+			) {
+				// The function already created a scope for its body.
+				context.next();
+			} else {
+				create_block_scope(node, context);
+			}
+		},
 		BlockStatement(node, context) {
 			const parent = context.path.at(-1);
 			if (

--- a/packages/tsrx/src/transform/jsx/helpers.js
+++ b/packages/tsrx/src/transform/jsx/helpers.js
@@ -243,7 +243,6 @@ export function tsx_with_ts_locations() {
 export function is_template_if_node(node) {
 	return (
 		node?.type === 'JSXIfExpression' ||
-		node?.metadata?.tsrxDirective === 'if' ||
 		(node?.type === 'IfStatement' && node?.statementType === 'IfStatement')
 	);
 }
@@ -255,7 +254,6 @@ export function is_template_if_node(node) {
 export function is_template_for_of_node(node) {
 	return (
 		node?.type === 'JSXForExpression' ||
-		node?.metadata?.tsrxDirective === 'for' ||
 		(node?.type === 'ForOfStatement' && node?.statementType === 'ForOfStatement')
 	);
 }
@@ -267,7 +265,6 @@ export function is_template_for_of_node(node) {
 export function is_template_switch_node(node) {
 	return (
 		node?.type === 'JSXSwitchExpression' ||
-		node?.metadata?.tsrxDirective === 'switch' ||
 		(node?.type === 'SwitchStatement' && node?.statementType === 'SwitchStatement')
 	);
 }
@@ -279,7 +276,6 @@ export function is_template_switch_node(node) {
 export function is_template_try_node(node) {
 	return (
 		node?.type === 'JSXTryExpression' ||
-		node?.metadata?.tsrxDirective === 'try' ||
 		(node?.type === 'TryStatement' && node?.statementType === 'TryStatement')
 	);
 }

--- a/packages/tsrx/src/transform/jsx/index.js
+++ b/packages/tsrx/src/transform/jsx/index.js
@@ -2302,7 +2302,7 @@ function create_style_anchor_name(transform_context) {
 }
 
 /**
- * @param {ESTreeJSX.JSXElement} element
+ * @param {AST.TSRXJSXElement} element
  */
 function disable_style_anchor_verification(element) {
 	if (element.openingElement?.name) {

--- a/packages/tsrx/src/utils/builders.js
+++ b/packages/tsrx/src/utils/builders.js
@@ -1199,10 +1199,12 @@ export function jsx_element_fresh(
 }
 
 /**
- * @param {ESTreeJSX.JSXElement} node
- * @param {ESTreeJSX.JSXOpeningElement['attributes']} attributes
- * @param {ESTreeJSX.JSXElement['children']} children
- * @returns {ESTreeJSX.JSXElement}
+ * Elements carry the parser's widened TSRX shape (dynamic-tag names, lowered
+ * template children) — see {@link jsx_fragment}.
+ * @param {AST.TSRXJSXElement} node
+ * @param {ESTreeJSX.TSRXJSXOpeningElement['attributes']} attributes
+ * @param {AST.TSRXJSXElement['children']} children
+ * @returns {AST.TSRXJSXElement}
  */
 export function jsx_element(node, attributes = [], children = []) {
 	return {
@@ -1228,9 +1230,12 @@ export function jsx_element(node, attributes = [], children = []) {
 }
 
 /**
- * @param {ESTreeJSX.JSXFragment['children']} children
+ * Fragments carry the parser's widened TSRX shape: template lowering places
+ * any node in `children` (statement blocks, directives, code-block IIFEs),
+ * not just printable JSX children.
+ * @param {AST.TSRXJSXFragment['children']} children
  * @param {ESTreeJSX.JSXOpeningFragment['attributes']} [attributes]
- * @returns {ESTreeJSX.JSXFragment}
+ * @returns {AST.TSRXJSXFragment}
  */
 export function jsx_fragment(children = [], attributes = []) {
 	return {

--- a/packages/tsrx/src/utils/builders.js
+++ b/packages/tsrx/src/utils/builders.js
@@ -369,26 +369,6 @@ export function literal(value, raw, loc_info) {
 }
 
 /**
- * Ripple template `Text` node wrapping a string literal of `value`. Used by the
- * Ripple normalizer when lowering a JSX text child to a template Text node.
- *
- * Remove once Ripple transformers move to the parser's JSX AST
- *
- * @param {string} value
- * @param {AST.NodeWithLocation} [loc_info]
- * @returns {AST.Text}
- */
-export function text(value, loc_info) {
-	const node = /** @type {AST.Text} */ ({
-		type: 'Text',
-		expression: literal(value, JSON.stringify(value), loc_info),
-		metadata: { path: [] },
-	});
-
-	return set_location(node, loc_info);
-}
-
-/**
  * @param {AST.Expression | AST.Super} object
  * @param {string | AST.Expression | AST.PrivateIdentifier} property
  * @param {boolean} computed
@@ -1267,44 +1247,6 @@ export function jsx_fragment(children = [], attributes = []) {
 		children,
 		metadata: { path: [] },
 	};
-}
-
-/**
- * Ripple's internal fragment template node (the normalized form of a
- * `JSXFragment`).
- * @param {AST.Node[]} [children]
- * @param {AST.NodeWithLocation} [loc_info]
- * @returns {AST.TsrxFragment}
- */
-export function tsrx_fragment(children = [], loc_info) {
-	const node = /** @type {AST.TsrxFragment} */ (
-		/** @type {unknown} */ ({
-			type: 'TsrxFragment',
-			children,
-			attributes: [],
-			selfClosing: false,
-			metadata: { path: [] },
-		})
-	);
-
-	return set_location(node, loc_info);
-}
-
-/**
- * Ripple's internal expression template child (the normalized form of a
- * `JSXExpressionContainer` child).
- * @param {AST.Expression} expression
- * @param {AST.NodeWithLocation} [loc_info]
- * @returns {AST.TSRXExpression}
- */
-export function tsrx_expression(expression, loc_info) {
-	const node = /** @type {AST.TSRXExpression} */ ({
-		type: 'TSRXExpression',
-		expression,
-		metadata: { path: [] },
-	});
-
-	return set_location(node, loc_info);
 }
 
 /**

--- a/packages/tsrx/src/utils/builders.js
+++ b/packages/tsrx/src/utils/builders.js
@@ -1200,8 +1200,9 @@ export function jsx_element_fresh(
 
 /**
  * Elements carry the parser's widened TSRX shape (dynamic-tag names, lowered
- * template children) — see {@link jsx_fragment}.
- * @param {AST.TSRXJSXElement} node
+ * template children) — see {@link jsx_fragment}. A `JSXStyleElement` shares
+ * the element shape and may be re-emitted as an empty `<style>` element.
+ * @param {AST.TSRXJSXElement | AST.JSXStyleElement} node
  * @param {ESTreeJSX.TSRXJSXOpeningElement['attributes']} attributes
  * @param {AST.TSRXJSXElement['children']} children
  * @returns {AST.TSRXJSXElement}

--- a/packages/tsrx/types/index.d.ts
+++ b/packages/tsrx/types/index.d.ts
@@ -104,6 +104,12 @@ interface BaseNodeMetaData {
 	tsrx_for_pattern_id?: AST.Identifier;
 	/** Memoized render-body statements (see get_native_tsrx_function_body). */
 	tsrx_render_body?: AST.Node[];
+	/** Memoized resolved render slot of a `@{ … }` code block (see get_code_block_render). */
+	tsrx_render_slot?: { render: AST.Node | null };
+	/** Memoized template-child lowering of a `@{ … }` code block (see get_code_block_template_child). */
+	tsrx_template_child?: { child: AST.Node | null };
+	/** Memoized `<> … </>` wrapper for a value-position directive (see get_directive_value_wrapper). */
+	tsrx_value_wrapper?: AST.TSRXJSXFragment;
 	ts_name?: string;
 	delegated?: any;
 	returned_tsrx_return?: AST.ReturnStatement;
@@ -269,6 +275,7 @@ declare module 'estree' {
 
 	// Include TypeScript node types and TSRX-specific nodes in NodeMap
 	interface NodeMap {
+		JSXSpreadChild: ESTreeJSX.JSXSpreadChild;
 		TSRXJSXElement: TSRXJSXElement;
 		TSRXJSXFragment: TSRXJSXFragment;
 		TSRXJSXOpeningElement: ESTreeJSX.TSRXJSXOpeningElement;
@@ -283,6 +290,8 @@ declare module 'estree' {
 	}
 
 	interface ExpressionMap {
+		TSRXJSXElement: TSRXJSXElement;
+		TSRXJSXFragment: TSRXJSXFragment;
 		JSXCodeBlock: JSXCodeBlock;
 		JSXStyleElement: JSXStyleElement;
 		JSXIfExpression: JSXIfExpression;
@@ -386,6 +395,13 @@ declare module 'estree' {
 		pending?: AST.BlockStatement | null;
 		metadata: BaseNodeMetaData;
 	}
+
+	/** A `@if`/`@for`/`@switch`/`@try` template control-flow directive. */
+	type JSXTemplateDirective =
+		| JSXIfExpression
+		| JSXForExpression
+		| JSXSwitchExpression
+		| JSXTryExpression;
 
 	interface ParenthesizedExpression extends AST.BaseNode {
 		type: 'ParenthesizedExpression';

--- a/packages/tsrx/types/index.d.ts
+++ b/packages/tsrx/types/index.d.ts
@@ -110,6 +110,8 @@ interface BaseNodeMetaData {
 	tsrx_template_child?: { child: AST.Node | null };
 	/** Memoized `<> … </>` wrapper for a value-position directive (see get_directive_value_wrapper). */
 	tsrx_value_wrapper?: AST.TSRXJSXFragment;
+	/** Memoized element tag expression (see get_element_id). */
+	id_node?: AST.Expression;
 	ts_name?: string;
 	delegated?: any;
 	returned_tsrx_return?: AST.ReturnStatement;
@@ -323,6 +325,8 @@ declare module 'estree' {
 			AST.NodeWithMaybeComments {
 		openingElement: ESTreeJSX.TSRXJSXOpeningElement;
 		closingElement: ESTreeJSX.TSRXJSXClosingElement | null;
+		/** The parser marks dynamic `<{expr}>` tags; lower_dynamic_element clears it on its copy. */
+		isDynamic?: boolean;
 		/** Loose-mode recovery: the element was never closed. */
 		unclosed?: boolean;
 		/**
@@ -743,6 +747,8 @@ declare module 'estree-jsx' {
 	}
 
 	interface TSRXJSXOpeningElement extends Omit<JSXOpeningElement, 'name'> {
+		/** The parser marks dynamic `<{expr}>` tags; lower_dynamic_element clears it on its copy. */
+		isDynamic?: boolean;
 		// AST.MemberExpression: the parser never produces it, but the to_ts
 		// transform plants the visited member chain (`<Foo.Bar>`) into the name
 		// slot for the TSX printer and its source mappings.

--- a/packages/tsrx/types/index.d.ts
+++ b/packages/tsrx/types/index.d.ts
@@ -110,8 +110,6 @@ interface BaseNodeMetaData {
 	tsrx_template_child?: { child: AST.Node | null };
 	/** Memoized `<> … </>` wrapper for a value-position directive (see get_directive_value_wrapper). */
 	tsrx_value_wrapper?: AST.TSRXJSXFragment;
-	/** Memoized element tag expression (see get_element_id). */
-	id_node?: AST.Expression;
 	ts_name?: string;
 	delegated?: any;
 	returned_tsrx_return?: AST.ReturnStatement;

--- a/packages/tsrx/types/index.d.ts
+++ b/packages/tsrx/types/index.d.ts
@@ -303,7 +303,14 @@ declare module 'estree' {
 			AST.NodeWithMaybeComments {
 		openingElement: ESTreeJSX.TSRXJSXOpeningElement;
 		closingElement: ESTreeJSX.TSRXJSXClosingElement | null;
-		children: TSRXJSXChild[];
+		/** Loose-mode recovery: the element was never closed. */
+		unclosed?: boolean;
+		/**
+		 * The parser emits {@link TSRXJSXChild}; the compile pre-passes lower
+		 * template children in place (retyped directives, code-block IIFEs,
+		 * merged text runs), so any node can appear here by transform time.
+		 */
+		children: AST.Node[];
 		metadata: BaseNodeMetaData & {
 			ts_name?: string;
 		};
@@ -311,7 +318,8 @@ declare module 'estree' {
 
 	interface TSRXJSXFragment
 		extends Omit<ESTreeJSX.JSXFragment, 'children'>, AST.NodeWithMaybeComments {
-		children: TSRXJSXChild[];
+		/** See {@link TSRXJSXElement}'s `children`. */
+		children: AST.Node[];
 	}
 
 	interface JSXCodeBlock extends AST.BaseExpression {
@@ -691,11 +699,25 @@ declare module 'estree-jsx' {
 	}
 
 	interface TSRXJSXOpeningElement extends Omit<JSXOpeningElement, 'name'> {
-		name: AST.MemberExpression | JSXIdentifier | JSXNamespacedName | JSXExpressionContainer;
+		// AST.MemberExpression: the parser never produces it, but the to_ts
+		// transform plants the visited member chain (`<Foo.Bar>`) into the name
+		// slot for the TSX printer and its source mappings.
+		name:
+			| JSXMemberExpression
+			| JSXIdentifier
+			| JSXNamespacedName
+			| JSXExpressionContainer
+			| import('estree').MemberExpression;
 	}
 
 	interface TSRXJSXClosingElement extends Omit<JSXClosingElement, 'name'> {
-		name: AST.MemberExpression | JSXIdentifier | JSXNamespacedName | JSXExpressionContainer;
+		// See TSRXJSXOpeningElement's `name`.
+		name:
+			| JSXMemberExpression
+			| JSXIdentifier
+			| JSXNamespacedName
+			| JSXExpressionContainer
+			| import('estree').MemberExpression;
 	}
 
 	interface ExpressionMap {
@@ -1379,7 +1401,7 @@ export interface AnalysisState extends BaseState {
 			filename: string;
 		};
 	};
-	elements?: Array<ESTreeJSX.JSXElement>;
+	elements?: Array<AST.TSRXJSXElement | AST.JSXStyleElement>;
 	function_depth?: number;
 	collect?: boolean;
 	metadata: BaseStateMetaData & {
@@ -1458,7 +1480,25 @@ export interface TransformClientState extends BaseState {
 }
 
 /** Override zimmerframe types and provide our own */
-type NodeOf<T extends string, X> = X extends { type: T } ? X : never;
+/**
+ * Where stock `@types/estree-jsx` and the TSRX parser shapes share a `type`
+ * tag, visitors receive the TSRX shape — the parser only ever produces that
+ * one (dynamic tag names, code-block children, `metadata`, `start`/`end`).
+ * Interface merging cannot widen the stock interfaces' property types, so the
+ * TSRXJSX* variants override the plain ones here instead.
+ */
+interface VisitorNodeOverrides {
+	JSXElement: AST.TSRXJSXElement;
+	JSXFragment: AST.TSRXJSXFragment;
+	JSXOpeningElement: ESTreeJSX.TSRXJSXOpeningElement;
+	JSXClosingElement: ESTreeJSX.TSRXJSXClosingElement;
+}
+
+type NodeOf<T extends string, X> = T extends keyof VisitorNodeOverrides
+	? VisitorNodeOverrides[T]
+	: X extends { type: T }
+		? X
+		: never;
 
 type SpecializedVisitors<T extends AST.Node | AST.CSS.Node, U> = {
 	[K in T['type']]?: Visitor<NodeOf<K, T>, U, T>;

--- a/packages/tsrx/types/index.d.ts
+++ b/packages/tsrx/types/index.d.ts
@@ -94,6 +94,16 @@ interface BaseNodeMetaData {
 	tsrx_render_fragment?: boolean;
 	/** A merged text run produced by normalize_children - renders through the text path. */
 	tsrx_text?: boolean;
+	/** Control-flow node renders as the sole child of its parent (controlled anchor). */
+	is_controlled?: boolean;
+	/** Control-flow node is the root of a render body - anchors on `__anchor`. */
+	root_controlled?: boolean;
+	/** Append target set by transform_children when all siblings are static component children. */
+	append_into?: AST.Identifier;
+	/** Generated pattern id substituted for a destructured keyed `@for` left. */
+	tsrx_for_pattern_id?: AST.Identifier;
+	/** Memoized render-body statements (see get_native_tsrx_function_body). */
+	tsrx_render_body?: AST.Node[];
 	ts_name?: string;
 	delegated?: any;
 	returned_tsrx_return?: AST.ReturnStatement;

--- a/packages/tsrx/types/index.d.ts
+++ b/packages/tsrx/types/index.d.ts
@@ -143,6 +143,10 @@ interface FunctionMetaData extends BaseNodeMetaData {
 	is_method?: boolean;
 	tracked?: boolean;
 	has_lazy_descendants?: boolean;
+	/** The component's extracted `<style>` stylesheet (element-level scoped-class info lives on BaseNodeMetaData's `css`). */
+	component_css?: AST.CSS.StyleSheet | null;
+	/** Top-level scoped classes collected while pruning the component's CSS. */
+	topScopedClasses?: TopScopedClasses;
 	synthetic_children?: boolean;
 	generated_helpers?: any[];
 	generated_statics?: any[];
@@ -362,21 +366,38 @@ declare module 'estree' {
 		metadata: BaseNodeMetaData;
 	}
 
-	interface JSXForExpression extends AST.BaseExpression {
+	interface JSXForExpressionBase extends AST.BaseExpression {
 		type: 'JSXForExpression';
-		statementType: 'ForStatement' | 'ForInStatement' | 'ForOfStatement';
-		body: AST.Statement;
-		init?: AST.VariableDeclaration | AST.Expression | null;
-		test?: AST.Expression | null;
-		update?: AST.Expression | null;
-		left?: AST.VariableDeclaration | AST.Pattern;
-		right?: AST.Expression;
-		await?: boolean;
+		/** The parser raises unless the directive body is a `{ … }` block. */
+		body: AST.BlockStatement;
 		index?: AST.Identifier | null;
 		key?: AST.Expression | null;
 		empty?: AST.BlockStatement | null;
 		metadata: BaseNodeMetaData;
 	}
+
+	interface JSXForOfExpression extends JSXForExpressionBase {
+		statementType: 'ForOfStatement';
+		left: AST.VariableDeclaration | AST.Pattern;
+		right: AST.Expression;
+		await?: boolean;
+	}
+
+	interface JSXForInExpression extends JSXForExpressionBase {
+		statementType: 'ForInStatement';
+		left: AST.VariableDeclaration | AST.Pattern;
+		right: AST.Expression;
+	}
+
+	interface JSXForPlainExpression extends JSXForExpressionBase {
+		statementType: 'ForStatement';
+		init?: AST.VariableDeclaration | AST.Expression | null;
+		test?: AST.Expression | null;
+		update?: AST.Expression | null;
+	}
+
+	/** `@for` — discriminated on `statementType` (for-of / for-in / for(;;)). */
+	type JSXForExpression = JSXForOfExpression | JSXForInExpression | JSXForPlainExpression;
 
 	interface JSXSwitchExpression extends AST.BaseExpression {
 		type: 'JSXSwitchExpression';
@@ -1088,8 +1109,10 @@ declare module 'estree' {
 	> {
 		typeAnnotation: TypeNode;
 	}
-	interface TSTypeAssertion extends AcornTSNode<TSESTree.TSTypeAssertion> {
+	interface TSTypeAssertion extends Omit<AcornTSNode<TSESTree.TSTypeAssertion>, 'typeAnnotation'> {
+		// Have to override it to use our Expression for required properties like metadata
 		expression: AST.Expression;
+		typeAnnotation: TypeNode;
 	}
 	interface TSTypeLiteral extends Omit<AcornTSNode<TSESTree.TSTypeLiteral>, 'members'> {
 		members: TypeElement[];

--- a/packages/tsrx/types/index.d.ts
+++ b/packages/tsrx/types/index.d.ts
@@ -1558,7 +1558,12 @@ export type CatchAllVisitor<T, U, V> = (
 	visit: VisitFn<V>,
 ) => V | void;
 
-export type Visitor<T, U, V> = (node: T, context: Context<V, U>) => V | void;
+/**
+ * A visitor may replace a node with several: zimmerframe stores the returned
+ * array verbatim in the parent's statement list and the printer flattens
+ * nested statement arrays.
+ */
+export type Visitor<T, U, V> = (node: T, context: Context<V, U>) => V | V[] | void;
 
 export type Visitors<T extends AST.Node | AST.CSS.Node, U> = T['type'] extends '_'
 	? never

--- a/packages/tsrx/types/index.d.ts
+++ b/packages/tsrx/types/index.d.ts
@@ -89,6 +89,14 @@ interface BaseNodeMetaData {
 	templateMode?: 'script' | 'template';
 	script_only?: boolean;
 	tsrxDirective?: 'if' | 'for' | 'switch' | 'try';
+	/** A retyped expression-position directive whose branch bodies are template children. */
+	tsrx_template_directive?: boolean;
+	/** A synthetic wrapper for a nested `@{ @{ ... } }` code-block render chain. */
+	tsrx_code_block_chain?: boolean;
+	/** A synthesized render-body fragment (see create_native_tsrx_render_function). */
+	tsrx_render_fragment?: boolean;
+	/** A merged text run produced by normalize_children - renders through the text path. */
+	tsrx_text?: boolean;
 	ts_name?: string;
 	delegated?: any;
 	returned_tsrx_return?: AST.ReturnStatement;
@@ -248,30 +256,16 @@ declare module 'estree' {
 		tracked?: boolean;
 	}
 
-	interface SimpleLiteral extends AST.LiteralNode {}
-	interface RegExpLiteral extends AST.LiteralNode {}
-	interface BigIntLiteral extends AST.LiteralNode {}
-
 	interface TrackedNode {
 		tracked?: boolean;
 	}
 
-	interface LiteralNode {
-		was_expression?: boolean;
-	}
-
 	// Include TypeScript node types and TSRX-specific nodes in NodeMap
 	interface NodeMap {
-		Element: Element;
-		TsrxFragment: TsrxFragment;
-		Text: Text;
 		TSRXJSXElement: TSRXJSXElement;
 		TSRXJSXFragment: TSRXJSXFragment;
 		TSRXJSXOpeningElement: ESTreeJSX.TSRXJSXOpeningElement;
 		TSRXJSXClosingElement: ESTreeJSX.TSRXJSXClosingElement;
-		TSRXExpression: TSRXExpression;
-		Attribute: Attribute;
-		SpreadAttribute: SpreadAttribute;
 		JSXCodeBlock: JSXCodeBlock;
 		JSXStyleElement: JSXStyleElement;
 		JSXIfExpression: JSXIfExpression;
@@ -282,10 +276,6 @@ declare module 'estree' {
 	}
 
 	interface ExpressionMap {
-		Element: Element;
-		TsrxFragment: TsrxFragment;
-		Text: Text;
-		TSRXExpression: TSRXExpression;
 		JSXCodeBlock: JSXCodeBlock;
 		JSXStyleElement: JSXStyleElement;
 		JSXIfExpression: JSXIfExpression;
@@ -298,69 +288,6 @@ declare module 'estree' {
 	}
 
 	type TraversableAstNode = AST.Node & Record<string, unknown>;
-
-	// Ripple-normalized template node shapes. The core parser emits JSX-shaped
-	// TSRX nodes; @tsrx/ripple creates these during its normalization pass.
-	interface Attribute extends AST.BaseNode {
-		type: 'Attribute';
-		name: AST.Identifier;
-		value: any;
-		shorthand?: boolean;
-		metadata: BaseNodeMetaData;
-	}
-
-	interface SpreadAttribute extends AST.BaseNode {
-		type: 'SpreadAttribute';
-		argument: AST.Expression;
-		metadata: BaseNodeMetaData;
-	}
-
-	interface Element extends AST.BaseExpression {
-		type: 'Element';
-		id: AST.Expression;
-		attributes: Array<Attribute | SpreadAttribute>;
-		children: AST.Node[];
-		openingElement: ESTreeJSX.JSXOpeningElement;
-		closingElement: ESTreeJSX.JSXClosingElement | null;
-		selfClosing?: boolean;
-		unclosed?: boolean;
-		isDynamic?: boolean;
-		css?: string;
-		metadata: BaseNodeMetaData;
-		start: number;
-		end: number;
-	}
-
-	interface TsrxFragment extends AST.BaseExpression {
-		type: 'TsrxFragment';
-		children: AST.Node[];
-		openingElement?: ESTreeJSX.JSXOpeningFragment;
-		closingElement?: ESTreeJSX.JSXClosingFragment | null;
-		selfClosing?: boolean;
-		attributes?: Array<Attribute | SpreadAttribute>;
-		metadata: BaseNodeMetaData & {
-			/**
-			 * A synthetic wrapper for a nested code-block render chain
-			 * (`@{ @{ … } }`), so render-slot consumers see a template node;
-			 * template-children lowering unwraps it.
-			 */
-			tsrx_code_block_chain?: boolean;
-		};
-		start: number;
-		end: number;
-	}
-
-	interface Text extends AST.BaseExpression {
-		type: 'Text';
-		expression: AST.Expression;
-		metadata: BaseNodeMetaData;
-	}
-
-	interface TSRXExpression extends AST.BaseExpression {
-		type: 'TSRXExpression';
-		expression: AST.Expression;
-		metadata: BaseNodeMetaData;
-	}
 
 	type TSRXJSXChild =
 		| ESTreeJSX.JSXText
@@ -1452,7 +1379,7 @@ export interface AnalysisState extends BaseState {
 			filename: string;
 		};
 	};
-	elements?: Array<ESTreeJSX.JSXElement | AST.Element>;
+	elements?: Array<ESTreeJSX.JSXElement>;
 	function_depth?: number;
 	collect?: boolean;
 	metadata: BaseStateMetaData & {

--- a/packages/tsrx/types/index.d.ts
+++ b/packages/tsrx/types/index.d.ts
@@ -88,9 +88,6 @@ interface BaseNodeMetaData {
 	dynamicElement?: boolean;
 	templateMode?: 'script' | 'template';
 	script_only?: boolean;
-	tsrxDirective?: 'if' | 'for' | 'switch' | 'try';
-	/** A retyped expression-position directive whose branch bodies are template children. */
-	tsrx_template_directive?: boolean;
 	/** A synthetic wrapper for a nested `@{ @{ ... } }` code-block render chain. */
 	tsrx_code_block_chain?: boolean;
 	/** A synthesized render-body fragment (see create_native_tsrx_render_function). */


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> This is a broad compiler/AST contract change across core, ripple, and IDE mappings; regressions could affect parsing, codegen, hydration, and editor features.
> 
> **Overview**
> Ripple’s compile pipeline no longer builds or consumes a Ripple-specific template AST. **`parse()`** now exposes the parser’s JSX nodes (`JSXElement`, `JSXFragment`, `JSXText`, `JSXExpressionContainer`, etc.), and **`@tsrx/core`** drops the old normalized types and builders (`Element`, `TsrxFragment`, `Text`, `TSRXExpression`, …).
> 
> The **analyzer and client/server transforms** were updated to walk that AST directly and to work **copy-on-write** (no in-place mutation of the parsed tree). That removes the extra clone in **`compile_to_volar_mappings`** and restores **scoped-CSS** hover/go-to-definition on `class` attributes in the IDE.
> 
> Tooling follows the same shapes: the **Prettier plugin** drops legacy `typeParameters` printing on calls/`new` and treats **`JSXForExpression`** loop headers via `statementType` when deciding semicolons on `const` inits. Tests and hydration golden output were refreshed for JSX node types and minor codegen tweaks (e.g. reactive label text via `set_text`/`render` in some components).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f400670e750db3178332d5fc1bb5aa2fe0cdba3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->