### PR TITLE
fix(prettier-plugin): format JSX expressions and styles

### DIFF
--- a/.changeset/calm-mails-format.md
+++ b/.changeset/calm-mails-format.md
@@ -1,0 +1,5 @@
+---
+'@tsrx/prettier-plugin': patch
+---
+
+Format embedded `<style>` blocks in standalone Prettier, preserve CSS lines when embedding is unavailable, and keep fitting binary or logical JSX children inline.

--- a/benchmarks/streaming-ssr/page-solid.tsrx
+++ b/benchmarks/streaming-ssr/page-solid.tsrx
@@ -37,9 +37,7 @@ export function Page() @{
 			@try {
 				<AsyncSection index={index} />
 			} @pending {
-				<p class="loading">
-					{'loading ' + index}
-				</p>
+				<p class="loading">{'loading ' + index}</p>
 			}
 		}
 	</main>

--- a/benchmarks/streaming-ssr/page.tsrx
+++ b/benchmarks/streaming-ssr/page.tsrx
@@ -35,9 +35,7 @@ export function Page() @{
 			@try {
 				<AsyncSection index={index} />
 			} @pending {
-				<p class="loading">
-					{'loading ' + index}
-				</p>
+				<p class="loading">{'loading ' + index}</p>
 			}
 		}
 	</main>

--- a/packages/prettier-plugin/src/index.js
+++ b/packages/prettier-plugin/src/index.js
@@ -20,6 +20,7 @@
 
 import { parseModule } from '@tsrx/core';
 import { doc } from 'prettier';
+import postcssPlugin from 'prettier/parser-postcss.js';
 
 const { builders, utils } = doc;
 const {
@@ -51,6 +52,9 @@ export const languages = [
 
 /** @type {import('prettier').Plugin['parsers']} */
 export const parsers = {
+	// Carry the embedded stylesheet parsers with the TSRX plugin so browser
+	// consumers of prettier/standalone do not need to register PostCSS separately.
+	...postcssPlugin.parsers,
 	tsrx: {
 		astFormat: 'ripple-ast',
 		/**
@@ -82,6 +86,7 @@ export const parsers = {
 
 /** @type {import('prettier').Plugin['printers']} */
 export const printers = {
+	...postcssPlugin.printers,
 	'ripple-ast': {
 		/**
 		 * @param {AstPath<AST.Node | AST.CSS.StyleSheet>} path
@@ -123,8 +128,8 @@ export const printers = {
 						return body;
 					} catch {
 						// A stylesheet that doesn't parse (e.g. mid-edit code) is an expected
-						// state, not an error: keep it verbatim and stay quiet.
-						return node.source;
+						// state, not an error: keep its authored lines and stay quiet.
+						return replaceEndOfLine(node.source.trim());
 					}
 				};
 			}
@@ -1664,7 +1669,8 @@ function printRippleNode(node, path, options, print, args) {
 			if (!node.source || !node.source.trim()) {
 				nodeContent = '';
 			} else {
-				nodeContent = node.source.trim();
+				// Preserve authored lines when embedded-language formatting is disabled.
+				nodeContent = replaceEndOfLine(node.source.trim());
 			}
 			break;
 		}
@@ -5820,10 +5826,10 @@ function isSimpleJSXExpressionChild(child) {
 		expression?.type === 'Identifier' ||
 		expression?.type === 'Literal' ||
 		expression?.type === 'TemplateLiteral' ||
-		// Stock Prettier keeps a single `{expr}` child inline regardless of the
-		// expression kind (member access, calls, etc.); only multiple children break.
 		expression?.type === 'MemberExpression' ||
-		expression?.type === 'CallExpression'
+		expression?.type === 'CallExpression' ||
+		expression?.type === 'BinaryExpression' ||
+		expression?.type === 'LogicalExpression'
 	);
 }
 
@@ -6091,6 +6097,21 @@ function printJSXElement(node, path, options, print) {
 		(child) => child.type !== 'JSXText' || child.value.trim(),
 	);
 	const singleMeaningfulChild = meaningfulChildren.length === 1 ? meaningfulChildren[0] : null;
+	const singleExpression =
+		singleMeaningfulChild?.type === 'JSXExpressionContainer'
+			? singleMeaningfulChild.expression
+			: null;
+	if (
+		!forceMultiline &&
+		childrenDocs.length === 1 &&
+		(singleExpression?.type === 'BinaryExpression' ||
+			singleExpression?.type === 'LogicalExpression')
+	) {
+		// Keep a short operation against its tags, but give a wrapping operation
+		// an indented element body instead of aligning continuations after `{`.
+		// Group the opening tag with that body so wrapped attributes break both.
+		return group([openingTag, indent([softline, childrenDocs[0]]), softline, '</', tagName, '>']);
+	}
 	if (
 		!forceMultiline &&
 		childrenDocs.length === 1 &&

--- a/packages/prettier-plugin/src/index.test.js
+++ b/packages/prettier-plugin/src/index.test.js
@@ -341,12 +341,30 @@ const items=[1,2,3];
 	</style>
 }`;
 
-		const result = await format(input, {
+		const options = {
 			useTabs: true,
 			singleQuote: true,
 			embeddedLanguageFormatting: 'off',
-		});
+		};
+		const result = await format(input, options);
+
 		expect(result).toBeWithNewline(input);
+		expect(await format(result, options)).toBe(result);
+	});
+
+	it('preserves style lines when embedded formatting fails', async () => {
+		const input = `export default function App() @{
+	<style>
+		.demo {
+			color red;
+		}
+	</style>
+}`;
+		const options = { useTabs: true, singleQuote: true };
+		const result = await format(input, options);
+
+		expect(result).toBeWithNewline(input);
+		expect(await format(result, options)).toBe(result);
 	});
 
 	it('formats setup statements before the TSRX return', async () => {

--- a/packages/prettier-plugin/src/index.test.js
+++ b/packages/prettier-plugin/src/index.test.js
@@ -1,8 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import prettier from 'prettier';
+import standalonePrettier from 'prettier/standalone';
+import estreePlugin from 'prettier/plugins/estree';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
-import { languages, parsers } from './index.js';
+import { languages, parsers, printers } from './index.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -292,6 +294,61 @@ const items=[1,2,3];
 		expect(result).toBeWithNewline(expected);
 	});
 
+	it('formats style tags with standalone Prettier', async () => {
+		const input = `export default function App() @{
+	<style>
+		.demo { display: grid; gap: 0.5rem; justify-items: start; }
+		button { padding: 0.4rem 0.9rem; color: inherit; }
+	</style>
+}`;
+		const expected = `export default function App() @{
+	<style>
+		.demo {
+			display: grid;
+			gap: 0.5rem;
+			justify-items: start;
+		}
+		button {
+			padding: 0.4rem 0.9rem;
+			color: inherit;
+		}
+	</style>
+}`;
+		const options = {
+			parser: 'tsrx',
+			plugins: [{ languages, parsers, printers }, estreePlugin],
+			useTabs: true,
+			tabWidth: 2,
+			singleQuote: true,
+			printWidth: 100,
+		};
+
+		const result = await standalonePrettier.format(input, options);
+		expect(result).toBeWithNewline(expected);
+		expect(await standalonePrettier.format(result, options)).toBe(result);
+	});
+
+	it('preserves style lines when embedded formatting is disabled', async () => {
+		const input = `export default function App() @{
+	<style>
+		.demo {
+			display: grid;
+			gap: 0.5rem;
+		}
+		button {
+			color: inherit;
+		}
+	</style>
+}`;
+
+		const result = await format(input, {
+			useTabs: true,
+			singleQuote: true,
+			embeddedLanguageFormatting: 'off',
+		});
+		expect(result).toBeWithNewline(input);
+	});
+
 	it('formats setup statements before the TSRX return', async () => {
 		const input = `function Counter(){let count=track(0);const increment=()=>count++;return <button onClick={increment}>{count}</button>}`;
 		const expected = `function Counter() {
@@ -323,6 +380,51 @@ const items=[1,2,3];
 }`;
 
 		const result = await format(input);
+		expect(result).toBeWithNewline(expected);
+	});
+
+	it('keeps a lone binary expression child inline when it fits', async () => {
+		const input = `export function App() @{
+  <h2>{'Count: ' + count}</h2>
+}`;
+		const expected = `export function App() @{
+  <h2>{'Count: ' + count}</h2>
+}`;
+
+		const result = await format(input, { singleQuote: true });
+		expect(result).toBeWithNewline(expected);
+	});
+
+	it('indents a lone binary expression child when it wraps', async () => {
+		const input = `export function App() @{
+  <h2>{firstLongIdentifier + secondLongIdentifier + thirdLongIdentifier}</h2>
+}`;
+		const expected = `export function App() @{
+  <h2>
+    {firstLongIdentifier +
+      secondLongIdentifier +
+      thirdLongIdentifier}
+  </h2>
+}`;
+
+		const result = await format(input, { printWidth: 40 });
+		expect(result).toBeWithNewline(expected);
+	});
+
+	it('indents a lone binary expression child after wrapped attributes', async () => {
+		const input = `export function App() @{
+  <h2 firstLongAttributeName={firstLongAttributeValue} secondLongAttributeName={secondLongAttributeValue}>{a + b}</h2>
+}`;
+		const expected = `export function App() @{
+  <h2
+    firstLongAttributeName={firstLongAttributeValue}
+    secondLongAttributeName={secondLongAttributeValue}
+  >
+    {a + b}
+  </h2>
+}`;
+
+		const result = await format(input, { printWidth: 50 });
 		expect(result).toBeWithNewline(expected);
 	});
 
@@ -5360,9 +5462,7 @@ const foo = <><Bar {...props} /></>;`;
 			const expected = `export function Test() {
   const a = 1
   const b = 2
-  <div>
-    {a + b}
-  </div>
+  <div>{a + b}</div>
 }`;
 			const result = await format(input, { singleQuote: true, semi: false });
 			expect(result).toBeWithNewline(expected);
@@ -5377,9 +5477,7 @@ const foo = <><Bar {...props} /></>;`;
 			const expected = `export function Test() {
   const a = 1;
   const b = 2;
-  <div>
-    {a + b}
-  </div>
+  <div>{a + b}</div>
 }`;
 			const result = await format(input, { singleQuote: true, semi: true });
 			expect(result).toBeWithNewline(expected);

--- a/packages/ripple/tests/client/array/array.static.test.tsrx
+++ b/packages/ripple/tests/client/array/array.static.test.tsrx
@@ -138,9 +138,7 @@ describe('RippleArray > static', () => {
 						<div>{'Loading...'}</div>
 					} @catch (e) {
 						<>
-							<pre>
-								{'Error: ' + (e as Error).message}
-							</pre>
+							<pre>{'Error: ' + (e as Error).message}</pre>
 							<pre>{'No items'}</pre>
 						</>
 					}

--- a/packages/ripple/tests/client/async-suspend.test.tsrx
+++ b/packages/ripple/tests/client/async-suspend.test.tsrx
@@ -361,9 +361,7 @@ describe('async suspense', () => {
 				});
 				// this is to make the times_rendered render together with double
 				<>
-					<div class="double">
-						{double + (++times_rendered - times_rendered)}
-					</div>
+					<div class="double">{double + (++times_rendered - times_rendered)}</div>
 					<div class="quadruple">{quadruple}</div>
 				</>
 			}
@@ -456,9 +454,7 @@ describe('async suspense', () => {
 				});
 				// this is to make the times_rendered render together with double
 				<>
-					<div class="double">
-						{double + (++times_rendered - times_rendered)}
-					</div>
+					<div class="double">{double + (++times_rendered - times_rendered)}</div>
 					<div class="quadruple">{quadruple}</div>
 				</>
 			}
@@ -541,9 +537,7 @@ describe('async suspense', () => {
 			});
 			// this is to make the times_rendered render together with double
 			<>
-				<div class="double">
-					{double + (++times_rendered - times_rendered)}
-				</div>
+				<div class="double">{double + (++times_rendered - times_rendered)}</div>
 				<div class="quadruple">{quadruple}</div>
 			</>
 		}

--- a/packages/ripple/tests/client/basic/basic.collections.test.tsrx
+++ b/packages/ripple/tests/client/basic/basic.collections.test.tsrx
@@ -86,9 +86,7 @@ describe('basic client > collections', () => {
 			<>
 				<pre>{String(array[3])}</pre>
 				<pre>{array[0]}</pre>
-				<pre>
-					{TRACKED_ARRAY in array}
-				</pre>
+				<pre>{TRACKED_ARRAY in array}</pre>
 				<button
 					onClick={() => {
 						array.push(array.length + 1);

--- a/packages/ripple/tests/client/basic/basic.errors.test.tsrx
+++ b/packages/ripple/tests/client/basic/basic.errors.test.tsrx
@@ -17,9 +17,7 @@ describe('basic client > errors', () => {
 			<div>
 				<button onClick={triggerError}>{'Trigger Error'}</button>
 				@if (hasError) {
-					<div class="error">
-						{'Error caught: ' + errorMessage}
-					</div>
+					<div class="error">{'Error caught: ' + errorMessage}</div>
 				} @else {
 					<div class="success">{'No error'}</div>
 				}

--- a/packages/ripple/tests/client/basic/basic.reactivity.test.tsrx
+++ b/packages/ripple/tests/client/basic/basic.reactivity.test.tsrx
@@ -92,9 +92,7 @@ describe('basic client > reactivity', () => {
 			let &[count] = track(5);
 			<>
 				<div class="count">{count}</div>
-				<div class="doubled">
-					{count * 2}
-				</div>
+				<div class="doubled">{count * 2}</div>
 				<div class="is-even">
 					{count % 2 === 0 ? 'Even' : 'Odd'}
 				</div>
@@ -162,18 +160,10 @@ describe('basic client > reactivity', () => {
 				>
 					{'second: ' + second.value}
 				</button>
-				<div>
-					{'Sum: ' + total.value}
-				</div>
-				<div>
-					{'Comma Separated: ' + arr.map((a) => a.value).join(', ')}
-				</div>
-				<div>
-					{'Number to string: ' + arr.map((a) => String(a.value))}
-				</div>
-				<div>
-					{'Even numbers: ' + arr.map((a) => a.value).filter((a) => a % 2 === 0)}
-				</div>
+				<div>{'Sum: ' + total.value}</div>
+				<div>{'Comma Separated: ' + arr.map((a) => a.value).join(', ')}</div>
+				<div>{'Number to string: ' + arr.map((a) => String(a.value))}</div>
+				<div>{'Even numbers: ' + arr.map((a) => a.value).filter((a) => a % 2 === 0)}</div>
 			</>
 		}
 
@@ -381,9 +371,7 @@ describe('basic client > reactivity', () => {
 		function App() @{
 			const t = track({ a: 1, b: 2, c: 3 });
 			const doublet = track(t);
-			<pre>
-				{t === doublet}
-			</pre>
+			<pre>{t === doublet}</pre>
 		}
 
 		render(App);

--- a/packages/ripple/tests/client/basic/basic.rendering.test.tsrx
+++ b/packages/ripple/tests/client/basic/basic.rendering.test.tsrx
@@ -411,12 +411,8 @@ second
 			const staticMessage = 'Welcome to Ripple!';
 			<div class="mixed-content">
 				<h1>{staticMessage}</h1>
-				<p class="greeting">
-					{'Hello, ' + name + '!'}
-				</p>
-				<p class="notifications">
-					{'You have ' + count + ' notifications'}
-				</p>
+				<p class="greeting">{'Hello, ' + name + '!'}</p>
+				<p class="notifications">{'You have ' + count + ' notifications'}</p>
 				<button
 					onClick={() => {
 						count++;

--- a/packages/ripple/tests/client/boundaries.test.tsrx
+++ b/packages/ripple/tests/client/boundaries.test.tsrx
@@ -18,9 +18,7 @@ describe('passing reactivity between boundaries tests', () => {
 			let &[count, countTracked] = track(0);
 			const &[double] = createDouble(countTracked);
 			<>
-				<div>
-					{'Double: ' + double}
-				</div>
+				<div>{'Double: ' + double}</div>
 				<button
 					onClick={() => {
 						count++;
@@ -67,9 +65,7 @@ describe('passing reactivity between boundaries tests', () => {
 			let count = track(0);
 			const { double } = createDouble({ count });
 			<>
-				<div>
-					{'Double: ' + double.value}
-				</div>
+				<div>{'Double: ' + double.value}</div>
 				<button
 					onClick={() => {
 						count.value++;

--- a/packages/ripple/tests/client/code-block-children.test.tsrx
+++ b/packages/ripple/tests/client/code-block-children.test.tsrx
@@ -28,9 +28,7 @@ describe('code blocks in template children position', () => {
 					@{
 						const y = 2;
 						@{
-							<span class="sum">
-								{x + y}
-							</span>
+							<span class="sum">{x + y}</span>
 						}
 					}
 				}
@@ -118,9 +116,7 @@ describe('code blocks in template children position', () => {
 					@{
 						const x = 2;
 						@{
-							<span class="sum">
-								{x + y}
-							</span>
+							<span class="sum">{x + y}</span>
 						}
 					}
 				}
@@ -163,9 +159,7 @@ describe('code blocks in template children position', () => {
 					@{
 						const y = 2;
 						@{
-							<span class="sum">
-								{x + y}
-							</span>
+							<span class="sum">{x + y}</span>
 						}
 					}
 				}

--- a/packages/ripple/tests/client/composite/composite.reactivity.test.tsrx
+++ b/packages/ripple/tests/client/composite/composite.reactivity.test.tsrx
@@ -198,9 +198,7 @@ describe('composite > reactivity', () => {
 			effect(() => {
 				logs.push(`Child effect: ${a}, ${b}, ${c}`);
 			});
-			<div>
-				{a + ' ' + b + ' ' + c}
-			</div>
+			<div>{a + ' ' + b + ' ' + c}</div>
 		}
 
 		render(App);

--- a/packages/ripple/tests/client/for.test.tsrx
+++ b/packages/ripple/tests/client/for.test.tsrx
@@ -136,9 +136,7 @@ describe('for statements', () => {
 			<>
 				<div>
 					@for (let item of items; index i) {
-						<div>
-							{i + ' : ' + item}
-						</div>
+						<div>{i + ' : ' + item}</div>
 					}
 				</div>
 				<button
@@ -174,9 +172,7 @@ describe('for statements', () => {
 			]);
 			<>
 				@for (let item of items; index i; key item.id) {
-					<div>
-						{i + ':' + item.text}
-					</div>
+					<div>{i + ':' + item.text}</div>
 				}
 				<button
 					onClick={() => {
@@ -243,9 +239,7 @@ describe('for statements', () => {
 			<>
 				<div>
 					@for (let item of items; index idx; key item.id) {
-						<span class="item">
-							{idx + ':' + item.text}
-						</span>
+						<span class="item">{idx + ':' + item.text}</span>
 					}
 				</div>
 				<button
@@ -279,9 +273,7 @@ describe('for statements', () => {
 			]);
 			<>
 				@for (let item of items; index i; key item.id) {
-					<div>
-						{i + ':' + item.text}
-					</div>
+					<div>{i + ':' + item.text}</div>
 				}
 				<button
 					onClick={() => {

--- a/packages/ripple/tests/client/head.test.tsrx
+++ b/packages/ripple/tests/client/head.test.tsrx
@@ -94,9 +94,7 @@ describe('head elements', () => {
 			let prefix = 'Count: ';
 			<>
 				<head>
-					<title>
-						{prefix + count}
-					</title>
+					<title>{prefix + count}</title>
 				</head>
 				<div>
 					<button

--- a/packages/ripple/tests/client/object.test.tsrx
+++ b/packages/ripple/tests/client/object.test.tsrx
@@ -59,9 +59,7 @@ describe('RippleObject', () => {
 		function ObjectTest() @{
 			const obj = new RippleObject({ a: -1, b: 1 });
 			obj.a = 0;
-			<pre>
-				{'a' in obj && 'b' in obj}
-			</pre>
+			<pre>{'a' in obj && 'b' in obj}</pre>
 		}
 
 		render(ObjectTest);
@@ -165,9 +163,7 @@ describe('RippleObject', () => {
 			const obj = new RippleObject({ a: 0, b: 1, c: { d: { e: 8 } } });
 			<>
 				<pre>{obj.a}</pre>
-				<pre>
-					{TRACKED_OBJECT in obj}
-				</pre>
+				<pre>{TRACKED_OBJECT in obj}</pre>
 				<pre>{JSON.stringify(obj)}</pre>
 				<button
 					onClick={() => {

--- a/packages/ripple/tests/client/switch.test.tsrx
+++ b/packages/ripple/tests/client/switch.test.tsrx
@@ -77,9 +77,7 @@ describe('switch statements', () => {
 				<button onClick={() => (value = 'y')}>{'Change Value'}</button>
 				@switch (value) {
 					@default: {
-						<div>
-							{'Default for ' + value}
-						</div>
+						<div>{'Default for ' + value}</div>
 					}
 				}
 			</>
@@ -149,27 +147,19 @@ describe('switch statements', () => {
 				@switch (status) {
 					@case 'active': {
 						message = 'Currently active.';
-						<div>
-							{'Status: ' + message}
-						</div>
+						<div>{'Status: ' + message}</div>
 					}
 					@case 'pending': {
 						message = 'Waiting for completion.';
-						<div>
-							{'Status: ' + message}
-						</div>
+						<div>{'Status: ' + message}</div>
 					}
 					@case 'completed': {
 						message = 'Task finished!';
-						<div class="success">
-							{'Status: ' + message}
-						</div>
+						<div class="success">{'Status: ' + message}</div>
 					}
 					@default: {
 						message = 'An error occurred.';
-						<div class="error">
-							{'Status: ' + message}
-						</div>
+						<div class="error">{'Status: ' + message}</div>
 					}
 				}
 			</>
@@ -285,9 +275,7 @@ describe('switch statements', () => {
 							<div>{' Case A'}</div>
 						}
 						@case 'x': {
-							<div>
-								{' Default Case for ' + value}
-							</div>
+							<div>{' Default Case for ' + value}</div>
 						}
 						@case 'b': {
 							<div>{' Case B'}</div>

--- a/packages/ripple/tests/client/tsx.test.tsrx
+++ b/packages/ripple/tests/client/tsx.test.tsrx
@@ -164,9 +164,7 @@ describe('tsx expression', () => {
 		function App() @{
 			let &[count] = track(0);
 			const el = <>
-				<div>
-					{'count: ' + count}
-				</div>
+				<div>{'count: ' + count}</div>
 			</>;
 			<>
 				{el}
@@ -740,9 +738,7 @@ describe('tsrx expression', () => {
 		function App() @{
 			let &[count] = track(0);
 			const el = <>
-				<div>
-					{'count: ' + count}
-				</div>
+				<div>{'count: ' + count}</div>
 			</>;
 			<>
 				{el}

--- a/packages/ripple/tests/hydration/compiled/client/head.js
+++ b/packages/ripple/tests/hydration/compiled/client/head.js
@@ -253,11 +253,11 @@ export function MultipleHeadBlocks() {
 		_$_.expression(node_8, () => _$_.tsrx_element((__anchor, __block) => {
 			var div_8 = root_19();
 
-			_$_.head('9a44f25d', (__anchor) => {
+			_$_.head('e50b427b', (__anchor) => {
 				_$_.document.title = 'First Head';
 			});
 
-			_$_.head('0873e476', (__anchor) => {
+			_$_.head('68467dce', (__anchor) => {
 				var meta_1 = root_20();
 
 				_$_.append(__anchor, meta_1);
@@ -278,7 +278,7 @@ export function HeadWithStyle() {
 		_$_.expression(node_9, () => _$_.tsrx_element((__anchor, __block) => {
 			var div_9 = root_22();
 
-			_$_.head('d75c5358', (__anchor) => {
+			_$_.head('3a8578a5', (__anchor) => {
 				_$_.document.title = 'Styled Page';
 			});
 

--- a/packages/ripple/tests/hydration/compiled/client/streaming.js
+++ b/packages/ripple/tests/hydration/compiled/client/streaming.js
@@ -308,7 +308,7 @@ function HeadContent() {
 							_$_.pop(p_7);
 						}
 
-						_$_.head('e957a664', (__anchor) => {
+						_$_.head('814bacd9', (__anchor) => {
 							_$_.render(() => {
 								_$_.document.title = 'title:' + lazy_5.value;
 							});

--- a/packages/ripple/tests/hydration/compiled/server/head.js
+++ b/packages/ripple/tests/hydration/compiled/server/head.js
@@ -168,7 +168,7 @@ export function MultipleHeadBlocks() {
 			_$_.output_push(__out);
 			__out = '';
 			_$_.set_output_target('head');
-			__out += '<!--9a44f25d--><title>First Head</title><!--0873e476--><meta name="author" content="Test Author" />';
+			__out += '<!--e50b427b--><title>First Head</title><!--68467dce--><meta name="author" content="Test Author" />';
 			_$_.output_push(__out);
 			__out = '';
 			_$_.set_output_target(null);
@@ -186,7 +186,7 @@ export function HeadWithStyle() {
 			_$_.output_push(__out);
 			__out = '';
 			_$_.set_output_target('head');
-			__out += '<!--d75c5358--><title>Styled Page</title>';
+			__out += '<!--3a8578a5--><title>Styled Page</title>';
 			_$_.output_push(__out);
 			__out = '';
 			_$_.set_output_target(null);

--- a/packages/ripple/tests/hydration/compiled/server/streaming.js
+++ b/packages/ripple/tests/hydration/compiled/server/streaming.js
@@ -306,7 +306,7 @@ function HeadContent() {
 				_$_.output_push(__out);
 				__out = '';
 				_$_.set_output_target('head');
-				__out += '<!--e957a664--><title>' + _$_.escape('title:' + lazy_5.value) + '</title>';
+				__out += '<!--814bacd9--><title>' + _$_.escape('title:' + lazy_5.value) + '</title>';
 				_$_.output_push(__out);
 				__out = '';
 				_$_.set_output_target(null);

--- a/packages/ripple/tests/hydration/components/head.tsrx
+++ b/packages/ripple/tests/hydration/components/head.tsrx
@@ -88,9 +88,7 @@ export function ComputedTitle() @{
 	let prefix = 'Count: ';
 	<>
 		<head>
-			<title>
-				{prefix + count}
-			</title>
+			<title>{prefix + count}</title>
 		</head>
 		<div>
 			<span>{count}</span>

--- a/packages/ripple/tests/hydration/components/streaming.tsrx
+++ b/packages/ripple/tests/hydration/components/streaming.tsrx
@@ -35,9 +35,7 @@ function BasicContent() @{
 	let &[data] = trackAsync(() => controls.basic.promise);
 	let &[count] = track(0);
 	<div class="resolved">
-		<span class="value">
-			{data + ':' + count}
-		</span>
+		<span class="value">{data + ':' + count}</span>
 		<button class="inc" onClick={() => count++}>{'inc'}</button>
 	</div>
 }
@@ -115,9 +113,7 @@ function HeadContent() @{
 		@if (data) {
 			<>
 				<head>
-					<title>
-						{'title:' + data}
-					</title>
+					<title>{'title:' + data}</title>
 				</head>
 				<p class="head-content">{data}</p>
 			</>

--- a/packages/ripple/tests/server/code-block-children.test.tsrx
+++ b/packages/ripple/tests/server/code-block-children.test.tsrx
@@ -24,9 +24,7 @@ describe('code blocks in template children position', () => {
 					@{
 						const y = 2;
 						@{
-							<span class="sum">
-								{x + y}
-							</span>
+							<span class="sum">{x + y}</span>
 						}
 					}
 				}
@@ -87,9 +85,7 @@ describe('code blocks in template children position', () => {
 					@{
 						const x = 2;
 						@{
-							<span class="sum">
-								{x + y}
-							</span>
+							<span class="sum">{x + y}</span>
 						}
 					}
 				}
@@ -110,9 +106,7 @@ describe('code blocks in template children position', () => {
 					@{
 						const y = 2;
 						@{
-							<span class="sum">
-								{x + y}
-							</span>
+							<span class="sum">{x + y}</span>
 						}
 					}
 				}

--- a/packages/ripple/tests/server/head.test.tsrx
+++ b/packages/ripple/tests/server/head.test.tsrx
@@ -58,9 +58,7 @@ describe('head elements', () => {
 			let prefix = 'Count: ';
 			<>
 				<head>
-					<title>
-						{prefix + count}
-					</title>
+					<title>{prefix + count}</title>
 				</head>
 				<div>
 					<span>{count}</span>

--- a/packages/ripple/tests/server/streaming-ssr.test.tsrx
+++ b/packages/ripple/tests/server/streaming-ssr.test.tsrx
@@ -299,9 +299,7 @@ describe('streaming try/pending boundaries', () => {
 		}
 
 		function RootCatch({ error }: { error: unknown }) @{
-			<h2>
-				{'root caught: ' + (error instanceof Error ? error.message : String(error))}
-			</h2>
+			<h2>{'root caught: ' + (error instanceof Error ? error.message : String(error))}</h2>
 		}
 
 		const { chunks, sink } = recordingSink();
@@ -423,16 +421,12 @@ describe('streaming nested and sibling boundaries', () => {
 
 		function First() @{
 			let &[data] = trackAsync(() => d_first.promise);
-			<p>
-				{'first: ' + data}
-			</p>
+			<p>{'first: ' + data}</p>
 		}
 
 		function Second() @{
 			let &[data] = trackAsync(() => d_second.promise);
-			<p>
-				{'second: ' + data}
-			</p>
+			<p>{'second: ' + data}</p>
 		}
 
 		function App() @{
@@ -475,21 +469,15 @@ describe('streaming nested and sibling boundaries', () => {
 			function makeApp(ds: Deferred<string>[]) {
 				function A() @{
 					let &[data] = trackAsync(() => ds[0].promise);
-					<p>
-						{'A:' + data}
-					</p>
+					<p>{'A:' + data}</p>
 				}
 				function B() @{
 					let &[data] = trackAsync(() => ds[1].promise);
-					<p>
-						{'B:' + data}
-					</p>
+					<p>{'B:' + data}</p>
 				}
 				function C() @{
 					let &[data] = trackAsync(() => ds[2].promise);
-					<p>
-						{'C:' + data}
-					</p>
+					<p>{'C:' + data}</p>
 				}
 
 				function App() @{
@@ -553,9 +541,7 @@ describe('streaming root boundary', () => {
 
 		function App() @{
 			let &[data] = trackAsync(() => d.promise);
-			<p>
-				{'app: ' + data}
-			</p>
+			<p>{'app: ' + data}</p>
 		}
 
 		function RootPending() @{
@@ -631,9 +617,7 @@ describe('streaming head content', () => {
 				@if (data) {
 					<>
 						<head>
-							<title>
-								{'title:' + data}
-							</title>
+							<title>{'title:' + data}</title>
 						</head>
 						<p class="has-head">{data}</p>
 					</>

--- a/packages/vite-plugin-preact/tests/runtime.test.tsrx
+++ b/packages/vite-plugin-preact/tests/runtime.test.tsrx
@@ -111,9 +111,7 @@ function ForOverMapApp() @{
 		['c', 3],
 	]);
 	@for (const [key, value] of entries) {
-		<li class="map-item" {key}>
-			{key + ':' + value}
-		</li>
+		<li class="map-item" {key}>{key + ':' + value}</li>
 	}
 }
 

--- a/packages/vite-plugin-react/tests/runtime.test.tsrx
+++ b/packages/vite-plugin-react/tests/runtime.test.tsrx
@@ -444,9 +444,7 @@ function ForOverMapApp() @{
 	]);
 
 	@for (const [key, value] of entries) {
-		<li className="map-item" {key}>
-			{key + ':' + value}
-		</li>
+		<li className="map-item" {key}>{key + ':' + value}</li>
 	}
 }
 
@@ -872,9 +870,7 @@ function ExplicitHookPanel(props: { multiplier: number }) {
 	const [base, setBase] = useState(5);
 
 	return <>
-		<p className="explicit-hook-result">
-			{base * props.multiplier}
-		</p>
+		<p className="explicit-hook-result">{base * props.multiplier}</p>
 		<button className="explicit-hook-inc" onClick={() => setBase(base + 1)}>{'inc base'}</button>
 	</>;
 }

--- a/packages/vite-plugin-solid/tests/runtime.test.tsrx
+++ b/packages/vite-plugin-solid/tests/runtime.test.tsrx
@@ -753,9 +753,7 @@ function SignalClosingOverScopeApp() @{
 		@if (multiplier() > 0) {
 			const [base, setBase] = createSignal(5);
 			<>
-				<p class="scope-result">
-					{base() * multiplier()}
-				</p>
+				<p class="scope-result">{base() * multiplier()}</p>
 				<button class="scope-inc-base" onClick={() => setBase(base() + 1)}>{'inc base'}</button>
 			</>
 		}
@@ -777,9 +775,7 @@ function SignalInForApp() @{
 			const item_value = (item as unknown as () => string)();
 			const [clicked, setClicked] = createSignal(false);
 			<div class="sig-for-item">
-				<span>
-					{item_value + (clicked() ? '!' : '')}
-				</span>
+				<span>{item_value + (clicked() ? '!' : '')}</span>
 				<button
 					class={'sig-for-click-' + item_value}
 					onClick={() => setClicked(true)}

--- a/playground/solid/README.md
+++ b/playground/solid/README.md
@@ -38,26 +38,18 @@ export function App() {
     <Child />
     <h1>{'Hello Solid World'}</h1>
     if (count() > 5)
-    {<div>
-      {'count is big: ' + count()}
-    </div>}
+    {<div>{'count is big: ' + count()}</div>}
     else if (count() > 2)
-    {<div>
-      {'count is medium: ' + count()}
-    </div>}
+    {<div>{'count is medium: ' + count()}</div>}
     else
-    {<div>
-      {'count is small: ' + count()}
-    </div>}
+    {<div>{'count is small: ' + count()}</div>}
     <button
       ref={buttonEl}
       onClick={() => setCount(count() + 1)}
     >{count()}</button>
     <ul>
       for (const item of items; index i)
-      {<li>
-        {'item ' + i() + ': ' + item}
-      </li>}
+      {<li>{'item ' + i() + ': ' + item}</li>}
     </ul>
     <>
       <hr />


### PR DESCRIPTION
## Summary

- bundle the PostCSS parsers and printer into the TSRX plugin so `prettier/standalone` formats embedded `<style>` blocks without separate CSS plugin registration
- preserve authored CSS lines when embedded-language formatting is disabled or unavailable
- keep fitting binary and logical JSX children inline, while cleanly indenting long expressions and children after wrapped attributes
- add focused standalone/idempotence regressions, update formatter baselines and generated hydration hashes, and include a patch changeset

## Root cause

The JSX child classifier excluded `BinaryExpression`, so a lone expression such as `{'Count: ' + count}` fell through to the multiline element layout. Separately, standalone Prettier could not resolve the embedded `css` parser; the fallback returned a newline-bearing string Doc, which Prettier flattened and wrapped as one line.

## Validation

- `corepack pnpm test` — 213 files passed; 4,589 tests passed and 45 skipped
- `corepack pnpm test --project prettier-plugin` — 354 tests passed
- `corepack pnpm exec tsgo --noEmit -p packages/prettier-plugin/tsconfig.typecheck.json`
- `corepack pnpm format:check`
- `corepack pnpm changeset:check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to the formatter and snapshot/baseline updates; no runtime auth, data, or framework behavior changes beyond output formatting.
> 
> **Overview**
> **`@tsrx/prettier-plugin`** now spreads **`prettier/parser-postcss`** parsers and printers into the plugin export so **`prettier/standalone`** can format embedded **`<style>`** blocks without registering a separate CSS plugin. When embedded CSS formatting is off, unavailable, or fails to parse, stylesheet bodies use **`replaceEndOfLine`** on trimmed source instead of raw strings that Prettier could collapse onto one line.
> 
> JSX printing treats **`BinaryExpression`** and **`LogicalExpression`** as simple lone children when they fit (**`<h2>{'Count: ' + count}</h2>`**), with a dedicated branch to indent wrapped expressions (including after attributes break). Widespread **`.tsrx`** and benchmark files were reformatted to match; hydration compiled fixtures only pick up new head-block comment hashes from those edits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a53feeb102d422334bb89a53fb865ea85994d967. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->