### PR TITLE
fix: replace stale ripplejs.com links with ripple-ts.com

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ There are numerous ways to contribute to Ripple, and many don't require writing
 code. Here are some ideas to get started:
 
 - **Start experimenting with Ripple**: Try out the
-  [Ripple Playground](https://www.ripplejs.com/playground) and see how it works.
+  [Ripple Playground](https://www.ripple-ts.com/playground) and see how it works.
   If you encounter issues or unexpected behavior, we'd love to hear about it
   through [opening an issue](#reporting-issues).
 - **Browse existing issues**: Check out our

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<a href="https://ripplejs.com">
+<a href="https://www.ripple-ts.com">
   <picture>
     <source media="(min-width: 768px)" srcset="assets/ripple-desktop.png">
     <img src="assets/ripple-mobile.png" alt="Ripple - the elegant TypeScript UI framework" />

--- a/grammars/tree-sitter/README.md
+++ b/grammars/tree-sitter/README.md
@@ -1,6 +1,6 @@
 # @ripple-ts/tree-sitter
 
-Tree-sitter grammar for [Ripple](https://www.ripplejs.com).
+Tree-sitter grammar for [Ripple](https://www.ripple-ts.com).
 
 ## Overview
 

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -3,7 +3,7 @@
 [![npm version](https://img.shields.io/npm/v/%40tsrx%2Feslint-plugin?logo=npm)](https://www.npmjs.com/package/@tsrx/eslint-plugin)
 [![npm downloads](https://img.shields.io/npm/dm/%40tsrx%2Feslint-plugin?logo=npm&label=downloads)](https://www.npmjs.com/package/@tsrx/eslint-plugin)
 
-ESLint plugin for [Ripple](https://ripplejs.com) - helps enforce best practices
+ESLint plugin for [Ripple](https://www.ripple-ts.com) - helps enforce best practices
 and catch common mistakes when writing Ripple applications.
 
 Works just like `eslint-plugin-react` - simply install and use the recommended
@@ -217,7 +217,7 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 
 ## Related
 
-- [Ripple](https://ripplejs.com) - The Ripple framework
+- [Ripple](https://www.ripple-ts.com) - The Ripple framework
 - [@ripple-ts/vite-plugin](https://www.npmjs.com/package/@ripple-ts/vite-plugin) -
   Vite plugin for Ripple
 - [@tsrx/prettier-plugin](https://www.npmjs.com/package/@tsrx/prettier-plugin) -


### PR DESCRIPTION
Standardizes docs links to the canonical ripple-ts.com domain.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only URL updates with no runtime, build, or security impact.
> 
> **Overview**
> Updates documentation and README links that still pointed at **ripplejs.com** so they use the canonical **www.ripple-ts.com** URLs instead.
> 
> The hero link in the root **README**, the Playground link in **CONTRIBUTING.md**, and Ripple framework links in **grammars/tree-sitter/README.md** and **packages/eslint-plugin/README.md** (including the Related section) are aligned with the domain already used elsewhere in the repo for docs and playground.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6195ac900241e9a0ba7ee4a988a9ada7ded9793c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->