### PR TITLE
fix(tsrx): parse same-line JSX array elements

### DIFF
--- a/.changeset/tidy-ravens-parse.md
+++ b/.changeset/tidy-ravens-parse.md
@@ -1,0 +1,5 @@
+---
+'@tsrx/core': patch
+---
+
+Fixed parsing multiple paired JSX elements on the same line after a comma, including array literals nested in JSX expression children.

--- a/packages/tsrx/src/plugin.js
+++ b/packages/tsrx/src/plugin.js
@@ -2381,6 +2381,14 @@ export function TSRXPlugin(config) {
 				const top = ctx[ci];
 				const second = ctx[ci - 1];
 
+				// A paired JSX element/fragment finishes on the closing tag's `>`, which
+				// leaves `exprAllowed` false even when the already-read next token is a
+				// comma. Re-arm expression mode for the value after that comma, matching
+				// the tokenizer state produced by a self-closing JSX element.
+				if (this.type === tt.comma) {
+					this.exprAllowed = true;
+				}
+
 				// Expression-bodied templates (no statement child) followed by `,`
 				// in an object/array literal need surgical fixups; statement-bodied
 				// templates fall through to the JSX-expression-container strip.

--- a/packages/tsrx/tests/utils/parser.test.js
+++ b/packages/tsrx/tests/utils/parser.test.js
@@ -552,6 +552,34 @@ abc
 		expect(returned.alternate.elements.map((element) => element.type)).toEqual(['JSXElement']);
 	});
 
+	it('parses same-line JSX elements in an array expression', () => {
+		const ast = parseModule(
+			'const fruits = [<Item key="apple">Apple</Item>, <Item key="banana">Banana</Item>];',
+			'App.tsx',
+		);
+
+		const fruits = ast.body[0].declarations[0].init;
+		expect(fruits.type).toBe('ArrayExpression');
+		expect(fruits.elements.map((element) => element.type)).toEqual(['JSXElement', 'JSXElement']);
+		expect(fruits.elements.map((element) => element.children[0].value)).toEqual([
+			'Apple',
+			'Banana',
+		]);
+	});
+
+	it('parses a same-line JSX array inside an expression child', () => {
+		const returned = getReturned(
+			`function App() {
+				return <Item title="Root">{[<Item key="c1">A</Item>, <Item key="c2">B</Item>] as any}</Item>;
+			}`,
+		);
+
+		const array = returned.children[0].expression.expression;
+		expect(array.type).toBe('ArrayExpression');
+		expect(array.elements.map((element) => element.type)).toEqual(['JSXElement', 'JSXElement']);
+		expect(array.elements.map((element) => element.children[0].value)).toEqual(['A', 'B']);
+	});
+
 	it('preserves template text after a self-closing child', () => {
 		const returned = getReturned(
 			`function App() {


### PR DESCRIPTION
## Summary

- restore expression tokenization after a paired JSX element or fragment is followed by a comma
- cover same-line JSX arrays in a TypeScript module and inside a JSX expression child
- add a patch changeset for `@tsrx/core`

## Root cause

The paired closing-tag path reads the following comma, allowing Acorn to re-enter expression mode, but a legacy cleanup immediately resets `exprAllowed` to `false`. The next same-line `<` is consequently tokenized as a relational operator. A newline masked the defect through the line-start JSX fallback.

This conflicted with Prettier, which can collapse short multiline JSX arrays onto one line.

## Validation

- `./node_modules/.bin/vitest run --project tsrx-utils packages/tsrx/tests/utils/parser.test.js --reporter=dot` — 211 passed
- `pnpm typecheck`
- `pnpm changeset:check`
- `pnpm format:check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized tokenizer fix in existing JSX context cleanup with targeted parser tests; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes a tokenizer bug where **multiple paired JSX elements on one line**, separated by commas, failed to parse (e.g. `[<Item>A</Item>, <Item>B</Item>]`).
> 
> After a closing tag’s `>`, the parser left `exprAllowed` false even when the next token was already a comma, so the following `<` was read as a relational operator instead of `jsxTagStart`. A newline hid the issue via line-start JSX handling; **Prettier-style single-line JSX arrays** exposed it.
> 
> **`#popTokenContextsAfterTemplateExpressionElement`** now sets `exprAllowed = true` when the current token is a comma, aligning paired elements with self-closing JSX. Tests cover module-level arrays and arrays inside JSX expression children; **`@tsrx/core`** gets a patch changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f42ceff59c9d88676fae14202edd64d3ed77e52d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->