### PR TITLE
chore: extend typescript plugin support

### DIFF
--- a/.changeset/octane-compiler-support.md
+++ b/.changeset/octane-compiler-support.md
@@ -1,0 +1,5 @@
+---
+'@tsrx/typescript-plugin': patch
+---
+
+Support the octane tsrx target: resolve octane projects to the compiler entry inside the `octane` package (`src/compiler/volar.js`, via a new optional per-candidate entry path), and normalize its camelCase `compileToVolarMappings` export to the plugin's `compile_to_volar_mappings` contract so already-published octane versions work in both the editor plugin and `tsrx-tsc`. Also stop `tsrx-tsc` runs from warning `getExtraServiceScripts() is not available` once per file.

--- a/packages/typescript-plugin/package.json
+++ b/packages/typescript-plugin/package.json
@@ -41,7 +41,8 @@
     "@tsrx/ripple": "workspace:*",
     "@tsrx/solid": "workspace:*",
     "@tsrx/preact": "workspace:*",
-    "@tsrx/vue": "workspace:*"
+    "@tsrx/vue": "workspace:*",
+    "octane": "*"
   },
   "peerDependenciesMeta": {
     "@tsrx/react": {
@@ -57,6 +58,9 @@
       "optional": true
     },
     "@tsrx/vue": {
+      "optional": true
+    },
+    "octane": {
       "optional": true
     }
   },

--- a/packages/typescript-plugin/src/language.js
+++ b/packages/typescript-plugin/src/language.js
@@ -30,7 +30,7 @@ const { log, logWarning, logError } = createLogging('[Ripple Language]');
 /** @type {Set<string>} */
 const loggedCompilationFailures = new Set();
 export const RIPPLE_EXTENSIONS = ['.tsrx'];
-/** @typedef {[string, string[], string[], string[]]} CompilerCandidate */
+/** @typedef {[string, string[], string[], string[], string[]?]} CompilerCandidate */
 /** @type {CompilerCandidate[]} */
 export const COMPILER_CANDIDATES = [
 	[
@@ -63,7 +63,16 @@ export const COMPILER_CANDIDATES = [
 		['.tsrx'],
 		['@tsrx/vue', '@tsrx/vite-plugin-vue'],
 	],
+	[
+		'octane',
+		['node_modules', 'octane'],
+		['.tsrx'],
+		['octane', '@octanejs/vite-plugin'],
+		['src', 'compiler', 'volar.js'],
+	],
 ];
+
+const DEFAULT_COMPILER_ENTRY_PARTS = ['src', 'index.js'];
 
 /**
  * @param {string} file_name
@@ -138,36 +147,44 @@ export function getRippleLanguagePlugin() {
 				}
 				return undefined;
 			},
-			/**
-			 * Register each embedded `<script>` body as its own TypeScript service
-			 * script so volar-service-typescript's semantic features (type-aware
-			 * completions, hover, go-to-definition, diagnostics, imports) run against it
-			 * and map back to the `.tsrx` source — the same way `<style>` bodies get CSS
-			 * intellisense, except semantic TS additionally requires a service-script
-			 * registration (a self-contained languageId is not enough).
-			 *
-			 * The returned `code` must be the exact same instance stored in the root's
-			 * `embeddedCodes` (volar matches it by identity), and each `fileName` must be
-			 * unique. Only honored on the language-server (`createTypeScriptProject`)
-			 * path, not the tsserver-plugin path.
-			 * @param {string} fileName
-			 * @param {VirtualCode} ripple_code
-			 */
-			getExtraServiceScripts(fileName, ripple_code) {
-				/** @type {Array<{ fileName: string, code: VirtualCode, extension: string, scriptKind: number }>} */
-				const scripts = [];
-				for (const code of forEachEmbeddedCode(ripple_code)) {
-					if (code.languageId === 'typescript') {
-						scripts.push({
-							fileName: `${fileName}.${code.id}.ts`,
-							code,
-							extension: '.ts',
-							scriptKind: ts.ScriptKind.TS,
-						});
-					}
-				}
-				return scripts;
-			},
+			// Volar's tsc program proxy (`proxyCreateProgram`) does not support
+			// extra service scripts and warns ONCE PER PARSED FILE when the hook
+			// is merely present — omit it entirely under tsrx-tsc (the bin sets
+			// TSRX_TSC before loading this module).
+			...(process.env.TSRX_TSC === 'true'
+				? null
+				: {
+						/**
+						 * Register each embedded `<script>` body as its own TypeScript service
+						 * script so volar-service-typescript's semantic features (type-aware
+						 * completions, hover, go-to-definition, diagnostics, imports) run against it
+						 * and map back to the `.tsrx` source — the same way `<style>` bodies get CSS
+						 * intellisense, except semantic TS additionally requires a service-script
+						 * registration (a self-contained languageId is not enough).
+						 *
+						 * The returned `code` must be the exact same instance stored in the root's
+						 * `embeddedCodes` (volar matches it by identity), and each `fileName` must be
+						 * unique. Only honored on the language-server (`createTypeScriptProject`)
+						 * path, not the tsserver-plugin path.
+						 * @param {string} fileName
+						 * @param {VirtualCode} ripple_code
+						 */
+						getExtraServiceScripts(fileName, ripple_code) {
+							/** @type {Array<{ fileName: string, code: VirtualCode, extension: string, scriptKind: number }>} */
+							const scripts = [];
+							for (const code of forEachEmbeddedCode(ripple_code)) {
+								if (code.languageId === 'typescript') {
+									scripts.push({
+										fileName: `${fileName}.${code.id}.ts`,
+										code,
+										extension: '.ts',
+										scriptKind: ts.ScriptKind.TS,
+									});
+								}
+							}
+							return scripts;
+						},
+					}),
 		},
 	};
 }
@@ -979,7 +996,20 @@ function package_manifest_matches_compiler(package_manifest, compiler_name, pack
 function get_tsrx_compiler(normalized_file_name) {
 	const compiler_path = get_compiler_entry_for_file(normalized_file_name);
 	if (compiler_path) {
-		return require(compiler_path);
+		const compiler_module = require(compiler_path);
+		if (
+			typeof compiler_module?.compile_to_volar_mappings !== 'function' &&
+			typeof compiler_module?.compileToVolarMappings === 'function'
+		) {
+			// Octane's volar entry exports the same contract under a camelCase
+			// name (`compileToVolarMappings`); normalize so already-published
+			// octane versions work without an octane-side release.
+			return {
+				...compiler_module,
+				compile_to_volar_mappings: compiler_module.compileToVolarMappings,
+			};
+		}
+		return compiler_module;
 	}
 }
 
@@ -1009,11 +1039,12 @@ export function find_workspace_compiler_entry_for_file(
 				compiler_dir_parts,
 				supported_extensions,
 				package_hints,
+				entry_parts = DEFAULT_COMPILER_ENTRY_PARTS,
 			] of COMPILER_CANDIDATES) {
 				if (!supported_extensions.includes(ext)) {
 					continue;
 				}
-				const full_path = [dir, ...compiler_dir_parts, 'src', 'index.js'].join('/');
+				const full_path = [dir, ...compiler_dir_parts, ...entry_parts].join('/');
 				if (exists_sync(full_path)) {
 					available_candidates.push([compiler_name, full_path, package_hints]);
 				}
@@ -1065,12 +1096,13 @@ export function get_compiler_entry_for_file(normalized_file_name) {
 			compiler_dir_parts,
 			supported_extensions,
 			package_hints,
+			entry_parts = DEFAULT_COMPILER_ENTRY_PARTS,
 		] of COMPILER_CANDIDATES) {
 			if (!supported_extensions.includes(ext)) {
 				continue;
 			}
 			const full_path = path.join(current_dir, ...compiler_dir_parts);
-			const entry_path = path.join(full_path, 'src', 'index.js');
+			const entry_path = path.join(full_path, ...entry_parts);
 			if (fs.existsSync(entry_path)) {
 				available_candidates.push([compiler_name, entry_path, package_hints]);
 			}
@@ -1111,8 +1143,14 @@ export function get_tsrx_compiler_name_for_file(file_name) {
 	}
 
 	const normalized_entry = entry.replace(/\\/g, '/');
-	for (const [compiler_name, compiler_dir_parts] of COMPILER_CANDIDATES) {
-		const suffix = '/' + [...compiler_dir_parts, 'src', 'index.js'].join('/');
+	for (const [
+		compiler_name,
+		compiler_dir_parts,
+		,
+		,
+		entry_parts = DEFAULT_COMPILER_ENTRY_PARTS,
+	] of COMPILER_CANDIDATES) {
+		const suffix = '/' + [...compiler_dir_parts, ...entry_parts].join('/');
 		if (normalized_entry.endsWith(suffix)) {
 			return compiler_name;
 		}

--- a/packages/typescript-plugin/tests/compiler-resolution.test.js
+++ b/packages/typescript-plugin/tests/compiler-resolution.test.js
@@ -39,6 +39,9 @@ describe('typescript-plugin compiler resolution', () => {
 			const vue_candidate = COMPILER_CANDIDATES.find(
 				([package_name]) => package_name === '@tsrx/vue',
 			);
+			const octane_candidate = COMPILER_CANDIDATES.find(
+				([package_name]) => package_name === 'octane',
+			);
 			const solid_candidate = COMPILER_CANDIDATES.find(
 				([package_name]) => package_name === '@tsrx/solid',
 			);
@@ -51,7 +54,8 @@ describe('typescript-plugin compiler resolution', () => {
 				!react_candidate ||
 				!solid_candidate ||
 				!preact_candidate ||
-				!vue_candidate
+				!vue_candidate ||
+				!octane_candidate
 			) {
 				throw new Error('Missing compiler candidates');
 			}
@@ -61,6 +65,7 @@ describe('typescript-plugin compiler resolution', () => {
 			expect(vue_candidate[2]).toEqual(['.tsrx']);
 			expect(solid_candidate[2]).toEqual(['.tsrx']);
 			expect(preact_candidate[2]).toEqual(['.tsrx']);
+			expect(octane_candidate[2]).toEqual(['.tsrx']);
 		});
 	});
 
@@ -125,6 +130,40 @@ describe('typescript-plugin compiler resolution', () => {
 			const workspace = create_fixture_workspace('vue-only');
 			const file_name = path.join(workspace, 'src', 'App.tsrx');
 			const expected = path.join(workspace, 'node_modules', '@tsrx', 'vue', 'src', 'index.js');
+
+			expect(find_workspace_compiler_entry_for_file(file_name, fs.existsSync, new Map())).toBe(
+				expected,
+			);
+		});
+
+		it('selects the octane compiler (package-internal entry path) in an octane-only project', () => {
+			const workspace = create_fixture_workspace('octane-only');
+			const file_name = path.join(workspace, 'src', 'App.tsrx');
+			const expected = path.join(
+				workspace,
+				'node_modules',
+				'octane',
+				'src',
+				'compiler',
+				'volar.js',
+			);
+
+			expect(find_workspace_compiler_entry_for_file(file_name, fs.existsSync, new Map())).toBe(
+				expected,
+			);
+		});
+
+		it('prefers the octane compiler when multiple compilers exist in an octane project', () => {
+			const workspace = create_fixture_workspace('both-octane');
+			const file_name = path.join(workspace, 'src', 'App.tsrx');
+			const expected = path.join(
+				workspace,
+				'node_modules',
+				'octane',
+				'src',
+				'compiler',
+				'volar.js',
+			);
 
 			expect(find_workspace_compiler_entry_for_file(file_name, fs.existsSync, new Map())).toBe(
 				expected,
@@ -227,10 +266,12 @@ describe('typescript-plugin compiler resolution', () => {
 			{ name: 'solid-only', expected: ['@tsrx', 'solid'] },
 			{ name: 'preact-only', expected: ['@tsrx', 'preact'] },
 			{ name: 'vue-only', expected: ['@tsrx', 'vue'] },
+			{ name: 'octane-only', expected: ['octane', 'src', 'compiler', 'volar.js'] },
 			{ name: 'both', expected: ['@tsrx', 'ripple'] },
 			{ name: 'both-react', expected: ['@tsrx', 'react'] },
 			{ name: 'both-preact', expected: ['@tsrx', 'preact'] },
 			{ name: 'both-vue', expected: ['@tsrx', 'vue'] },
+			{ name: 'both-octane', expected: ['octane', 'src', 'compiler', 'volar.js'] },
 		];
 
 		for (const test_case of cases) {
@@ -260,6 +301,8 @@ describe('typescript-plugin compiler resolution', () => {
 			{ name: 'vue-only', compiler: '@tsrx/vue', is_ripple: false },
 			{ name: 'both', compiler: '@tsrx/ripple', is_ripple: true },
 			{ name: 'both-react', compiler: '@tsrx/react', is_ripple: false },
+			{ name: 'octane-only', compiler: 'octane', is_ripple: false },
+			{ name: 'both-octane', compiler: 'octane', is_ripple: false },
 		];
 
 		for (const test_case of cases) {

--- a/packages/typescript-plugin/tests/plugin-integration.test.js
+++ b/packages/typescript-plugin/tests/plugin-integration.test.js
@@ -109,6 +109,30 @@ describe('typescript-plugin language plugin integration', () => {
 		expect(virtual_code.generatedCode).toContain('compiler:react');
 	});
 
+	// Octane exercises BOTH octane-specific paths at once: the package-internal
+	// compiler entry (src/compiler/volar.js instead of the @tsrx/* layout) and
+	// the camelCase `compileToVolarMappings` module-shape normalization.
+	it('creates virtual code with the octane compiler in an octane project', () => {
+		const plugin = create_plugin();
+		const workspace = create_fixture_workspace('octane-only');
+		const file_name = path.join(workspace, 'src', 'App.tsrx');
+		const virtual_code = create_virtual_code(plugin, file_name, 'export default <div>Hello</div>;');
+
+		expect(virtual_code).toBeInstanceOf(TSRXVirtualCode);
+		expect(virtual_code.generatedCode).toContain('compiler:octane');
+		expect(virtual_code.generatedCode).toContain(file_name);
+	});
+
+	it('prefers the octane compiler when other compilers also exist in an octane project', () => {
+		const plugin = create_plugin();
+		const workspace = create_fixture_workspace('both-octane');
+		const file_name = path.join(workspace, 'src', 'App.tsrx');
+		const virtual_code = create_virtual_code(plugin, file_name, 'export default <div>Hello</div>;');
+
+		expect(virtual_code).toBeInstanceOf(TSRXVirtualCode);
+		expect(virtual_code.generatedCode).toContain('compiler:octane');
+	});
+
 	it('creates virtual code with the vue compiler in a vue-only project', () => {
 		const plugin = create_plugin();
 		const workspace = create_fixture_workspace('vue-only');

--- a/packages/typescript-plugin/tests/workspace-fixtures.js
+++ b/packages/typescript-plugin/tests/workspace-fixtures.js
@@ -115,6 +115,38 @@ const COMPILER_STUBS = {
 	},
 };
 `,
+	// Octane ships its compiler inside the `octane` package at
+	// `src/compiler/volar.js` and exports the contract under a camelCase name —
+	// this stub mirrors the real published shape so the tests cover the
+	// plugin's entry-path override AND its module-shape normalization.
+	octane: `module.exports = {
+	compileToVolarMappings(source, filename) {
+		const code = \`/* compiler:octane */\\nexport const filename = \${JSON.stringify(filename)};\\nexport default \${JSON.stringify(source)};\`;
+		return {
+			code,
+			mappings: [
+				{
+					sourceOffsets: [0],
+					generatedOffsets: [0],
+					lengths: [source.length],
+					generatedLengths: [source.length],
+					data: {
+						verification: false,
+						completion: true,
+						semantic: true,
+						navigation: true,
+						structure: true,
+						format: true,
+						customData: {},
+					},
+				},
+			],
+			cssMappings: [],
+			errors: [],
+		};
+	},
+};
+`,
 	vue: `module.exports = {
 	compile_to_volar_mappings(source, filename) {
 		const code = \`/* compiler:vue */\\nexport const filename = \${JSON.stringify(filename)};\\nexport default \${JSON.stringify(source)};\`;
@@ -203,6 +235,28 @@ export const WORKSPACE_CONFIGS = {
 		},
 		compilers: ['vue'],
 	},
+	'octane-only': {
+		package_json: {
+			name: '@octanejs/fixture-octane-only-project',
+			private: true,
+			devDependencies: {
+				octane: 'workspace:*',
+				'@octanejs/vite-plugin': 'workspace:*',
+			},
+		},
+		compilers: ['octane'],
+	},
+	'both-octane': {
+		package_json: {
+			name: '@octanejs/fixture-octane-project',
+			private: true,
+			devDependencies: {
+				octane: 'workspace:*',
+				'@octanejs/vite-plugin': 'workspace:*',
+			},
+		},
+		compilers: ['ripple', 'react', 'octane'],
+	},
 	both: {
 		package_json: {
 			name: '@ripple-ts/fixture-ripple-project',
@@ -259,6 +313,13 @@ const created_workspaces = [];
  * @param {keyof typeof COMPILER_STUBS} compiler_name
  */
 function write_compiler_stub(workspace_dir, compiler_name) {
+	if (compiler_name === 'octane') {
+		// Octane's layout: the compiler entry lives INSIDE the octane package.
+		const compiler_dir = path.join(workspace_dir, 'node_modules', 'octane', 'src', 'compiler');
+		fs.mkdirSync(compiler_dir, { recursive: true });
+		fs.writeFileSync(path.join(compiler_dir, 'volar.js'), COMPILER_STUBS[compiler_name]);
+		return;
+	}
 	const compiler_dir = path.join(workspace_dir, 'node_modules', '@tsrx', compiler_name, 'src');
 	fs.mkdirSync(compiler_dir, { recursive: true });
 	fs.writeFileSync(path.join(compiler_dir, 'index.js'), COMPILER_STUBS[compiler_name]);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1297,6 +1297,9 @@ importers:
       '@volar/typescript':
         specifier: catalog:default
         version: 2.4.28
+      octane:
+        specifier: '*'
+        version: 0.1.6(@typescript-eslint/types@8.56.1)
       typescript:
         specifier: catalog:peer
         version: 5.9.3
@@ -3531,6 +3534,9 @@ packages:
 
   '@toon-format/toon@2.1.0':
     resolution: {integrity: sha512-JwWptdF5eOA0HaQxbKAzkpQtR4wSWTEfDlEy/y3/4okmOAX1qwnpLZMmtEWr+ncAhTTY1raCKH0kteHhSXnQqg==}
+
+  '@tsrx/core@0.1.40':
+    resolution: {integrity: sha512-JLvoVchSw3qVgrMj6hEPqhF4iojAasENLuyohWkKoF9k6Sk3nFR3puBE2++iL67g2RuvhQ7sLfKQg2VUxcdGUQ==}
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
@@ -5922,6 +5928,10 @@ packages:
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  octane@0.1.6:
+    resolution: {integrity: sha512-4sKhojUhH/OZFkE5a3GGRIT1hlDAWd42tKfv4V1jb9ah1rsgs5eXYiBfE1Yv0u4OGinZatK0XLbUNPO8nM74FQ==}
+    engines: {node: '>=22'}
 
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
@@ -9120,6 +9130,21 @@ snapshots:
 
   '@toon-format/toon@2.1.0': {}
 
+  '@tsrx/core@0.1.40(@typescript-eslint/types@8.56.1)':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@noble/hashes': 2.2.0
+      '@sveltejs/acorn-typescript': 1.0.10(acorn@8.16.0)
+      '@types/estree': 1.0.8
+      '@types/estree-jsx': 1.0.5
+      acorn: 8.16.0
+      esrap: 2.2.8(@typescript-eslint/types@8.56.1)
+      is-reference: 3.0.3
+      magic-string: 0.30.21
+      zimmerframe: 1.1.4
+    transitivePeerDependencies:
+      - '@typescript-eslint/types'
+
   '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
@@ -11594,6 +11619,14 @@ snapshots:
   object-keys@1.1.1: {}
 
   obug@2.1.1: {}
+
+  octane@0.1.6(@typescript-eslint/types@8.56.1):
+    dependencies:
+      '@tsrx/core': 0.1.40(@typescript-eslint/types@8.56.1)
+      devalue: 5.8.1
+      esrap: 2.2.8(@typescript-eslint/types@8.56.1)
+    transitivePeerDependencies:
+      - '@typescript-eslint/types'
 
   on-finished@2.4.1:
     dependencies:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Targeted plugin resolution and a conditional hook omission for `tsrx-tsc`; existing @tsrx targets keep the default entry path. Risk is mainly mis-resolution when multiple compilers are installed without matching package.json hints.
> 
> **Overview**
> Adds **octane** as a first-class TSRX compiler target in `@tsrx/typescript-plugin`, with an optional optional peer dependency on `octane`.
> 
> Compiler resolution now supports a **per-candidate entry path** (default remains `src/index.js`). Octane resolves to `node_modules/octane/src/compiler/volar.js` instead of the `@tsrx/*` layout. When the loaded module only exposes camelCase `compileToVolarMappings`, the plugin **aliases** it to `compile_to_volar_mappings` so published octane versions work without an octane release.
> 
> For **`tsrx-tsc`** runs (`TSRX_TSC=true`), `getExtraServiceScripts` is omitted from the language plugin so Volar’s tsc proxy stops emitting **once-per-file** `getExtraServiceScripts() is not available` warnings; editor / language-server behavior is unchanged.
> 
> Tests and fixtures cover octane-only and multi-compiler octane project preference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a901498e8b6f37c88736ade372d89270022ebf4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->