### PR TITLE
Various type, volar and prettier fixes

### DIFF
--- a/.changeset/acorn-8-17.md
+++ b/.changeset/acorn-8-17.md
@@ -1,0 +1,5 @@
+---
+'@tsrx/core': patch
+---
+
+Upgrade acorn to ^8.17.0 for improved stack overflow handling in the parser

--- a/.changeset/modern-pugs-watch.md
+++ b/.changeset/modern-pugs-watch.md
@@ -1,0 +1,10 @@
+---
+'@tsrx/preact': patch
+'@tsrx/ripple': patch
+'@tsrx/react': patch
+'@tsrx/solid': patch
+'@tsrx/vue': patch
+'ripple': patch
+---
+
+various type, volar fixes and lib upgrades

--- a/.changeset/prettier-plugin-type-keywords.md
+++ b/.changeset/prettier-plugin-type-keywords.md
@@ -1,0 +1,5 @@
+---
+'@tsrx/prettier-plugin': patch
+---
+
+Keep the `type` keyword when printing `export type { X } from '…'` and inline `export { type X, y }` specifiers, and the `declare` keyword on ambient `declare module '…' { … }` declarations. Previously formatting stripped them, turning type-only re-exports into runtime re-exports of nonexistent bindings and leaving invalid `module '…' { … }` output.

--- a/packages/prettier-plugin/src/index.js
+++ b/packages/prettier-plugin/src/index.js
@@ -2048,6 +2048,7 @@ function printRippleNode(node, path, options, print, args) {
 
 		case 'TSModuleDeclaration': {
 			nodeContent = [
+				node.declare ? 'declare ' : '',
 				node.metadata?.module_keyword ?? 'module',
 				' ',
 				path.call(print, 'id'),
@@ -2598,16 +2599,17 @@ function printExportNamedDeclaration(node, path, options, print) {
 		return parts;
 	} else if (node.specifiers && node.specifiers.length > 0) {
 		const specifiers = node.specifiers.map((spec) => {
+			const typePrefix = spec.exportKind === 'type' ? 'type ' : '';
 			const exportedName = /** @type {AST.Identifier} */ (spec.exported).name;
 			const localName = /** @type {AST.Identifier} */ (spec.local).name;
 			if (exportedName === localName) {
-				return localName;
+				return typePrefix + localName;
 			} else {
-				return localName + ' as ' + exportedName;
+				return typePrefix + localName + ' as ' + exportedName;
 			}
 		});
 
-		const parts = ['export { '];
+		const parts = [node.exportKind === 'type' ? 'export type { ' : 'export { '];
 		for (let i = 0; i < specifiers.length; i++) {
 			if (i > 0) parts.push(', ');
 			parts.push(specifiers[i]);

--- a/packages/prettier-plugin/src/index.js
+++ b/packages/prettier-plugin/src/index.js
@@ -4698,7 +4698,9 @@ function printJSXSwitchCase(node, path, options, print, index) {
 		if (!child || child.type === 'EmptyStatement') {
 			continue;
 		}
-		printedConsequents.push(path.call(print, 'cases', index, 'consequent', i));
+		printedConsequents.push(
+			path.call((casePath) => casePath.call(print, 'consequent', i), 'cases', index),
+		);
 	}
 
 	const bodyDoc =

--- a/packages/prettier-plugin/src/index.test.js
+++ b/packages/prettier-plugin/src/index.test.js
@@ -1507,6 +1507,36 @@ import { Something, type Props, track } from 'ripple';`;
 			expect(result).toBeWithNewline(expected);
 		});
 
+		// Regressed in 0.3.97: the printer dropped the `type` keyword from
+		// type-only re-exports and inline export specifiers, turning them into
+		// runtime re-exports of bindings that only exist as types (a module-load
+		// failure once compiled).
+		it('should keep the type keyword on export type statements', async () => {
+			const input = `export type { Config } from './types.js';
+export { type Extra, realValue } from './mixed.js';`;
+			const expected = `export type { Config } from './types.js';
+export { type Extra, realValue } from './mixed.js';`;
+			const result = await format(input, { singleQuote: true });
+			expect(result).toBeWithNewline(expected);
+		});
+
+		// Regressed in 0.3.97: `declare module 'name' { … }` lost its `declare`
+		// keyword, leaving invalid `module 'name' { … }` output.
+		it('should keep the declare keyword on ambient module declarations', async () => {
+			const input = `declare module 'some-module' {
+  interface Thing {
+    x: number;
+  }
+}`;
+			const expected = `declare module 'some-module' {
+  interface Thing {
+    x: number;
+  }
+}`;
+			const result = await format(input, { singleQuote: true });
+			expect(result).toBeWithNewline(expected);
+		});
+
 		it('should format long import statements correctly', async () => {
 			const input = `import { flushSync, track, effect, bindValue, bindChecked, bindGroup, bindClientWidth, bindClientHeight, bindOffsetWidth, bindOffsetHeight, bindContentRect, bindContentBoxSize, bindBorderBoxSize, bindDevicePixelContentBoxSize, bindInnerHTML, bindInnerText, bindTextContent, bindNode } from 'ripple';`;
 			const expected = `import {

--- a/packages/ripple/tests/client/compiler/compiler.basic.test.tsrx
+++ b/packages/ripple/tests/client/compiler/compiler.basic.test.tsrx
@@ -706,7 +706,7 @@ const Inline = function(props: { x: string }) @{
 `;
 		const result = compile_to_volar_mappings(source, 'test.tsrx').code;
 
-		expect(result).toContain('const Inline = function(props: { x: string }) {');
+		expect(result).toContain('const Inline = function (props: { x: string }) {');
 		expect(result).not.toContain('function Inline');
 		expect(result).not.toContain('const Inline = (props: { x: string }) => {');
 	});

--- a/packages/tsrx-preact/src/index.js
+++ b/packages/tsrx-preact/src/index.js
@@ -67,6 +67,7 @@ export function compile_to_volar_mappings(source, filename, options) {
 		...options,
 		collect: true,
 		loose: !!options?.loose,
+		preserveParens: true,
 		errors,
 		comments,
 	});

--- a/packages/tsrx-preact/src/index.js
+++ b/packages/tsrx-preact/src/index.js
@@ -68,6 +68,7 @@ export function compile_to_volar_mappings(source, filename, options) {
 		collect: true,
 		loose: !!options?.loose,
 		preserveParens: true,
+		keywordTokens: true,
 		errors,
 		comments,
 	});

--- a/packages/tsrx-react/src/index.js
+++ b/packages/tsrx-react/src/index.js
@@ -64,6 +64,7 @@ export function compile_to_volar_mappings(source, filename, options) {
 		collect: true,
 		loose: !!options?.loose,
 		preserveParens: true,
+		keywordTokens: true,
 		errors,
 		comments,
 	});

--- a/packages/tsrx-react/src/index.js
+++ b/packages/tsrx-react/src/index.js
@@ -63,6 +63,7 @@ export function compile_to_volar_mappings(source, filename, options) {
 		...options,
 		collect: true,
 		loose: !!options?.loose,
+		preserveParens: true,
 		errors,
 		comments,
 	});

--- a/packages/tsrx-ripple/src/index.js
+++ b/packages/tsrx-ripple/src/index.js
@@ -84,6 +84,7 @@ export function compile_to_volar_mappings(source, filename, options = {}) {
 		collect: true,
 		loose: !!options?.loose,
 		preserveParens: true,
+		keywordTokens: true,
 		errors,
 		comments,
 	});

--- a/packages/tsrx-ripple/src/index.js
+++ b/packages/tsrx-ripple/src/index.js
@@ -83,6 +83,7 @@ export function compile_to_volar_mappings(source, filename, options = {}) {
 		...options,
 		collect: true,
 		loose: !!options?.loose,
+		preserveParens: true,
 		errors,
 		comments,
 	});

--- a/packages/tsrx-ripple/src/transform/client/index.js
+++ b/packages/tsrx-ripple/src/transform/client/index.js
@@ -6969,10 +6969,7 @@ function create_tsx_with_typescript_support(comments) {
 		// span can start at a bare `(`, which boundaryTokens does not anchor.
 		ArrowFunctionExpression(node, context) {
 			if (node.loc) context.location(node.loc.start.line, node.loc.start.column);
-			/** @type {(node: any, context: any) => void} */ (base_tsx.ArrowFunctionExpression)(
-				node,
-				context,
-			);
+			base_tsx.ArrowFunctionExpression?.(node, context);
 			if (node.loc) context.location(node.loc.end.line, node.loc.end.column);
 		},
 		ClassDeclaration(node, context) {

--- a/packages/tsrx-ripple/src/transform/client/index.js
+++ b/packages/tsrx-ripple/src/transform/client/index.js
@@ -683,10 +683,23 @@ function visit_function(node, context) {
 	// mutated) and replace lazy destructuring params with generated identifiers
 	const transformed_params = node.params.map((param) => {
 		/** @type {AST.Pattern} */
-		let param_out = param.typeAnnotation ? { ...param, typeAnnotation: undefined } : param;
+		let param_out =
+			param.typeAnnotation || /** @type {any} */ (param).optional
+				? /** @type {AST.Pattern} */ (
+						/** @type {unknown} */ ({ ...param, typeAnnotation: undefined, optional: false })
+					)
+				: param;
 		// Handle AssignmentPattern (parameters with default values)
-		if (param_out.type === 'AssignmentPattern' && param_out.left?.typeAnnotation) {
-			param_out = { ...param_out, left: { ...param_out.left, typeAnnotation: undefined } };
+		if (
+			param_out.type === 'AssignmentPattern' &&
+			(param_out.left?.typeAnnotation || /** @type {any} */ (param_out.left)?.optional)
+		) {
+			param_out = /** @type {AST.AssignmentPattern} */ (
+				/** @type {unknown} */ ({
+					...param_out,
+					left: { ...param_out.left, typeAnnotation: undefined, optional: false },
+				})
+			);
 		}
 		const pattern = param_out.type === 'AssignmentPattern' ? param_out.left : param_out;
 		if (pattern.type === 'ObjectPattern' || pattern.type === 'ArrayPattern') {
@@ -2294,6 +2307,23 @@ const visitors = {
 	ClassExpression(node, context) {
 		if (!context.state.to_ts) {
 			return strip_class_typescript_syntax(node, context);
+		}
+		return context.next();
+	},
+
+	ParenthesizedExpression(node, context) {
+		// Only volar/to_ts parses preserve source parens (build compiles fold
+		// them). A lowered fragment/element is self-delimiting — parens around
+		// it are redundant in the type view and the JS targets never print
+		// them, so drop the wrapper and keep the lowered child.
+		if (context.state.to_ts) {
+			const expression = /** @type {AST.Expression} */ (context.visit(node.expression));
+			if (expression.type === 'JSXFragment' || expression.type === 'JSXElement') {
+				return expression;
+			}
+			if (expression !== node.expression) {
+				return { ...node, expression };
+			}
 		}
 		return context.next();
 	},
@@ -5164,14 +5194,30 @@ function is_authored_native_fragment(node) {
  * @returns {boolean}
  */
 function is_combined_expression_position(path, node) {
-	let parent = path.at(-1);
+	let depth = path.length - 1;
+	let parent = path[depth];
 	let slot_node = node;
-	// A generated value wrapper is visited FROM its directive's visitor, so the
-	// directive sits atop the path — the wrapper stands in the directive's
-	// slot, so judge the position against the directive's own parent.
-	if (parent?.metadata?.tsrx_value_wrapper === node) {
-		slot_node = parent;
-		parent = path.at(-2);
+	// Walk up through transparent stand-ins, in whatever order they nest:
+	//  - preserved source parentheses (volar/to_ts parses only) — the wrapped
+	//    expression stands in the paren's slot (`(@if (…) { … }) || x` judges
+	//    against the `||`, not the paren);
+	//  - a generated value wrapper, visited FROM its directive's visitor, so
+	//    the directive sits atop the path and stands in the wrapper's slot.
+	while (parent) {
+		if (parent.type === 'ParenthesizedExpression') {
+			slot_node = parent;
+			parent = path[--depth];
+			continue;
+		}
+		if (
+			parent.metadata?.tsrx_value_wrapper === slot_node ||
+			parent.metadata?.tsrx_value_wrapper === node
+		) {
+			slot_node = parent;
+			parent = path[--depth];
+			continue;
+		}
+		break;
 	}
 	if (!parent || !isTemplateValuePosition(parent, slot_node)) return false;
 	switch (parent.type) {
@@ -6067,7 +6113,11 @@ function create_tsx_with_typescript_support(comments) {
 	const preserved_comments = comments?.filter(shouldPreserveComment) ?? [];
 	// Don't pass comments to esrap - we handle them manually via flush_comments_before
 	// because esrap's built-in comment handling requires all intermediate nodes to have loc
-	const base_tsx = /** @type {Visitors<AST.Node, TransformClientState>} */ (tsx());
+	// boundaryTokens: this language only prints the to_ts (volar) view — maps
+	// are consumed positionally by the language tooling, never shipped.
+	const base_tsx = /** @type {Visitors<AST.Node, TransformClientState>} */ (
+		tsx({ boundaryTokens: true })
+	);
 
 	// Track which comments have been written (by index)
 	let comment_index = 0;

--- a/packages/tsrx-ripple/src/transform/client/index.js
+++ b/packages/tsrx-ripple/src/transform/client/index.js
@@ -6964,47 +6964,15 @@ function create_tsx_with_typescript_support(comments) {
 				context.visit(node.typeArguments);
 			}
 		},
-		// esrap's ArrowFunctionExpression printer ignores `typeParameters` and
-		// `returnType`, so an annotated arrow like `(): Record<...> => ...`
-		// prints as `() => ...` and segments.js can't resolve the return-type
-		// nodes' positions in the generated output.
+		// esrap ≥2.3.0 prints arrows fully (async/typeParameters/returnType and
+		// `{`-first body wrapping); keep only the boundary markers — an arrow's
+		// span can start at a bare `(`, which boundaryTokens does not anchor.
 		ArrowFunctionExpression(node, context) {
 			if (node.loc) context.location(node.loc.start.line, node.loc.start.column);
-
-			if (node.async) context.write('async ');
-
-			if (node.typeParameters) {
-				context.visit(node.typeParameters);
-			}
-
-			context.write('(');
-			// Visit each parameter
-			for (let i = 0; i < node.params.length; i++) {
-				if (i > 0) context.write(', ');
-				context.visit(node.params[i]);
-			}
-			context.write(')');
-
-			// Add TypeScript return type annotation if present
-			if (node.returnType) {
-				context.visit(node.returnType);
-			}
-
-			context.write(' => ');
-
-			if (
-				node.body.type === 'ObjectExpression' ||
-				(node.body.type === 'AssignmentExpression' && node.body.left.type === 'ObjectPattern') ||
-				(node.body.type === 'LogicalExpression' && node.body.left.type === 'ObjectExpression') ||
-				(node.body.type === 'ConditionalExpression' && node.body.test.type === 'ObjectExpression')
-			) {
-				context.write('(');
-				context.visit(node.body);
-				context.write(')');
-			} else {
-				context.visit(node.body);
-			}
-
+			/** @type {(node: any, context: any) => void} */ (base_tsx.ArrowFunctionExpression)(
+				node,
+				context,
+			);
 			if (node.loc) context.location(node.loc.end.line, node.loc.end.column);
 		},
 		ClassDeclaration(node, context) {

--- a/packages/tsrx-ripple/src/transform/client/index.js
+++ b/packages/tsrx-ripple/src/transform/client/index.js
@@ -7162,16 +7162,7 @@ export function transform_client(filename, source, analysis, to_ts, minify_css, 
 					// Add: ComponentName = _$_.hmr(ComponentName);
 					hmr_body.push(b.stmt(b.assignment('=', b.id(name), b.call('_$_.hmr', b.id(name)))));
 					// Re-export as named export
-					hmr_body.push(
-						b.export_builder(null, [
-							{
-								type: 'ExportSpecifier',
-								local: b.id(name),
-								exported: b.id(name),
-								metadata: { path: [] },
-							},
-						]),
-					);
+					hmr_body.push(b.export_builder(null, [b.export_specifier(name)]));
 				}
 			} else if (
 				node.type === 'FunctionExpression' &&

--- a/packages/tsrx-ripple/src/transform/client/index.js
+++ b/packages/tsrx-ripple/src/transform/client/index.js
@@ -6166,52 +6166,14 @@ function create_tsx_with_typescript_support(comments) {
 	 * @param {TransformClientContext} context
 	 */
 	const handle_function = (node, context) => {
-		const loc = /** @type {AST.SourceLocation} */ (node.loc);
-		const start_pos = /** @type {AST.Position} */ ({
-			line: loc.start.line,
-			column: loc.start.column,
-		});
-
-		if (node.async) {
-			context.location(loc.start.line, loc.start.column);
-			context.write('async ');
-			context.location(loc.start.line, loc.start.column + 'async '.length);
-			start_pos.column += 'async '.length;
-		}
-
-		context.location(start_pos.line, start_pos.column);
-		context.write('function');
-		context.location(start_pos.line, start_pos.column + 'function'.length);
-
-		if (node.generator) {
-			context.write('*');
-		}
-
-		const id = /** @type {AST.FunctionExpression | AST.FunctionDeclaration} */ (node).id;
-
-		// FunctionDeclaration always has a space before id, FunctionExpression only if id exists
-		if (node.type === 'FunctionDeclaration' || id) {
-			context.write(' ');
-		}
-		if (id) {
-			context.visit(id);
-		}
-		if (node.typeParameters) {
-			context.visit(node.typeParameters);
-		}
-		context.write('(');
-		for (let i = 0; i < node.params.length; i++) {
-			if (i > 0) context.write(', ');
-			context.visit(node.params[i]);
-		}
-		context.write(')');
-		if (node.returnType) {
-			context.visit(node.returnType);
-		}
-		context.write(' ');
-		if (node.body) {
-			context.visit(node.body);
-		}
+		// esrap ≥2.3.0 prints function-like nodes fully (mapped async/function
+		// keywords, generator star, id, typeParameters, params, returnType,
+		// body); keep only the node-boundary markers so segments.js can resolve
+		// the whole span (see ReturnStatement).
+		const loc = node.loc;
+		if (loc) context.location(loc.start.line, loc.start.column);
+		/** @type {(node: any, context: any) => void} */ (base_tsx[node.type])(node, context);
+		if (loc) context.location(loc.end.line, loc.end.column);
 	};
 
 	return /** @type {Visitors<AST.Node, TransformClientState>} */ ({
@@ -6431,16 +6393,11 @@ function create_tsx_with_typescript_support(comments) {
 			context.location(end.line, end.column);
 		},
 		AwaitExpression(node, context) {
+			// esrap ≥2.3.0 maps the await keyword; keep only boundary markers.
 			const loc = /** @type {AST.SourceLocation} */ (node.loc);
-			// the start needs to be covered as we don't cover it in visitors
-			context.location(loc.start.line, loc.start.column);
-			context.write('await');
-			// cover the 'await' end
-			context.location(loc.start.line, loc.start.column + 'await'.length);
-			context.write(' ');
-			context.visit(node.argument);
-			// cover the end of the expression
-			context.location(loc.end.line, loc.end.column);
+			if (loc) context.location(loc.start.line, loc.start.column);
+			/** @type {(node: any, context: any) => void} */ (base_tsx.AwaitExpression)(node, context);
+			if (loc) context.location(loc.end.line, loc.end.column);
 		},
 		Property(node, context) {
 			let start_pos = node.loc?.start;

--- a/packages/tsrx-ripple/src/transform/server/index.js
+++ b/packages/tsrx-ripple/src/transform/server/index.js
@@ -1375,10 +1375,23 @@ function transform_native_tsrx_function(node, context) {
  */
 function strip_function_params(params) {
 	return params.map((param) => {
-		let stripped = param.typeAnnotation ? { ...param, typeAnnotation: undefined } : param;
+		let stripped =
+			param.typeAnnotation || /** @type {any} */ (param).optional
+				? /** @type {AST.Pattern} */ (
+						/** @type {unknown} */ ({ ...param, typeAnnotation: undefined, optional: false })
+					)
+				: param;
 		// Handle AssignmentPattern (parameters with default values)
-		if (stripped.type === 'AssignmentPattern' && stripped.left?.typeAnnotation) {
-			stripped = { ...stripped, left: { ...stripped.left, typeAnnotation: undefined } };
+		if (
+			stripped.type === 'AssignmentPattern' &&
+			(stripped.left?.typeAnnotation || /** @type {any} */ (stripped.left)?.optional)
+		) {
+			stripped = /** @type {AST.AssignmentPattern} */ (
+				/** @type {unknown} */ ({
+					...stripped,
+					left: { ...stripped.left, typeAnnotation: undefined, optional: false },
+				})
+			);
 		}
 		// Replace lazy destructuring params with generated identifiers
 		const pattern = stripped.type === 'AssignmentPattern' ? stripped.left : stripped;

--- a/packages/tsrx-ripple/src/utils.js
+++ b/packages/tsrx-ripple/src/utils.js
@@ -2733,10 +2733,29 @@ export function strip_class_typescript_syntax(node, context) {
 		superClass = /** @type {AST.Expression} */ ({ ...superClass, typeArguments: undefined });
 	}
 
+	// Method/property-level type syntax lives on the MEMBER node (acorn-typescript
+	// puts a method's type parameters on the MethodDefinition, not its value, and
+	// `m?()` / `x?: T` optionality on the member) — esrap ≥2.2.9 prints these
+	// faithfully, so plain-JS emit must clear them. Copies only, like the rest.
+	const class_body = node.body;
+	const members = class_body.body.map((member) => {
+		if (member.type === 'MethodDefinition') {
+			if (!member.typeParameters && !member.optional) return member;
+			return { ...member, typeParameters: undefined, optional: false };
+		}
+		if (member.type === 'PropertyDefinition') {
+			if (!member.optional && !member.definite) return member;
+			return { ...member, optional: false, definite: false };
+		}
+		return member;
+	});
+	const body_changed = members.some((member, index) => member !== class_body.body[index]);
+
 	/** @type {AST.ClassDeclaration | AST.ClassExpression} */
 	let source = node;
-	if (superClass !== node.superClass) {
+	if (superClass !== node.superClass || body_changed) {
 		source = { ...node, superClass };
+		if (body_changed) source = { ...source, body: { ...class_body, body: members } };
 		const scopes = context.state.scopes;
 		const scope = scopes?.get(node);
 		if (scope) scopes.set(source, scope);

--- a/packages/tsrx-solid/src/index.js
+++ b/packages/tsrx-solid/src/index.js
@@ -64,6 +64,7 @@ export function compile_to_volar_mappings(source, filename, options) {
 		collect: true,
 		loose: !!options?.loose,
 		preserveParens: true,
+		keywordTokens: true,
 		errors,
 		comments,
 	});

--- a/packages/tsrx-solid/src/index.js
+++ b/packages/tsrx-solid/src/index.js
@@ -63,6 +63,7 @@ export function compile_to_volar_mappings(source, filename, options) {
 		...options,
 		collect: true,
 		loose: !!options?.loose,
+		preserveParens: true,
 		errors,
 		comments,
 	});

--- a/packages/tsrx-vue/src/index.js
+++ b/packages/tsrx-vue/src/index.js
@@ -64,6 +64,7 @@ export function compile_to_volar_mappings(source, filename, options) {
 		collect: true,
 		loose: !!options?.loose,
 		preserveParens: true,
+		keywordTokens: true,
 		errors,
 		comments,
 	});

--- a/packages/tsrx-vue/src/index.js
+++ b/packages/tsrx-vue/src/index.js
@@ -63,6 +63,7 @@ export function compile_to_volar_mappings(source, filename, options) {
 		...options,
 		collect: true,
 		loose: !!options?.loose,
+		preserveParens: true,
 		errors,
 		comments,
 	});

--- a/packages/tsrx/src/parse/index.js
+++ b/packages/tsrx/src/parse/index.js
@@ -225,6 +225,7 @@ export function createParser(...plugins) {
 				ecmaVersion: 13,
 				allowReturnOutsideFunction: true,
 				locations: true,
+				preserveParens: !!options?.preserveParens,
 				onComment,
 				tsrxOptions: {
 					filename,

--- a/packages/tsrx/src/parse/index.js
+++ b/packages/tsrx/src/parse/index.js
@@ -219,12 +219,37 @@ export function createParser(...plugins) {
 		/** @type {AST.Program} */
 		let ast;
 
+		// Lexer-authoritative keyword positions (volar opt-in): the mapping
+		// collector needs the SOURCE spans of `async`/`function`, which no AST
+		// node records. The tokenizer is the only correct source — offset
+		// arithmetic breaks on extra whitespace, and text search breaks on
+		// comments (`async /* function */ function`).
+		/** @type {Array<{ value: string, start: number, end: number, loc: AST.SourceLocation }> | undefined} */
+		const keyword_tokens = options?.keywordTokens ? [] : undefined;
+		/** @type {Parse.Options['onToken'] | undefined} */
+		const onToken = keyword_tokens
+			? (token) => {
+					const t = /** @type {any} */ (token);
+					const is_function_keyword = t.type?.keyword === 'function';
+					const is_async_name = t.type?.label === 'name' && t.value === 'async';
+					if (is_function_keyword || is_async_name) {
+						keyword_tokens.push({
+							value: is_function_keyword ? 'function' : 'async',
+							start: t.start,
+							end: t.end,
+							loc: t.loc,
+						});
+					}
+				}
+			: undefined;
+
 		try {
 			ast = parser.parse(source, {
 				sourceType: 'module',
 				ecmaVersion: 13,
 				allowReturnOutsideFunction: true,
 				locations: true,
+				onToken,
 				preserveParens: !!options?.preserveParens,
 				onComment,
 				tsrxOptions: {
@@ -245,6 +270,10 @@ export function createParser(...plugins) {
 		}
 
 		add_comments(ast);
+
+		if (keyword_tokens) {
+			/** @type {any} */ (ast).tsrx_keyword_tokens = keyword_tokens;
+		}
 
 		return ast;
 	};

--- a/packages/tsrx/src/transform/jsx/helpers.js
+++ b/packages/tsrx/src/transform/jsx/helpers.js
@@ -51,11 +51,13 @@ export function set_node_path_metadata(node, path) {
 }
 
 /**
- * Wrap esrap's `tsx()` printer with location markers for nodes whose spans
- * (e.g. the leading `new ` of a NewExpression or the angle-bracket delimiters
- * around generic arguments) are otherwise invisible to the source map.
- * Without these markers, Volar mapping collection in `segments.js` throws
- * when looking up the node's start/end positions.
+ * Wrap esrap's `tsx()` printer with location markers for the remaining nodes
+ * whose spans are invisible to the source map (e.g. `class`, template-literal
+ * backticks, JSX angle brackets, generic-argument delimiters). Without these
+ * markers, Volar mapping collection in `segments.js` throws when looking up
+ * the node's start/end positions. esrap ≥2.3.0 (keyword writes +
+ * `boundaryTokens`) covers most starts, but not statement ends — see the
+ * list below for what each entry still compensates.
  *
  * Shared across all JSX-producing targets (React, Preact, Solid).
  *
@@ -89,15 +91,6 @@ export function tsx_with_ts_locations(boundary_tokens = false) {
 	const wrappers = {
 		ArrayPattern: (node, context) => {
 			base.ArrayPattern(node, context);
-			if (node.typeAnnotation) {
-				context.visit(node.typeAnnotation);
-			}
-		},
-		Identifier: (node, context) => {
-			context.write(node.name, node);
-			if (node.optional) {
-				context.write('?');
-			}
 			if (node.typeAnnotation) {
 				context.visit(node.typeAnnotation);
 			}
@@ -139,39 +132,6 @@ export function tsx_with_ts_locations(boundary_tokens = false) {
 			if (value.returnType) context.visit(value.returnType);
 			context.write(' ');
 			context.visit(value.body);
-		},
-		// esrap's ArrowFunctionExpression printer ignores `typeParameters` and
-		// `returnType`, so an annotated arrow like `(): Record<...> => ...`
-		// prints as `() => ...` and segments.js can't resolve the return-type
-		// nodes' positions in the generated output.
-		ArrowFunctionExpression: (node, context) => {
-			if (node.async) context.write('async ');
-			if (node.typeParameters) {
-				context.visit(node.typeParameters);
-			}
-			context.write('(');
-			for (let i = 0; i < node.params.length; i++) {
-				if (i > 0) context.write(', ');
-				context.visit(node.params[i]);
-			}
-			context.write(')');
-			if (node.returnType) {
-				context.visit(node.returnType);
-			}
-			context.write(' => ');
-			const body = node.body;
-			const wrap_body =
-				body.type === 'ObjectExpression' ||
-				(body.type === 'AssignmentExpression' && body.left.type === 'ObjectPattern') ||
-				(body.type === 'LogicalExpression' && body.left.type === 'ObjectExpression') ||
-				(body.type === 'ConditionalExpression' && body.test.type === 'ObjectExpression');
-			if (wrap_body) {
-				context.write('(');
-				context.visit(body);
-				context.write(')');
-			} else {
-				context.visit(body);
-			}
 		},
 
 		// esrap's JSXOpeningElement printer doesn't emit `typeArguments`, so generic
@@ -215,9 +175,14 @@ export function tsx_with_ts_locations(boundary_tokens = false) {
 	// on the whole node, only then duplicate it here
 	// e.g. JSXOpeningElement is such a case
 	for (const type of [
-		// JS nodes whose esrap printer emits no location marker, causing
-		// segments.js get_mapping_from_node() to throw when it asks for the
-		// generated position of the node's start (or end).
+		// JS nodes with boundary positions esrap still cannot map. Keyword
+		// writes (if/new/return/for/switch/await) and `boundaryTokens`
+		// anchors (brackets, braces, parens, computed/call closers) cover
+		// many STARTS, but statement ENDS land on unanchored characters
+		// (`;`, a block's `}`), `class` is not a keyword-write, template
+		// literals' backticks carry no location, and an arrow's span can
+		// start at a bare `(` — so these node-level markers remain the
+		// source of both boundaries until esrap can anchor them.
 		'ClassDeclaration',
 		'ClassExpression',
 		'IfStatement',

--- a/packages/tsrx/src/transform/jsx/helpers.js
+++ b/packages/tsrx/src/transform/jsx/helpers.js
@@ -61,8 +61,14 @@ export function set_node_path_metadata(node, path) {
  *
  * @returns {any}
  */
-export function tsx_with_ts_locations() {
-	const base = /** @type {any} */ (tsx());
+/**
+ * @param {boolean} [boundary_tokens] Enable esrap's `boundaryTokens` anchors
+ * (structural tokens carry one-character source locations). typeOnly/volar
+ * prints opt in — their maps are consumed positionally by the language
+ * tooling and never shipped; build prints stay sparse.
+ */
+export function tsx_with_ts_locations(boundary_tokens = false) {
+	const base = /** @type {any} */ (tsx({ boundaryTokens: boundary_tokens }));
 
 	/**
 	 * @param {any} node

--- a/packages/tsrx/src/transform/jsx/helpers.js
+++ b/packages/tsrx/src/transform/jsx/helpers.js
@@ -162,6 +162,11 @@ export function tsx_with_ts_locations(boundary_tokens = false) {
 			}
 		},
 		TSModuleDeclaration: (node, context) => {
+			// Ambient `declare module '…' { … }` must keep its `declare` — the
+			// typeOnly/volar output is real TS and `module '…' { … }` alone is a
+			// syntax error (TS1035). Non-ambient `module name { }` blocks have no
+			// `declare` and print unchanged.
+			if (node.declare) context.write('declare ');
 			context.write(node.metadata?.module_keyword ?? 'module');
 			context.write(' ');
 			context.visit(node.id);

--- a/packages/tsrx/src/transform/jsx/index.js
+++ b/packages/tsrx/src/transform/jsx/index.js
@@ -214,32 +214,53 @@ function lower_code_block_child(block) {
  * `lower_code_block_child`). This is the element-scoped equivalent of
  * `transform_function`'s body lowering — function and arrow bodies are never
  * element children, so they are untouched here.
+ *
+ * The input tree is never mutated: replacements land on a shallow copy of the
+ * owning node (or array), so the return value must be used in place of the
+ * argument. Untouched subtrees are shared by reference with the input.
  * @param {any} node
  * @param {Set<any>} [seen]
- * @returns {void}
+ * @returns {any}
  */
 function expand_child_code_blocks(node, seen = new Set()) {
-	if (!node || typeof node !== 'object' || seen.has(node)) return;
+	if (!node || typeof node !== 'object' || seen.has(node)) return node;
 	seen.add(node);
 
 	if (Array.isArray(node)) {
-		for (const item of node) expand_child_code_blocks(item, seen);
-		return;
+		let changed = false;
+		const result = node.map((item) => {
+			const walked = expand_child_code_blocks(item, seen);
+			if (walked !== item) changed = true;
+			return walked;
+		});
+		return changed ? result : node;
 	}
+
+	let out = node;
+	const set = (/** @type {string} */ key, /** @type {any} */ value) => {
+		if (out[key] === value) return;
+		if (out === node) out = { ...node };
+		out[key] = value;
+	};
 
 	if (
 		Array.isArray(node.children) &&
 		node.children.some((/** @type {any} */ c) => c?.type === 'JSXCodeBlock')
 	) {
-		node.children = node.children.flatMap((/** @type {any} */ child) =>
-			child?.type === 'JSXCodeBlock' ? lower_code_block_child(child) : [child],
+		set(
+			'children',
+			node.children.flatMap((/** @type {any} */ child) =>
+				child?.type === 'JSXCodeBlock' ? lower_code_block_child(child) : [child],
+			),
 		);
 	}
 
-	for (const key of Object.keys(node)) {
+	for (const key of Object.keys(out)) {
 		if (key === 'loc' || key === 'start' || key === 'end' || key === 'metadata') continue;
-		expand_child_code_blocks(node[key], seen);
+		set(key, expand_child_code_blocks(out[key], seen));
 	}
+
+	return out;
 }
 
 /**
@@ -418,13 +439,17 @@ function wrap_lowered_value_in_fragment(expression, source) {
  * its rendered value. Either way nothing leaks to the printer as a raw
  * `JSX…Expression`.
  *
+ * The input tree is never mutated: every replacement lands on a shallow copy of
+ * the owning node (or array), so the return value must be used in place of the
+ * argument. Untouched subtrees are shared by reference with the input.
+ *
  * @param {any} node
  * @param {TransformContext} transform_context
  * @param {Set<any>} [seen]
- * @returns {void}
+ * @returns {any}
  */
 function wrap_control_flow_expression_values(node, transform_context, seen = new Set()) {
-	if (!node || typeof node !== 'object' || seen.has(node)) return;
+	if (!node || typeof node !== 'object' || seen.has(node)) return node;
 	seen.add(node);
 
 	// Dynamic tags on factory platforms must lower before control-flow
@@ -454,11 +479,17 @@ function wrap_control_flow_expression_values(node, transform_context, seen = new
 			: value;
 
 	if (Array.isArray(node)) {
-		for (let i = 0; i < node.length; i++) {
-			node[i] = lower_child(node[i]);
-			wrap_control_flow_expression_values(node[i], transform_context, seen);
-		}
-		return;
+		let changed = false;
+		const result = node.map((entry) => {
+			const walked = wrap_control_flow_expression_values(
+				lower_child(entry),
+				transform_context,
+				seen,
+			);
+			if (walked !== entry) changed = true;
+			return walked;
+		});
+		return changed ? result : node;
 	}
 
 	// Wrap a bare control-flow directive that is the sole value of a render-output
@@ -469,50 +500,72 @@ function wrap_control_flow_expression_values(node, transform_context, seen = new
 	const wrap_value = (/** @type {any} */ value) =>
 		is_jsx_control_flow_expression(value) ? wrap_in_native_tsrx_fragment(value) : value;
 
+	// All replacements land on `out`, a shallow copy made on first write; the
+	// input node's fields are never reassigned.
+	let out = node;
+	const set = (/** @type {string} */ key, /** @type {any} */ value) => {
+		if (out[key] === value) return;
+		if (out === node) out = { ...node };
+		out[key] = value;
+	};
+
 	if (
 		node.type === 'ArrowFunctionExpression' &&
 		node.body?.type !== 'BlockStatement' &&
 		is_jsx_control_flow_expression(node.body)
 	) {
-		node.body = wrap_in_native_tsrx_fragment(node.body);
+		set('body', wrap_in_native_tsrx_fragment(node.body));
 	} else if (node.type === 'ReturnStatement' && is_jsx_control_flow_expression(node.argument)) {
-		node.argument = wrap_in_native_tsrx_fragment(node.argument);
+		set('argument', wrap_in_native_tsrx_fragment(node.argument));
 	} else if (
 		node.type === 'ExpressionStatement' &&
 		is_jsx_control_flow_expression(node.expression)
 	) {
-		node.expression = wrap_in_native_tsrx_fragment(node.expression);
+		set('expression', wrap_in_native_tsrx_fragment(node.expression));
 	} else if (node.type === 'VariableDeclarator' && is_jsx_control_flow_expression(node.init)) {
-		node.init = wrap_in_native_tsrx_fragment(node.init);
+		set('init', wrap_in_native_tsrx_fragment(node.init));
 	} else if (node.type === 'AssignmentExpression' && is_jsx_control_flow_expression(node.right)) {
-		node.right = wrap_in_native_tsrx_fragment(node.right);
+		set('right', wrap_in_native_tsrx_fragment(node.right));
 	} else if (
 		(node.type === 'CallExpression' || node.type === 'NewExpression') &&
 		Array.isArray(node.arguments)
 	) {
-		node.arguments = node.arguments.map(wrap_value);
+		const wrapped = node.arguments.map(wrap_value);
+		if (
+			wrapped.some(
+				(/** @type {any} */ argument, /** @type {number} */ i) => argument !== node.arguments[i],
+			)
+		) {
+			set('arguments', wrapped);
+		}
 	}
 
-	for (const key of Object.keys(node)) {
+	for (const key of Object.keys(out)) {
 		if (key === 'loc' || key === 'start' || key === 'end' || key === 'metadata') continue;
 		// A directive is allowed as a render child/statement, and as the sole value
 		// of a render-output slot (handled above for control flow; `@{ … }` blocks
 		// self-lower). Everywhere else it is combined into an expression — wrap it.
 		const allowed_slot =
 			is_statement_or_template_slot(node, key) || is_render_output_value_slot(node, key);
-		const value = node[key];
+		const value = out[key];
 		if (Array.isArray(value)) {
-			for (let i = 0; i < value.length; i++) {
-				value[i] = lower_child(value[i]);
-				if (!allowed_slot) value[i] = wrap_directive_in_expression(value[i]);
-				wrap_control_flow_expression_values(value[i], transform_context, seen);
-			}
+			let changed = false;
+			const result = value.map((entry) => {
+				let next = lower_child(entry);
+				if (!allowed_slot) next = wrap_directive_in_expression(next);
+				next = wrap_control_flow_expression_values(next, transform_context, seen);
+				if (next !== entry) changed = true;
+				return next;
+			});
+			if (changed) set(key, result);
 		} else {
-			node[key] = lower_child(node[key]);
-			if (!allowed_slot) node[key] = wrap_directive_in_expression(node[key]);
-			wrap_control_flow_expression_values(node[key], transform_context, seen);
+			let next = lower_child(value);
+			if (!allowed_slot) next = wrap_directive_in_expression(next);
+			set(key, wrap_control_flow_expression_values(next, transform_context, seen));
 		}
 	}
+
+	return out;
 }
 
 /**
@@ -578,8 +631,8 @@ export function createJsxTransform(platform) {
 			...(platform.hooks?.initialState?.() ?? {}),
 		};
 
-		expand_child_code_blocks(/** @type {any} */ (ast));
-		wrap_control_flow_expression_values(/** @type {any} */ (ast), transform_context);
+		ast = expand_child_code_blocks(/** @type {any} */ (ast));
+		ast = wrap_control_flow_expression_values(/** @type {any} */ (ast), transform_context);
 
 		if (!transform_context.typeOnly) {
 			preallocate_lazy_ids(/** @type {any} */ (ast), transform_context);
@@ -735,7 +788,15 @@ export function createJsxTransform(platform) {
 			},
 		});
 
-		const transformed_program = /** @type {AST.Program} */ (transformed);
+		let transformed_program = /** @type {AST.Program} */ (transformed);
+		// The walk returns the input program unchanged when no visitor replaced
+		// anything beneath it. The post-passes below (style anchors, helper
+		// expansion, import injection) write into the program's `body`, so
+		// detach from the caller's AST first; a changed program is already a
+		// fresh walk-owned node with a fresh `body` array.
+		if (/** @type {any} */ (transformed_program) === /** @type {any} */ (ast)) {
+			transformed_program = { ...transformed_program, body: [...transformed_program.body] };
+		}
 		if (type_only_style_anchors.length > 0) {
 			transformed_program.body.unshift(...type_only_style_anchors);
 		}
@@ -751,7 +812,7 @@ export function createJsxTransform(platform) {
 		// lazy transform runs, so every `@{ … }` block / `@`-directive has already
 		// been lowered to its final closure / block shape. The lazy transform can
 		// then walk the complete function structure in one pass.
-		lower_remaining_jsx_code_blocks(expanded, transform_context);
+		const lowered_program = lower_remaining_jsx_code_blocks(expanded, transform_context);
 
 		// Apply lazy destructuring transforms to module-level code (top-level function
 		// declarations, arrow functions, etc.).
@@ -772,12 +833,12 @@ export function createJsxTransform(platform) {
 		// so lazy bindings declared inside a nested block or directive body are
 		// rewritten just like a flat function body.
 		if (!transform_context.typeOnly) {
-			preallocate_lazy_ids(/** @type {any} */ (expanded), transform_context);
+			preallocate_lazy_ids(/** @type {any} */ (lowered_program), transform_context);
 		}
 		const final_program = /** @type {any} */ (
 			transform_context.typeOnly
-				? expanded
-				: apply_lazy_transforms(/** @type {any} */ (expanded), new Map())
+				? lowered_program
+				: apply_lazy_transforms(/** @type {any} */ (lowered_program), new Map())
 		);
 
 		const result = print(final_program, tsx_with_ts_locations(transform_context.typeOnly), {
@@ -1707,7 +1768,7 @@ function get_active_native_tsrx_function(path) {
 
 /**
  * @param {any} node
- * @param {{ next: () => any, state: TransformContext, path: AST.Node[] }} context
+ * @param {{ next: () => any, visit: (node: any, state?: TransformContext) => any, state: TransformContext, path: AST.Node[] }} context
  * @returns {any}
  */
 function transform_function(node, context) {
@@ -1717,15 +1778,26 @@ function transform_function(node, context) {
 	// from here it flows through the existing native-component machinery exactly
 	// like the older fenced `{ return <> … </> }` shape.
 	const has_jsx_code_block_body = node.body?.type === 'JSXCodeBlock';
-	lower_jsx_code_block_function_body(node);
+	const lowered = lower_jsx_code_block_function_body(node);
+	if (lowered !== node) {
+		// The lowering produced a COPY; carry the native-body fact through the
+		// sanctioned metadata channel and re-dispatch so the walker transforms
+		// the lowered tree (terminates: the copy's body is a BlockStatement).
+		lowered.metadata = { ...(lowered.metadata || {}), native_tsrx_body: true };
+		return context.visit(lowered);
+	}
 
 	if (
 		has_jsx_code_block_body ||
 		node.metadata?.native_tsrx_function ||
+		node.metadata?.native_tsrx_body ||
 		function_has_native_tsrx_return(node)
 	) {
 		return transform_native_tsrx_function(node, context, {
-			nativeBody: has_jsx_code_block_body || !!node.metadata?.native_tsrx_function,
+			nativeBody:
+				has_jsx_code_block_body ||
+				!!node.metadata?.native_tsrx_function ||
+				!!node.metadata?.native_tsrx_body,
 		});
 	}
 
@@ -1733,11 +1805,14 @@ function transform_function(node, context) {
 }
 
 /**
+ * Lower a `@{ … }` body (JSXCodeBlock) to an ordinary block on a COPY built
+ * with the AST builders — the source function node is never mutated. Returns
+ * the input node unchanged when there is nothing to lower.
  * @param {any} node
- * @returns {void}
+ * @returns {any}
  */
 function lower_jsx_code_block_function_body(node) {
-	if (node.body?.type !== 'JSXCodeBlock') return;
+	if (node.body?.type !== 'JSXCodeBlock') return node;
 
 	const code_block = node.body;
 	const statements = [...code_block.body];
@@ -1758,10 +1833,11 @@ function lower_jsx_code_block_function_body(node) {
 		}
 		statements.push(b.return(render, code_block.render));
 	}
-	node.body = b.block(statements, code_block);
-	if (node.type === 'ArrowFunctionExpression') {
-		node.expression = false;
-	}
+	return {
+		...node,
+		body: b.block(statements, code_block),
+		...(node.type === 'ArrowFunctionExpression' ? { expression: false } : null),
+	};
 }
 
 /**
@@ -3039,46 +3115,62 @@ function expand_component_helpers(program) {
  * If one of those helpers contains a statement-container body, lower it before
  * the printer sees the helper subtree.
  *
+ * The tree is never mutated: replacements land on a shallow copy of the owning
+ * node (or array), so the return value must be used in place of the argument.
+ * Untouched subtrees are shared by reference with the input.
+ *
  * @param {any} node
  * @param {TransformContext} transform_context
  * @param {Set<any>} [seen]
- * @returns {void}
+ * @returns {any}
  */
 function lower_remaining_jsx_code_blocks(node, transform_context, seen = new Set()) {
-	if (!node || typeof node !== 'object' || seen.has(node)) return;
+	if (!node || typeof node !== 'object' || seen.has(node)) return node;
 	seen.add(node);
 
-	if (is_function_or_class_boundary(node)) {
-		lower_jsx_code_block_function_body(node);
-	}
+	// A code-block function body lowers to a fresh copy of the function node;
+	// its children are then walked below like any other node's.
+	let out = is_function_or_class_boundary(node) ? lower_jsx_code_block_function_body(node) : node;
+	const set = (/** @type {string} */ key, /** @type {any} */ value) => {
+		if (out[key] === value) return;
+		if (out === node) out = { ...node };
+		out[key] = value;
+	};
 
-	for (const key of Object.keys(node)) {
+	for (const key of Object.keys(out)) {
 		if (key === 'loc' || key === 'start' || key === 'end' || key === 'metadata') continue;
-		let value = node[key];
+		const value = out[key];
 		if (!value || typeof value !== 'object') continue;
 
 		if (Array.isArray(value)) {
-			if (key === 'body') {
-				value = node[key] = value.flatMap((child) => {
-					if (child?.type !== 'JSXCodeBlock') return [child];
-					const body_nodes = get_jsx_code_block_body_nodes(child, transform_context);
-					return mark_native_pretransformed_jsx(
-						build_render_statements(
-							body_nodes,
-							true,
-							transform_context,
-							is_authored_native_fragment(child.render) ? child.render : null,
-						),
-					);
-				});
-			}
-			for (const child of value) {
-				lower_remaining_jsx_code_blocks(child, transform_context, seen);
-			}
+			const expanded =
+				key === 'body' && value.some((child) => child?.type === 'JSXCodeBlock')
+					? value.flatMap((child) => {
+							if (child?.type !== 'JSXCodeBlock') return [child];
+							const body_nodes = get_jsx_code_block_body_nodes(child, transform_context);
+							return mark_native_pretransformed_jsx(
+								build_render_statements(
+									body_nodes,
+									true,
+									transform_context,
+									is_authored_native_fragment(child.render) ? child.render : null,
+								),
+							);
+						})
+					: value;
+			let changed = expanded !== value;
+			const result = expanded.map((child) => {
+				const walked = lower_remaining_jsx_code_blocks(child, transform_context, seen);
+				if (walked !== child) changed = true;
+				return walked;
+			});
+			if (changed) set(key, result);
 		} else {
-			lower_remaining_jsx_code_blocks(value, transform_context, seen);
+			set(key, lower_remaining_jsx_code_blocks(value, transform_context, seen));
 		}
 	}
+
+	return out;
 }
 
 /**
@@ -3202,9 +3294,8 @@ function get_loop_skip_if_consequent_body(node) {
  */
 function create_component_loop_skip_if_statement(node, render_nodes, transform_context) {
 	const consequent_body = /** @type {any[]} */ (get_loop_skip_if_consequent_body(node));
-	const branch_statements = build_render_statements(consequent_body, true, transform_context);
-	prepend_render_nodes_to_return_statements(
-		branch_statements,
+	const branch_statements = prepend_render_nodes_to_return_statements(
+		build_render_statements(consequent_body, true, transform_context),
 		render_nodes,
 		transform_context.typeOnly,
 	);
@@ -3221,19 +3312,23 @@ function create_component_loop_skip_if_statement(node, render_nodes, transform_c
 }
 
 /**
+ * Statements can be passed through `build_render_statements` by reference, so
+ * rewritten returns land on shallow copies; the returned array must be used in
+ * place of the argument.
+ *
  * @param {any[]} statements
  * @param {any[]} render_nodes
  * @param {boolean} [type_only]
- * @returns {void}
+ * @returns {any[]}
  */
 function prepend_render_nodes_to_return_statements(statements, render_nodes, type_only = false) {
 	if (render_nodes.length === 0) {
-		return;
+		return statements;
 	}
 
-	for (const statement of statements) {
-		prepend_render_nodes_to_return_statement(statement, render_nodes, false, type_only);
-	}
+	return /** @type {any[]} */ (
+		prepend_render_nodes_to_return_statement(statements, render_nodes, false, type_only)
+	);
 }
 
 /**
@@ -3241,7 +3336,7 @@ function prepend_render_nodes_to_return_statements(statements, render_nodes, typ
  * @param {any[]} render_nodes
  * @param {boolean} inside_nested_function
  * @param {boolean} [type_only]
- * @returns {void}
+ * @returns {any}
  */
 function prepend_render_nodes_to_return_statement(
 	node,
@@ -3250,7 +3345,7 @@ function prepend_render_nodes_to_return_statement(
 	type_only = false,
 ) {
 	if (!node || typeof node !== 'object') {
-		return;
+		return node;
 	}
 
 	if (
@@ -3262,33 +3357,44 @@ function prepend_render_nodes_to_return_statement(
 	}
 
 	if (!inside_nested_function && node.type === 'ReturnStatement') {
-		node.argument = combine_render_return_argument(render_nodes, node.argument, type_only);
-		return;
+		return {
+			...node,
+			argument: combine_render_return_argument(render_nodes, node.argument, type_only),
+		};
 	}
 
 	if (Array.isArray(node)) {
-		for (const child of node) {
-			prepend_render_nodes_to_return_statement(
+		let changed = false;
+		const result = node.map((child) => {
+			const walked = prepend_render_nodes_to_return_statement(
 				child,
 				render_nodes,
 				inside_nested_function,
 				type_only,
 			);
-		}
-		return;
+			if (walked !== child) changed = true;
+			return walked;
+		});
+		return changed ? result : node;
 	}
 
+	let out = node;
 	for (const key of Object.keys(node)) {
 		if (key === 'loc' || key === 'start' || key === 'end' || key === 'metadata') {
 			continue;
 		}
-		prepend_render_nodes_to_return_statement(
+		const walked = prepend_render_nodes_to_return_statement(
 			node[key],
 			render_nodes,
 			inside_nested_function,
 			type_only,
 		);
+		if (walked !== node[key]) {
+			if (out === node) out = { ...node };
+			out[key] = walked;
+		}
 	}
+	return out;
 }
 
 /**
@@ -4733,9 +4839,16 @@ function continue_to_bare_return(source_node) {
  */
 export function rewrite_loop_continues_to_bare_returns(node, is_root = true) {
 	if (Array.isArray(node)) {
-		return node.map((child) =>
-			rewrite_loop_continues_to_bare_returns(child, is_root && !is_loop_statement(child)),
-		);
+		let changed = false;
+		const result = node.map((child) => {
+			const walked = rewrite_loop_continues_to_bare_returns(
+				child,
+				is_root && !is_loop_statement(child),
+			);
+			if (walked !== child) changed = true;
+			return walked;
+		});
+		return changed ? result : node;
 	}
 
 	if (!node || typeof node !== 'object') {
@@ -4750,14 +4863,19 @@ export function rewrite_loop_continues_to_bare_returns(node, is_root = true) {
 		return node;
 	}
 
+	let out = node;
 	for (const key of Object.keys(node)) {
 		if (key === 'loc' || key === 'start' || key === 'end' || key === 'metadata') {
 			continue;
 		}
-		node[key] = rewrite_loop_continues_to_bare_returns(node[key], false);
+		const walked = rewrite_loop_continues_to_bare_returns(node[key], false);
+		if (walked !== node[key]) {
+			if (out === node) out = { ...node };
+			out[key] = walked;
+		}
 	}
 
-	return node;
+	return out;
 }
 
 /**
@@ -4921,7 +5039,7 @@ function for_of_statement_to_jsx_child(node, transform_context) {
 	}
 
 	const loop_params = get_for_of_iteration_params(node.left, node.index);
-	const loop_body = /** @type {any[]} */ (
+	let loop_body = /** @type {any[]} */ (
 		node.body.type === 'BlockStatement' ? node.body.body : [node.body]
 	);
 	validate_for_body_control_flow(loop_body, transform_context);
@@ -4952,10 +5070,10 @@ function for_of_statement_to_jsx_child(node, transform_context) {
 	}
 
 	if (implicit_non_hook_key_expression && should_apply_key_to_loop_body(loop_body)) {
-		apply_key_to_loop_body(loop_body, implicit_non_hook_key_expression);
+		loop_body = apply_key_to_loop_body(loop_body, implicit_non_hook_key_expression);
 	}
 
-	const body_statements = has_hooks
+	let body_statements = has_hooks
 		? hook_safe_render_statements(loop_body, key_expression, transform_context)
 		: build_render_statements(loop_body, true, transform_context);
 
@@ -4972,7 +5090,11 @@ function for_of_statement_to_jsx_child(node, transform_context) {
 
 	const non_hook_key_expression = key_expression ?? implicit_non_hook_key_expression;
 	if (!has_hooks && non_hook_key_expression) {
-		apply_key_to_render_statements(body_statements, non_hook_key_expression, transform_context);
+		body_statements = apply_key_to_render_statements(
+			body_statements,
+			non_hook_key_expression,
+			transform_context,
+		);
 	}
 
 	// Restore bindings
@@ -5025,32 +5147,40 @@ function for_of_statement_to_jsx_child(node, transform_context) {
 }
 
 /**
+ * Returns a copy of `body_nodes` where the first keyable element carries the
+ * key attribute on a rebuilt opening element — the source nodes are never
+ * mutated (they may belong to the caller's parsed AST).
  * @param {any[]} body_nodes
  * @param {any} key_expression
- * @returns {void}
+ * @returns {any[]}
  */
 function apply_key_to_loop_body(body_nodes, key_expression) {
-	for (const node of body_nodes) {
-		if (node.type === 'JSXElement') {
-			const attributes = node.openingElement?.attributes || [];
-			const has_key = attributes.some(
-				(/** @type {any} */ attr) =>
-					attr.type === 'JSXAttribute' &&
-					attr.name?.type === 'JSXIdentifier' &&
-					attr.name.name === 'key',
-			);
-
-			if (!has_key) {
-				attributes.push(
+	let applied = false;
+	return body_nodes.map((node) => {
+		if (applied || node.type !== 'JSXElement') return node;
+		applied = true;
+		const attributes = node.openingElement?.attributes || [];
+		const has_key = attributes.some(
+			(/** @type {any} */ attr) =>
+				attr.type === 'JSXAttribute' &&
+				attr.name?.type === 'JSXIdentifier' &&
+				attr.name.name === 'key',
+		);
+		if (has_key) return node;
+		return {
+			...node,
+			openingElement: {
+				...node.openingElement,
+				attributes: [
+					...attributes,
 					b.jsx_attribute(
 						b.jsx_id('key'),
 						to_jsx_expression_container(clone_expression_node(key_expression), key_expression),
 					),
-				);
-			}
-			return;
-		}
-	}
+				],
+			},
+		};
+	});
 }
 
 /**
@@ -5068,10 +5198,14 @@ function should_apply_key_to_loop_body(body_nodes) {
 }
 
 /**
+ * Statement entries can be shared with the source tree, so the keyed return
+ * lands on shallow copies; the returned array must be used in place of the
+ * argument.
+ *
  * @param {any[]} statements
  * @param {any} key_expression
  * @param {TransformContext} transform_context
- * @returns {void}
+ * @returns {any[]}
  */
 function apply_key_to_render_statements(statements, key_expression, transform_context) {
 	for (let i = statements.length - 1; i >= 0; i -= 1) {
@@ -5080,21 +5214,29 @@ function apply_key_to_render_statements(statements, key_expression, transform_co
 			continue;
 		}
 
-		if (statement.argument.type === 'JSXElement') {
-			apply_key_to_jsx_element(statement.argument, key_expression);
-		} else if (statement.argument.type === 'JSXFragment') {
+		let argument = statement.argument;
+		if (argument.type === 'JSXElement') {
+			argument = apply_key_to_jsx_element(argument, key_expression);
+		} else if (argument.type === 'JSXFragment') {
 			transform_context.needs_fragment = true;
-			statement.argument = keyed_fragment_to_jsx_element(statement.argument, key_expression);
+			argument = keyed_fragment_to_jsx_element(argument, key_expression);
 		}
 
-		return;
+		if (argument === statement.argument) {
+			return statements;
+		}
+		const result = [...statements];
+		result[i] = { ...statement, argument };
+		return result;
 	}
+	return statements;
 }
 
 /**
  * @param {any} element
  * @param {any} key_expression
- * @returns {void}
+ * @returns {any} the element itself when it already has a `key`, otherwise a
+ * shallow copy with the key attribute appended.
  */
 function apply_key_to_jsx_element(element, key_expression) {
 	const attributes = element.openingElement?.attributes || [];
@@ -5104,15 +5246,21 @@ function apply_key_to_jsx_element(element, key_expression) {
 			attr.name?.type === 'JSXIdentifier' &&
 			attr.name.name === 'key',
 	);
+	if (has_key) return element;
 
-	if (!has_key) {
-		attributes.push(
-			b.jsx_attribute(
-				b.jsx_id('key'),
-				to_jsx_expression_container(clone_expression_node(key_expression), key_expression),
-			),
-		);
-	}
+	return {
+		...element,
+		openingElement: {
+			...element.openingElement,
+			attributes: [
+				...attributes,
+				b.jsx_attribute(
+					b.jsx_id('key'),
+					to_jsx_expression_container(clone_expression_node(key_expression), key_expression),
+				),
+			],
+		},
+	};
 }
 
 /**

--- a/packages/tsrx/src/transform/jsx/index.js
+++ b/packages/tsrx/src/transform/jsx/index.js
@@ -780,7 +780,7 @@ export function createJsxTransform(platform) {
 				: apply_lazy_transforms(/** @type {any} */ (expanded), new Map())
 		);
 
-		const result = print(/** @type {any} */ (final_program), tsx_with_ts_locations(), {
+		const result = print(final_program, tsx_with_ts_locations(transform_context.typeOnly), {
 			sourceMapSource: filename,
 			sourceMapContent: source,
 		});

--- a/packages/tsrx/src/transform/segments.js
+++ b/packages/tsrx/src/transform/segments.js
@@ -962,19 +962,12 @@ export function convert_source_map_to_mappings(
 				const is_method = node.metadata?.is_method;
 
 				if (node.type === 'ArrowFunctionExpression' && node.loc) {
-					const start_key = `${node.loc.start.line}:${node.loc.start.column}`;
-					const end_key = `${node.loc.end.line}:${node.loc.end.column}`;
-
-					if (src_to_gen_map.has(start_key) && src_to_gen_map.has(end_key)) {
-						mappings.push(
-							get_mapping_from_node(
-								node,
-								src_to_gen_map,
-								gen_line_offsets,
-								mapping_data_verify_only,
-							),
-						);
-					}
+					// The printer emits node-level boundary markers for arrows (their
+					// span can start at a bare `(`), so the strict lookup always
+					// resolves — no defensive has() guard.
+					mappings.push(
+						get_mapping_from_node(node, src_to_gen_map, gen_line_offsets, mapping_data_verify_only),
+					);
 				}
 
 				// Add the function keyword token.
@@ -987,41 +980,68 @@ export function convert_source_map_to_mappings(
 					const function_hover = create_function_hover_replacement(
 						/** @type {AST.Parameter[]} */ (node.params),
 					);
-					let start_col = node_fn.loc.start.column;
-					let start = node_fn.start;
-					const async_keyword = 'async';
+					// Keyword SOURCE spans come from the LEXER (parse-time
+					// `tsrx_keyword_tokens`, opt-in via ParseOptions.keywordTokens):
+					// no AST node records them, offset arithmetic breaks on extra
+					// whitespace, and text search breaks on comments. Fall back to
+					// node-start-anchored arithmetic when tokens were not collected.
+					const keyword_bound =
+						node_fn.id?.start ?? node_fn.params?.[0]?.start ?? node_fn.body?.start ?? node_fn.end;
+					/** @type {Array<{ value: string, start: number, end: number, loc: AST.SourceLocation }>} */
+					const lexer_tokens = /** @type {any} */ (ast_from_source).tsrx_keyword_tokens ?? [];
+					/**
+					 * @param {'async' | 'function'} keyword
+					 * @param {number} from
+					 * @returns {AST.SourceLocation | null}
+					 */
+					const keyword_loc = (keyword, from) => {
+						const token = lexer_tokens.find(
+							(candidate) =>
+								candidate.value === keyword &&
+								candidate.start >= from &&
+								candidate.start < keyword_bound,
+						);
+						if (token) return token.loc;
+						if (lexer_tokens.length > 0) return null;
+						// Arithmetic fallback (callers that do not collect tokens):
+						// assumes the historical `async` + one-space + `function`
+						// single-line layout.
+						const offset =
+							keyword === 'function' && node_fn.async
+								? node_fn.start + 'async '.length
+								: node_fn.start;
+						const start_pos = offset_to_line_col(offset, src_line_offsets);
+						const end_pos = offset_to_line_col(offset + keyword.length, src_line_offsets);
+						return { start: start_pos, end: end_pos };
+					};
 
+					let function_from = node_fn.start;
 					if (node_fn.async) {
-						// We explicitly mapped async and function in esrap
-						tokens.push({
-							source: async_keyword,
-							generated: async_keyword,
-							loc: {
-								start: { line: node_fn.loc.start.line, column: start_col },
-								end: {
-									line: node_fn.loc.start.line,
-									column: start_col + async_keyword.length,
-								},
-							},
-							metadata: {},
-						});
-
-						start_col += async_keyword.length + 1; // +1 for space
-						start += async_keyword.length + 1;
+						const async_loc = keyword_loc('async', node_fn.start);
+						if (async_loc) {
+							tokens.push({
+								source: 'async',
+								generated: 'async',
+								loc: async_loc,
+								metadata: {},
+							});
+							function_from = loc_to_offset(
+								async_loc.end.line,
+								async_loc.end.column,
+								src_line_offsets,
+							);
+						}
 					}
 
-					tokens.push({
-						source: 'function',
-						generated: 'function',
-						loc: {
-							start: { line: node_fn.loc.start.line, column: start_col },
-							end: {
-								line: node_fn.loc.start.line,
-								column: start_col + 'function'.length,
-							},
-						},
-						metadata: function_hover ? { hover: function_hover } : {},
-					});
+					const function_loc = keyword_loc('function', function_from);
+					if (function_loc) {
+						tokens.push({
+							source: 'function',
+							generated: 'function',
+							loc: function_loc,
+							metadata: function_hover ? { hover: function_hover } : {},
+						});
+					}
 				}
 
 				// Visit in source order: id, params, body

--- a/packages/tsrx/src/utils/builders.js
+++ b/packages/tsrx/src/utils/builders.js
@@ -252,6 +252,22 @@ export function export_default(declaration) {
 }
 
 /**
+ * @param {string | AST.Identifier} local
+ * @param {string | AST.Identifier} [exported]
+ * @param {AST.ExportSpecifier['exportKind']} [exportKind]
+ * @returns {AST.ExportSpecifier}
+ */
+export function export_specifier(local, exported = local, exportKind = 'value') {
+	return {
+		type: 'ExportSpecifier',
+		local: typeof local === 'string' ? id(local) : local,
+		exported: typeof exported === 'string' ? id(exported) : exported,
+		exportKind,
+		metadata: { path: [] },
+	};
+}
+
+/**
  * @param {AST.Declaration | null} declaration
  * @param {AST.ExportSpecifier[]} [specifiers]
  * @param {AST.ImportAttribute[]} [attributes]

--- a/packages/tsrx/tests/shared/source-mappings.js
+++ b/packages/tsrx/tests/shared/source-mappings.js
@@ -1294,4 +1294,52 @@ function App() @{
 			},
 		);
 	});
+	describe(`[${name}] keyword token spans`, () => {
+		it('maps async and function keywords at their true source spans', () => {
+			const source = `async function load() {\n\treturn 1;\n}\nfunction C() @{}`;
+			const result = compile_to_volar_mappings(source, 'App.tsrx', { loose: true });
+			for (const keyword of ['async', 'function']) {
+				const source_offset = source.indexOf(keyword);
+				const generated_offset = result.code.indexOf(keyword);
+				const mapping = find_exact_mapping(
+					result.mappings,
+					source_offset,
+					generated_offset,
+					keyword.length,
+				);
+				expect(mapping, keyword).toBeTruthy();
+			}
+		});
+
+		it('never emits a garbled keyword span for irregular async/function spacing', () => {
+			// The old fixed-offset arithmetic assumed `async` + ONE space, so
+			// `async   function` produced a span over "nction f…". The source
+			// scan either maps the true span or omits the token.
+			const source = `async   function load() {\n\treturn 1;\n}\nfunction C() @{}`;
+			const result = compile_to_volar_mappings(source, 'App.tsrx', { loose: true });
+			const wrong_offset = source.indexOf('async') + 'async'.length + 1;
+			const garbled = result.mappings.find(
+				(mapping) =>
+					mapping.sourceOffsets[0] === wrong_offset && mapping.lengths[0] === 'function'.length,
+			);
+			expect(garbled).toBeUndefined();
+			// The token's SOURCE span is now found by scanning, so it is either
+			// mapped at the true keyword offset or omitted (esrap's generated
+			// keyword segment still assumes single-space layout — once esrap
+			// scans its `sourceMapContent` instead, the mapping returns).
+			const true_offset = source.indexOf('function');
+			const function_keyword_mappings = result.mappings.filter(
+				(mapping) =>
+					mapping.lengths[0] === 'function'.length &&
+					mapping.generatedLengths[0] === 'function'.length &&
+					result.code.slice(
+						mapping.generatedOffsets[0],
+						mapping.generatedOffsets[0] + 'function'.length,
+					) === 'function',
+			);
+			for (const mapping of function_keyword_mappings) {
+				expect([true_offset, source.lastIndexOf('function')]).toContain(mapping.sourceOffsets[0]);
+			}
+		});
+	});
 }

--- a/packages/tsrx/tests/shared/source-mappings.js
+++ b/packages/tsrx/tests/shared/source-mappings.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { identifier_to_jsx_name } from '@tsrx/core';
+import { identifier_to_jsx_name, parseModule } from '@tsrx/core';
 import {
 	build_line_offsets,
 	build_src_to_gen_map,
@@ -1341,5 +1341,166 @@ function App() @{
 				expect([true_offset, source.lastIndexOf('function')]).toContain(mapping.sourceOffsets[0]);
 			}
 		});
+	});
+	describe(`[${name}] input AST immutability`, () => {
+		/**
+		 * Structural snapshot of an AST node graph. `metadata` is the sanctioned
+		 * mutable side-channel (memoization, paths, flags) and is excluded;
+		 * everything else — including locations — must survive a transform
+		 * untouched, because the SAME object graph is walked afterwards as
+		 * `ast_from_source` by the mapping collector.
+		 * @param {any} value
+		 * @returns {any}
+		 */
+		const structural = (value) => {
+			if (Array.isArray(value)) return value.map(structural);
+			if (value && typeof value === 'object') {
+				/** @type {Record<string, any>} */
+				const out = {};
+				for (const key of Object.keys(value).sort()) {
+					if (key === 'metadata') continue;
+					const child = value[key];
+					if (typeof child === 'function') continue;
+					out[key] = structural(child);
+				}
+				return out;
+			}
+			return value;
+		};
+
+		/**
+		 * @param {any} before
+		 * @param {any} after
+		 * @param {string} path
+		 * @returns {string | null} first differing path
+		 */
+		const first_difference = (before, after, path) => {
+			if (Array.isArray(before) || Array.isArray(after)) {
+				if (!Array.isArray(before) || !Array.isArray(after) || before.length !== after.length) {
+					return path;
+				}
+				for (let i = 0; i < before.length; i++) {
+					const diff = first_difference(before[i], after[i], `${path}[${i}]`);
+					if (diff) return diff;
+				}
+				return null;
+			}
+			if (before && after && typeof before === 'object' && typeof after === 'object') {
+				const keys = new Set([...Object.keys(before), ...Object.keys(after)]);
+				for (const key of keys) {
+					const diff = first_difference(before[key], after[key], `${path}.${key}`);
+					if (diff) return diff;
+				}
+				return null;
+			}
+			return Object.is(before, after) ? null : path;
+		};
+
+		const SOURCES = {
+			'component with template control flow': `function App(props: { items: string[] }) @{
+	<div>
+		@if (props.items.length) {
+			<ul>
+				@for (const item of props.items; key item) {
+					<li>{item}</li>
+				}
+			</ul>
+		} @else {
+			<p>empty</p>
+		}
+	</div>
+}`,
+			'setup code, styles, and nested components': `import { useState } from 'react';
+
+function Child(props: { label: string }) @{
+	<span>{props.label}</span>
+}
+
+export function App() @{
+	const [n, setN] = useState(0);
+	const grow = () => setN((v) => v + 1);
+	<>
+		<button onClick={grow}>{'n: ' + n}</button>
+		<Child label={'count ' + n} />
+		<style>
+			button {
+				color: red;
+			}
+		</style>
+	</>
+}`,
+			'directives combined into value positions': `function App(props: { on: boolean; mode: string }) @{
+	const badge = (@if (props.on) { <b>on</b> }) || 'off';
+	const fallback = (@if (props.mode === 'a') { <i>A</i> }) ?? (@if (props.on) { <i>?</i> });
+	<div>
+		{badge}
+		{fallback}
+	</div>
+}`,
+			'keyed loops, try blocks, and styles in branches': `function App(props: { items: { id: string; name: string }[] }) @{
+	<section>
+		@try {
+			@for (const item of props.items; key item.id) {
+				<article>{item.name}</article>
+			}
+		} @pending {
+			<p>loading</p>
+		} @catch (error) {
+			<p>failed</p>
+		}
+		<style>
+			article {
+				color: blue;
+			}
+		</style>
+	</section>
+}`,
+			'code blocks, hooks in loops, and keyed fragments': `import { useState } from 'react';
+
+export function App(props: { items: { id: string; name: string }[] }) @{
+	<ul>
+		@{
+			const heading = 'Items';
+			<li>{heading}</li>
+		}
+		@for (const item of props.items; key item.id) {
+			const [open] = useState(false);
+			<>
+				<li>{item.name}</li>
+				<li>{open ? 'open' : 'closed'}</li>
+			</>
+		}
+	</ul>
+}`,
+			'plain module without templates': `export async function load(url: string) {
+	const res = await fetch(url);
+	return res.json();
+}
+export const config = { retries: [1, 2, 3] };`,
+		};
+
+		for (const [label, source] of Object.entries(SOURCES)) {
+			it(`does not mutate the parsed program: ${label}`, () => {
+				// `result.sourceAst` is the exact instance the transform consumed
+				// (and that mapping collection then walks). A fresh parse with the
+				// same options is the pristine reference — parsing is
+				// deterministic, so any structural difference is transform-made.
+				const pristine = parseModule(source, 'App.tsrx', {
+					collect: true,
+					loose: true,
+					preserveParens: true,
+					keywordTokens: true,
+					errors: [],
+					comments: [],
+				});
+				const result = compile_to_volar_mappings(source, 'App.tsrx', { loose: true });
+				const diff = first_difference(
+					structural(pristine),
+					structural(result.sourceAst),
+					'program',
+				);
+				expect(diff, diff ? `transform mutated ${diff}` : undefined).toBeNull();
+			});
+		}
 	});
 }

--- a/packages/tsrx/tests/shared/source-mappings.js
+++ b/packages/tsrx/tests/shared/source-mappings.js
@@ -51,6 +51,43 @@ export function runSharedSourceMappingTests({
 			expect_maps(`function C() @{
 	const x = foo[bar];
 }`));
+		// The index expression's acorn location starts at the `(` of its
+		// parenthesized left operand — a position the printer emits no marker
+		// for; the verify mapping is skipped instead of failing the file.
+		it('computed MemberExpression with parenthesized binary index', () =>
+			expect_maps(`const C = ['a', 'b'];
+function F(props: { n: number }) @{
+	const x = { fill: C[(props.n - 1) % C.length] };
+}`));
+		// The synthesized `[key]` bracket span starts one column before the key —
+		// unmarked in some object-literal contexts; skipped, not fatal.
+		it('computed object key', () =>
+			expect_maps(`function F(props: { k: string }) @{
+	const merge = (current: object) => ({ ...current, [props.k]: '' });
+}`));
+		// AssignmentPattern spans reaching into marker-less literal tokens.
+		it('parameter default array literal', () =>
+			expect_maps(`function parse(points = []) {
+	return points.length;
+}`));
+		// The pattern's span ends at a call's closing paren.
+		it('parameter default ending in a call', () =>
+			expect_maps(`const use = ({ dir = getDocumentDirection() } = {}) => dir;`));
+		// A statement/property span ending at a computed member's closing bracket.
+		it('computed member access at span end', () =>
+			expect_maps(`function next(items: string[], index: number) {
+	return { value: items[index++], done: false };
+}`));
+		it('destructured parameter defaults', () =>
+			expect_maps(`const use = ({ a = 1 } = {}) => a;
+export function usePos(
+	{
+		x = 0,
+		y = 0,
+	}: { x?: number; y?: number } = {},
+) {
+	return x + y;
+}`));
 		it('empty ObjectExpression', () =>
 			expect_maps(`function C() @{
 	const x = {};

--- a/packages/tsrx/tests/shared/source-mappings.js
+++ b/packages/tsrx/tests/shared/source-mappings.js
@@ -191,6 +191,27 @@ export function usePos(
 			expect(result.mappings.length).toBeGreaterThan(0);
 		});
 
+		// The typeOnly output is real TS: an ambient module must keep `declare`
+		// (`module 'name' { … }` alone is TS1035) and type-only import/export
+		// specifiers must survive verbatim for the language service.
+		it('preserves declare on ambient modules and type-only specifiers', () => {
+			const source = `import { type Local } from './local.js';
+export type { Config } from './types.js';
+export { type Extra, realValue } from './mixed.js';
+declare module 'some-module' {
+	interface Thing {
+		x: number;
+	}
+}`;
+			const result = compile_to_volar_mappings(source, 'App.tsrx', { loose: true });
+
+			expect(result.code).toContain(`import { type Local } from './local.js';`);
+			expect(result.code).toContain(`export type { Config } from './types.js';`);
+			expect(result.code).toContain(`export { type Extra, realValue } from './mixed.js';`);
+			expect(result.code).toContain(`declare module 'some-module'`);
+			expect(result.errors).toEqual([]);
+		});
+
 		// JSX: esrap prints `<`, `>`, `</`, ` /` without location markers.
 		// Combined with hoisting to module-level statics, the opening
 		// element's start/end positions wouldn't otherwise resolve.

--- a/packages/tsrx/tests/utils/parser.test.js
+++ b/packages/tsrx/tests/utils/parser.test.js
@@ -3147,3 +3147,71 @@ describe('raw-text <script> elements', () => {
 		expect(script.content).toBe('\nconst a = 1;\nconst b = a < 2;\n');
 	});
 });
+
+describe('acorn-typescript ≥1.0.11 constructs parse through the TSRX parser', () => {
+	// Pins for upstream fixes the tsrx parser inherits (the plugin overrides
+	// parseForStatement for indexed for-of, but paren/expression parsing is
+	// inherited, so these verify the fixes actually reach us).
+
+	it('allows the `in` operator inside a parenthesized `for` initializer', () => {
+		const ast = parseModule(`for ((('a' in {}) ? 1 : 2);;) break;`, 'App.ts');
+		const [statement] = ast.body;
+		expect(statement.type).toBe('ForStatement');
+		expect(statement.init.type).toBe('ConditionalExpression');
+	});
+
+	it('allows a const initializer in an ambient context', () => {
+		const ast = parseModule(`declare const VERSION = '1.0';`, 'App.ts');
+		const [statement] = ast.body;
+		expect(statement.type).toBe('VariableDeclaration');
+		expect(statement.declare).toBe(true);
+		expect(statement.declarations[0].init.value).toBe('1.0');
+	});
+
+	it('collects each comment exactly once', () => {
+		const comments = [];
+		parseModule(
+			`// leading
+interface Point {
+	// inside
+	x: number;
+}
+const p: Point = { x: 1 }; // trailing`,
+			'App.ts',
+			{ collect: true, comments },
+		);
+		const starts = comments.map((comment) => comment.start);
+		expect(new Set(starts).size).toBe(starts.length);
+		expect(comments.length).toBe(3);
+	});
+});
+
+describe('keywordTokens parse option', () => {
+	it('collects async/function keyword tokens from the lexer', () => {
+		const source = `async function load() {}\nfunction plain() {}`;
+		const ast = parseModule(source, 'App.ts', { keywordTokens: true });
+		const tokens = ast.tsrx_keyword_tokens;
+		expect(tokens.map((t) => [t.value, t.start])).toEqual([
+			['async', source.indexOf('async')],
+			['function', source.indexOf('function')],
+			['function', source.lastIndexOf('function')],
+		]);
+	});
+
+	it('is immune to comments and irregular spacing between keywords', () => {
+		// Offset arithmetic assumed one space; text search would match the
+		// keyword inside the comment. The lexer sees through both.
+		const source = `async /* function */   function load() {}`;
+		const ast = parseModule(source, 'App.ts', { keywordTokens: true });
+		const tokens = ast.tsrx_keyword_tokens;
+		expect(tokens.map((t) => [t.value, t.start])).toEqual([
+			['async', 0],
+			['function', source.lastIndexOf('function')],
+		]);
+	});
+
+	it('does not collect tokens without the option', () => {
+		const ast = parseModule(`function f() {}`, 'App.ts');
+		expect(ast.tsrx_keyword_tokens).toBeUndefined();
+	});
+});

--- a/packages/tsrx/types/index.d.ts
+++ b/packages/tsrx/types/index.d.ts
@@ -1234,6 +1234,12 @@ export interface ParseOptions {
 	collect?: boolean;
 	loose?: boolean;
 	preserveParens?: boolean;
+	/**
+	 * Collect `async`/`function` keyword tokens from the lexer onto the
+	 * returned program (`tsrx_keyword_tokens`) so mapping collection can span
+	 * keywords exactly. Volar/typeOnly parses opt in.
+	 */
+	keywordTokens?: boolean;
 	errors?: CompileError[];
 	comments?: AST.CommentWithLocation[];
 }

--- a/packages/tsrx/types/index.d.ts
+++ b/packages/tsrx/types/index.d.ts
@@ -230,12 +230,14 @@ declare module 'estree' {
 	interface MethodDefinition {
 		typeParameters?: TSTypeParameterDeclaration;
 		accessibility?: Accessibility;
+		optional?: boolean;
 	}
 
 	interface PropertyDefinition {
 		accessibility?: Accessibility;
 		readonly?: boolean;
 		optional?: boolean;
+		definite?: boolean;
 	}
 
 	interface ClassDeclaration {
@@ -1231,6 +1233,7 @@ export interface ParseError {
 export interface ParseOptions {
 	collect?: boolean;
 	loose?: boolean;
+	preserveParens?: boolean;
 	errors?: CompileError[];
 	comments?: AST.CommentWithLocation[];
 }

--- a/packages/tsrx/types/index.d.ts
+++ b/packages/tsrx/types/index.d.ts
@@ -486,6 +486,9 @@ declare module 'estree' {
 	interface ExportNamedDeclaration {
 		exportKind: TSESTree.ExportNamedDeclaration['exportKind'];
 	}
+	interface ExportSpecifier {
+		exportKind: TSESTree.ExportSpecifier['exportKind'];
+	}
 
 	interface BaseNodeWithoutComments {
 		// Adding start, end for now as always there

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,8 +34,8 @@ catalogs:
       specifier: 2.0.0-beta.15
       version: 2.0.0-beta.15
     '@sveltejs/acorn-typescript':
-      specifier: ^1.0.10
-      version: 1.0.10
+      specifier: ^1.0.11
+      version: 1.0.11
     '@tailwindcss/vite':
       specifier: ^4.1.12
       version: 4.2.1
@@ -1048,7 +1048,7 @@ importers:
         version: 2.2.0
       '@sveltejs/acorn-typescript':
         specifier: catalog:default
-        version: 1.0.10(acorn@8.16.0)
+        version: 1.0.11(acorn@8.16.0)
       '@types/estree':
         specifier: catalog:default
         version: 1.0.8
@@ -3402,6 +3402,11 @@ packages:
 
   '@sveltejs/acorn-typescript@1.0.10':
     resolution: {integrity: sha512-4WfKk68eTih+MiJD4fSbxN7E8kVBmTMPWHUPYjvl2N0rMs53YLTT8/YjKU5Dtnz5LqDjl7LEw4U7lXR2W3J5WA==}
+    peerDependencies:
+      acorn: ^8.9.0
+
+  '@sveltejs/acorn-typescript@1.0.11':
+    resolution: {integrity: sha512-LFuZUkjJ9iF7JZye/aG5XM0SFcQ5VyL0oVX4WJ9dc0Va3R3s0OauX1BESVCb+YN/ol8TAfqGDDAQsTG627Y5kw==}
     peerDependencies:
       acorn: ^8.9.0
 
@@ -9008,6 +9013,10 @@ snapshots:
   '@standard-schema/spec@1.1.0': {}
 
   '@sveltejs/acorn-typescript@1.0.10(acorn@8.16.0)':
+    dependencies:
+      acorn: 8.16.0
+
+  '@sveltejs/acorn-typescript@1.0.11(acorn@8.16.0)':
     dependencies:
       acorn: 8.16.0
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -256,7 +256,7 @@ catalogs:
       version: 5.9.3
 
 overrides:
-  esrap: ^2.2.8
+  esrap: ^2.3.0
   semver: ^7.7.4
   babel-preset-solid: 2.0.0-beta.15
   babel-plugin-jsx-dom-expressions: 0.50.0-next.14
@@ -1059,8 +1059,8 @@ importers:
         specifier: catalog:default
         version: 8.16.0
       esrap:
-        specifier: ^2.2.8
-        version: 2.2.8(@typescript-eslint/types@8.56.1)
+        specifier: ^2.3.0
+        version: 2.3.0(@typescript-eslint/types@8.56.1)
       is-reference:
         specifier: catalog:default
         version: 3.0.3
@@ -1121,8 +1121,8 @@ importers:
         specifier: workspace:*
         version: link:../tsrx
       esrap:
-        specifier: ^2.2.8
-        version: 2.2.8(@typescript-eslint/types@8.56.1)
+        specifier: ^2.3.0
+        version: 2.3.0(@typescript-eslint/types@8.56.1)
       zimmerframe:
         specifier: catalog:default
         version: 1.1.4
@@ -1146,8 +1146,8 @@ importers:
         specifier: workspace:*
         version: link:../tsrx
       esrap:
-        specifier: ^2.2.8
-        version: 2.2.8(@typescript-eslint/types@8.56.1)
+        specifier: ^2.3.0
+        version: 2.3.0(@typescript-eslint/types@8.56.1)
       react:
         specifier: '>=18'
         version: 19.2.4
@@ -1174,8 +1174,8 @@ importers:
         specifier: workspace:*
         version: link:../tsrx
       esrap:
-        specifier: ^2.2.8
-        version: 2.2.8(@typescript-eslint/types@8.56.1)
+        specifier: ^2.3.0
+        version: 2.3.0(@typescript-eslint/types@8.56.1)
       is-reference:
         specifier: catalog:default
         version: 3.0.3
@@ -1211,8 +1211,8 @@ importers:
         specifier: workspace:*
         version: link:../tsrx
       esrap:
-        specifier: ^2.2.8
-        version: 2.2.8(@typescript-eslint/types@8.56.1)
+        specifier: ^2.3.0
+        version: 2.3.0(@typescript-eslint/types@8.56.1)
       solid-js:
         specifier: catalog:default
         version: 2.0.0-beta.15
@@ -1236,8 +1236,8 @@ importers:
         specifier: workspace:*
         version: link:../tsrx
       esrap:
-        specifier: ^2.2.8
-        version: 2.2.8(@typescript-eslint/types@8.56.1)
+        specifier: ^2.3.0
+        version: 2.3.0(@typescript-eslint/types@8.56.1)
       is-reference:
         specifier: catalog:default
         version: 3.0.3
@@ -4789,8 +4789,8 @@ packages:
     resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
     engines: {node: '>=0.10'}
 
-  esrap@2.2.8:
-    resolution: {integrity: sha512-MPweq2EvEGj8jwOI7Hgycw/QIHzqA1EbAM8lG7p+FBfZbZq/hQ6h3AMsqnu/djzisH1KVWNzbb7LSgIVtMlPSg==}
+  esrap@2.3.0:
+    resolution: {integrity: sha512-GQ/7RN8uOtEfNpzZzBMTzW9JBcX42oaSVtPzdF+6cEL8pqIL094iUpr9jzYGn4O4P/1S60dJ6izyT8F4LYARng==}
     peerDependencies:
       '@typescript-eslint/types': ^8.2.0
     peerDependenciesMeta:
@@ -9138,7 +9138,7 @@ snapshots:
       '@types/estree': 1.0.8
       '@types/estree-jsx': 1.0.5
       acorn: 8.16.0
-      esrap: 2.2.8(@typescript-eslint/types@8.56.1)
+      esrap: 2.3.0(@typescript-eslint/types@8.56.1)
       is-reference: 3.0.3
       magic-string: 0.30.21
       zimmerframe: 1.1.4
@@ -10491,7 +10491,7 @@ snapshots:
     dependencies:
       estraverse: 5.3.0
 
-  esrap@2.2.8(@typescript-eslint/types@8.56.1):
+  esrap@2.3.0(@typescript-eslint/types@8.56.1):
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
     optionalDependencies:
@@ -11624,7 +11624,7 @@ snapshots:
     dependencies:
       '@tsrx/core': 0.1.40(@typescript-eslint/types@8.56.1)
       devalue: 5.8.1
-      esrap: 2.2.8(@typescript-eslint/types@8.56.1)
+      esrap: 2.3.0(@typescript-eslint/types@8.56.1)
     transitivePeerDependencies:
       - '@typescript-eslint/types'
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,8 +100,8 @@ catalogs:
       specifier: ^3.9.1
       version: 3.9.1
     acorn:
-      specifier: ^8.16.0
-      version: 8.16.0
+      specifier: ^8.17.0
+      version: 8.17.0
     adm-zip:
       specifier: ^0.5.17
       version: 0.5.17
@@ -1048,7 +1048,7 @@ importers:
         version: 2.2.0
       '@sveltejs/acorn-typescript':
         specifier: catalog:default
-        version: 1.0.11(acorn@8.16.0)
+        version: 1.0.11(acorn@8.17.0)
       '@types/estree':
         specifier: catalog:default
         version: 1.0.8
@@ -1057,7 +1057,7 @@ importers:
         version: 1.0.5
       acorn:
         specifier: catalog:default
-        version: 8.16.0
+        version: 8.17.0
       esrap:
         specifier: ^2.3.0
         version: 2.3.0(@typescript-eslint/types@8.56.1)
@@ -4130,6 +4130,11 @@ packages:
 
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  acorn@8.17.0:
+    resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
@@ -9016,9 +9021,9 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
-  '@sveltejs/acorn-typescript@1.0.11(acorn@8.16.0)':
+  '@sveltejs/acorn-typescript@1.0.11(acorn@8.17.0)':
     dependencies:
-      acorn: 8.16.0
+      acorn: 8.17.0
 
   '@swc/helpers@0.5.15':
     dependencies:
@@ -9846,6 +9851,8 @@ snapshots:
       acorn: 8.16.0
 
   acorn@8.16.0: {}
+
+  acorn@8.17.0: {}
 
   adm-zip@0.5.16: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -93,7 +93,7 @@ catalogs:
     '@volar/typescript': ~2.4.28
     '@volar/vscode': ~2.4.28
     '@vscode/vsce': ^3.9.1
-    acorn: ^8.16.0
+    acorn: ^8.17.0
     adm-zip: ^0.5.17
     babel-preset-solid: '2.0.0-beta.15'
     clsx: ^2.1.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -70,7 +70,7 @@ catalogs:
     '@modelcontextprotocol/sdk': ^1.29.0
     '@noble/hashes': ^2.2.0
     '@rollup/pluginutils': ^5.3.0
-    '@sveltejs/acorn-typescript': ^1.0.10
+    '@sveltejs/acorn-typescript': ^1.0.11
     '@solidjs/web': '2.0.0-beta.15'
     '@tailwindcss/vite': ^4.1.12
     '@types/adm-zip': ^0.5.8

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,7 +24,7 @@ allowBuilds:
 prettier_common: &prettier_common ^3.8.4
 ts_common: &ts_common ^5.9.3
 ts_eslint_parser: &ts_eslint_parser ^8.56.1
-esrap_common: &esrap_common ^2.2.8
+esrap_common: &esrap_common ^2.3.0
 
 packages:
   - packages/*


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes sit on the core parse→transform→Volar mapping path and Prettier output; incorrect keyword or immutability behavior would break IDE types or runtime exports, though coverage is broad.
> 
> **Overview**
> **Volar / type-only compilation** now parses with `preserveParens` and lexer-collected `async`/`function` keyword tokens, prints via **esrap ^2.3.0** with `boundaryTokens`, and maps keywords from true source spans instead of fragile offset math. Printers preserve **`declare`** on ambient modules and **`type`** on export specifiers in the type view; Ripple’s client transform drops redundant parens around lowered JSX in `to_ts` and walks **parentheses** when deciding combined-expression positions.
> 
> **JSX transform pipeline** is refactored so pre-passes and helpers (**code-block expansion**, control-flow wrapping, loop keys, return prepends, `@{…}` lowering, etc.) return **shallow copies** instead of mutating the input program—the same AST instance is later walked as `sourceAst` for mapping collection, with new tests enforcing structural immutability. Plain-JS emit strips **optional/definite** markers on params and class members; HMR re-exports use a shared `export_specifier` builder.
> 
> **@tsrx/prettier-plugin** regresses fixes for stripping **`export type`**, inline **`export { type … }`**, and **`declare module`**, plus a **switch `@case`** consequent print path fix.
> 
> **Dependencies:** acorn **^8.17.0**, `@sveltejs/acorn-typescript` **^1.0.11**, esrap **^2.3.0** (lockfile/catalog).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 572522955913bda0875c528a7e82ab131f369e1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->