### PR TITLE
fix(prettier-plugin): keep parens on same-precedence same-operator right operands

### DIFF
--- a/.changeset/great-mirrors-repeat.md
+++ b/.changeset/great-mirrors-repeat.md
@@ -1,0 +1,5 @@
+---
+'@tsrx/prettier-plugin': patch
+---
+
+fix(prettier-plugin): keep author parens on same-precedence, same-operator right operands — `a - (b - c)`, `a / (b / c)`, and `'x' + (n + 1)` no longer reformat to a regrouped (semantics-changing) chain; `(a ** b) ** c` keeps its left-operand parens since `**` is right-associative

--- a/packages/prettier-plugin/src/index.js
+++ b/packages/prettier-plugin/src/index.js
@@ -403,6 +403,16 @@ function binaryExpressionNeedsParens(node, parent) {
 		if (nodePrecedence === parentPrecedence && node.operator !== parent.operator) {
 			return true;
 		}
+		if (nodePrecedence === parentPrecedence) {
+			// Same precedence, same operator: dropping the parens regroups a
+			// left-associative chain (`a - (b - c)` !== `a - b - c`; even `+` is
+			// non-associative once strings are involved), so the RIGHT operand
+			// keeps its parens. `**` is right-associative — there it's the LEFT
+			// operand that must keep them.
+			if (parent.operator === '**' ? parent.left === node : parent.right === node) {
+				return true;
+			}
+		}
 	}
 
 	return false;

--- a/packages/prettier-plugin/src/index.test.js
+++ b/packages/prettier-plugin/src/index.test.js
@@ -2285,6 +2285,42 @@ const program =
 			expect(result).toBeWithNewline(expected);
 		});
 
+		it('should keep parens around the right operand of a same-operator subtraction', async () => {
+			const expected = `const d = a - (b - c);`;
+
+			const result = await format(expected, { singleQuote: true, printWidth: 100 });
+			expect(result).toBeWithNewline(expected);
+		});
+
+		it('should keep parens around the right operand of a same-operator division', async () => {
+			const expected = `const d = a / (b / c);`;
+
+			const result = await format(expected, { singleQuote: true, printWidth: 100 });
+			expect(result).toBeWithNewline(expected);
+		});
+
+		it('should keep parens around a right-side addition under string concatenation', async () => {
+			const expected = `const s = 'x' + (n + 1);`;
+
+			const result = await format(expected, { singleQuote: true, printWidth: 100 });
+			expect(result).toBeWithNewline(expected);
+		});
+
+		it('should drop redundant parens around the left operand of a same-operator addition', async () => {
+			const input = `const s = (a + b) + c;`;
+			const expected = `const s = a + b + c;`;
+
+			const result = await format(input, { singleQuote: true, printWidth: 100 });
+			expect(result).toBeWithNewline(expected);
+		});
+
+		it('should keep parens around the left operand of exponentiation', async () => {
+			const expected = `const p = (a ** b) ** c;`;
+
+			const result = await format(expected, { singleQuote: true, printWidth: 100 });
+			expect(result).toBeWithNewline(expected);
+		});
+
 		it('should have parents around low-precedence logical expression', async () => {
 			const input = `files = [...files ?? [], ...dt.files];
 files = [...(files ?? []), ...dt.files];`;


### PR DESCRIPTION
## Summary

`binaryExpressionNeedsParens` checked operator precedence but not associativity, so author parens on a same-precedence **same-operator** right operand were dropped — a semantics-changing reformat:

| Input | Before (wrong) | After |
|---|---|---|
| `a - (b - c)` | `a - b - c` | kept |
| `a / (b / c)` | `a / b / c` | kept |
| `'x' + (n + 1)` | `'x' + n + 1` | kept (string concat makes even `+` non-associative) |
| `(a + b) + c` | `a + b + c` | still dropped (left operand is safe) |
| `(a ** b) ** c` | — | kept (`**` is right-associative, so the **left** operand needs parens) |

The fix: same precedence + same operator → keep parens when the node is the parent's right operand (left operand for right-associative `**`).

This was found while formatting octane sources, where the octane repo currently carries a local pnpm patch for it; this PR upstreams the fix so that patch can be dropped.

## Testing

- 5 new unit tests in `index.test.js` covering the table above
- `vitest run packages/prettier-plugin/src/index.test.js` — 343 passed
- prettier-plugin typecheck + format:check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to parenthesis preservation in the formatter with unit tests; no runtime or security impact.
> 
> **Overview**
> Fixes **semantics-changing** formatting where author parentheses on binary chains were dropped when child and parent shared the same operator and precedence.
> 
> `binaryExpressionNeedsParens` now keeps parentheses when precedence and operator match and the parenthesized node is the **right** operand (left-associative ops), or the **left** operand for right-associative `**`. Examples that stay stable: `a - (b - c)`, `a / (b / c)`, `'x' + (n + 1)`, `(a ** b) ** c`. Redundant left-side parens on `+` still drop, e.g. `(a + b) + c` → `a + b + c`.
> 
> Five formatter tests cover these cases; changeset records a patch for `@tsrx/prettier-plugin`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a94208fb7983288aa3db9dd0f9144465f36d868f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->