### PR TITLE
fix: preserve type args in some instances

### DIFF
--- a/.changeset/curly-spoons-smile.md
+++ b/.changeset/curly-spoons-smile.md
@@ -1,0 +1,5 @@
+---
+'@tsrx/core': patch
+---
+
+Preserve generic type arguments in interface heritage clauses in type-only output and Volar mappings.

--- a/packages/tsrx/src/transform/jsx/helpers.js
+++ b/packages/tsrx/src/transform/jsx/helpers.js
@@ -191,9 +191,8 @@ export function tsx_with_ts_locations() {
 		// semantics, that leaves segments.js unable to map the omitted node.
 		TSExpressionWithTypeArguments: (node, context) => {
 			context.visit(node.expression);
-			const type_arguments = node.typeParameters ?? node.typeArguments;
-			if (type_arguments) {
-				context.visit(type_arguments);
+			if (node.typeParameters) {
+				context.visit(node.typeParameters);
 			}
 		},
 		TSModuleDeclaration: (node, context) => {

--- a/packages/tsrx/src/transform/jsx/helpers.js
+++ b/packages/tsrx/src/transform/jsx/helpers.js
@@ -185,6 +185,17 @@ export function tsx_with_ts_locations() {
 			}
 			context.write('>');
 		},
+		// esrap's TSExpressionWithTypeArguments printer only emits `expression`,
+		// dropping interface heritage arguments such as the `<T>` in
+		// `interface Foo<T> extends Bar<T> {}`. Besides changing the declaration's
+		// semantics, that leaves segments.js unable to map the omitted node.
+		TSExpressionWithTypeArguments: (node, context) => {
+			context.visit(node.expression);
+			const type_arguments = node.typeParameters ?? node.typeArguments;
+			if (type_arguments) {
+				context.visit(type_arguments);
+			}
+		},
 		TSModuleDeclaration: (node, context) => {
 			context.write(node.metadata?.module_keyword ?? 'module');
 			context.write(' ');

--- a/packages/tsrx/tests/shared/source-mappings.js
+++ b/packages/tsrx/tests/shared/source-mappings.js
@@ -140,6 +140,19 @@ export function runSharedSourceMappingTests({
 			expect_maps(
 				`function assert(x: any): asserts x { if (!x) throw new Error(); } function C() @{}`,
 			));
+		it.each([
+			'interface Foo<T> extends Bar<T> {}',
+			'interface Foo extends Bar<string> {}',
+			'interface Foo<T, U> extends Bar<T>, Baz<U> {}',
+			'interface Foo<T> extends Namespace.Bar<Array<T>> {}',
+			'export interface Foo<T extends object> extends Bar<Readonly<T>> {}',
+		])('preserves generic interface heritage arguments: %s', (source) => {
+			const result = compile_to_volar_mappings(source, 'App.tsrx', { loose: true });
+
+			expect(result.code).toContain(source);
+			expect(result.errors).toEqual([]);
+			expect(result.mappings.length).toBeGreaterThan(0);
+		});
 
 		// JSX: esrap prints `<`, `>`, `</`, ` /` without location markers.
 		// Combined with hoisting to module-level statics, the opening


### PR DESCRIPTION
During some testing, I caught that:

```typescript
interface Foo<T> extends Bar<T> {}
```

Appeared to be transformed into:

```typescript
interface Foo<T> extends Bar {}
```

Breaking some TSRX usage that relied on this.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized printer override and regression tests in the type-only output path; no runtime or auth/data changes.
> 
> **Overview**
> Fixes a bug where **interface `extends` clauses with type arguments** were stripped in type-only / Volar output (e.g. `interface Foo<T> extends Bar<T> {}` became `extends Bar {}`), breaking typings and IDE mappings.
> 
> The esrap TSX printer override in `tsx_with_ts_locations` now visits **`TSExpressionWithTypeArguments.typeParameters`** so heritage generics are emitted and `segments.js` can map them. Shared source-mapping tests assert several `extends Bar<…>` shapes round-trip unchanged with valid Volar mappings; changeset records a **patch** for `@tsrx/core`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee83337d739e6c4cda3be155e9972ff5e9fbd125. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->