### PR TITLE
feat(tsrx): type-only lowering for a platform server-module dialect

### DIFF
--- a/.changeset/server-module-type-lowering.md
+++ b/.changeset/server-module-type-lowering.md
@@ -1,0 +1,5 @@
+---
+'@tsrx/core': patch
+---
+
+Add an opt-in `platform.serverModule` descriptor to `createJsxTransform`: in typeOnly output, a platform's file-local `module <blockName> { … }` server-module dialect and its boundary `import { x } from '<importSpecifier>'` statements are lowered to plain checkable TS (block imports hoisted, the block lowered to a namespace keeping the authored name, boundary imports lowered to destructures / `type` aliases, colliding hoisted locals aliased through a mangled namespace import). Verbatim, the dialect can never typecheck (TS1147 in-block import, TS2307 boundary import). Platforms without the option, and all runtime/build output, are untouched. The namespace references derived from the authored `'server'` specifier map its inner span with hover/navigation but WITHOUT semantic tokens, so the specifier keeps its string syntax highlighting instead of being partially repainted as a namespace token.

--- a/packages/tsrx/src/source-map-utils.js
+++ b/packages/tsrx/src/source-map-utils.js
@@ -62,6 +62,24 @@ export const mapping_data_completion_only = {
 };
 
 /**
+ * Full language support minus editor repainting, for a generated IDENTIFIER
+ * whose SOURCE span sits inside a string literal (e.g. the namespace
+ * reference a server-module lowering derives from the authored `'server'`
+ * import specifier). Hover, go-to-def, references, and diagnostics resolve
+ * through the mapping — `semantic` stays truthy via the object form, which
+ * Volar's `isHoverEnabled` accepts — but semantic TOKENS are suppressed with
+ * `shouldHighlight: () => false` so the span keeps its authored TextMate
+ * (string) coloring instead of being repainted as a variable. Completion is
+ * off: identifier completions inside a string literal are never valid.
+ * @type {Partial<VolarCodeMapping['data']>}
+ */
+export const mapping_data_string_span = {
+	...mapping_data,
+	completion: false,
+	semantic: { shouldHighlight: () => false },
+};
+
+/**
  * Convert byte offset to line/column
  * @param {number} offset
  * @param {LineOffsets} line_offsets

--- a/packages/tsrx/src/transform/jsx/index.js
+++ b/packages/tsrx/src/transform/jsx/index.js
@@ -60,6 +60,7 @@ import {
 	capture_jsx_child as captureJsxChild,
 } from '../jsx-interleave.js';
 import { is_hoist_safe_jsx_node } from '../jsx-hoist.js';
+import { lower_server_module_for_types } from './server-module.js';
 
 const TEMPLATE_FRAGMENT_ERROR =
 	'JSX fragment syntax is not needed in TSRX templates. TSRX renders in immediate mode, so everything is already a fragment. Use `<>...</>` only in expression position.';
@@ -630,6 +631,19 @@ export function createJsxTransform(platform) {
 			// needs_show / needs_for flags) via `hooks.initialState`.
 			...(platform.hooks?.initialState?.() ?? {}),
 		};
+
+		// Opt-in server-module dialect (`module <name> { … }` plus its boundary
+		// `import … from '<specifier>'`): lower to plain checkable TS before any
+		// other pass sees the program. TYPE-ONLY output only — the runtime/build
+		// emit never reaches this branch, because the platform's own compiler
+		// owns the dialect's real codegen (isolation validation, RPC stubs).
+		// Copy-on-write: a program without a server block passes through as the
+		// same object.
+		if (transform_context.typeOnly && platform.serverModule) {
+			ast = /** @type {any} */ (
+				lower_server_module_for_types(/** @type {any} */ (ast), platform.serverModule)
+			);
+		}
 
 		ast = expand_child_code_blocks(/** @type {any} */ (ast));
 		ast = wrap_control_flow_expression_values(/** @type {any} */ (ast), transform_context);

--- a/packages/tsrx/src/transform/jsx/server-module.js
+++ b/packages/tsrx/src/transform/jsx/server-module.js
@@ -22,11 +22,11 @@
  *     import { db } from './db.ts';      namespace server {
  *     export function f() { … }     →      export function f() { … }
  *   }                                    }
- *   import { f } from 'server';          const { f } = server;
+ *   import { f } from 'server';          import f = server.f;
  *
  * The lowered namespace keeps the AUTHORED name and identifier location, so
- * hovering the block's name resolves, and the destructure's namespace
- * reference marks the namespace as used (a server block nobody imports from
+ * hovering the block's name resolves, and the aliases' namespace
+ * references mark the namespace as used (a server block nobody imports from
  * is the ONE case `noUnusedLocals` still flags — on the authored name, which
  * is the correct signal). A `declare module '<specifier>'` bridge (which
  * would have let the authored import statement survive verbatim) is NOT
@@ -34,14 +34,17 @@
  * a module AUGMENTATION — TS2664 when no module 'server' exists, and TS2666
  * for the `export =` even when a global stub supplies one; augmentations
  * also merge program-wide, which would break the dialect's file-local
- * semantics. The destructure keeps the import's specifier locations, so
+ * semantics. Each lowered alias keeps the import's specifier locations, so
  * hover/rename on the imported names and on the `'<specifier>'` source
  * still resolve.
  *
  * Block imports hoist to module top level (namespaces close over module
  * scope, so the body still resolves them — `noUnusedLocals` counts those
- * uses), and each boundary import becomes a destructure of the namespace
- * value (type-only specifiers become `type x = server.x` aliases). When a
+ * uses), and each boundary import becomes `import x = server.x` aliases
+ * that keep every meaning of the export — an authored named import binds
+ * value AND type, so a class or enum stays usable as a type (type-only
+ * specifiers become `type x = server.x` aliases; a string-named import
+ * falls back to a value-only destructure). When a
  * hoisted import's local name is also used anywhere in the client module
  * (the compiler's isolation rule stops the server block from referencing
  * client bindings, but nothing stops both sides from importing — or
@@ -461,13 +464,16 @@ function lower_declaration(declaration, outside_names, block_name) {
 
 /**
  * Rewrite one `import { x, type T } from '<specifier>'` statement into
- * bindings on the lowered namespace. Value specifiers become one
- * `const { x } = <ns>;` destructure; type-only specifiers become
- * `type T = <ns>.T;` aliases. A specifier-less boundary import binds
- * nothing and is dropped (the runtime compiler accepts and elides it),
- * while non-named specifiers (default / namespace imports) are a hard
- * compile error in the dialect — those statements stay verbatim so the
- * editor's TS2307 mirrors the build error.
+ * bindings on the lowered namespace. Value specifiers become
+ * `import x = <ns>.x;` aliases — the authored import carries EVERY
+ * meaning of the export, so a `const { x } = <ns>;` destructure would
+ * strip the type meaning of a class or enum. Type-only specifiers become
+ * `type T = <ns>.T;` aliases; a string-named import (which no entity name
+ * can express) falls back to a value-only destructure. A specifier-less
+ * boundary import binds nothing and is dropped (the runtime compiler
+ * accepts and elides it), while non-named specifiers (default / namespace
+ * imports) are a hard compile error in the dialect — those statements
+ * stay verbatim so the editor's TS2307 mirrors the build error.
  *
  * @param {any} statement
  * @param {string} block_name
@@ -478,26 +484,26 @@ function lower_server_import(statement, block_name) {
 	if (specifiers.some((/** @type {any} */ s) => s.type !== 'ImportSpecifier')) {
 		return [statement];
 	}
-	const type_specifiers = [];
-	const value_specifiers = [];
-	for (const specifier of specifiers) {
-		if (statement.importKind === 'type' || specifier.importKind === 'type') {
-			type_specifiers.push(specifier);
-		} else {
-			value_specifiers.push(specifier);
-		}
-	}
 
 	// Each reference to the namespace carries the authored import source's
 	// inner span, so hover / go-to-def on the module name resolves to the
 	// lowered block while the literal keeps its string coloring.
 	const namespace_ref = () => string_span_namespace_ref(block_name, statement.source);
 	const lowered = [];
-	if (value_specifiers.length > 0) {
-		lowered.push(build_destructure(value_specifiers, namespace_ref, statement));
+	const destructured_specifiers = [];
+	for (const specifier of specifiers) {
+		if (statement.importKind === 'type' || specifier.importKind === 'type') {
+			lowered.push(build_type_alias(specifier, namespace_ref));
+		} else if (specifier.imported?.type === 'Identifier') {
+			lowered.push(
+				build_import_equals(specifier, qualified_name(namespace_ref(), { ...specifier.imported })),
+			);
+		} else {
+			destructured_specifiers.push(specifier);
+		}
 	}
-	for (const specifier of type_specifiers) {
-		lowered.push(build_type_alias(specifier, namespace_ref));
+	if (destructured_specifiers.length > 0) {
+		lowered.push(build_destructure(destructured_specifiers, namespace_ref, statement));
 	}
 	return lowered;
 }

--- a/packages/tsrx/src/transform/jsx/server-module.js
+++ b/packages/tsrx/src/transform/jsx/server-module.js
@@ -46,14 +46,24 @@
  * (the compiler's isolation rule stops the server block from referencing
  * client bindings, but nothing stops both sides from importing — or
  * referencing a global named — `db`), hoisting it verbatim would collide or
- * shadow. Those imports hoist as a mangled namespace import instead and are
- * re-bound inside the namespace: `const { db } = __tsrx_server_import$0;`
- * for value specifiers and `type T = __tsrx_server_import$0.T;` for
- * type-only ones. (An `import db = …` alias would preserve dual
- * value+type meanings, but the mapping walker rejects
- * TSImportEqualsDeclaration; a colliding CLASS import therefore keeps
- * only its value meaning — an acceptable corner, since a collision
- * already requires the client half to use the same name.)
+ * shadow. Those imports hoist as a mangled namespace import instead —
+ * always a VALUE import keeping the authored `with { … }` attributes,
+ * because an import-equals alias cannot reference a type-only import
+ * (TS1380) — and each original binding is rebuilt inside the namespace:
+ * `import db = __tsrx_server_import$0.db;` for value specifiers (the one
+ * alias form that keeps EVERY meaning, so a colliding class import stays
+ * usable as a type) and `type T = __tsrx_server_import$0.T;` for type-only
+ * ones. Three corners cannot use import-equals: a string-named import
+ * (`'x y' as db`) keeps a value-only destructure (a string can never
+ * appear in an entity name); a value DEFAULT import hoists an extra
+ * mangled DEFAULT specifier rebound with `const` (no entity name reaches
+ * a default — `import db = ns.default` is TS1359 and the default binding
+ * itself has no namespace meaning — so a colliding default CLASS import
+ * keeps only its value meaning, while a type-only default becomes
+ * `type x = ns.default`); and a type-only NAMESPACE import rebinds as a
+ * plain import-equals, which adds a value meaning the authored form
+ * lacked. Each is an acceptable corner — a collision already requires the
+ * client half to use the same name.
  *
  * The rewrite is copy-on-write: every replacement node is built with
  * spreads/builders and carries the ORIGINAL node's start/end/loc wherever it
@@ -244,23 +254,37 @@ function build_destructure(specifiers, make_init, loc_node) {
 }
 
 /**
- * `type <local> = <left>.<imported>;` for a type-only import specifier.
+ * `<left>.<right>` qualified name. Callers pass a `right` that carries the
+ * authored specifier span, so hover / rename on the imported name resolve.
+ *
+ * @param {AST.Identifier} left
+ * @param {any} right
+ */
+function qualified_name(left, right) {
+	return {
+		type: 'TSQualifiedName',
+		left,
+		right,
+		metadata: { path: [] },
+	};
+}
+
+/**
+ * `type <local> = <left>.<right>;` for a type-only import specifier.
+ * `right` defaults to the specifier's imported name; a DEFAULT import
+ * passes `default` (which has no authored span of its own).
  *
  * @param {any} specifier
  * @param {() => AST.Identifier} make_left
+ * @param {any} [right]
  */
-function build_type_alias(specifier, make_left) {
+function build_type_alias(specifier, make_left, right = { ...specifier.imported }) {
 	return with_location(
 		b.ts_type_alias(
 			{ ...specifier.local },
 			/** @type {any} */ ({
 				type: 'TSTypeReference',
-				typeName: {
-					type: 'TSQualifiedName',
-					left: make_left(),
-					right: { ...specifier.imported },
-					metadata: { path: [] },
-				},
+				typeName: qualified_name(make_left(), right),
 				metadata: { path: [] },
 			}),
 		),
@@ -269,58 +293,116 @@ function build_type_alias(specifier, make_left) {
 }
 
 /**
+ * `import <local> = <reference>;` — an import-equals alias, the one form
+ * that preserves every meaning (value, type, namespace) of the referenced
+ * binding, where a `const` keeps only the value and a `type` alias only
+ * the type.
+ *
+ * @param {any} specifier
+ * @param {any} module_reference
+ */
+function build_import_equals(specifier, module_reference) {
+	return with_location(
+		/** @type {any} */ ({
+			type: 'TSImportEqualsDeclaration',
+			id: { ...specifier.local },
+			moduleReference: module_reference,
+			importKind: 'value',
+			metadata: { path: [] },
+		}),
+		specifier,
+	);
+}
+
+/**
  * Lower one block import whose local name(s) collide with outside code:
- * hoist as a mangled namespace import and rebuild each original binding
- * inside the namespace body. Value specifiers destructure the namespace
- * object; type-only specifiers become `type` aliases; default imports
- * bind `<ns>.default`; a namespace specifier rebinds the whole object.
+ * hoist under mangled names as a VALUE import (an import-equals alias
+ * cannot reference a type-only import — TS1380) and rebuild each original
+ * binding inside the namespace body. Named value specifiers and namespace
+ * specifiers become `import x = …` aliases keeping every meaning of the
+ * mangled namespace specifier; type-only specifiers become `type` aliases
+ * (`<ns>.default` for a type-only default); string-named imports
+ * destructure the namespace object (a string cannot appear in an entity
+ * name). A value DEFAULT import has no entity-name path at all
+ * (`import x = <ns>.default` is TS1359, and a default-import binding has
+ * no namespace meaning), so it hoists an extra mangled DEFAULT specifier
+ * and rebinds it with `const` — exact default-import semantics, which
+ * `<ns>.default` is not (a JSON module's namespace has no `default`
+ * member under bundler resolution).
  *
  * @param {any} statement
  * @param {string} hoisted_name
  */
 function lower_colliding_import(statement, hoisted_name) {
+	const default_name = hoisted_name + '_default';
+	const aliases = [];
+	const destructured_specifiers = [];
+	let needs_default_hoist = false;
+	let needs_namespace_hoist = false;
+	for (const specifier of statement.specifiers) {
+		const type_only = statement.importKind === 'type' || specifier.importKind === 'type';
+		if (specifier.type === 'ImportNamespaceSpecifier') {
+			needs_namespace_hoist = true;
+			aliases.push(build_import_equals(specifier, b.id(hoisted_name)));
+		} else if (specifier.type === 'ImportDefaultSpecifier') {
+			if (type_only) {
+				needs_namespace_hoist = true;
+				aliases.push(build_type_alias(specifier, () => b.id(hoisted_name), b.id('default')));
+			} else {
+				needs_default_hoist = true;
+				const declarator = with_location(
+					b.declarator({ ...specifier.local }, b.id(default_name)),
+					specifier,
+				);
+				aliases.push(with_location(b.declaration('const', [declarator]), specifier));
+			}
+		} else if (type_only) {
+			needs_namespace_hoist = true;
+			aliases.push(build_type_alias(specifier, () => b.id(hoisted_name)));
+		} else if (specifier.imported?.type === 'Identifier') {
+			needs_namespace_hoist = true;
+			aliases.push(
+				build_import_equals(
+					specifier,
+					qualified_name(b.id(hoisted_name), { ...specifier.imported }),
+				),
+			);
+		} else {
+			needs_namespace_hoist = true;
+			destructured_specifiers.push(specifier);
+		}
+	}
+	if (destructured_specifiers.length > 0) {
+		aliases.push(build_destructure(destructured_specifiers, () => b.id(hoisted_name), statement));
+	}
+
+	// Only the specifiers the aliases reference — an unreferenced mangled
+	// specifier would draw a spurious `noUnusedLocals` diagnostic.
+	const hoist_specifiers = [];
+	if (needs_default_hoist) {
+		hoist_specifiers.push({
+			type: 'ImportDefaultSpecifier',
+			local: b.id(default_name),
+			metadata: { path: [] },
+		});
+	}
+	if (needs_namespace_hoist) {
+		hoist_specifiers.push({
+			type: 'ImportNamespaceSpecifier',
+			local: b.id(hoisted_name),
+			metadata: { path: [] },
+		});
+	}
 	const hoisted = with_location(
 		{
 			type: 'ImportDeclaration',
-			specifiers: [
-				{
-					type: 'ImportNamespaceSpecifier',
-					local: b.id(hoisted_name),
-					metadata: { path: [] },
-				},
-			],
+			specifiers: hoist_specifiers,
 			source: with_location({ ...statement.source }, statement.source),
-			importKind: statement.importKind,
+			importKind: 'value',
+			attributes: statement.attributes,
 		},
 		statement,
 	);
-
-	const aliases = [];
-	const value_specifiers = [];
-	for (const specifier of statement.specifiers) {
-		const type_only = statement.importKind === 'type' || specifier.importKind === 'type';
-		if (
-			specifier.type === 'ImportNamespaceSpecifier' ||
-			specifier.type === 'ImportDefaultSpecifier'
-		) {
-			const is_default = specifier.type === 'ImportDefaultSpecifier';
-			const declarator = with_location(
-				b.declarator(
-					{ ...specifier.local },
-					is_default ? b.member(b.id(hoisted_name), 'default') : b.id(hoisted_name),
-				),
-				specifier,
-			);
-			aliases.push(with_location(b.declaration('const', [declarator]), specifier));
-		} else if (type_only) {
-			aliases.push(build_type_alias(specifier, () => b.id(hoisted_name)));
-		} else {
-			value_specifiers.push(specifier);
-		}
-	}
-	if (value_specifiers.length > 0) {
-		aliases.push(build_destructure(value_specifiers, () => b.id(hoisted_name), statement));
-	}
 	return { hoisted, aliases };
 }
 

--- a/packages/tsrx/src/transform/jsx/server-module.js
+++ b/packages/tsrx/src/transform/jsx/server-module.js
@@ -57,8 +57,10 @@
  * alias form that keeps EVERY meaning, so a colliding class import stays
  * usable as a type) and `type T = __tsrx_server_import$0.T;` for type-only
  * ones. Three corners cannot use import-equals: a string-named import
- * (`'x y' as db`) keeps a value-only destructure (a string can never
- * appear in an entity name); a value DEFAULT import hoists an extra
+ * (`'x y' as db`) keeps a value-only destructure even when type-only — a
+ * string can never appear in an entity name OR a qualified type
+ * reference, so the destructure is the one parseable fallback; a value
+ * DEFAULT import hoists an extra
  * mangled DEFAULT specifier rebound with `const` (no entity name reaches
  * a default — `import db = ns.default` is TS1359 and the default binding
  * itself has no namespace meaning — so a colliding default CLASS import
@@ -324,9 +326,9 @@ function build_import_equals(specifier, module_reference) {
  * binding inside the namespace body. Named value specifiers and namespace
  * specifiers become `import x = …` aliases keeping every meaning of the
  * mangled namespace specifier; type-only specifiers become `type` aliases
- * (`<ns>.default` for a type-only default); string-named imports
- * destructure the namespace object (a string cannot appear in an entity
- * name). A value DEFAULT import has no entity-name path at all
+ * (`<ns>.default` for a type-only default); string-named imports — even
+ * type-only ones — destructure the namespace object (a string cannot
+ * appear in an entity name or qualified type reference). A value DEFAULT import has no entity-name path at all
  * (`import x = <ns>.default` is TS1359, and a default-import binding has
  * no namespace meaning), so it hoists an extra mangled DEFAULT specifier
  * and rebinds it with `const` — exact default-import semantics, which
@@ -359,10 +361,17 @@ function lower_colliding_import(statement, hoisted_name) {
 				);
 				aliases.push(with_location(b.declaration('const', [declarator]), specifier));
 			}
+		} else if (specifier.imported?.type !== 'Identifier') {
+			// String-named — neither an entity name nor a qualified type
+			// reference can hold a string, so type-only ones land here too:
+			// the destructure is the one PARSEABLE fallback, at the cost of
+			// binding only a value.
+			needs_namespace_hoist = true;
+			destructured_specifiers.push(specifier);
 		} else if (type_only) {
 			needs_namespace_hoist = true;
 			aliases.push(build_type_alias(specifier, () => b.id(hoisted_name)));
-		} else if (specifier.imported?.type === 'Identifier') {
+		} else {
 			needs_namespace_hoist = true;
 			aliases.push(
 				build_import_equals(
@@ -370,9 +379,6 @@ function lower_colliding_import(statement, hoisted_name) {
 					qualified_name(b.id(hoisted_name), { ...specifier.imported }),
 				),
 			);
-		} else {
-			needs_namespace_hoist = true;
-			destructured_specifiers.push(specifier);
 		}
 	}
 	if (destructured_specifiers.length > 0) {
@@ -468,8 +474,9 @@ function lower_declaration(declaration, outside_names, block_name) {
  * `import x = <ns>.x;` aliases — the authored import carries EVERY
  * meaning of the export, so a `const { x } = <ns>;` destructure would
  * strip the type meaning of a class or enum. Type-only specifiers become
- * `type T = <ns>.T;` aliases; a string-named import (which no entity name
- * can express) falls back to a value-only destructure. A specifier-less
+ * `type T = <ns>.T;` aliases; a string-named import — even a type-only
+ * one, since neither an entity name nor a qualified type reference can
+ * express it — falls back to a value-only destructure. A specifier-less
  * boundary import binds nothing and is dropped (the runtime compiler
  * accepts and elides it), while non-named specifiers (default / namespace
  * imports) are a hard compile error in the dialect — those statements
@@ -492,14 +499,16 @@ function lower_server_import(statement, block_name) {
 	const lowered = [];
 	const destructured_specifiers = [];
 	for (const specifier of specifiers) {
-		if (statement.importKind === 'type' || specifier.importKind === 'type') {
+		if (specifier.imported?.type !== 'Identifier') {
+			// String-named — inexpressible in an entity name or qualified type
+			// reference alike, so type-only ones fall back here too.
+			destructured_specifiers.push(specifier);
+		} else if (statement.importKind === 'type' || specifier.importKind === 'type') {
 			lowered.push(build_type_alias(specifier, namespace_ref));
-		} else if (specifier.imported?.type === 'Identifier') {
+		} else {
 			lowered.push(
 				build_import_equals(specifier, qualified_name(namespace_ref(), { ...specifier.imported })),
 			);
-		} else {
-			destructured_specifiers.push(specifier);
 		}
 	}
 	if (destructured_specifiers.length > 0) {

--- a/packages/tsrx/src/transform/jsx/server-module.js
+++ b/packages/tsrx/src/transform/jsx/server-module.js
@@ -1,0 +1,462 @@
+/** @import * as AST from 'estree' */
+/** @import { JsxPlatform } from '@tsrx/core/types' */
+
+/**
+ * Type-only lowering of a platform's `module <name> { … }` server-module
+ * dialect (opt-in via `platform.serverModule`).
+ *
+ * The platform's runtime compiler owns the real semantics of a server
+ * block: it validates isolation, emits the server namespace for SSR, and
+ * replaces `import { fn } from '<specifier>'` with RPC stubs for the
+ * browser. The type-only path never runs that codegen — it prints the
+ * parsed AST as virtual TSX, which used to render the block verbatim.
+ * Verbatim `module server { import … }` can NEVER typecheck: a static
+ * import inside a namespace body is TS1147, and the companion
+ * `import { fn } from 'server'` is TS2307 (no such module). So the dialect
+ * was un-typecheckable in editors.
+ *
+ * This module rewrites the PARSED ast (before the type-only transform
+ * prints it) into plain, checkable TypeScript with identical types:
+ *
+ *   module server {                      import { db } from './db.ts';
+ *     import { db } from './db.ts';      namespace server {
+ *     export function f() { … }     →      export function f() { … }
+ *   }                                    }
+ *   import { f } from 'server';          const { f } = server;
+ *
+ * The lowered namespace keeps the AUTHORED name and identifier location, so
+ * hovering the block's name resolves, and the destructure's namespace
+ * reference marks the namespace as used (a server block nobody imports from
+ * is the ONE case `noUnusedLocals` still flags — on the authored name, which
+ * is the correct signal). A `declare module '<specifier>'` bridge (which
+ * would have let the authored import statement survive verbatim) is NOT
+ * possible: the virtual TSX is a module, where `declare module 'server'` is
+ * a module AUGMENTATION — TS2664 when no module 'server' exists, and TS2666
+ * for the `export =` even when a global stub supplies one; augmentations
+ * also merge program-wide, which would break the dialect's file-local
+ * semantics. The destructure keeps the import's specifier locations, so
+ * hover/rename on the imported names and on the `'<specifier>'` source
+ * still resolve.
+ *
+ * Block imports hoist to module top level (namespaces close over module
+ * scope, so the body still resolves them — `noUnusedLocals` counts those
+ * uses), and each boundary import becomes a destructure of the namespace
+ * value (type-only specifiers become `type x = server.x` aliases). When a
+ * hoisted import's local name is also used anywhere in the client module
+ * (the compiler's isolation rule stops the server block from referencing
+ * client bindings, but nothing stops both sides from importing — or
+ * referencing a global named — `db`), hoisting it verbatim would collide or
+ * shadow. Those imports hoist as a mangled namespace import instead and are
+ * re-bound inside the namespace: `const { db } = __tsrx_server_import$0;`
+ * for value specifiers and `type T = __tsrx_server_import$0.T;` for
+ * type-only ones. (An `import db = …` alias would preserve dual
+ * value+type meanings, but the mapping walker rejects
+ * TSImportEqualsDeclaration; a colliding CLASS import therefore keeps
+ * only its value meaning — an acceptable corner, since a collision
+ * already requires the client half to use the same name.)
+ *
+ * The rewrite is copy-on-write: every replacement node is built with
+ * spreads/builders and carries the ORIGINAL node's start/end/loc wherever it
+ * corresponds to authored code, so the transform's esrap print emits real
+ * source-mapped segments and hover / go-to-def / diagnostics keep mapping
+ * back to the source. The original parse is never mutated.
+ */
+
+import * as b from '../../utils/builders.js';
+
+const HOISTED_IMPORT_PREFIX = '__tsrx_server_import$';
+
+/** Object keys that never contain child AST nodes. */
+const WALK_SKIP_KEYS = new Set([
+	'loc',
+	'start',
+	'end',
+	'range',
+	'parent',
+	'metadata',
+	'leadingComments',
+	'trailingComments',
+	'comments',
+]);
+
+/**
+ * A non-ambient `TSModuleDeclaration` authored with the `module` keyword,
+ * narrowed to the one name the platform's dialect supports. Blocks with any
+ * other name are a hard compile error in the runtime compiler, so leaving
+ * them verbatim (where TS flags them) mirrors the build failure instead of
+ * hiding it.
+ *
+ * @param {any} node
+ * @param {string} block_name
+ */
+function is_server_module_declaration(node, block_name) {
+	return (
+		node?.type === 'TSModuleDeclaration' &&
+		node.declare !== true &&
+		node.metadata?.module_keyword === 'module' &&
+		identifier_name(node.id) === block_name
+	);
+}
+
+/**
+ * @param {any} node
+ * @returns {string | null}
+ */
+function identifier_name(node) {
+	if (node?.type === 'Identifier') return node.name;
+	if (node?.type === 'Literal' && typeof node.value === 'string') return node.value;
+	return null;
+}
+
+/**
+ * @param {any} node
+ * @param {string} import_specifier
+ */
+function is_server_import(node, import_specifier) {
+	return node?.type === 'ImportDeclaration' && node.source?.value === import_specifier;
+}
+
+/**
+ * Copy `node`'s authored location onto a replacement node.
+ * @param {any} node
+ * @param {any} source
+ * @returns {any}
+ */
+function with_location(node, source) {
+	if (source?.start != null) node.start = source.start;
+	if (source?.end != null) node.end = source.end;
+	if (source?.loc != null) node.loc = source.loc;
+	node.metadata ??= { path: [] };
+	return node;
+}
+
+/**
+ * A namespace reference standing in for an authored STRING-LITERAL span (the
+ * `'server'` import source, or a string-named block id). It carries the
+ * literal's INNER span — the text between the quotes — so the mapping is
+ * exactly identifier-shaped, plus the `string_literal_source_span` metadata
+ * flag the mapping collector turns into hover/navigation WITHOUT semantic
+ * tokens: repainting part of an authored string literal as a namespace
+ * token breaks the editor's string coloring (the quotes stay outside the
+ * mapping for the same reason).
+ *
+ * @param {string} name
+ * @param {any} literal
+ * @returns {AST.Identifier}
+ */
+function string_span_namespace_ref(name, literal) {
+	const node = b.id(name);
+	node.metadata.string_literal_source_span = true;
+	if (
+		typeof literal?.start === 'number' &&
+		typeof literal?.end === 'number' &&
+		literal.end - literal.start >= name.length + 2
+	) {
+		node.start = literal.start + 1;
+		node.end = literal.end - 1;
+	}
+	if (literal?.loc != null) {
+		// Fresh position objects: the authored literal's own loc must survive
+		// the transform untouched (copy-on-write), and a module specifier is
+		// always single-line, so shifting columns inside it is safe.
+		node.loc = {
+			start: { line: literal.loc.start.line, column: literal.loc.start.column + 1 },
+			end: { line: literal.loc.end.line, column: literal.loc.end.column - 1 },
+		};
+	}
+	return node;
+}
+
+/**
+ * Every identifier name that appears OUTSIDE the server block. This
+ * deliberately over-approximates "top-level client bindings": a hoisted
+ * server import may not only collide with a client import of the same name
+ * (a TS2300 duplicate we would introduce) but also shadow a GLOBAL the
+ * client code references (e.g. a server-side `import { crypto } from …`
+ * changing what client `crypto` resolves to). Treating any outside use of
+ * the name as a conflict costs nothing but an alias, and keeps the lowering
+ * from ever changing what the client half of the file typechecks against.
+ *
+ * @param {any} ast
+ * @param {any} declaration
+ * @returns {Set<string>}
+ */
+function collect_outside_identifier_names(ast, declaration) {
+	/** @type {Set<string>} */
+	const names = new Set();
+	const seen = new WeakSet();
+	/** @param {any} node */
+	function walk(node) {
+		if (node === null || typeof node !== 'object' || seen.has(node) || node === declaration) {
+			return;
+		}
+		seen.add(node);
+		if (Array.isArray(node)) {
+			for (const child of node) walk(child);
+			return;
+		}
+		if (typeof node.type !== 'string') return;
+		if (node.type === 'Identifier' || node.type === 'JSXIdentifier') {
+			names.add(node.name);
+		}
+		for (const [key, value] of Object.entries(node)) {
+			if (WALK_SKIP_KEYS.has(key)) continue;
+			if (value !== null && typeof value === 'object') walk(value);
+		}
+	}
+	walk(ast);
+	return names;
+}
+
+/**
+ * `const { a, b: c } = <init>;` rebinding each specifier's imported
+ * name to its local name. Property nodes keep the authored specifier
+ * locations so hover / rename still target the source. `make_init`
+ * builds a fresh init expression per call (nodes are never shared).
+ *
+ * @param {any[]} specifiers
+ * @param {() => AST.Expression} make_init
+ * @param {any} loc_node
+ */
+function build_destructure(specifiers, make_init, loc_node) {
+	const pattern = with_location(
+		b.object_pattern(
+			/** @type {any} */ (
+				specifiers.map((specifier) =>
+					with_location(
+						b.prop(
+							'init',
+							{ ...specifier.imported },
+							{ ...specifier.local },
+							false,
+							specifier.imported?.type === 'Identifier' &&
+								specifier.imported.name === specifier.local?.name,
+						),
+						specifier,
+					),
+				)
+			),
+		),
+		loc_node,
+	);
+	const declarator = with_location(b.declarator(pattern, make_init()), loc_node);
+	return with_location(b.declaration('const', [declarator]), loc_node);
+}
+
+/**
+ * `type <local> = <left>.<imported>;` for a type-only import specifier.
+ *
+ * @param {any} specifier
+ * @param {() => AST.Identifier} make_left
+ */
+function build_type_alias(specifier, make_left) {
+	return with_location(
+		b.ts_type_alias(
+			{ ...specifier.local },
+			/** @type {any} */ ({
+				type: 'TSTypeReference',
+				typeName: {
+					type: 'TSQualifiedName',
+					left: make_left(),
+					right: { ...specifier.imported },
+					metadata: { path: [] },
+				},
+				metadata: { path: [] },
+			}),
+		),
+		specifier,
+	);
+}
+
+/**
+ * Lower one block import whose local name(s) collide with outside code:
+ * hoist as a mangled namespace import and rebuild each original binding
+ * inside the namespace body. Value specifiers destructure the namespace
+ * object; type-only specifiers become `type` aliases; default imports
+ * bind `<ns>.default`; a namespace specifier rebinds the whole object.
+ *
+ * @param {any} statement
+ * @param {string} hoisted_name
+ */
+function lower_colliding_import(statement, hoisted_name) {
+	const hoisted = with_location(
+		{
+			type: 'ImportDeclaration',
+			specifiers: [
+				{
+					type: 'ImportNamespaceSpecifier',
+					local: b.id(hoisted_name),
+					metadata: { path: [] },
+				},
+			],
+			source: with_location({ ...statement.source }, statement.source),
+			importKind: statement.importKind,
+		},
+		statement,
+	);
+
+	const aliases = [];
+	const value_specifiers = [];
+	for (const specifier of statement.specifiers) {
+		const type_only = statement.importKind === 'type' || specifier.importKind === 'type';
+		if (
+			specifier.type === 'ImportNamespaceSpecifier' ||
+			specifier.type === 'ImportDefaultSpecifier'
+		) {
+			const is_default = specifier.type === 'ImportDefaultSpecifier';
+			const declarator = with_location(
+				b.declarator(
+					{ ...specifier.local },
+					is_default ? b.member(b.id(hoisted_name), 'default') : b.id(hoisted_name),
+				),
+				specifier,
+			);
+			aliases.push(with_location(b.declaration('const', [declarator]), specifier));
+		} else if (type_only) {
+			aliases.push(build_type_alias(specifier, () => b.id(hoisted_name)));
+		} else {
+			value_specifiers.push(specifier);
+		}
+	}
+	if (value_specifiers.length > 0) {
+		aliases.push(build_destructure(value_specifiers, () => b.id(hoisted_name), statement));
+	}
+	return { hoisted, aliases };
+}
+
+/**
+ * Replace the server block with hoisted imports plus a namespace-valued
+ * binding the checker can see through.
+ *
+ * @param {any} declaration
+ * @param {Set<string>} outside_names
+ * @param {string} block_name
+ */
+function lower_declaration(declaration, outside_names, block_name) {
+	const hoisted_imports = [];
+	const aliases = [];
+	const rest = [];
+	let hoisted_index = 0;
+
+	for (const statement of declaration.body?.body ?? []) {
+		if (statement.type !== 'ImportDeclaration') {
+			rest.push(statement);
+			continue;
+		}
+		const collides = (statement.specifiers ?? []).some((/** @type {any} */ specifier) =>
+			outside_names.has(specifier.local?.name),
+		);
+		if (!collides) {
+			// Authored node, hoisted as-is — its locations map 1:1.
+			hoisted_imports.push(statement);
+			continue;
+		}
+		const lowered = lower_colliding_import(statement, HOISTED_IMPORT_PREFIX + hoisted_index++);
+		hoisted_imports.push(lowered.hoisted);
+		aliases.push(...lowered.aliases);
+	}
+
+	// The lowered namespace deliberately keeps the authored block name: the
+	// authored `module <name>` id already claims that name in the file (the
+	// runtime compiler declares it as a module binding), so reusing it cannot
+	// introduce a new collision, and it is what makes hover on the block's
+	// name — and on the boundary import's source, whose span the destructure's
+	// init identifier carries — resolve to the block. The id is always an
+	// Identifier (the authored id could be a string Literal, whose span then
+	// gets the same string-literal mapping treatment as the import source).
+	const id =
+		declaration.id?.type === 'Literal'
+			? string_span_namespace_ref(block_name, declaration.id)
+			: with_location(b.id(block_name), declaration.id);
+	const namespace = {
+		...declaration,
+		id,
+		metadata: { ...declaration.metadata, module_keyword: 'namespace' },
+		body: { ...declaration.body, body: [...aliases, ...rest] },
+	};
+	return [...hoisted_imports, namespace];
+}
+
+/**
+ * Rewrite one `import { x, type T } from '<specifier>'` statement into
+ * bindings on the lowered namespace. Value specifiers become one
+ * `const { x } = <ns>;` destructure; type-only specifiers become
+ * `type T = <ns>.T;` aliases. A specifier-less boundary import binds
+ * nothing and is dropped (the runtime compiler accepts and elides it),
+ * while non-named specifiers (default / namespace imports) are a hard
+ * compile error in the dialect — those statements stay verbatim so the
+ * editor's TS2307 mirrors the build error.
+ *
+ * @param {any} statement
+ * @param {string} block_name
+ */
+function lower_server_import(statement, block_name) {
+	const specifiers = statement.specifiers ?? [];
+	if (specifiers.length === 0) return [];
+	if (specifiers.some((/** @type {any} */ s) => s.type !== 'ImportSpecifier')) {
+		return [statement];
+	}
+	const type_specifiers = [];
+	const value_specifiers = [];
+	for (const specifier of specifiers) {
+		if (statement.importKind === 'type' || specifier.importKind === 'type') {
+			type_specifiers.push(specifier);
+		} else {
+			value_specifiers.push(specifier);
+		}
+	}
+
+	// Each reference to the namespace carries the authored import source's
+	// inner span, so hover / go-to-def on the module name resolves to the
+	// lowered block while the literal keeps its string coloring.
+	const namespace_ref = () => string_span_namespace_ref(block_name, statement.source);
+	const lowered = [];
+	if (value_specifiers.length > 0) {
+		lowered.push(build_destructure(value_specifiers, namespace_ref, statement));
+	}
+	for (const specifier of type_specifiers) {
+		lowered.push(build_type_alias(specifier, namespace_ref));
+	}
+	return lowered;
+}
+
+/**
+ * Lower the server-module dialect in a parsed program to plain TS the type
+ * checker accepts. Returns the ORIGINAL ast unchanged (same object) when
+ * the file has no server block; otherwise returns a new Program that shares
+ * every untouched statement with the original parse.
+ *
+ * Only the FIRST server declaration is lowered — a second one is a hard
+ * compile error in the runtime compiler, and leaving it verbatim surfaces a
+ * TS error in the same place. Likewise a boundary import without any server
+ * block stays verbatim (TS2307), mirroring the build error.
+ *
+ * @param {AST.Program} ast
+ * @param {NonNullable<JsxPlatform['serverModule']>} server_module
+ * @returns {AST.Program}
+ */
+export function lower_server_module_for_types(ast, server_module) {
+	const { blockName: block_name, importSpecifier: import_specifier } = server_module;
+	const body = /** @type {any[] | undefined} */ (ast?.body);
+	if (!Array.isArray(body)) return ast;
+	const declaration = body.find((node) => is_server_module_declaration(node, block_name));
+	// A body-less `module server;` only occurs mid-edit / in loose parses;
+	// leave it for TS to flag rather than fabricating an empty namespace.
+	if (declaration === undefined || !Array.isArray(declaration.body?.body)) return ast;
+
+	const outside_names = collect_outside_identifier_names(ast, declaration);
+	// The lowered namespace claims the authored block name at module scope; a
+	// block import local with the same name must be aliased out of its way.
+	outside_names.add(block_name);
+	const new_body = [];
+	for (const statement of body) {
+		if (statement === declaration) {
+			new_body.push(...lower_declaration(declaration, outside_names, block_name));
+		} else if (is_server_import(statement, import_specifier)) {
+			new_body.push(...lower_server_import(statement, block_name));
+		} else {
+			new_body.push(statement);
+		}
+	}
+	return { ...ast, body: new_body };
+}

--- a/packages/tsrx/src/transform/jsx/server-module.js
+++ b/packages/tsrx/src/transform/jsx/server-module.js
@@ -148,12 +148,17 @@ function with_location(node, source) {
 /**
  * A namespace reference standing in for an authored STRING-LITERAL span (the
  * `'server'` import source, or a string-named block id). It carries the
- * literal's INNER span — the text between the quotes — so the mapping is
- * exactly identifier-shaped, plus the `string_literal_source_span` metadata
- * flag the mapping collector turns into hover/navigation WITHOUT semantic
- * tokens: repainting part of an authored string literal as a namespace
- * token breaks the editor's string coloring (the quotes stay outside the
- * mapping for the same reason).
+ * literal's INNER span — the text between the quotes — as its source
+ * mapping: `source_length` pins the mapped length to that inner text, since
+ * the GENERATED identifier is the block name, whose length the authored
+ * specifier need not share (`blockName` and `importSpecifier` may differ).
+ * The `string_literal_source_span` metadata flag makes the mapping
+ * collector serve hover/navigation WITHOUT semantic tokens: repainting part
+ * of an authored string literal as a namespace token breaks the editor's
+ * string coloring (the quotes stay outside the mapping for the same
+ * reason). A literal without usable positions gets NO loc at all — the
+ * collector then skips the mapping entirely rather than deriving a span
+ * from the wrong length.
  *
  * @param {string} name
  * @param {any} literal
@@ -165,19 +170,20 @@ function string_span_namespace_ref(name, literal) {
 	if (
 		typeof literal?.start === 'number' &&
 		typeof literal?.end === 'number' &&
-		literal.end - literal.start >= name.length + 2
+		literal.end - literal.start >= 2
 	) {
 		node.start = literal.start + 1;
 		node.end = literal.end - 1;
-	}
-	if (literal?.loc != null) {
-		// Fresh position objects: the authored literal's own loc must survive
-		// the transform untouched (copy-on-write), and a module specifier is
-		// always single-line, so shifting columns inside it is safe.
-		node.loc = {
-			start: { line: literal.loc.start.line, column: literal.loc.start.column + 1 },
-			end: { line: literal.loc.end.line, column: literal.loc.end.column - 1 },
-		};
+		node.metadata.source_length = literal.end - literal.start - 2;
+		if (literal.loc != null) {
+			// Fresh position objects: the authored literal's own loc must survive
+			// the transform untouched (copy-on-write), and a module specifier is
+			// always single-line, so shifting columns inside it is safe.
+			node.loc = {
+				start: { line: literal.loc.start.line, column: literal.loc.start.column + 1 },
+				end: { line: literal.loc.end.line, column: literal.loc.end.column - 1 },
+			};
+		}
 	}
 	return node;
 }

--- a/packages/tsrx/src/transform/segments.js
+++ b/packages/tsrx/src/transform/segments.js
@@ -60,6 +60,7 @@ import {
 	mapping_data_verify_only,
 	mapping_data_verify_complete,
 	mapping_data_completion_only,
+	mapping_data_string_span,
 	build_line_offsets,
 	get_mapping_from_node,
 } from '../source-map-utils.js';
@@ -585,6 +586,14 @@ export function convert_source_map_to_mappings(
 					}
 					if (node.metadata?.disable_verification) {
 						token.mappingData = { ...mapping_data, verification: false };
+					}
+					// A generated identifier whose source span sits inside a string
+					// literal (e.g. a server-module lowering's namespace reference
+					// carrying the authored `'server'` import specifier): serve
+					// hover/navigation but never semantic tokens, so the span keeps
+					// its TextMate string coloring.
+					if (node.metadata?.string_literal_source_span) {
+						token.mappingData = mapping_data_string_span;
 					}
 					tokens.push(token);
 					add_extra_source_mapping_tokens(node);

--- a/packages/tsrx/src/transform/segments.js
+++ b/packages/tsrx/src/transform/segments.js
@@ -2240,6 +2240,16 @@ export function convert_source_map_to_mappings(
 					visit(node.expression);
 				}
 				return;
+			} else if (node.type === 'TSImportEqualsDeclaration') {
+				// TypeScript import alias: import foo = ns.bar;
+				// Visit in source order: id, then the referenced entity name
+				if (node.id) {
+					visit(node.id);
+				}
+				if (node.moduleReference) {
+					visit(node.moduleReference);
+				}
+				return;
 			} else if (node.type === 'TSInstantiationExpression') {
 				// TypeScript instantiation expression: new Foo<T>()
 				if (node.expression) {

--- a/packages/tsrx/tests/utils/server-module-lowering.test.js
+++ b/packages/tsrx/tests/utils/server-module-lowering.test.js
@@ -360,6 +360,41 @@ describe('server-module type-only lowering', () => {
 			}
 		});
 
+		it('maps the full specifier span when blockName and importSpecifier differ in length', () => {
+			// The generated identifier is always the block name; the mapped
+			// SOURCE span must still be the authored specifier's inner text —
+			// longer or shorter — and never run past the literal's quotes.
+			for (const specifier of ['server:module', 'srv']) {
+				const platform = {
+					...SERVER_MODULE_PLATFORM,
+					serverModule: { blockName: 'server', importSpecifier: specifier },
+				};
+				const source =
+					'module server {\n\texport const x = 1;\n}\n' +
+					`import { x } from '${specifier}';\n` +
+					'export const start = () => x;\n';
+				const result = compile_to_volar_mappings(source, { platform });
+				expect(result.errors).toEqual([]);
+				const literal_start = source.indexOf(`'${specifier}'`);
+				const inner_start = literal_start + 1;
+				const span_mappings = result.mappings.filter((m) => m.sourceOffsets[0] === inner_start);
+				expect(span_mappings.length).toBeGreaterThanOrEqual(1);
+				for (const mapping of span_mappings) {
+					expect(mapping.lengths[0]).toBe(specifier.length);
+					expect(mapping.generatedLengths[0]).toBe('server'.length);
+				}
+				// Nothing may cross the quotes into surrounding source.
+				const literal_end = literal_start + specifier.length + 2;
+				for (const mapping of result.mappings) {
+					const start = mapping.sourceOffsets[0];
+					const end = start + mapping.lengths[0];
+					if (end <= literal_start || start >= literal_end) continue;
+					expect(start).toBeGreaterThanOrEqual(inner_start);
+					expect(end).toBeLessThanOrEqual(inner_start + specifier.length);
+				}
+			}
+		});
+
 		it('keeps default full-feature mapping data on ordinary identifier mappings', () => {
 			const result = compile_to_volar_mappings(DIALECT_SOURCE);
 			const place_order_offset = DIALECT_SOURCE.indexOf('placeOrder, type Receipt');

--- a/packages/tsrx/tests/utils/server-module-lowering.test.js
+++ b/packages/tsrx/tests/utils/server-module-lowering.test.js
@@ -1,0 +1,339 @@
+import { describe, expect, it } from 'vitest';
+import { createJsxTransform, createVolarMappingsResult, parseModule } from '../../src/index.js';
+
+/**
+ * Type-only lowering of the opt-in server-module dialect
+ * (`platform.serverModule`). The dialect — a non-ambient
+ * `module server { … }` block whose body may hold static imports, plus a
+ * boundary `import { x } from 'server'` — can never typecheck verbatim
+ * (TS1147 for the in-block import, TS2307 for the boundary import), so
+ * platforms that own such a dialect ask the shared type-only transform to
+ * lower it to plain checkable TS. Platforms WITHOUT the option must see
+ * byte-identical passthrough.
+ */
+
+const SERVER_MODULE_PLATFORM = {
+	name: 'server-module-test',
+	imports: {
+		fragment: 'test-platform',
+		suspense: 'test-platform',
+		dynamic: 'test-platform/dynamic',
+		errorBoundary: 'test-platform/error-boundary',
+	},
+	jsx: {
+		rewriteClassAttr: false,
+		classAttrName: 'class',
+	},
+	validation: {
+		requireUseServerForAwait: false,
+	},
+	serverModule: { blockName: 'server', importSpecifier: 'server' },
+};
+
+const PLAIN_PLATFORM = {
+	...SERVER_MODULE_PLATFORM,
+	name: 'plain-test',
+	serverModule: undefined,
+};
+
+const PARSE_OPTIONS = {
+	collect: true,
+	loose: true,
+	preserveParens: true,
+	keywordTokens: true,
+};
+
+/**
+ * Mirrors a platform's editor pipeline: parse → type-only transform → Volar
+ * mappings (the same wiring tsrx-react's `compile_to_volar_mappings` and
+ * downstream octane's `compileToVolarMappings` use).
+ */
+function compile_to_volar_mappings(
+	source,
+	{ platform = SERVER_MODULE_PLATFORM, typeOnly = true } = {},
+) {
+	const errors = [];
+	const comments = [];
+	const ast = parseModule(source, 'App.tsrx', { ...PARSE_OPTIONS, errors, comments });
+	const transform = createJsxTransform(platform);
+	const transformed = transform(ast, source, 'App.tsrx', {
+		collect: true,
+		loose: true,
+		typeOnly,
+		errors,
+		comments,
+	});
+	const result = createVolarMappingsResult({
+		ast: transformed.ast,
+		ast_from_source: ast,
+		source,
+		generated_code: transformed.code,
+		source_map: transformed.map,
+		errors,
+	});
+	return { ...result, errors };
+}
+
+const DIALECT_SOURCE =
+	'module server {\n' +
+	"\timport { commitOrder } from './server-domain.ts';\n" +
+	'\n' +
+	'\texport type Receipt = { id: string };\n' +
+	'\n' +
+	'\texport async function placeOrder(request: unknown) {\n' +
+	'\t\treturn commitOrder(request);\n' +
+	'\t}\n' +
+	'}\n' +
+	'\n' +
+	"import { placeOrder, type Receipt } from 'server';\n" +
+	'\n' +
+	'export function App() @{\n' +
+	"\tconst pending = placeOrder('r1');\n" +
+	'\t<button>{String(pending)}</button>\n' +
+	'}\n';
+
+describe('server-module type-only lowering', () => {
+	it('hoists block imports and lowers the block to a namespace keeping the authored name and id location', () => {
+		const result = compile_to_volar_mappings(DIALECT_SOURCE);
+		expect(result.errors).toEqual([]);
+		// The dialect never reaches the virtual TSX...
+		expect(result.code).not.toContain('module server');
+		expect(result.code).not.toContain("from 'server'");
+		// ...the block import is hoisted to module top level, ahead of the
+		// namespace the block lowered into.
+		const hoisted_at = result.code.indexOf("import { commitOrder } from './server-domain.ts';");
+		const namespace_at = result.code.indexOf('namespace server');
+		expect(hoisted_at).toBeGreaterThanOrEqual(0);
+		expect(namespace_at).toBeGreaterThan(hoisted_at);
+		// The namespace id keeps the AUTHORED block-name span, so the block's
+		// `server` identifier still resolves for hover / rename.
+		const block_name_offset = DIALECT_SOURCE.indexOf('server');
+		const mapped_source_offsets = new Set(result.mappings.flatMap((m) => m.sourceOffsets));
+		expect(mapped_source_offsets.has(block_name_offset)).toBe(true);
+		// Authored identifiers inside the block and at the boundary import keep
+		// their mappings too.
+		expect(mapped_source_offsets.has(DIALECT_SOURCE.indexOf('commitOrder'))).toBe(true);
+		expect(mapped_source_offsets.has(DIALECT_SOURCE.indexOf('placeOrder'))).toBe(true);
+	});
+
+	it("lowers `import { x } from 'server'` to a destructure and type-only specifiers to type aliases", () => {
+		const result = compile_to_volar_mappings(DIALECT_SOURCE);
+		expect(result.errors).toEqual([]);
+		expect(result.code).toContain('const { placeOrder } = server;');
+		expect(result.code).toContain('type Receipt = server.Receipt;');
+	});
+
+	it('aliases hoisted block imports whose local names the client half also uses', () => {
+		const source =
+			"import { commitOrder } from './client-domain.ts';\n" +
+			'\n' +
+			'module server {\n' +
+			"\timport { commitOrder, type Money } from './server-domain.ts';\n" +
+			'\n' +
+			'\texport async function placeOrder(amount: Money) {\n' +
+			'\t\treturn commitOrder(amount);\n' +
+			'\t}\n' +
+			'}\n' +
+			'\n' +
+			"import { placeOrder } from 'server';\n" +
+			'\n' +
+			'export const start = () => [commitOrder, placeOrder];\n';
+		const result = compile_to_volar_mappings(source);
+		expect(result.errors).toEqual([]);
+		expect(result.code).not.toContain('module server');
+		// The client import hoists untouched; the colliding block import hoists
+		// under a mangled namespace and is re-bound inside the namespace with
+		// BOTH meanings preserved: a value destructure and a type alias.
+		expect(result.code).toContain("import { commitOrder } from './client-domain.ts';");
+		expect(result.code).toContain("import * as __tsrx_server_import$0 from './server-domain.ts';");
+		expect(result.code).toContain('const { commitOrder } = __tsrx_server_import$0;');
+		expect(result.code).toContain('type Money = __tsrx_server_import$0.Money;');
+		// The verbatim block import must NOT be hoisted (it would be a TS2300
+		// duplicate of the client import).
+		expect(result.code).not.toContain(
+			"import { commitOrder, type Money } from './server-domain.ts';",
+		);
+	});
+
+	it('renames imported-as bindings through the destructure', () => {
+		const source =
+			'module server {\n' +
+			'\texport function placeOrder(request: unknown) {\n' +
+			'\t\treturn request;\n' +
+			'\t}\n' +
+			'}\n' +
+			"import { placeOrder as sendOrder } from 'server';\n" +
+			'export const start = () => sendOrder(1);\n';
+		const result = compile_to_volar_mappings(source);
+		expect(result.errors).toEqual([]);
+		expect(result.code).toContain('const { placeOrder: sendOrder } = server;');
+	});
+
+	describe('degenerate inputs pass through verbatim', () => {
+		it("keeps a boundary import without any server block (the editor's TS2307 mirrors the build error)", () => {
+			const source = "import { f } from 'server';\nexport const start = () => f();\n";
+			const result = compile_to_volar_mappings(source);
+			expect(result.code).toContain("from 'server'");
+		});
+
+		it('keeps default/namespace boundary imports (a hard compile error in the dialect)', () => {
+			const source =
+				'module server {\n\texport const x = 1;\n}\n' +
+				"import serverDefault from 'server';\n" +
+				'export const start = () => serverDefault;\n';
+			const result = compile_to_volar_mappings(source);
+			// The block still lowers, but the unsupported import stays for TS to flag.
+			expect(result.code).toContain('namespace server');
+			expect(result.code).toContain("import serverDefault from 'server';");
+		});
+
+		it('drops a specifier-less boundary import (the runtime compiler accepts and elides it)', () => {
+			const source = 'module server {\n\texport const x = 1;\n}\n' + "import 'server';\n";
+			const result = compile_to_volar_mappings(source);
+			expect(result.code).toContain('namespace server');
+			expect(result.code).not.toContain("import 'server'");
+		});
+
+		it('lowers only the first server block; a duplicate stays verbatim for TS to flag', () => {
+			const source =
+				'module server {\n\texport const x = 1;\n}\n' +
+				'module server {\n\texport const y = 2;\n}\n';
+			const result = compile_to_volar_mappings(source);
+			expect(result.code).toContain('namespace server');
+			expect(result.code).toContain('module server');
+		});
+
+		it('never lowers in runtime (non-typeOnly) output even with the option set', () => {
+			const source = 'module server {\n\texport const x = 1;\n}\n';
+			const result = compile_to_volar_mappings(source, { typeOnly: false });
+			expect(result.code).toContain('module server');
+			expect(result.code).not.toContain('namespace server');
+		});
+
+		it('is byte-identical passthrough for platforms without the option', () => {
+			const with_dialect = compile_to_volar_mappings(DIALECT_SOURCE, { platform: PLAIN_PLATFORM });
+			expect(with_dialect.code).toContain('module server');
+			expect(with_dialect.code).toContain("from 'server'");
+			// A file with no dialect at all compiles identically under both
+			// platforms — the option only gates the pre-pass.
+			const plain_source = 'export function App() @{\n\t<button>{String(1)}</button>\n}\n';
+			const a = compile_to_volar_mappings(plain_source, { platform: PLAIN_PLATFORM });
+			const b = compile_to_volar_mappings(plain_source);
+			expect(b.code).toBe(a.code);
+			expect(JSON.stringify(b.mappings)).toBe(JSON.stringify(a.mappings));
+		});
+	});
+
+	describe("the authored `'server'` specifier span", () => {
+		const literal_start = DIALECT_SOURCE.indexOf("from 'server'") + 'from '.length;
+		const inner_start = literal_start + 1; // skip the opening quote
+		const inner_length = 'server'.length;
+
+		it('maps hover/navigation to the namespace WITHOUT semantic tokens, keeping string coloring', () => {
+			const result = compile_to_volar_mappings(DIALECT_SOURCE);
+			const span_mappings = result.mappings.filter(
+				(m) => m.sourceOffsets[0] === inner_start && m.lengths[0] === inner_length,
+			);
+			// The boundary import produced a value destructure AND a type alias;
+			// each namespace reference carries the specifier span.
+			expect(span_mappings.length).toBeGreaterThanOrEqual(2);
+			for (const mapping of span_mappings) {
+				// Hover stays enabled: Volar's `isHoverEnabled` is `!!data.semantic`,
+				// and the object form keeps it truthy...
+				expect(mapping.data.semantic).toBeTruthy();
+				// ...while semantic TOKENS are disabled, so the editor never
+				// repaints part of the string literal as a namespace token.
+				expect(typeof mapping.data.semantic).toBe('object');
+				expect(mapping.data.semantic.shouldHighlight()).toBe(false);
+				// Go-to-def / references on the specifier resolve to the block.
+				expect(mapping.data.navigation).toBe(true);
+				expect(mapping.data.verification).toBe(true);
+				// Identifier completions inside a string literal are never valid.
+				expect(mapping.data.completion).toBe(false);
+			}
+			// The quotes stay outside every mapping (pure string coloring), and no
+			// OTHER mapping repaints any part of the literal: everything that
+			// overlaps the literal span has semantic tokens disabled.
+			const literal_end = literal_start + "'server'".length;
+			for (const mapping of result.mappings) {
+				const start = mapping.sourceOffsets[0];
+				const end = start + mapping.lengths[0];
+				if (end <= literal_start || start >= literal_end) continue;
+				expect(start).toBe(inner_start);
+				expect(end).toBe(inner_start + inner_length);
+				expect(mapping.data.semantic.shouldHighlight()).toBe(false);
+			}
+		});
+
+		it('keeps default full-feature mapping data on ordinary identifier mappings', () => {
+			const result = compile_to_volar_mappings(DIALECT_SOURCE);
+			const place_order_offset = DIALECT_SOURCE.indexOf('placeOrder, type Receipt');
+			const identifier_mapping = result.mappings.find(
+				(m) => m.sourceOffsets[0] === place_order_offset && m.lengths[0] === 'placeOrder'.length,
+			);
+			expect(identifier_mapping).toBeDefined();
+			expect(identifier_mapping.data.semantic).toBe(true);
+			expect(identifier_mapping.data.navigation).toBe(true);
+			expect(identifier_mapping.data.completion).toBe(true);
+		});
+	});
+
+	describe('input AST immutability', () => {
+		// Structural snapshot excluding `metadata` (the sanctioned mutable side
+		// channel) — same oracle as the shared source-mappings harness: the
+		// lowering is copy-on-write, so the parse consumed by the transform must
+		// remain byte-equal to a pristine parse.
+		const structural = (value) => {
+			if (Array.isArray(value)) return value.map(structural);
+			if (value && typeof value === 'object') {
+				const out = {};
+				for (const key of Object.keys(value).sort()) {
+					if (key === 'metadata') continue;
+					const child = value[key];
+					if (typeof child === 'function') continue;
+					out[key] = structural(child);
+				}
+				return out;
+			}
+			return value;
+		};
+
+		for (const [label, source] of [
+			['the full dialect', DIALECT_SOURCE],
+			[
+				'a colliding block import',
+				"import { db } from './client.ts';\n" +
+					'module server {\n' +
+					"\timport { db, type T } from './server.ts';\n" +
+					'\texport const use = () => db;\n' +
+					'}\n' +
+					"import { use } from 'server';\n" +
+					'export const start = () => [db, use];\n',
+			],
+		]) {
+			it(`does not mutate the parsed program: ${label}`, () => {
+				const pristine = parseModule(source, 'App.tsrx', {
+					...PARSE_OPTIONS,
+					errors: [],
+					comments: [],
+				});
+				const result = compile_to_volar_mappings(source);
+				expect(structural(result.sourceAst)).toEqual(structural(pristine));
+				// Compiling the SAME program twice from one parse must be stable:
+				// the first run may not leave state behind that changes the second.
+				const errors = [];
+				const comments = [];
+				const shared_ast = parseModule(source, 'App.tsrx', {
+					...PARSE_OPTIONS,
+					errors,
+					comments,
+				});
+				const transform = createJsxTransform(SERVER_MODULE_PLATFORM);
+				const options = { collect: true, loose: true, typeOnly: true, errors, comments };
+				const first = transform(shared_ast, source, 'App.tsrx', options);
+				const second = transform(shared_ast, source, 'App.tsrx', options);
+				expect(second.code).toBe(first.code);
+			});
+		}
+	});
+});

--- a/packages/tsrx/tests/utils/server-module-lowering.test.js
+++ b/packages/tsrx/tests/utils/server-module-lowering.test.js
@@ -223,6 +223,33 @@ describe('server-module type-only lowering', () => {
 		expect(result.code).not.toContain('import * as __tsrx_server_import$0 ');
 	});
 
+	it('destructures string-named imports — type-only included — in both lowering paths', () => {
+		// The inline `{ type 'c d' as T }` form is a parse error upstream; the
+		// statement-level `import type { … }` form is how a string-named
+		// specifier reaches the lowering as type-only.
+		const source =
+			"import { db, T } from './client.ts';\n" +
+			'module server {\n' +
+			"\timport { 'a b' as db } from './server.ts';\n" +
+			"\timport type { 'c d' as T } from './server-types.ts';\n" +
+			'\texport const use = (): T => db;\n' +
+			'}\n' +
+			"import { 'weird name' as use } from 'server';\n" +
+			"import type { 'o k' as OK } from 'server';\n" +
+			'export const start = (): OK | null => [db, T, use] && null;\n';
+		const result = compile_to_volar_mappings(source);
+		expect(result.errors).toEqual([]);
+		// A string can appear in neither an entity name nor a qualified type
+		// reference — `type T = ns.'c d'` would not even parse, breaking the
+		// whole virtual file. The destructure is the one parseable fallback,
+		// binding only a value.
+		expect(result.code).toContain("const { 'a b': db } = __tsrx_server_import$0;");
+		expect(result.code).toContain("const { 'c d': T } = __tsrx_server_import$1;");
+		expect(result.code).toContain("const { 'weird name': use } = server;");
+		expect(result.code).toContain("const { 'o k': OK } = server;");
+		expect(result.code).not.toContain(".'");
+	});
+
 	it('renames imported-as bindings through the import-equals alias', () => {
 		const source =
 			'module server {\n' +

--- a/packages/tsrx/tests/utils/server-module-lowering.test.js
+++ b/packages/tsrx/tests/utils/server-module-lowering.test.js
@@ -116,11 +116,14 @@ describe('server-module type-only lowering', () => {
 		expect(mapped_source_offsets.has(DIALECT_SOURCE.indexOf('placeOrder'))).toBe(true);
 	});
 
-	it("lowers `import { x } from 'server'` to a destructure and type-only specifiers to type aliases", () => {
+	it("lowers `import { x } from 'server'` to import-equals aliases and type-only specifiers to type aliases", () => {
 		const result = compile_to_volar_mappings(DIALECT_SOURCE);
 		expect(result.errors).toEqual([]);
-		expect(result.code).toContain('const { placeOrder } = server;');
+		// import-equals keeps every meaning of the export — a destructure would
+		// strip the type meaning of a class or enum exported from the block.
+		expect(result.code).toContain('import placeOrder = server.placeOrder');
 		expect(result.code).toContain('type Receipt = server.Receipt;');
+		expect(result.code).not.toContain('const { placeOrder }');
 	});
 
 	it('aliases hoisted block imports whose local names the client half also uses', () => {
@@ -220,7 +223,7 @@ describe('server-module type-only lowering', () => {
 		expect(result.code).not.toContain('import * as __tsrx_server_import$0 ');
 	});
 
-	it('renames imported-as bindings through the destructure', () => {
+	it('renames imported-as bindings through the import-equals alias', () => {
 		const source =
 			'module server {\n' +
 			'\texport function placeOrder(request: unknown) {\n' +
@@ -231,7 +234,7 @@ describe('server-module type-only lowering', () => {
 			'export const start = () => sendOrder(1);\n';
 		const result = compile_to_volar_mappings(source);
 		expect(result.errors).toEqual([]);
-		expect(result.code).toContain('const { placeOrder: sendOrder } = server;');
+		expect(result.code).toContain('import sendOrder = server.placeOrder');
 	});
 
 	describe('degenerate inputs pass through verbatim', () => {

--- a/packages/tsrx/tests/utils/server-module-lowering.test.js
+++ b/packages/tsrx/tests/utils/server-module-lowering.test.js
@@ -143,16 +143,81 @@ describe('server-module type-only lowering', () => {
 		expect(result.code).not.toContain('module server');
 		// The client import hoists untouched; the colliding block import hoists
 		// under a mangled namespace and is re-bound inside the namespace with
-		// BOTH meanings preserved: a value destructure and a type alias.
+		// BOTH meanings preserved: an import-equals alias and a type alias.
 		expect(result.code).toContain("import { commitOrder } from './client-domain.ts';");
 		expect(result.code).toContain("import * as __tsrx_server_import$0 from './server-domain.ts';");
-		expect(result.code).toContain('const { commitOrder } = __tsrx_server_import$0;');
+		expect(result.code).toContain('import commitOrder = __tsrx_server_import$0.commitOrder');
 		expect(result.code).toContain('type Money = __tsrx_server_import$0.Money;');
 		// The verbatim block import must NOT be hoisted (it would be a TS2300
 		// duplicate of the client import).
 		expect(result.code).not.toContain(
 			"import { commitOrder, type Money } from './server-domain.ts';",
 		);
+	});
+
+	it('rebinds a colliding namespace import as an import-equals alias keeping both meanings', () => {
+		const source =
+			"import { api } from './client-api.ts';\n" +
+			'module server {\n' +
+			"\timport * as api from './server-api.ts';\n" +
+			'\texport type Names = api.Names;\n' +
+			'\texport const list = () => api.names;\n' +
+			'}\n' +
+			"import { list } from 'server';\n" +
+			'export const start = () => [api, list];\n';
+		const result = compile_to_volar_mappings(source);
+		expect(result.errors).toEqual([]);
+		// A `const api = …` alias would keep only the value meaning; the
+		// import-equals alias keeps `api.Names` checkable in type position too.
+		expect(result.code).toContain('import api = __tsrx_server_import$0');
+		expect(result.code).not.toContain('const api');
+	});
+
+	it('rebinds colliding type-only default and namespace imports through a value hoist', () => {
+		const source =
+			"import { Config, api } from './client.ts';\n" +
+			'module server {\n' +
+			"\timport type Config from './server-config.ts';\n" +
+			"\timport type * as api from './server-api.ts';\n" +
+			'\texport type Snapshot = { config: Config; names: api.Names };\n' +
+			'}\n' +
+			"import { type Snapshot } from 'server';\n" +
+			'export const start = (): Snapshot | null => null;\n';
+		const result = compile_to_volar_mappings(source);
+		expect(result.errors).toEqual([]);
+		// The mangled hoists must be VALUE imports (an import-equals alias of a
+		// type-only import is TS1380), and the type-only default must rebind as
+		// a type alias — a `const` alias would be type-only-used-as-value
+		// (TS1361) at the editor.
+		expect(result.code).not.toContain('import type * as');
+		expect(result.code).toContain("import * as __tsrx_server_import$0 from './server-config.ts';");
+		expect(result.code).toContain("import * as __tsrx_server_import$1 from './server-api.ts';");
+		expect(result.code).toContain('type Config = __tsrx_server_import$0.default;');
+		expect(result.code).toContain('import api = __tsrx_server_import$1');
+		expect(result.code).not.toContain('const Config');
+	});
+
+	it('keeps import attributes on the mangled hoist of a colliding import', () => {
+		const source =
+			"import config from './client-config.json' with { type: 'json' };\n" +
+			'module server {\n' +
+			"\timport config from './server-config.json' with { type: 'json' };\n" +
+			'\texport const read = () => config;\n' +
+			'}\n' +
+			"import { read } from 'server';\n" +
+			'export const start = () => [config, read];\n';
+		const result = compile_to_volar_mappings(source);
+		expect(result.errors).toEqual([]);
+		// Dropping the `with { … }` clause would break resolution for
+		// attribute-sensitive modules such as JSON imports. The default rebinds
+		// off a mangled DEFAULT specifier — a JSON module's namespace has no
+		// `default` member under bundler resolution — and no unreferenced
+		// namespace specifier is hoisted (`noUnusedLocals` would flag it).
+		expect(result.code).toContain(
+			"import __tsrx_server_import$0_default from './server-config.json' with { type: 'json' };",
+		);
+		expect(result.code).toContain('const config = __tsrx_server_import$0_default;');
+		expect(result.code).not.toContain('import * as __tsrx_server_import$0 ');
 	});
 
 	it('renames imported-as bindings through the destructure', () => {
@@ -305,10 +370,12 @@ describe('server-module type-only lowering', () => {
 				"import { db } from './client.ts';\n" +
 					'module server {\n' +
 					"\timport { db, type T } from './server.ts';\n" +
-					'\texport const use = () => db;\n' +
+					"\timport type * as util from './server-util.ts';\n" +
+					"\timport settings from './settings.json' with { type: 'json' };\n" +
+					'\texport const use = (): [T, util.X] => [db, settings];\n' +
 					'}\n' +
 					"import { use } from 'server';\n" +
-					'export const start = () => [db, use];\n',
+					'export const start = () => [db, use, util, settings];\n',
 			],
 		]) {
 			it(`does not mutate the parsed program: ${label}`, () => {

--- a/packages/tsrx/types/index.d.ts
+++ b/packages/tsrx/types/index.d.ts
@@ -79,6 +79,14 @@ interface BaseNodeMetaData {
 	source_name?: string;
 	source_length?: number;
 	module_keyword?: 'module' | 'namespace';
+	/**
+	 * Generated identifier whose SOURCE span sits inside an authored string
+	 * literal (e.g. a server-module lowering's namespace reference carrying
+	 * the `'server'` import specifier). The mapping collector serves
+	 * hover/navigation from it but disables semantic tokens so the span
+	 * keeps its string coloring.
+	 */
+	string_literal_source_span?: boolean;
 	is_capitalized?: boolean;
 	commentContainerId?: number;
 	parenthesized?: boolean;

--- a/packages/tsrx/types/index.d.ts
+++ b/packages/tsrx/types/index.d.ts
@@ -979,7 +979,13 @@ declare module 'estree' {
 		typeParameters: TSTypeParameterDeclaration | undefined;
 		parameters: Parameter[];
 	}
-	interface TSImportEqualsDeclaration extends AcornTSNode<TSESTree.TSImportEqualsDeclaration> {}
+	interface TSImportEqualsDeclaration extends Omit<
+		AcornTSNode<TSESTree.TSImportEqualsDeclaration>,
+		'id' | 'moduleReference'
+	> {
+		id: AST.Identifier;
+		moduleReference: EntityName | TSExternalModuleReference;
+	}
 	interface TSImportType extends Omit<
 		AcornTSNode<TSESTree.TSImportType>,
 		'argument' | 'qualifier' | 'typeParameters'

--- a/packages/tsrx/types/jsx-platform.d.ts
+++ b/packages/tsrx/types/jsx-platform.d.ts
@@ -435,6 +435,26 @@ export interface JsxPlatform {
 	};
 
 	/**
+	 * Opt-in lowering for a platform's file-local server-module dialect in
+	 * TYPE-ONLY output. When set, a non-ambient `module <blockName> { … }`
+	 * block and its companion `import { x } from '<importSpecifier>'`
+	 * statements are rewritten into plain checkable TS (block imports hoisted
+	 * to module scope, the block itself lowered to a namespace keeping the
+	 * authored name, boundary imports lowered to destructures / `type`
+	 * aliases on that namespace) before the type-only transform prints them.
+	 * Verbatim, the dialect can never typecheck: a static import inside a
+	 * namespace body is TS1147 and the boundary import is TS2307. Runtime /
+	 * build output is untouched — the platform's own compiler owns the
+	 * dialect's real codegen. When absent, the pre-pass is skipped entirely.
+	 */
+	serverModule?: {
+		/** Authored block name (`module server { … }` → `'server'`). */
+		blockName: string;
+		/** Boundary import's module specifier (`from 'server'` → `'server'`). */
+		importSpecifier: string;
+	};
+
+	/**
 	 * Optional overrides for parts of the transform that diverge substantially
 	 * between platforms (control flow, component lowering, imports, element
 	 * attributes). When absent, each hook falls back to the React/Preact-style


### PR DESCRIPTION
Add an opt-in `platform.serverModule` descriptor to createJsxTransform (`{ blockName, importSpecifier }`). In typeOnly output the shared transform now lowers a file-local `module <blockName> { … }` block plus its boundary `import { x } from '<importSpecifier>'` statements to plain checkable TS: block imports hoist to module scope (mangled and re-aliased inside the namespace when a local name is also used by the client half), the block lowers to a namespace keeping the authored name and id span, and boundary imports lower to `const { x } = <ns>;` destructures / `type T = <ns>.T;` aliases. Verbatim, the dialect can never typecheck (TS1147 in-block import, TS2307 boundary import). Platforms without the option and all runtime/build emit are untouched. Ported from octane's volar-server-module lowering.

The namespace references derived from the authored `'server'` specifier map the literal's INNER span with hover/navigation but WITHOUT semantic tokens (`semantic: { shouldHighlight: () => false }`): a quote-anchored, full-semantic mapping made Volar repaint `'serve` as a namespace token while `r'` stayed string-colored — mixed highlighting on the import specifier. The quotes stay unmapped, so TextMate string coloring survives end to end.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the shared type-only JSX transform and Volar mapping pipeline; behavior is gated behind `serverModule` and `typeOnly`, but incorrect lowering could affect editor diagnostics for platform server blocks.
> 
> **Overview**
> **Type-only server-module lowering** is now opt-in via `platform.serverModule` (`blockName`, `importSpecifier`) on `createJsxTransform`. When `typeOnly` is set, a pre-pass rewrites the file-local `module <blockName> { … }` dialect and matching `import … from '<importSpecifier>'` into checkable TypeScript: block imports hoist to module scope, the block becomes a `namespace` with the authored name, and boundary imports become `import x = …` / `type` aliases (with mangled namespace hoists when names collide with client code). Runtime/build output and platforms without the option are unchanged; invalid cases (duplicate blocks, boundary import without a block) stay verbatim so editor errors mirror the compiler.
> 
> **Editor mappings** add `mapping_data_string_span` and `string_literal_source_span` so namespace references mapped onto the inner text of `'server'` keep hover/navigation while suppressing semantic highlighting inside the string literal. Segment collection also visits `TSImportEqualsDeclaration` for the new lowered nodes.
> 
> Types document `JsxPlatform.serverModule` and expanded `TSImportEqualsDeclaration` AST shapes; a large Vitest suite covers lowering, collisions, passthrough, and mapping behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a4915e0593475a967f25773ca3c79c2465435cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->