### PR TITLE
fix(tsrx): parse multiline self-closing expressions

### DIFF
--- a/.changeset/self-closing-expression-lookahead.md
+++ b/.changeset/self-closing-expression-lookahead.md
@@ -1,0 +1,5 @@
+---
+'@tsrx/core': patch
+---
+
+Fixed parsing multiline self-closing JSX expressions when whitespace follows `/>`, including parenthesized return expressions and ternaries whose other branch is a fragment or array. The tokenizer now uses the preceding token boundary when deciding whether the following source is template text.

--- a/packages/prettier-plugin/src/index.test.js
+++ b/packages/prettier-plugin/src/index.test.js
@@ -510,6 +510,54 @@ function App() {
 }`);
 	});
 
+	it('formats a multiline parenthesized self-closing expression', async () => {
+		const result = await format(`const value = (
+  <Item />
+);`);
+
+		expect(result).toBeWithNewline('const value = <Item />;');
+	});
+
+	it('formats a return ternary from a self-closing element to a fragment', async () => {
+		const input = `function ElementToFragment(condition) {
+  return condition ? (
+    <Item />
+  ) : (
+    <>
+      <Item />
+    </>
+  );
+}`;
+		const expected = `function ElementToFragment(condition) {
+  return condition
+    ? <Item />
+    : <>
+        <Item />
+      </>;
+}`;
+
+		const result = await format(input);
+		expect(result).toBeWithNewline(expected);
+		expect(await format(result)).toBe(result);
+	});
+
+	it('formats a return ternary from a self-closing element to an array', async () => {
+		const input = `function ElementToArray(condition) {
+  return condition ? (
+    <Item />
+  ) : (
+    [<Item />]
+  );
+}`;
+		const expected = `function ElementToArray(condition) {
+  return condition ? <Item /> : [<Item />];
+}`;
+
+		const result = await format(input);
+		expect(result).toBeWithNewline(expected);
+		expect(await format(result)).toBe(result);
+	});
+
 	it('hugs a `@{ }` code block to an element body', async () => {
 		const input = `function App(){return <div>@{const x=1;<span>{x}</span>}</div>}`;
 		const expected = `function App() {

--- a/packages/tsrx/src/plugin.js
+++ b/packages/tsrx/src/plugin.js
@@ -1000,13 +1000,15 @@ export function TSRXPlugin(config) {
 				// following raw text belongs to an enclosing template, not to it. With no
 				// enclosing template (e.g. a top-level `return <div />`), the trailing
 				// text is plain JS and must not be read as template raw text.
+				// Inter-token whitespace has already advanced `pos`; `lastTokEnd` still
+				// identifies the consumed `/>` boundary.
 				const opening = this.#openingNativeTemplateNode;
 				if (
 					opening &&
 					current_template_node === opening &&
 					/** @type {any} */ (opening).openingElement?.selfClosing &&
-					this.input.charCodeAt(this.pos - 1) === CharCode.greaterThan &&
-					this.input.charCodeAt(this.pos - 2) === CharCode.slash
+					this.input.charCodeAt(this.lastTokEnd - 1) === CharCode.greaterThan &&
+					this.input.charCodeAt(this.lastTokEnd - 2) === CharCode.slash
 				) {
 					const enclosing = this.#path.findLast(
 						(node) => node !== opening && this.#isNativeTemplateNode(node),

--- a/packages/tsrx/tests/utils/parser.test.js
+++ b/packages/tsrx/tests/utils/parser.test.js
@@ -500,6 +500,72 @@ abc
 		expect(span.children[0].value).toBe('   keep');
 	});
 
+	it('parses a multiline parenthesized self-closing element in an expression', () => {
+		const ast = parseModule(
+			`const value = (
+				<Item />
+			);
+			const after = true;`,
+			'App.tsrx',
+		);
+
+		const [valueDeclaration, afterDeclaration] = ast.body;
+		const value = valueDeclaration.declarations[0].init;
+		expect(value.type).toBe('JSXElement');
+		expect(value.openingElement.name.name).toBe('Item');
+		expect(afterDeclaration.declarations[0].init.value).toBe(true);
+	});
+
+	it('parses a return ternary from a self-closing element to a fragment', () => {
+		const returned = getReturned(
+			`function App(condition) {
+				return condition ? (
+					<Item />
+				) : (
+					<>
+						<Item />
+					</>
+				);
+			}`,
+		);
+
+		expect(returned.type).toBe('ConditionalExpression');
+		expect(returned.consequent.type).toBe('JSXElement');
+		expect(returned.alternate.type).toBe('JSXFragment');
+		expect(returned.alternate.children.map((child) => child.type)).toEqual(['JSXElement']);
+	});
+
+	it('parses a return ternary from a self-closing element to an array', () => {
+		const returned = getReturned(
+			`function App(condition) {
+				return condition ? (
+					<Item />
+				) : (
+					[<Item />]
+				);
+			}`,
+		);
+
+		expect(returned.type).toBe('ConditionalExpression');
+		expect(returned.consequent.type).toBe('JSXElement');
+		expect(returned.alternate.type).toBe('ArrayExpression');
+		expect(returned.alternate.elements.map((element) => element.type)).toEqual(['JSXElement']);
+	});
+
+	it('preserves template text after a self-closing child', () => {
+		const returned = getReturned(
+			`function App() {
+				return <div>
+					<Item />
+					tail
+				</div>;
+			}`,
+		);
+
+		expect(returned.children.map((child) => child.type)).toEqual(['JSXElement', 'JSXText']);
+		expect(returned.children[1].value).toContain('tail');
+	});
+
 	it('parses a ternary with JSX element branches inside an expression container', () => {
 		const returned = getReturned(
 			`function App() {


### PR DESCRIPTION
## Summary

- fix TSRX raw-text lookahead after multiline self-closing JSX expressions
- cover the minimal parenthesized expression, return-position Fragment/array ternaries, formatter idempotence, and enclosing-template text preservation
- add a patch changeset for `@tsrx/core`

## Root cause

The smallest reproducer is:

```tsx
const value = (
  <Item />
);
```

This is valid TSRX, but the parser failed at the closing `)`. Acorn skips inter-token whitespace before Ripple decides whether to read template raw text, so `this.pos` had already advanced past the newline to the next script delimiter. The existing self-closing-tag guard therefore missed the preceding `/>` and emitted a stale `jsxText` token that swallowed `)`, `:`, or `]`.

The guard now checks `lastTokEnd`, the stable boundary of the consumed `/>` token. This keeps existing TSRX semantics: text after a self-closing child still belongs to an enclosing native template, while top-level expression delimiters stay JavaScript tokens.

## Validation

- `vitest run packages/tsrx/tests/utils/parser.test.js --project=tsrx-utils` (209 tests)
- `vitest run packages/prettier-plugin/src/index.test.js --project=prettier-plugin` (346 tests)
- `pnpm typecheck`
- `pnpm format:check`
- `pnpm changeset:check`
- `git diff --check`
- formatted Octane Phase 2's full `fragment-reconciliation.tsrx` fixture through Ripple's public Prettier plugin; a second pass was byte-identical

## Octane follow-up

After Octane consumes the `@tsrx/core` release containing this fix, [octanejs/octane#91](https://github.com/octanejs/octane/pull/91) can remove the complete temporary `.prettierignore` block (current lines 20–23): the three explanatory comment lines plus `packages/octane/tests/conformance/_fixtures/fragment-reconciliation.tsrx`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Targets core TSRX tokenization with a small boundary fix; regression risk is mitigated by broad parser and formatter tests, but lexer changes can affect many templates.
> 
> **Overview**
> Fixes TSRX parsing when a self-closing element is followed by whitespace and then JavaScript delimiters (e.g. `const value = (\n  <Item />\n);`), which previously failed at `)` because the tokenizer misclassified trailing text as template raw text.
> 
> The self-closing `/>` guard in `packages/tsrx/src/plugin.js` now keys off **`lastTokEnd`** instead of **`pos`**, since inter-token whitespace moves `pos` past the consumed `/>` while `lastTokEnd` still marks that boundary. Enclosing-template text after a self-closing child is unchanged; top-level expression punctuation stays plain JS.
> 
> Adds parser and Prettier plugin tests for parenthesized self-closing expressions, return ternaries (fragment/array branches), formatter idempotence, and template text after self-closing children. Ships a patch changeset for `@tsrx/core`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b9ebd1a119fb311a57f8ae05d9890fc6d9b4669. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->