### PR TITLE
fix(prettier-plugin): print type-predicate return types

### DIFF
--- a/.changeset/prettier-type-predicates.md
+++ b/.changeset/prettier-type-predicates.md
@@ -1,0 +1,5 @@
+---
+'@tsrx/prettier-plugin': patch
+---
+
+Print TypeScript type-predicate return types (`value is string`, `asserts x is T`, `asserts x`, `this is Element`). Previously `TSTypePredicate` had no printer case and formatted as `/* Unknown: TSTypePredicate */`, corrupting the file.

--- a/packages/prettier-plugin/src/index.js
+++ b/packages/prettier-plugin/src/index.js
@@ -2297,6 +2297,20 @@ function printRippleNode(node, path, options, print, args) {
 			break;
 		}
 
+		case 'TSTypePredicate': {
+			/** @type {Doc[]} */
+			const predicateParts = [];
+			if (node.asserts) predicateParts.push('asserts ');
+			predicateParts.push(
+				node.parameterName.type === 'TSThisType' ? 'this' : node.parameterName.name,
+			);
+			if (node.typeAnnotation) {
+				predicateParts.push(' is ', path.call(print, 'typeAnnotation'));
+			}
+			nodeContent = predicateParts;
+			break;
+		}
+
 		case 'TSTypeLiteral':
 			nodeContent = printTSTypeLiteral(node, path, options, print);
 			break;

--- a/packages/prettier-plugin/src/index.test.js
+++ b/packages/prettier-plugin/src/index.test.js
@@ -1522,6 +1522,26 @@ export { type Extra, realValue } from './mixed.js';`;
 
 		// Regressed in 0.3.97: `declare module 'name' { … }` lost its `declare`
 		// keyword, leaving invalid `module 'name' { … }` output.
+		// Regression: TSTypePredicate had no printer case, so predicate return
+		// types (`(v): v is string =>`, `asserts x is T`) printed as
+		// `/* Unknown: TSTypePredicate */`.
+		it('should print type predicate return types', async () => {
+			const input = `const isString = (value: unknown): value is string => typeof value === 'string';
+function assertUser(x: unknown): asserts x is User {}
+function isSelf(this: Node): this is Element {
+  return true;
+}
+function assertTruthy(x: unknown): asserts x {}`;
+			const expected = `const isString = (value: unknown): value is string => typeof value === 'string';
+function assertUser(x: unknown): asserts x is User {}
+function isSelf(this: Node): this is Element {
+  return true;
+}
+function assertTruthy(x: unknown): asserts x {}`;
+			const result = await format(input, { singleQuote: true });
+			expect(result).toBeWithNewline(expected);
+		});
+
 		it('should keep the declare keyword on ambient module declarations', async () => {
 			const input = `declare module 'some-module' {
   interface Thing {


### PR DESCRIPTION
TSTypePredicate had no printer case, so predicate returns ((v): v is string =>, asserts x is T, this is Element) formatted as /* Unknown: TSTypePredicate */ and corrupted the file.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized formatter change with regression tests; no runtime or security impact beyond correct output for predicate syntax.
> 
> **Overview**
> Fixes **Prettier formatting for TypeScript type predicates** in `@tsrx/prettier-plugin`. Return types such as `value is string`, `asserts x is User`, `asserts x`, and `this is Element` no longer emit `/* Unknown: TSTypePredicate */` and corrupt the source.
> 
> The Ripple AST printer now handles **`TSTypePredicate`**: optional `asserts`, the parameter (`this` or a name), and an optional ` is <type>` via the existing type printer. A regression test covers arrow predicates, assert signatures, `this` predicates, and bare `asserts x`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17f2a7360a32ee613c5c033a7d30f27c0a14e961. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->