### PR TITLE
fix: correct typos in docs guide (control-flow, events, reactivity)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ There are numerous ways to contribute to Ripple, and many don't require writing
 code. Here are some ideas to get started:
 
 - **Start experimenting with Ripple**: Try out the
-  [Ripple Playground](https://www.ripplejs.com/playground) and see how it works.
+  [Ripple Playground](https://www.ripple-ts.com/playground) and see how it works.
   If you encounter issues or unexpected behavior, we'd love to hear about it
   through [opening an issue](#reporting-issues).
 - **Browse existing issues**: Check out our

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<a href="https://ripplejs.com">
+<a href="https://www.ripple-ts.com">
   <picture>
     <source media="(min-width: 768px)" srcset="assets/ripple-desktop.png">
     <img src="assets/ripple-mobile.png" alt="Ripple - the elegant TypeScript UI framework" />

--- a/grammars/tree-sitter/README.md
+++ b/grammars/tree-sitter/README.md
@@ -1,6 +1,6 @@
 # @ripple-ts/tree-sitter
 
-Tree-sitter grammar for [Ripple](https://www.ripplejs.com).
+Tree-sitter grammar for [Ripple](https://www.ripple-ts.com).
 
 ## Overview
 

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -3,7 +3,7 @@
 [![npm version](https://img.shields.io/npm/v/%40tsrx%2Feslint-plugin?logo=npm)](https://www.npmjs.com/package/@tsrx/eslint-plugin)
 [![npm downloads](https://img.shields.io/npm/dm/%40tsrx%2Feslint-plugin?logo=npm&label=downloads)](https://www.npmjs.com/package/@tsrx/eslint-plugin)
 
-ESLint plugin for [Ripple](https://ripplejs.com) - helps enforce best practices
+ESLint plugin for [Ripple](https://www.ripple-ts.com) - helps enforce best practices
 and catch common mistakes when writing Ripple applications.
 
 Works just like `eslint-plugin-react` - simply install and use the recommended
@@ -217,7 +217,7 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 
 ## Related
 
-- [Ripple](https://ripplejs.com) - The Ripple framework
+- [Ripple](https://www.ripple-ts.com) - The Ripple framework
 - [@ripple-ts/vite-plugin](https://www.npmjs.com/package/@ripple-ts/vite-plugin) -
   Vite plugin for Ripple
 - [@tsrx/prettier-plugin](https://www.npmjs.com/package/@tsrx/prettier-plugin) -

--- a/website-new/docs/guide/control-flow.md
+++ b/website-new/docs/guide/control-flow.md
@@ -61,7 +61,7 @@ to render inline.
 ## Switch statements
 
 Use `@switch` to conditionally render content based on a value. It works with
-both static and reactive values. Each `and` has its own `{...}`
+both static and reactive values. Each `case` has its own `{...}`
 body. Cases do not fall through, and `break`/`return` are not used inside `@switch`.
 
 <Code>

--- a/website-new/docs/guide/events.md
+++ b/website-new/docs/guide/events.md
@@ -227,7 +227,7 @@ Unlike using `addEventListener`, `on()` guarantees proper execution order with
 respect to attribute-based handlers such as `onClick`, and is also optimized with
 event delegation for events that support it.
 
-The options, exluding `customName`, that can be passed in to `on()` are the same
+The options, excluding `customName`, that can be passed in to `on()` are the same
 ones that can be used for event attributes with the object syntax.
 
 <Code console>

--- a/website-new/docs/guide/reactivity.md
+++ b/website-new/docs/guide/reactivity.md
@@ -53,7 +53,7 @@ console.log(count.value); // 1
 ```
 
 Using `&[...]` lazy destructuring is typically preferred in most cases because it produces
-cleaner, more readable code. However, `.value` is useful when need top performance,
+cleaner, more readable code. However, `.value` is useful when you need top performance,
 especially in hot paths, or to keep the `Tracked<V>` object around — for example,
 when storing tracked values in data structures, passing them as props typed as `Tracked<T>`,
 or when you need both the tracked object and its value in different contexts.

--- a/website/docs/guide/control-flow.md
+++ b/website/docs/guide/control-flow.md
@@ -61,7 +61,7 @@ to render inline.
 ## Switch statements
 
 Use `@switch` to conditionally render content based on a value. It works with
-both static and reactive values. Each `and` has its own `{...}`
+both static and reactive values. Each `case` has its own `{...}`
 body. Cases do not fall through, and `break`/`return` are not used inside `@switch`.
 
 <Code>

--- a/website/docs/guide/events.md
+++ b/website/docs/guide/events.md
@@ -227,7 +227,7 @@ Unlike using `addEventListener`, `on()` guarantees proper execution order with
 respect to attribute-based handlers such as `onClick`, and is also optimized with
 event delegation for events that support it.
 
-The options, exluding `customName`, that can be passed in to `on()` are the same
+The options, excluding `customName`, that can be passed in to `on()` are the same
 ones that can be used for event attributes with the object syntax.
 
 <Code console>

--- a/website/docs/guide/reactivity.md
+++ b/website/docs/guide/reactivity.md
@@ -53,7 +53,7 @@ console.log(count.value); // 1
 ```
 
 Using `&[...]` lazy destructuring is typically preferred in most cases because it produces
-cleaner, more readable code. However, `.value` is useful when need top performance,
+cleaner, more readable code. However, `.value` is useful when you need top performance,
 especially in hot paths, or to keep the `Tracked<V>` object around — for example,
 when storing tracked values in data structures, passing them as props typed as `Tracked<T>`,
 or when you need both the tracked object and its value in different contexts.


### PR DESCRIPTION
Fixes a few typos in the website guide docs.