### PR TITLE
fix: update compiler error message and playground example

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ There are numerous ways to contribute to Ripple, and many don't require writing
 code. Here are some ideas to get started:
 
 - **Start experimenting with Ripple**: Try out the
-  [Ripple Playground](https://www.ripplejs.com/playground) and see how it works.
+  [Ripple Playground](https://www.ripple-ts.com/playground) and see how it works.
   If you encounter issues or unexpected behavior, we'd love to hear about it
   through [opening an issue](#reporting-issues).
 - **Browse existing issues**: Check out our

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<a href="https://ripplejs.com">
+<a href="https://www.ripple-ts.com">
   <picture>
     <source media="(min-width: 768px)" srcset="assets/ripple-desktop.png">
     <img src="assets/ripple-mobile.png" alt="Ripple - the elegant TypeScript UI framework" />

--- a/grammars/tree-sitter/README.md
+++ b/grammars/tree-sitter/README.md
@@ -1,6 +1,6 @@
 # @ripple-ts/tree-sitter
 
-Tree-sitter grammar for [Ripple](https://www.ripplejs.com).
+Tree-sitter grammar for [Ripple](https://www.ripple-ts.com).
 
 ## Overview
 

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -3,7 +3,7 @@
 [![npm version](https://img.shields.io/npm/v/%40tsrx%2Feslint-plugin?logo=npm)](https://www.npmjs.com/package/@tsrx/eslint-plugin)
 [![npm downloads](https://img.shields.io/npm/dm/%40tsrx%2Feslint-plugin?logo=npm&label=downloads)](https://www.npmjs.com/package/@tsrx/eslint-plugin)
 
-ESLint plugin for [Ripple](https://ripplejs.com) - helps enforce best practices
+ESLint plugin for [Ripple](https://www.ripple-ts.com) - helps enforce best practices
 and catch common mistakes when writing Ripple applications.
 
 Works just like `eslint-plugin-react` - simply install and use the recommended
@@ -217,7 +217,7 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 
 ## Related
 
-- [Ripple](https://ripplejs.com) - The Ripple framework
+- [Ripple](https://www.ripple-ts.com) - The Ripple framework
 - [@ripple-ts/vite-plugin](https://www.npmjs.com/package/@ripple-ts/vite-plugin) -
   Vite plugin for Ripple
 - [@tsrx/prettier-plugin](https://www.npmjs.com/package/@tsrx/prettier-plugin) -

--- a/packages/tsrx-ripple/src/transform/client/index.js
+++ b/packages/tsrx-ripple/src/transform/client/index.js
@@ -3241,7 +3241,9 @@ const visitors = {
 						),
 					);
 				} else {
-					throw new Error('TODO');
+					throw new Error(
+						'Unexpected attribute type encountered during client transformation: ' + attr.type,
+					);
 				}
 			}
 

--- a/playground/react/README.md
+++ b/playground/react/README.md
@@ -26,15 +26,14 @@ createRoot(target).render(
 ```tsrx
 import { useState, useEffect } from 'react';
 
-function Child() {
-  return <div>
-    const x = 1;
+function Child() @{
+  const x = 1;
+  console.log(x);
 
-    console.log(x);
-  </div>;
+  <div>Child component</div>
 }
 
-export function App() {
+export function App() @{
   const [count, setCount] = useState(0);
   const items = [1, 2, 3];
 
@@ -42,35 +41,32 @@ export function App() {
     console.log(count);
   }, [count]);
 
-  return <>
-    <Child />
-    <h1>
-      {'Hello World'}
-      if (count > 1) {
-        return null;
-      }
-    </h1>
-    if (count > 1) {
-      <div>
-        const [x] = useState(1);
+  if (count > 2) {
+    return null;
+  }
 
-        {'Count is more than ' + x}
-      </div>
+  <Child />
+  <h1>
+    {'Hello World'}
+    @if (count > 1) {
+      <span> (Expanded)</span>
     }
-    <button onClick={() => setCount(count + 1)}>{count}</button>
-    if (count > 2) {
-      return null;
+  </h1>
+  @if (count > 1) {
+    const [x] = useState(1);
+
+    <div>{'Count is more than ' + x}</div>
+  }
+  <button onClick={() => setCount(count + 1)}>{count}</button>
+  @for (const item of items; index i) {
+    <div key={i}>{item}</div>
+  }
+  <style>
+    button {
+      border: 0;
+      color: red;
     }
-    for (const item of items; index i) {
-      <div key={i}>{item}</div>
-    }
-    <style>
-      button {
-        border: 0;
-        color: red;
-      }
-    </style>
-  </>;
+  </style>
 }
 ```
 


### PR DESCRIPTION
This pull request replaces a placeholder error in the compiler with a clear message and updates the react playground example to use modern syntax.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and README-only URL/example updates plus a clearer error string on an already-throwing path; no runtime behavior change on success paths.
> 
> **Overview**
> Replaces the client transform’s generic **`TODO`** throw with an error that names the unexpected JSX attribute **`type`**, so compiler failures are easier to debug.
> 
> Documentation links are updated from **`ripplejs.com`** to **`www.ripple-ts.com`** in the root README, contributing guide, tree-sitter grammar README, and ESLint plugin README.
> 
> The React playground README example is rewritten to current TSRX style: **`@{...}`** component bodies, **`@if`** / **`@for`**, and an early **`return null`** instead of the older inline-JSX-in-return pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7226cb1c9b5893bdafc46857700d722ce5480b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->