### PR TITLE
chore: fix package metadata and configuration paths

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ There are numerous ways to contribute to Ripple, and many don't require writing
 code. Here are some ideas to get started:
 
 - **Start experimenting with Ripple**: Try out the
-  [Ripple Playground](https://www.ripplejs.com/playground) and see how it works.
+  [Ripple Playground](https://www.ripple-ts.com/playground) and see how it works.
   If you encounter issues or unexpected behavior, we'd love to hear about it
   through [opening an issue](#reporting-issues).
 - **Browse existing issues**: Check out our

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<a href="https://ripplejs.com">
+<a href="https://www.ripple-ts.com">
   <picture>
     <source media="(min-width: 768px)" srcset="assets/ripple-desktop.png">
     <img src="assets/ripple-mobile.png" alt="Ripple - the elegant TypeScript UI framework" />

--- a/grammars/tree-sitter/README.md
+++ b/grammars/tree-sitter/README.md
@@ -1,6 +1,6 @@
 # @ripple-ts/tree-sitter
 
-Tree-sitter grammar for [Ripple](https://www.ripplejs.com).
+Tree-sitter grammar for [Ripple](https://www.ripple-ts.com).
 
 ## Overview
 

--- a/packages/create-ripple/README.md
+++ b/packages/create-ripple/README.md
@@ -64,7 +64,7 @@ A minimal Ripple application with:
 
 ## Requirements
 
-- Node.js 20.0.0 or higher
+- Node.js 22.0.0 or higher
 
 ## License
 

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -3,7 +3,7 @@
 [![npm version](https://img.shields.io/npm/v/%40tsrx%2Feslint-plugin?logo=npm)](https://www.npmjs.com/package/@tsrx/eslint-plugin)
 [![npm downloads](https://img.shields.io/npm/dm/%40tsrx%2Feslint-plugin?logo=npm&label=downloads)](https://www.npmjs.com/package/@tsrx/eslint-plugin)
 
-ESLint plugin for [Ripple](https://ripplejs.com) - helps enforce best practices
+ESLint plugin for [Ripple](https://www.ripple-ts.com) - helps enforce best practices
 and catch common mistakes when writing Ripple applications.
 
 Works just like `eslint-plugin-react` - simply install and use the recommended
@@ -217,7 +217,7 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 
 ## Related
 
-- [Ripple](https://ripplejs.com) - The Ripple framework
+- [Ripple](https://www.ripple-ts.com) - The Ripple framework
 - [@ripple-ts/vite-plugin](https://www.npmjs.com/package/@ripple-ts/vite-plugin) -
   Vite plugin for Ripple
 - [@tsrx/prettier-plugin](https://www.npmjs.com/package/@tsrx/prettier-plugin) -

--- a/packages/sublime-text-plugin/package.json
+++ b/packages/sublime-text-plugin/package.json
@@ -1,8 +1,15 @@
 {
   "name": "@ripple-ts/sublime-text-plugin",
   "version": "0.0.82",
-  "description": "",
+  "description": "Sublime Text support for TSRX and Ripple",
   "private": true,
+  "keywords": [
+    "sublime-text",
+    "sublime",
+    "plugin",
+    "ripple",
+    "tsrx"
+  ],
   "scripts": {
     "update-lock": "cd src/language-server && npm install --package-lock-only",
     "build": "npm run update-lock && node ./scripts/build.js"

--- a/packages/vscode-plugin/package.json
+++ b/packages/vscode-plugin/package.json
@@ -23,7 +23,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Ripple-TS/ripple.git",
-    "directory": "vscode-plugin"
+    "directory": "packages/vscode-plugin"
   },
   "scripts": {
     "build": "tsdown",

--- a/packages/zed-plugin/package.json
+++ b/packages/zed-plugin/package.json
@@ -1,13 +1,18 @@
 {
   "name": "@ripple-ts/zed-plugin",
   "version": "0.0.85",
-  "description": "",
+  "description": "Zed editor support for TSRX and Ripple",
   "private": true,
   "main": "index.js",
   "scripts": {},
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
+  "keywords": [
+    "zed",
+    "zed-extension",
+    "ripple",
+    "tsrx"
+  ],
+  "author": "Dominic Gannaway",
+  "license": "MIT",
   "config": {
     "@ripple-ts/language-server": "0.3.97"
   },


### PR DESCRIPTION
This pull request updates configuration directories and package files for the editor plugins to make them consistent across the project.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and package.json metadata only; no runtime or build logic changes.
> 
> **Overview**
> Updates project documentation and package metadata to use the **ripple-ts.com** site and align editor plugin packages with the monorepo layout.
> 
> **Documentation:** README, CONTRIBUTING, tree-sitter, eslint-plugin, and create-ripple READMEs now link to `https://www.ripple-ts.com` (and playground) instead of `ripplejs.com`. **create-ripple** requirements are bumped from Node.js 20 to **22.0.0+**.
> 
> **Packages:** `@ripple-ts/vscode-plugin` `repository.directory` is corrected to `packages/vscode-plugin`. **Sublime** and **Zed** plugins get descriptions, keywords, author, and license (MIT) filled in where they were empty or inconsistent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 911b263b92e3340c3fa544aef2d2a20572026991. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->