### PR TITLE
fix(tsrx): don't read `/` and `#` as template text in nested JS positions

### DIFF
--- a/.changeset/slash-hash-template-js-positions.md
+++ b/.changeset/slash-hash-template-js-positions.md
@@ -1,0 +1,5 @@
+---
+'@tsrx/core': patch
+---
+
+Fixed the tokenizer reading `/` and `#` as literal template-text characters in JS positions nested under a template element: division in a nested element's attribute expression (`<g><rect x={a - b / 2} /></g>`), division and private-field access in child expression containers (`{a / 2}`, `{this.#x}`), and division in control-flow directive headers (`@if (a / 2 > 1)`) all mis-parsed as "Unexpected token". The text special-case now skips expression containers and directive headers, where acorn's own tokenizer handles division vs regex correctly; literal `/` and `#` in template text are unchanged.

--- a/packages/tsrx/src/plugin.js
+++ b/packages/tsrx/src/plugin.js
@@ -2888,9 +2888,18 @@ export function TSRXPlugin(config) {
 					this.exprAllowed = false;
 				}
 
+				// A `/` or `#` in template TEXT position joins the text run as a
+				// literal character (`<div>5/2</div>`, `<div>#tag</div>`). This must
+				// not fire in the JS positions that can sit under a template element
+				// on the path: inside a `{ … }` expression container (an attribute or
+				// child expression — `<rect x={a / 2}/>`, `{this.#x}`) or inside a
+				// control-flow directive header (`@if (a / 2 > 1)`), where `/` is
+				// division and `#` is a private-field access.
 				if (
 					(code === CharCode.numberSign || code === CharCode.slash) &&
 					this.#functionBodyDepth === 0 &&
+					this.#jsxExpressionContainerDepth === 0 &&
+					!this.#readingJSXControlFlowHeader &&
 					this.#isNativeTemplateNode(this.#path.at(-1)) &&
 					!(
 						code === CharCode.slash &&

--- a/packages/tsrx/tests/utils/parser.test.js
+++ b/packages/tsrx/tests/utils/parser.test.js
@@ -2927,3 +2927,73 @@ foo();`;
 		expect(block.render.type).toBe('JSXFragment');
 	});
 });
+
+describe('division and private fields in template JS positions', () => {
+	// `/` and `#` in template TEXT are literal characters, which the tokenizer
+	// special-cases. That special case must not swallow the JS positions that sit
+	// under a template element on the node path: expression containers (attribute
+	// and child) and control-flow directive headers, where `/` is division and
+	// `#` is a private-field access.
+
+	it('parses `/` as division in a NESTED element attribute expression', () => {
+		const rect = findElement(
+			`function App(p) { return @{ <g id={p.id}><rect x={p.left - p.dotSize / 2} /></g> }; }`,
+			'rect',
+		);
+		const x = rect.openingElement.attributes[0].value.expression;
+		expect(x.type).toBe('BinaryExpression');
+		expect(x.operator).toBe('-');
+		expect(x.right.type).toBe('BinaryExpression');
+		expect(x.right.operator).toBe('/');
+	});
+
+	it('parses `/` as division in a child expression container', () => {
+		const g = findElement(`function App(p) { return @{ <g>{p.a / 2}</g> }; }`, 'g');
+		const expr = g.children.find((c) => c.type === 'JSXExpressionContainer').expression;
+		expect(expr.type).toBe('BinaryExpression');
+		expect(expr.operator).toBe('/');
+	});
+
+	it('parses `#` as a private-field access in a child expression container', () => {
+		const g = findElement(`class C { #x = 1; m() { return @{ <g>{this.#x}</g> }; } }`, 'g');
+		const expr = g.children.find((c) => c.type === 'JSXExpressionContainer').expression;
+		expect(expr.type).toBe('MemberExpression');
+		expect(expr.property.type).toBe('PrivateIdentifier');
+		expect(expr.property.name).toBe('x');
+	});
+
+	it('parses `/` as division in a directive header nested inside an element', () => {
+		const node = findNode(
+			`function App(p) { return @{ <g>@if (p.a / 2 > 1) { <rect /> }</g> }; }`,
+			'JSXIfExpression',
+		);
+		expect(node.test.type).toBe('BinaryExpression');
+		expect(node.test.operator).toBe('>');
+		expect(node.test.left.type).toBe('BinaryExpression');
+		expect(node.test.left.operator).toBe('/');
+	});
+
+	it('parses a regex literal inside a nested element attribute expression', () => {
+		const rect = findElement(
+			`function App(p) { return @{ <g><rect x={String(p.a).replace(/x/g, String(2 / p.b))} /></g> }; }`,
+			'rect',
+		);
+		const x = rect.openingElement.attributes[0].value.expression;
+		expect(x.type).toBe('CallExpression');
+		expect(x.arguments[0].type).toBe('Literal');
+		expect(x.arguments[0].regex).toEqual({ pattern: 'x', flags: 'g' });
+	});
+
+	it('still reads a literal `/` and `#` in template text as text', () => {
+		const div = findElement(
+			`function App(p) { return @{ <div>5/2 #tag {p.a}/{p.b}</div> }; }`,
+			'div',
+		);
+		const text = div.children
+			.filter((c) => c.type === 'JSXText')
+			.map((c) => c.value)
+			.join('|');
+		expect(text).toContain('5/2 #tag ');
+		expect(text).toContain('/');
+	});
+});


### PR DESCRIPTION
The tokenizer special-cases `/` and `#` in template-text position so they join text runs as literal characters (`<div>5/2</div>`, `<div>#tag</div>`). The guard only checked that the top of the node path is a native template element — which also holds while tokenizing INSIDE a `{ … }` expression container or a control-flow directive header nested under that element. Any of these threw "Unexpected token" at the slash/hash:

  <g id={id}><rect x={left - dotSize / 2} /></g>   // division in nested attr
  <g>{a / 2}</g>                                   // division in child expr
  <g>{this.#x}</g>                                 // private-field access
  <g>@if (a / 2 > 1) { <rect /> }</g>              // division in header

(Found porting recharts to octane — its Line component computes clip-rect geometry with divisions inside a nested <clipPath><rect …/>.)

The special case now bails when inside an expression container (#jsxExpressionContainerDepth > 0) or a directive header (#readingJSXControlFlowHeader), where acorn's own exprAllowed machinery already handles division vs regex correctly — regex literals in these positions keep working. Literal `/`/`#` in template text are unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core tokenizer behavior for TSRX templates; scope is narrow (two guard conditions) but parsing regressions would affect many templates.
> 
> **Overview**
> Fixes a tokenizer bug where **`/`** and **`#`** were forced into template **text** whenever parsing under a native template element, even inside real JavaScript.
> 
> The template-text shortcut in `getTokenFromCode` now **does not run** when `#jsxExpressionContainerDepth > 0` or `#readingJSXControlFlowHeader` is set. In those positions Acorn handles **division**, **private fields**, and **regex literals** normally. Literal `/` and `#` in actual template text (e.g. `5/2`, `#tag`) are unchanged.
> 
> Adds parser tests for nested attribute/child expressions, `@if` headers, regex in attributes, and literal text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9579e8c5c2df2b1db44c8a2b3e096beb4c752432. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->