### PR TITLE
fix(tsrx): re-emit preserved leading comments in typeOnly output

### DIFF
--- a/.changeset/preserve-leading-ts-comments.md
+++ b/.changeset/preserve-leading-ts-comments.md
@@ -1,0 +1,5 @@
+---
+'@tsrx/core': patch
+---
+
+Re-emit preserved leading comments in typeOnly output: `@jsxImportSource`/`@jsxRuntime`/`@jsxFrag`/`@jsx` pragmas join the preserved-comment set, and the shared tsx printer now writes preserved comments that lead the program at the top of the virtual TSX. Previously comment stripping silently dropped them, retyping a file's JSX or re-enabling checking a leading `@ts-nocheck` had disabled.

--- a/packages/tsrx/src/comment-utils.js
+++ b/packages/tsrx/src/comment-utils.js
@@ -59,13 +59,28 @@ export function is_jsdoc_ts_annotation(comment) {
 }
 
 /**
+ * Check if a comment is a TypeScript JSX pragma (`@jsxImportSource`,
+ * `@jsxRuntime`, `@jsxFrag`, `@jsx`). TS reads these from a file's LEADING
+ * comments to pick that file's JSX type source/factory, overriding tsconfig —
+ * dropping one silently retypes every JSX expression in the file.
+ * @param {AST.CommentWithLocation} comment
+ * @returns {boolean}
+ */
+export function is_jsx_pragma(comment) {
+	return /@jsx(ImportSource|Runtime|Frag)?\b/.test(comment.value);
+}
+
+/**
  * Check if a comment should be preserved in to_ts mode
  * @param {AST.CommentWithLocation} comment
  * @returns {boolean}
  */
 export function should_preserve_comment(comment) {
 	return (
-		is_ts_pragma(comment) || is_triple_slash_directive(comment) || is_jsdoc_ts_annotation(comment)
+		is_ts_pragma(comment) ||
+		is_triple_slash_directive(comment) ||
+		is_jsdoc_ts_annotation(comment) ||
+		is_jsx_pragma(comment)
 	);
 }
 

--- a/packages/tsrx/src/transform/jsx/helpers.js
+++ b/packages/tsrx/src/transform/jsx/helpers.js
@@ -80,7 +80,10 @@ export function tsx_with_ts_locations(boundary_tokens = false, comments = undefi
 
 	const leading_preserved = (/** @type {any} */ program) => {
 		if (!comments?.length) return [];
-		const first = program.body?.[0];
+		// Injected statements (dynamic-import/try-import prepends) carry no
+		// loc; anchor "leading" on the first statement that maps to source,
+		// else every preserved comment in the file would hoist to the top.
+		const first = program.body?.find((/** @type {any} */ node) => node.loc);
 		return comments.filter(
 			(/** @type {any} */ comment) =>
 				should_preserve_comment(comment) &&

--- a/packages/tsrx/src/transform/jsx/helpers.js
+++ b/packages/tsrx/src/transform/jsx/helpers.js
@@ -2,6 +2,7 @@
 /** @import { Visitors } from 'zimmerframe' */
 
 import tsx from 'esrap/languages/tsx';
+import { should_preserve_comment, format_comment } from '../../comment-utils.js';
 
 /**
  * Zimmerframe provides `path` as the ancestor chain. A native template node in
@@ -68,9 +69,28 @@ export function set_node_path_metadata(node, path) {
  * (structural tokens carry one-character source locations). typeOnly/volar
  * prints opt in — their maps are consumed positionally by the language
  * tooling and never shipped; build prints stay sparse.
+ * @param {AST.CommentWithLocation[]} [comments] Source comments; the ones
+ * `should_preserve_comment` classifies as semantic-to-TS (`@ts-nocheck`,
+ * `@jsxImportSource`, triple-slash references, …) and that LEAD the program
+ * are re-emitted at the top of the printed output. The generated TSX is real
+ * TS input — dropping a leading pragma changes how the whole file checks.
  */
-export function tsx_with_ts_locations(boundary_tokens = false) {
+export function tsx_with_ts_locations(boundary_tokens = false, comments = undefined) {
 	const base = /** @type {any} */ (tsx({ boundaryTokens: boundary_tokens }));
+
+	const leading_preserved = (/** @type {any} */ program) => {
+		if (!comments?.length) return [];
+		const first = program.body?.[0];
+		return comments.filter(
+			(/** @type {any} */ comment) =>
+				should_preserve_comment(comment) &&
+				(first?.loc == null ||
+					(comment.loc &&
+						(comment.loc.end.line < first.loc.start.line ||
+							(comment.loc.end.line === first.loc.start.line &&
+								comment.loc.end.column <= first.loc.start.column)))),
+		);
+	};
 
 	/**
 	 * @param {any} node
@@ -89,6 +109,15 @@ export function tsx_with_ts_locations(boundary_tokens = false) {
 
 	/** @type {Record<string, (node: any, context: any) => void>} */
 	const wrappers = {
+		Program: (node, context) => {
+			for (const comment of leading_preserved(node)) {
+				if (comment.loc) context.location(comment.loc.start.line, comment.loc.start.column);
+				context.write(format_comment(comment));
+				if (comment.loc) context.location(comment.loc.end.line, comment.loc.end.column);
+				context.newline();
+			}
+			base.Program(node, context);
+		},
 		ArrayPattern: (node, context) => {
 			base.ArrayPattern(node, context);
 			if (node.typeAnnotation) {

--- a/packages/tsrx/src/transform/jsx/index.js
+++ b/packages/tsrx/src/transform/jsx/index.js
@@ -841,10 +841,20 @@ export function createJsxTransform(platform) {
 				: apply_lazy_transforms(/** @type {any} */ (lowered_program), new Map())
 		);
 
-		const result = print(final_program, tsx_with_ts_locations(transform_context.typeOnly), {
-			sourceMapSource: filename,
-			sourceMapContent: source,
-		});
+		const result = print(
+			final_program,
+			// typeOnly output is real TS input: re-emit preserved leading comments
+			// (@jsxImportSource / @ts-nocheck / triple-slash references) so TS
+			// semantics survive the comment-stripping print.
+			tsx_with_ts_locations(
+				transform_context.typeOnly,
+				transform_context.typeOnly ? transform_context.comments : undefined,
+			),
+			{
+				sourceMapSource: filename,
+				sourceMapContent: source,
+			},
+		);
 
 		const { css, cssHash } = render_css_result(/** @type {any} */ (stylesheets));
 

--- a/packages/tsrx/tests/shared/source-mappings.js
+++ b/packages/tsrx/tests/shared/source-mappings.js
@@ -233,6 +233,23 @@ function App() @{
 			expect(result.errors).toEqual([]);
 		});
 
+		// Synthetic prepends (e.g. the injected Dynamic import for `<{tag}>`)
+		// have no loc. The "leading" check must anchor on the first statement
+		// that maps back to source — otherwise every preservable comment hoists
+		// to the top, and a trailing @ts-nocheck would silence checking for the
+		// whole virtual file.
+		it('does not hoist non-leading pragmas past synthetic loc-less prepends', () => {
+			const source = `/** @jsxImportSource custom-source */
+function App({ tag }: { tag: string }) @{
+	<{tag} class="a">{'x'}</{tag}>
+}
+// @ts-nocheck`;
+			const result = compile_to_volar_mappings(source, 'App.tsrx', { loose: true });
+			expect(result.code).toContain('@jsxImportSource custom-source');
+			expect(result.code).not.toContain('@ts-nocheck');
+			expect(result.errors).toEqual([]);
+		});
+
 		// JSX: esrap prints `<`, `>`, `</`, ` /` without location markers.
 		// Combined with hoisting to module-level statics, the opening
 		// element's start/end positions wouldn't otherwise resolve.

--- a/packages/tsrx/tests/shared/source-mappings.js
+++ b/packages/tsrx/tests/shared/source-mappings.js
@@ -212,6 +212,27 @@ declare module 'some-module' {
 			expect(result.errors).toEqual([]);
 		});
 
+		// The typeOnly print strips comments, but comments that ARE TS semantics
+		// (a leading @jsxImportSource pragma retypes every JSX expression in the
+		// file; triple-slash references add libs; @ts-nocheck disables checking)
+		// must survive at the top of the virtual file.
+		it('re-emits preserved leading comments (jsx pragma, references, ts-nocheck)', () => {
+			const source = `/** @jsxImportSource custom-source */
+/// <reference types="node" />
+// @ts-nocheck
+function App() @{
+	<b>{'x'}</b>
+}`;
+			const result = compile_to_volar_mappings(source, 'App.tsrx', { loose: true });
+			expect(result.code).toContain('@jsxImportSource custom-source');
+			expect(result.code).toMatch(/\/\/\/\s+<reference types="node" \/>/);
+			expect(result.code).toContain('@ts-nocheck');
+			expect(result.code.indexOf('@jsxImportSource')).toBeLessThan(
+				result.code.indexOf('function App'),
+			);
+			expect(result.errors).toEqual([]);
+		});
+
 		// JSX: esrap prints `<`, `>`, `</`, ` /` without location markers.
 		// Combined with hoisting to module-level statics, the opening
 		// element's start/end positions wouldn't otherwise resolve.


### PR DESCRIPTION
The typeOnly print strips comments wholesale, but some comments ARE TS semantics: a leading /** @jsxImportSource */ pragma retypes every JSX expression in the file, triple-slash references add libs, and @ts-nocheck disables checking. Add JSX pragmas (@jsxImportSource/@jsxRuntime/@jsxFrag/ @jsx) to should_preserve_comment and teach the shared tsx printer to re-emit preserved comments that lead the program at the top of the printed output, with location markers so mappings stay coherent. The ripple platform printer already flushed preserved comments inline; this covers the shared JSX targets (react/preact/solid/vue and downstream octane).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to typeOnly/Volar printing and comment preservation; behavior change improves TS checking fidelity with tests guarding edge cases.
> 
> **Overview**
> **typeOnly** Volar/editor TSX used to strip all comments, so TypeScript lost semantics from leading pragmas (`@jsxImportSource`, `@ts-nocheck`, triple-slash references) and JSX could be checked against the wrong factory.
> 
> This change treats **JSX pragmas** (`@jsx`, `@jsxFrag`, `@jsxRuntime`, `@jsxImportSource`) as preserve-worthy via `is_jsx_pragma`, extends the shared **`tsx_with_ts_locations`** printer to re-emit preserved comments that **lead** the program (with source locations for mappings), and wires **`typeOnly`** JSX print to pass `transform_context.comments`. **Leading** is anchored on the first statement with `loc`, so loc-less synthetic prepends (e.g. dynamic `<{tag}>`) do not hoist a trailing `@ts-nocheck` to the top of the virtual file.
> 
> Tests cover re-emitted leading pragmas and the non-hoisting case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bc3996d4eb44cc38e3d0e848da69f50b9a50788. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->