### PR TITLE
chore(language-server): invalidate anything  cached on watched files

### DIFF
--- a/.changeset/fresh-tsrx-project-state.md
+++ b/.changeset/fresh-tsrx-project-state.md
@@ -3,4 +3,4 @@
 "@tsrx/typescript-plugin": patch
 ---
 
-Reload Volar projects for nested and shared TypeScript config changes, and invalidate compiler and definition caches when their workspace inputs change.
+Reload Volar projects for nested and shared TypeScript config changes, restart the language server when package state can replace the ESM compiler graph, and refresh cached type definitions when they change.

--- a/.changeset/fresh-tsrx-project-state.md
+++ b/.changeset/fresh-tsrx-project-state.md
@@ -1,0 +1,6 @@
+---
+"@ripple-ts/language-server": patch
+"@tsrx/typescript-plugin": patch
+---
+
+Reload Volar projects for nested and shared TypeScript config changes, and invalidate compiler and definition caches when their workspace inputs change.

--- a/packages/language-server/src/definitionPlugin.js
+++ b/packages/language-server/src/definitionPlugin.js
@@ -12,8 +12,6 @@ import {
 } from '@tsrx/typescript-plugin/src/language.js';
 
 const { log } = createLogging('[Ripple Definition Plugin]');
-/** @type {string | undefined} */
-let ripple_dir;
 
 /**
  * @returns {LanguageServicePlugin}
@@ -69,7 +67,7 @@ export function createDefinitionPlugin() {
 						log(`Found replace definition for ${typeName}`);
 
 						const filePath = sourceUri.fsPath || sourceUri.path;
-						ripple_dir = ripple_dir ?? getRippleDirForFile(normalizeFileNameOrUri(filePath));
+						const ripple_dir = getRippleDirForFile(normalizeFileNameOrUri(filePath));
 
 						if (!ripple_dir) {
 							log(`Could not determine Ripple source directory for file: ${filePath}`);
@@ -85,7 +83,7 @@ export function createDefinitionPlugin() {
 							return;
 						}
 
-						const match = getCachedTypeMatches(typeName, fileContent);
+						const match = getCachedTypeMatches(typeName, fileContent, typesFilePath);
 
 						if (match && match.index !== undefined) {
 							const classStart = match.index + match[0].indexOf(typeName);

--- a/packages/language-server/src/server.js
+++ b/packages/language-server/src/server.js
@@ -14,9 +14,19 @@ import { createAutoInsertPlugin } from './autoInsertPlugin.js';
 import { createTypeScriptDiagnosticFilterPlugin } from './typescriptDiagnosticPlugin.js';
 import { createDocumentHighlightPlugin } from './documentHighlightPlugin.js';
 import { createDocumentSymbolPlugin } from './documentSymbolPlugin.js';
-import { getRippleLanguagePlugin, resolveConfig } from '@tsrx/typescript-plugin/src/language.js';
+import {
+	getRippleLanguagePlugin,
+	invalidateCompilerResolutionCaches,
+	invalidateTypeDefinitionCaches,
+	resolveConfig,
+} from '@tsrx/typescript-plugin/src/language.js';
 import { createTypeScriptServices } from './typescriptService.js';
 import { create as createCssService } from 'volar-service-css';
+import {
+	handleWorkspaceChanges,
+	trackTypeScriptConfigDependencies,
+	WORKSPACE_FILE_PATTERNS,
+} from './workspaceState.js';
 
 const { log, logError } = createLogging('[Ripple Language Server]');
 
@@ -52,13 +62,10 @@ export function createRippleLanguageServer() {
 
 	connection.listen();
 
-	// Create language plugin instance once and reuse it
-	// This prevents creating multiple instances if the callback is called multiple times
-	const rippleLanguagePlugin = getRippleLanguagePlugin();
-	log('Language plugin instance created');
-
 	/** @type {WeakSet<Function>} */
 	const wrappedFunctions = new WeakSet();
+	/** @type {Set<string>} */
+	const trackedTypeScriptConfigFiles = new Set();
 
 	/**
 	 * Ensure TypeScript hosts always see compiler options with Ripple defaults.
@@ -105,16 +112,23 @@ export function createRippleLanguageServer() {
 
 			const initResult = server.initialize(
 				params,
-				createTypeScriptProject(ts, undefined, ({ projectHost }) => {
+				createTypeScriptProject(ts, undefined, ({ configFileName, projectHost }) => {
 					wrapCompilerOptionsProvider(projectHost, 'getCompilationSettings');
 
 					return {
-						languagePlugins: [rippleLanguagePlugin],
+						// Keep language-plugin identity aligned with Volar's project
+						// lifecycle. Nested tsconfigs are separate configured projects.
+						languagePlugins: [getRippleLanguagePlugin()],
 						setup({ project }) {
 							wrapCompilerOptionsProvider(
 								project?.typescript?.languageServiceHost,
 								'getCompilationSettings',
 							);
+							trackTypeScriptConfigDependencies(trackedTypeScriptConfigFiles, {
+								configFileName,
+								compilerOptions: projectHost.getCompilationSettings(),
+								projectReferences: projectHost.getProjectReferences?.(),
+							});
 						},
 					};
 				}),
@@ -147,25 +161,32 @@ export function createRippleLanguageServer() {
 		log('Server initialized.');
 		server.initialized();
 
-		// Register file watchers for TypeScript/JavaScript files so the language
-		// server is notified when they change on disk. Without this, changes to
-		// .ts files that are imported by .tsrx files are not detected, causing
-		// stale diagnostics until the server is restarted.
+		server.fileWatcher.onDidChangeWatchedFiles(({ changes }) => {
+			const effects = handleWorkspaceChanges(
+				changes,
+				{
+					invalidateCompilerResolution: invalidateCompilerResolutionCaches,
+					invalidateTypeDefinitions: invalidateTypeDefinitionCaches,
+					reloadProjects: () => {
+						trackedTypeScriptConfigFiles.clear();
+						server.project.reload();
+					},
+					requestRefresh: (clearDiagnostics) =>
+						server.languageFeatures.requestRefresh(clearDiagnostics),
+				},
+				trackedTypeScriptConfigFiles,
+			);
+
+			if (effects.reloadProjects) {
+				log('Reloaded TypeScript projects after workspace configuration changed.');
+			}
+		});
+
+		// Register file watchers for source files, nested/shared TypeScript
+		// configs, and package state that affects compiler selection.
 		try {
-			await server.fileWatcher.watchFiles([
-				'**/*.ts',
-				'**/*.tsx',
-				'**/*.cts',
-				'**/*.mts',
-				'**/*.js',
-				'**/*.jsx',
-				'**/*.cjs',
-				'**/*.mjs',
-				'**/*.d.ts',
-				'**/tsconfig.json',
-				'**/jsconfig.json',
-			]);
-			log('File watchers registered for TypeScript/JavaScript files.');
+			await server.fileWatcher.watchFiles(WORKSPACE_FILE_PATTERNS);
+			log('Workspace file watchers registered.');
 		} catch (err) {
 			logError('Failed to register file watchers:', err);
 		}

--- a/packages/language-server/src/server.js
+++ b/packages/language-server/src/server.js
@@ -16,7 +16,6 @@ import { createDocumentHighlightPlugin } from './documentHighlightPlugin.js';
 import { createDocumentSymbolPlugin } from './documentSymbolPlugin.js';
 import {
 	getRippleLanguagePlugin,
-	invalidateCompilerResolutionCaches,
 	invalidateTypeDefinitionCaches,
 	resolveConfig,
 } from '@tsrx/typescript-plugin/src/language.js';
@@ -66,6 +65,17 @@ export function createRippleLanguageServer() {
 	const wrappedFunctions = new WeakSet();
 	/** @type {Set<string>} */
 	const trackedTypeScriptConfigFiles = new Set();
+	let restartScheduled = false;
+
+	/** Restart the process so Node drops the complete ESM compiler graph. */
+	function restartLanguageServer() {
+		if (restartScheduled) {
+			return;
+		}
+		restartScheduled = true;
+		log('Restarting after package state changed.');
+		setTimeout(() => process.exit(0), 50);
+	}
 
 	/**
 	 * Ensure TypeScript hosts always see compiler options with Ripple defaults.
@@ -165,10 +175,12 @@ export function createRippleLanguageServer() {
 			const effects = handleWorkspaceChanges(
 				changes,
 				{
-					invalidateCompilerResolution: invalidateCompilerResolutionCaches,
+					restartLanguageServer,
 					invalidateTypeDefinitions: invalidateTypeDefinitionCaches,
 					reloadProjects: () => {
-						trackedTypeScriptConfigFiles.clear();
+						// Volar recreates disposed projects lazily, so retain the
+						// previously discovered dependency paths until process restart.
+						// New project setups extend this set with their current paths.
 						server.project.reload();
 					},
 					requestRefresh: (clearDiagnostics) =>

--- a/packages/language-server/src/workspaceState.js
+++ b/packages/language-server/src/workspaceState.js
@@ -1,0 +1,168 @@
+import path from 'node:path';
+import { URI } from 'vscode-uri';
+
+export const WORKSPACE_FILE_PATTERNS = [
+	// Volar consumes source-file events itself to refresh filesystem snapshots
+	// and TypeScript project versions. These do not trigger the explicit cache
+	// invalidation or project reloads classified below.
+	'**/*.tsrx',
+	'**/*.ts',
+	'**/*.tsx',
+	'**/*.cts',
+	'**/*.mts',
+	'**/*.js',
+	'**/*.jsx',
+	'**/*.cjs',
+	'**/*.mjs',
+	'**/*.json',
+	'**/pnpm-lock.yaml',
+	'**/pnpm-workspace.yaml',
+	'**/yarn.lock',
+	'**/bun.lock',
+	'**/bun.lockb',
+];
+
+const PACKAGE_STATE_FILE_NAMES = new Set([
+	'package.json',
+	'package-lock.json',
+	'pnpm-lock.yaml',
+	'pnpm-workspace.yaml',
+	'yarn.lock',
+	'bun.lock',
+	'bun.lockb',
+]);
+
+/**
+ * @param {string} file_name
+ */
+export function isTypeScriptConfigFile(file_name) {
+	const base_name = path.basename(file_name).toLowerCase();
+	return (
+		base_name.endsWith('.json') &&
+		(base_name.includes('tsconfig') || base_name.includes('jsconfig'))
+	);
+}
+
+/**
+ * @param {string} file_name
+ */
+export function isTypeDefinitionFile(file_name) {
+	return /\.d\.[cm]?ts$/i.test(file_name);
+}
+
+/**
+ * @param {string} file_name
+ */
+export function isPackageStateFile(file_name) {
+	return PACKAGE_STATE_FILE_NAMES.has(path.basename(file_name).toLowerCase());
+}
+
+/**
+ * @param {string} file_name
+ */
+function normalizeFileName(file_name) {
+	return path.normalize(path.resolve(file_name));
+}
+
+/**
+ * Record every config file that contributed to a parsed TypeScript project.
+ * TypeScript allows both `extends` and project-reference configs to use names
+ * other than tsconfig.json, so filename matching alone is not sufficient.
+ * @param {Set<string>} config_files
+ * @param {{
+ *   configFileName?: string,
+ *   compilerOptions?: import('typescript').CompilerOptions,
+ *   projectReferences?: readonly import('typescript').ProjectReference[],
+ * }} project
+ */
+export function trackTypeScriptConfigDependencies(config_files, project) {
+	if (project.configFileName) {
+		config_files.add(normalizeFileName(project.configFileName));
+	}
+
+	const config_file = /** @type {import('typescript').TsConfigSourceFile | undefined} */ (
+		project.compilerOptions?.configFile
+	);
+	for (const extended_file of config_file?.extendedSourceFiles ?? []) {
+		config_files.add(normalizeFileName(extended_file));
+	}
+
+	for (const reference of project.projectReferences ?? []) {
+		config_files.add(normalizeFileName(reference.path));
+	}
+}
+
+/**
+ * Classify watched changes before mutating project state. Package changes are
+ * broader than config changes: they can change both the selected TSRX compiler
+ * and the compiler module loaded at that path.
+ * @param {import('@volar/language-server').FileEvent[]} changes
+ * @param {ReadonlySet<string>} [tracked_config_files]
+ */
+export function classifyWorkspaceChanges(changes, tracked_config_files = new Set()) {
+	let reloadProjects = false;
+	let invalidateCompilerResolution = false;
+	let invalidateAllTypeDefinitions = false;
+	/** @type {Set<string>} */
+	const changedTypeDefinitions = new Set();
+
+	for (const change of changes) {
+		const uri = URI.parse(change.uri);
+		const file_name = uri.scheme === 'file' ? uri.fsPath : uri.path;
+
+		if (
+			isTypeScriptConfigFile(file_name) ||
+			tracked_config_files.has(normalizeFileName(file_name))
+		) {
+			reloadProjects = true;
+		}
+
+		if (isPackageStateFile(file_name)) {
+			reloadProjects = true;
+			invalidateCompilerResolution = true;
+			invalidateAllTypeDefinitions = true;
+		} else if (isTypeDefinitionFile(file_name)) {
+			changedTypeDefinitions.add(file_name);
+		}
+	}
+
+	return {
+		reloadProjects,
+		invalidateCompilerResolution,
+		invalidateAllTypeDefinitions,
+		changedTypeDefinitions: [...changedTypeDefinitions],
+	};
+}
+
+/**
+ * @param {import('@volar/language-server').FileEvent[]} changes
+ * @param {{
+ *   reloadProjects: () => void,
+ *   requestRefresh: (clearDiagnostics: boolean) => unknown,
+ *   invalidateCompilerResolution: () => void,
+ *   invalidateTypeDefinitions: (file_name?: string) => void,
+ * }} hooks
+ * @param {ReadonlySet<string>} [tracked_config_files]
+ */
+export function handleWorkspaceChanges(changes, hooks, tracked_config_files) {
+	const effects = classifyWorkspaceChanges(changes, tracked_config_files);
+
+	if (effects.invalidateCompilerResolution) {
+		hooks.invalidateCompilerResolution();
+	}
+
+	if (effects.invalidateAllTypeDefinitions) {
+		hooks.invalidateTypeDefinitions();
+	} else {
+		for (const file_name of effects.changedTypeDefinitions) {
+			hooks.invalidateTypeDefinitions(file_name);
+		}
+	}
+
+	if (effects.reloadProjects) {
+		hooks.reloadProjects();
+		void hooks.requestRefresh(true);
+	}
+
+	return effects;
+}

--- a/packages/language-server/src/workspaceState.js
+++ b/packages/language-server/src/workspaceState.js
@@ -61,7 +61,11 @@ export function isPackageStateFile(file_name) {
  * @param {string} file_name
  */
 function normalizeFileName(file_name) {
-	return path.normalize(path.resolve(file_name));
+	const is_windows_path =
+		process.platform === 'win32' || /^[a-z]:[\\/]/i.test(file_name) || file_name.startsWith('\\\\');
+	const path_api = is_windows_path ? path.win32 : path;
+	const normalized = path_api.normalize(path_api.resolve(file_name));
+	return is_windows_path ? normalized.toLowerCase() : normalized;
 }
 
 /**

--- a/packages/language-server/src/workspaceState.js
+++ b/packages/language-server/src/workspaceState.js
@@ -66,8 +66,10 @@ function normalizeFileName(file_name) {
 
 /**
  * Record every config file that contributed to a parsed TypeScript project.
- * TypeScript allows both `extends` and project-reference configs to use names
- * other than tsconfig.json, so filename matching alone is not sufficient.
+ * This set is intentionally additive across project reloads because Volar
+ * recreates projects lazily. TypeScript allows both `extends` and
+ * project-reference configs to use names other than tsconfig.json, so filename
+ * matching alone is not sufficient.
  * @param {Set<string>} config_files
  * @param {{
  *   configFileName?: string,
@@ -93,16 +95,15 @@ export function trackTypeScriptConfigDependencies(config_files, project) {
 }
 
 /**
- * Classify watched changes before mutating project state. Package changes are
- * broader than config changes: they can change both the selected TSRX compiler
- * and the compiler module loaded at that path.
+ * Classify watched changes before mutating project state. Package changes need
+ * a process restart because Node does not expose a supported way to evict a
+ * loaded ESM compiler and its transitive module graph.
  * @param {import('@volar/language-server').FileEvent[]} changes
  * @param {ReadonlySet<string>} [tracked_config_files]
  */
 export function classifyWorkspaceChanges(changes, tracked_config_files = new Set()) {
 	let reloadProjects = false;
-	let invalidateCompilerResolution = false;
-	let invalidateAllTypeDefinitions = false;
+	let restartLanguageServer = false;
 	/** @type {Set<string>} */
 	const changedTypeDefinitions = new Set();
 
@@ -118,28 +119,25 @@ export function classifyWorkspaceChanges(changes, tracked_config_files = new Set
 		}
 
 		if (isPackageStateFile(file_name)) {
-			reloadProjects = true;
-			invalidateCompilerResolution = true;
-			invalidateAllTypeDefinitions = true;
+			restartLanguageServer = true;
 		} else if (isTypeDefinitionFile(file_name)) {
 			changedTypeDefinitions.add(file_name);
 		}
 	}
 
 	return {
-		reloadProjects,
-		invalidateCompilerResolution,
-		invalidateAllTypeDefinitions,
-		changedTypeDefinitions: [...changedTypeDefinitions],
+		restartLanguageServer,
+		reloadProjects: reloadProjects && !restartLanguageServer,
+		changedTypeDefinitions: restartLanguageServer ? [] : [...changedTypeDefinitions],
 	};
 }
 
 /**
  * @param {import('@volar/language-server').FileEvent[]} changes
  * @param {{
+ *   restartLanguageServer: () => void,
  *   reloadProjects: () => void,
  *   requestRefresh: (clearDiagnostics: boolean) => unknown,
- *   invalidateCompilerResolution: () => void,
  *   invalidateTypeDefinitions: (file_name?: string) => void,
  * }} hooks
  * @param {ReadonlySet<string>} [tracked_config_files]
@@ -147,16 +145,13 @@ export function classifyWorkspaceChanges(changes, tracked_config_files = new Set
 export function handleWorkspaceChanges(changes, hooks, tracked_config_files) {
 	const effects = classifyWorkspaceChanges(changes, tracked_config_files);
 
-	if (effects.invalidateCompilerResolution) {
-		hooks.invalidateCompilerResolution();
+	if (effects.restartLanguageServer) {
+		hooks.restartLanguageServer();
+		return effects;
 	}
 
-	if (effects.invalidateAllTypeDefinitions) {
-		hooks.invalidateTypeDefinitions();
-	} else {
-		for (const file_name of effects.changedTypeDefinitions) {
-			hooks.invalidateTypeDefinitions(file_name);
-		}
+	for (const file_name of effects.changedTypeDefinitions) {
+		hooks.invalidateTypeDefinitions(file_name);
 	}
 
 	if (effects.reloadProjects) {

--- a/packages/language-server/tests/workspaceState.test.js
+++ b/packages/language-server/tests/workspaceState.test.js
@@ -61,9 +61,8 @@ describe('language-server workspace state', () => {
 		]);
 
 		expect(effects).toEqual({
+			restartLanguageServer: false,
 			reloadProjects: true,
-			invalidateCompilerResolution: false,
-			invalidateAllTypeDefinitions: false,
 			changedTypeDefinitions: [],
 		});
 	});
@@ -99,10 +98,39 @@ describe('language-server workspace state', () => {
 		).toBe(false);
 	});
 
-	it('invalidates package/compiler and definition state before reloading projects', () => {
+	it('retains prior config dependencies while projects are lazily recreated', () => {
+		const tracked_config_files = new Set();
+		trackTypeScriptConfigDependencies(tracked_config_files, {
+			configFileName: '/workspace/tsconfig.json',
+			compilerOptions: {
+				configFile: {
+					extendedSourceFiles: ['/workspace/configs/previous-options.json'],
+				},
+			},
+		});
+
+		trackTypeScriptConfigDependencies(tracked_config_files, {
+			configFileName: '/workspace/tsconfig.json',
+			compilerOptions: {
+				configFile: {
+					extendedSourceFiles: ['/workspace/configs/current-options.json'],
+				},
+			},
+		});
+
+		expect(tracked_config_files).toEqual(
+			new Set([
+				path.resolve('/workspace/tsconfig.json'),
+				path.resolve('/workspace/configs/previous-options.json'),
+				path.resolve('/workspace/configs/current-options.json'),
+			]),
+		);
+	});
+
+	it('restarts the language server when package state changes', () => {
 		const calls = [];
 		const hooks = {
-			invalidateCompilerResolution: vi.fn(() => calls.push('compiler')),
+			restartLanguageServer: vi.fn(() => calls.push('restart')),
 			invalidateTypeDefinitions: vi.fn((file_name) =>
 				calls.push(file_name ? `types:${file_name}` : 'types:all'),
 			),
@@ -119,16 +147,17 @@ describe('language-server workspace state', () => {
 			hooks,
 		);
 
-		expect(effects.reloadProjects).toBe(true);
-		expect(hooks.invalidateTypeDefinitions).toHaveBeenCalledWith();
-		expect(hooks.invalidateTypeDefinitions).toHaveBeenCalledTimes(1);
-		expect(hooks.requestRefresh).toHaveBeenCalledWith(true);
-		expect(calls).toEqual(['compiler', 'types:all', 'reload', 'refresh']);
+		expect(effects).toEqual({
+			restartLanguageServer: true,
+			reloadProjects: false,
+			changedTypeDefinitions: [],
+		});
+		expect(calls).toEqual(['restart']);
 	});
 
 	it('invalidates only changed definition files without rebuilding projects', () => {
 		const hooks = {
-			invalidateCompilerResolution: vi.fn(),
+			restartLanguageServer: vi.fn(),
 			invalidateTypeDefinitions: vi.fn(),
 			reloadProjects: vi.fn(),
 			requestRefresh: vi.fn(),
@@ -147,7 +176,7 @@ describe('language-server workspace state', () => {
 			['/workspace/types/a.d.ts'],
 			['/workspace/types/b.d.mts'],
 		]);
-		expect(hooks.invalidateCompilerResolution).not.toHaveBeenCalled();
+		expect(hooks.restartLanguageServer).not.toHaveBeenCalled();
 		expect(hooks.reloadProjects).not.toHaveBeenCalled();
 		expect(hooks.requestRefresh).not.toHaveBeenCalled();
 	});

--- a/packages/language-server/tests/workspaceState.test.js
+++ b/packages/language-server/tests/workspaceState.test.js
@@ -127,6 +127,30 @@ describe('language-server workspace state', () => {
 		);
 	});
 
+	it('matches Windows config dependencies regardless of path casing', () => {
+		const tracked_config_files = new Set();
+		trackTypeScriptConfigDependencies(tracked_config_files, {
+			configFileName: 'C:\\Workspace\\tsconfig.json',
+			compilerOptions: {
+				configFile: {
+					extendedSourceFiles: ['C:\\Workspace\\Configs\\shared-options.json'],
+				},
+			},
+		});
+
+		const effects = classifyWorkspaceChanges(
+			[
+				{
+					uri: 'file:///c:/workspace/configs/shared-options.json',
+					type: CHANGED,
+				},
+			],
+			tracked_config_files,
+		);
+
+		expect(effects.reloadProjects).toBe(true);
+	});
+
 	it('restarts the language server when package state changes', () => {
 		const calls = [];
 		const hooks = {

--- a/packages/language-server/tests/workspaceState.test.js
+++ b/packages/language-server/tests/workspaceState.test.js
@@ -1,0 +1,154 @@
+import path from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+import { URI } from 'vscode-uri';
+import {
+	classifyWorkspaceChanges,
+	handleWorkspaceChanges,
+	isPackageStateFile,
+	isTypeDefinitionFile,
+	isTypeScriptConfigFile,
+	trackTypeScriptConfigDependencies,
+	WORKSPACE_FILE_PATTERNS,
+} from '../src/workspaceState.js';
+
+const CHANGED = 2;
+
+/** @param {string} file_name */
+function change(file_name) {
+	return {
+		uri: URI.file(file_name).toString(),
+		type: CHANGED,
+	};
+}
+
+describe('language-server workspace state', () => {
+	it('recognizes nested, shared, and named TypeScript configs', () => {
+		expect(isTypeScriptConfigFile('/workspace/tsconfig.json')).toBe(true);
+		expect(isTypeScriptConfigFile('/workspace/packages/app/tsconfig.json')).toBe(true);
+		expect(isTypeScriptConfigFile('/workspace/tsconfig.base.json')).toBe(true);
+		expect(isTypeScriptConfigFile('/workspace/configs/browser.tsconfig.json')).toBe(true);
+		expect(isTypeScriptConfigFile('/workspace/jsconfig.test.json')).toBe(true);
+		expect(isTypeScriptConfigFile('/workspace/package.json')).toBe(false);
+	});
+
+	it('watches TSRX sources, config variants, and package state', () => {
+		// Closed or externally changed TSRX files need the same Volar filesystem
+		// refresh as TypeScript and JavaScript source files.
+		expect(WORKSPACE_FILE_PATTERNS).toContain('**/*.tsrx');
+
+		// All JSON files are observed because TypeScript permits arbitrary names
+		// for extended and project-reference configs. The handler filters them
+		// against the config dependency graph before reloading.
+		expect(WORKSPACE_FILE_PATTERNS).toContain('**/*.json');
+		expect(WORKSPACE_FILE_PATTERNS).toContain('**/pnpm-lock.yaml');
+	});
+
+	it('classifies definition and package files independently', () => {
+		expect(isTypeDefinitionFile('/workspace/types/runtime.d.ts')).toBe(true);
+		expect(isTypeDefinitionFile('/workspace/types/runtime.d.mts')).toBe(true);
+		expect(isTypeDefinitionFile('/workspace/types/runtime.d.cts')).toBe(true);
+		expect(isTypeDefinitionFile('/workspace/src/runtime.ts')).toBe(false);
+		expect(isPackageStateFile('/workspace/package.json')).toBe(true);
+		expect(isPackageStateFile('/workspace/pnpm-lock.yaml')).toBe(true);
+		expect(isPackageStateFile('/workspace/data.json')).toBe(false);
+	});
+
+	it('reloads all Volar projects for any nested or shared config change', () => {
+		const effects = classifyWorkspaceChanges([
+			change('/workspace/tsconfig.base.json'),
+			change('/workspace/packages/a/tsconfig.json'),
+			change('/workspace/packages/b/browser.tsconfig.json'),
+		]);
+
+		expect(effects).toEqual({
+			reloadProjects: true,
+			invalidateCompilerResolution: false,
+			invalidateAllTypeDefinitions: false,
+			changedTypeDefinitions: [],
+		});
+	});
+
+	it('tracks arbitrary extended and project-reference config names', () => {
+		const tracked_config_files = new Set();
+		trackTypeScriptConfigDependencies(tracked_config_files, {
+			configFileName: '/workspace/tsconfig.json',
+			compilerOptions: {
+				configFile: {
+					extendedSourceFiles: ['/workspace/configs/shared-options.json'],
+				},
+			},
+			projectReferences: [{ path: '/workspace/packages/lib/browser-project.json' }],
+		});
+
+		expect(tracked_config_files).toEqual(
+			new Set([
+				path.resolve('/workspace/tsconfig.json'),
+				path.resolve('/workspace/configs/shared-options.json'),
+				path.resolve('/workspace/packages/lib/browser-project.json'),
+			]),
+		);
+		expect(
+			classifyWorkspaceChanges(
+				[change('/workspace/configs/shared-options.json')],
+				tracked_config_files,
+			).reloadProjects,
+		).toBe(true);
+		expect(
+			classifyWorkspaceChanges([change('/workspace/data/unrelated.json')], tracked_config_files)
+				.reloadProjects,
+		).toBe(false);
+	});
+
+	it('invalidates package/compiler and definition state before reloading projects', () => {
+		const calls = [];
+		const hooks = {
+			invalidateCompilerResolution: vi.fn(() => calls.push('compiler')),
+			invalidateTypeDefinitions: vi.fn((file_name) =>
+				calls.push(file_name ? `types:${file_name}` : 'types:all'),
+			),
+			reloadProjects: vi.fn(() => calls.push('reload')),
+			requestRefresh: vi.fn(() => calls.push('refresh')),
+		};
+
+		const effects = handleWorkspaceChanges(
+			[
+				change('/workspace/package.json'),
+				change('/workspace/types/runtime.d.ts'),
+				change('/workspace/tsconfig.base.json'),
+			],
+			hooks,
+		);
+
+		expect(effects.reloadProjects).toBe(true);
+		expect(hooks.invalidateTypeDefinitions).toHaveBeenCalledWith();
+		expect(hooks.invalidateTypeDefinitions).toHaveBeenCalledTimes(1);
+		expect(hooks.requestRefresh).toHaveBeenCalledWith(true);
+		expect(calls).toEqual(['compiler', 'types:all', 'reload', 'refresh']);
+	});
+
+	it('invalidates only changed definition files without rebuilding projects', () => {
+		const hooks = {
+			invalidateCompilerResolution: vi.fn(),
+			invalidateTypeDefinitions: vi.fn(),
+			reloadProjects: vi.fn(),
+			requestRefresh: vi.fn(),
+		};
+
+		handleWorkspaceChanges(
+			[
+				change('/workspace/types/a.d.ts'),
+				change('/workspace/types/b.d.mts'),
+				change('/workspace/src/app.ts'),
+			],
+			hooks,
+		);
+
+		expect(hooks.invalidateTypeDefinitions.mock.calls).toEqual([
+			['/workspace/types/a.d.ts'],
+			['/workspace/types/b.d.mts'],
+		]);
+		expect(hooks.invalidateCompilerResolution).not.toHaveBeenCalled();
+		expect(hooks.reloadProjects).not.toHaveBeenCalled();
+		expect(hooks.requestRefresh).not.toHaveBeenCalled();
+	});
+});

--- a/packages/typescript-plugin/src/language.js
+++ b/packages/typescript-plugin/src/language.js
@@ -1170,11 +1170,24 @@ export function is_ripple_platform_file(file_name) {
 }
 
 /**
+ * Create a stable key for filesystem caches. Windows paths are case-insensitive
+ * to TypeScript, while file URIs conventionally lowercase their drive letter.
+ * @param {string} file_name
+ */
+function getPathCacheKey(file_name) {
+	const is_windows_path =
+		process.platform === 'win32' || /^[a-z]:[\\/]/i.test(file_name) || file_name.startsWith('\\\\');
+	const path_api = is_windows_path ? path.win32 : path;
+	const normalized = path_api.normalize(file_name);
+	return is_windows_path ? normalized.toLowerCase() : normalized;
+}
+
+/**
  * @param {string} typesFilePath
  * @returns {string | undefined}
  */
 export function getCachedTypeDefinitionFile(typesFilePath) {
-	const cache_key = path.normalize(typesFilePath);
+	const cache_key = getPathCacheKey(typesFilePath);
 
 	let stat;
 	try {
@@ -1214,7 +1227,7 @@ export function getCachedTypeDefinitionFile(typesFilePath) {
  * @returns {RegExpMatchArray | undefined}
  */
 export function getCachedTypeMatches(typeName, text, sourceKey = text) {
-	const cache_key = sourceKey === text ? text : path.normalize(sourceKey);
+	const cache_key = sourceKey === text ? text : getPathCacheKey(sourceKey);
 	let source_cache = typeNameMatchCache.get(cache_key);
 	if (!source_cache || source_cache.text !== text) {
 		source_cache = {
@@ -1274,7 +1287,7 @@ export function invalidateCompilerResolutionCaches() {
  */
 export function invalidateTypeDefinitionCaches(typesFilePath) {
 	if (typesFilePath) {
-		const cache_key = path.normalize(typesFilePath);
+		const cache_key = getPathCacheKey(typesFilePath);
 		pathToTypesCache.delete(cache_key);
 		typeNameMatchCache.delete(cache_key);
 		return;

--- a/packages/typescript-plugin/src/language.js
+++ b/packages/typescript-plugin/src/language.js
@@ -29,8 +29,6 @@ const root_dirname = path.dirname(fileURLToPath(import.meta.url));
 const { log, logWarning, logError } = createLogging('[Ripple Language]');
 /** @type {Set<string>} */
 const loggedCompilationFailures = new Set();
-/** @type {Set<string>} */
-const loadedCompilerPaths = new Set();
 export const RIPPLE_EXTENSIONS = ['.tsrx'];
 /** @typedef {[string, string[], string[], string[], string[]?]} CompilerCandidate */
 /** @type {CompilerCandidate[]} */
@@ -998,7 +996,6 @@ function package_manifest_matches_compiler(package_manifest, compiler_name, pack
 function get_tsrx_compiler(normalized_file_name) {
 	const compiler_path = get_compiler_entry_for_file(normalized_file_name);
 	if (compiler_path) {
-		loadedCompilerPaths.add(compiler_path);
 		const compiler_module = require(compiler_path);
 		if (
 			typeof compiler_module?.compile_to_volar_mappings !== 'function' &&
@@ -1261,18 +1258,10 @@ export function get_compiler_dir_for_file(normalized_file_name) {
 export { get_compiler_dir_for_file as getRippleDirForFile };
 
 /**
- * Drop compiler selection and loaded-entry state after package manifests or
- * installed compiler packages change.
+ * Drop compiler-selection state. Loaded ESM compiler graphs cannot be evicted
+ * safely in-process; language-server package watchers restart the process.
  */
 export function invalidateCompilerResolutionCaches() {
-	for (const compiler_path of loadedCompilerPaths) {
-		try {
-			delete require.cache[require.resolve(compiler_path)];
-		} catch {
-			// The compiler may have been removed as part of the package change.
-		}
-	}
-	loadedCompilerPaths.clear();
 	path2RipplePathMap.clear();
 	pathToPackageManifestCache.clear();
 	loggedCompilationFailures.clear();

--- a/packages/typescript-plugin/src/language.js
+++ b/packages/typescript-plugin/src/language.js
@@ -29,6 +29,8 @@ const root_dirname = path.dirname(fileURLToPath(import.meta.url));
 const { log, logWarning, logError } = createLogging('[Ripple Language]');
 /** @type {Set<string>} */
 const loggedCompilationFailures = new Set();
+/** @type {Set<string>} */
+const loadedCompilerPaths = new Set();
 export const RIPPLE_EXTENSIONS = ['.tsrx'];
 /** @typedef {[string, string[], string[], string[], string[]?]} CompilerCandidate */
 /** @type {CompilerCandidate[]} */
@@ -878,9 +880,9 @@ export const resolveConfig = (config) => {
 
 /** @type {Map<string, string | null>} */
 export const path2RipplePathMap = new Map();
-/** @type {Map<string, string>} */
+/** @type {Map<string, { mtimeMs: number, size: number, content: string }>} */
 const pathToTypesCache = new Map();
-/** @type {Map<string, RegExpMatchArray>} */
+/** @type {Map<string, { text: string, matches: Map<string, RegExpMatchArray> }>} */
 const typeNameMatchCache = new Map();
 /** @type {Map<string, { name: string | null, dependencies: Set<string> } | null>} */
 const pathToPackageManifestCache = new Map();
@@ -996,6 +998,7 @@ function package_manifest_matches_compiler(package_manifest, compiler_name, pack
 function get_tsrx_compiler(normalized_file_name) {
 	const compiler_path = get_compiler_entry_for_file(normalized_file_name);
 	if (compiler_path) {
+		loadedCompilerPaths.add(compiler_path);
 		const compiler_module = require(compiler_path);
 		if (
 			typeof compiler_module?.compile_to_volar_mappings !== 'function' &&
@@ -1174,14 +1177,19 @@ export function is_ripple_platform_file(file_name) {
  * @returns {string | undefined}
  */
 export function getCachedTypeDefinitionFile(typesFilePath) {
-	const cached = pathToTypesCache.get(typesFilePath);
-	if (cached) {
-		return cached;
-	}
+	const cache_key = path.normalize(typesFilePath);
 
-	if (!fs.existsSync(typesFilePath)) {
+	let stat;
+	try {
+		stat = fs.statSync(typesFilePath);
+	} catch {
 		logWarning(`Types file does not exist at path: ${typesFilePath}`);
 		return;
+	}
+
+	const cached = pathToTypesCache.get(cache_key);
+	if (cached && cached.mtimeMs === stat.mtimeMs && cached.size === stat.size) {
+		return cached.content;
 	}
 
 	log(`Found ripple types at: ${typesFilePath}`);
@@ -1194,17 +1202,32 @@ export function getCachedTypeDefinitionFile(typesFilePath) {
 		return;
 	}
 
-	pathToTypesCache.set(typesFilePath, fileContent);
+	pathToTypesCache.set(cache_key, {
+		mtimeMs: stat.mtimeMs,
+		size: stat.size,
+		content: fileContent,
+	});
 	return fileContent;
 }
 
 /**
  * @param {string} typeName
  * @param {string} text
+ * @param {string} [sourceKey]
  * @returns {RegExpMatchArray | undefined}
  */
-export function getCachedTypeMatches(typeName, text) {
-	const cached = typeNameMatchCache.get(typeName);
+export function getCachedTypeMatches(typeName, text, sourceKey = text) {
+	const cache_key = sourceKey === text ? text : path.normalize(sourceKey);
+	let source_cache = typeNameMatchCache.get(cache_key);
+	if (!source_cache || source_cache.text !== text) {
+		source_cache = {
+			text,
+			matches: new Map(),
+		};
+		typeNameMatchCache.set(cache_key, source_cache);
+	}
+
+	const cached = source_cache.matches.get(typeName);
 	if (cached) {
 		return cached;
 	}
@@ -1216,7 +1239,7 @@ export function getCachedTypeMatches(typeName, text) {
 	const match = text.match(searchPattern);
 
 	if (match && match.index !== undefined) {
-		typeNameMatchCache.set(typeName, match);
+		source_cache.matches.set(typeName, match);
 		return match;
 	}
 
@@ -1237,8 +1260,43 @@ export function get_compiler_dir_for_file(normalized_file_name) {
 
 export { get_compiler_dir_for_file as getRippleDirForFile };
 
-/** Reset module-level state used in tests. */
-export function _reset_for_test() {
+/**
+ * Drop compiler selection and loaded-entry state after package manifests or
+ * installed compiler packages change.
+ */
+export function invalidateCompilerResolutionCaches() {
+	for (const compiler_path of loadedCompilerPaths) {
+		try {
+			delete require.cache[require.resolve(compiler_path)];
+		} catch {
+			// The compiler may have been removed as part of the package change.
+		}
+	}
+	loadedCompilerPaths.clear();
 	path2RipplePathMap.clear();
 	pathToPackageManifestCache.clear();
+	loggedCompilationFailures.clear();
+}
+
+/**
+ * Drop cached definition-file content and matches. A path invalidates only one
+ * file; omitting it clears all definition state.
+ * @param {string} [typesFilePath]
+ */
+export function invalidateTypeDefinitionCaches(typesFilePath) {
+	if (typesFilePath) {
+		const cache_key = path.normalize(typesFilePath);
+		pathToTypesCache.delete(cache_key);
+		typeNameMatchCache.delete(cache_key);
+		return;
+	}
+
+	pathToTypesCache.clear();
+	typeNameMatchCache.clear();
+}
+
+/** Reset all module-level state used in tests. */
+export function _reset_for_test() {
+	invalidateCompilerResolutionCaches();
+	invalidateTypeDefinitionCaches();
 }

--- a/packages/typescript-plugin/tests/cache-invalidation.test.js
+++ b/packages/typescript-plugin/tests/cache-invalidation.test.js
@@ -66,4 +66,14 @@ describe('typescript-plugin cache invalidation', () => {
 		invalidateTypeDefinitionCaches(source_key);
 		expect(getCachedTypeMatches('Shared', first, source_key)?.index).toBe(0);
 	});
+
+	it('invalidates Windows definition caches regardless of path casing', () => {
+		const text = 'export declare class Shared {}\n';
+		const first_match = getCachedTypeMatches('Shared', text, 'C:\\Workspace\\Types\\runtime.d.ts');
+
+		invalidateTypeDefinitionCaches('c:\\workspace\\types\\runtime.d.ts');
+
+		const second_match = getCachedTypeMatches('Shared', text, 'C:\\Workspace\\Types\\runtime.d.ts');
+		expect(second_match).not.toBe(first_match);
+	});
 });

--- a/packages/typescript-plugin/tests/cache-invalidation.test.js
+++ b/packages/typescript-plugin/tests/cache-invalidation.test.js
@@ -1,0 +1,69 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+	_reset_for_test,
+	getCachedTypeDefinitionFile,
+	getCachedTypeMatches,
+	invalidateTypeDefinitionCaches,
+} from '../src/language.js';
+
+/** @type {string[]} */
+const fixture_directories = [];
+
+function create_fixture_directory() {
+	const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'tsrx-language-cache-'));
+	fixture_directories.push(directory);
+	return directory;
+}
+
+describe('typescript-plugin cache invalidation', () => {
+	beforeEach(() => {
+		_reset_for_test();
+	});
+
+	afterEach(() => {
+		_reset_for_test();
+		while (fixture_directories.length > 0) {
+			fs.rmSync(/** @type {string} */ (fixture_directories.pop()), {
+				recursive: true,
+				force: true,
+			});
+		}
+	});
+
+	it('refreshes cached type-definition content when the file changes', () => {
+		const types_file = path.join(create_fixture_directory(), 'runtime.d.ts');
+		fs.writeFileSync(types_file, 'export declare class First {}\n');
+
+		expect(getCachedTypeDefinitionFile(types_file)).toContain('First');
+
+		fs.writeFileSync(types_file, 'export declare class SecondLonger {}\n');
+
+		expect(getCachedTypeDefinitionFile(types_file)).toContain('SecondLonger');
+	});
+
+	it('keeps type-name matches isolated by definition source', () => {
+		const first = 'export declare class Shared {}\n';
+		const second = '// a different prelude\nexport declare class Shared {}\n';
+
+		const first_match = getCachedTypeMatches('Shared', first, '/workspace/first.d.ts');
+		const second_match = getCachedTypeMatches('Shared', second, '/workspace/second.d.ts');
+
+		expect(first_match?.index).toBe(0);
+		expect(second_match?.index).toBeGreaterThan(0);
+	});
+
+	it('recomputes matches when one definition source gets new content', () => {
+		const source_key = '/workspace/runtime.d.ts';
+		const first = 'export declare class Shared {}\n';
+		const second = '// moved\nexport declare class Shared {}\n';
+
+		expect(getCachedTypeMatches('Shared', first, source_key)?.index).toBe(0);
+		expect(getCachedTypeMatches('Shared', second, source_key)?.index).toBeGreaterThan(0);
+
+		invalidateTypeDefinitionCaches(source_key);
+		expect(getCachedTypeMatches('Shared', first, source_key)?.index).toBe(0);
+	});
+});

--- a/packages/typescript-plugin/tests/compiler-resolution.test.js
+++ b/packages/typescript-plugin/tests/compiler-resolution.test.js
@@ -12,6 +12,7 @@ const {
 	is_ripple_platform_file,
 	COMPILER_CANDIDATES,
 	RIPPLE_EXTENSIONS,
+	invalidateCompilerResolutionCaches,
 	_reset_for_test,
 } = require('../src/language.js');
 
@@ -255,6 +256,38 @@ describe('typescript-plugin compiler resolution', () => {
 				),
 			).toBe(expected);
 			expect(exists_sync_calls).toBeGreaterThan(0);
+		});
+
+		it('re-resolves the target after package state is invalidated', () => {
+			const workspace = create_fixture_workspace('both');
+			const file_name = path.join(workspace, 'src', 'App.tsrx');
+			const package_json_path = path.join(workspace, 'package.json');
+
+			expect(get_tsrx_compiler_name_for_file(file_name)).toBe('@tsrx/ripple');
+
+			fs.writeFileSync(
+				package_json_path,
+				JSON.stringify(
+					{
+						name: '@tsrx/fixture-switched-project',
+						private: true,
+						devDependencies: {
+							'@tsrx/react': 'workspace:*',
+							'@tsrx/vite-plugin-react': 'workspace:*',
+						},
+					},
+					null,
+					2,
+				) + '\n',
+			);
+
+			// Both path and manifest results are intentionally sticky until the
+			// package watcher invalidates them.
+			expect(get_tsrx_compiler_name_for_file(file_name)).toBe('@tsrx/ripple');
+
+			invalidateCompilerResolutionCaches();
+
+			expect(get_tsrx_compiler_name_for_file(file_name)).toBe('@tsrx/react');
 		});
 	});
 

--- a/packages/typescript-plugin/tests/plugin-integration.test.js
+++ b/packages/typescript-plugin/tests/plugin-integration.test.js
@@ -1,14 +1,8 @@
-import fs from 'node:fs';
 import path from 'path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { cleanup_fixture_workspaces, create_fixture_workspace } from './workspace-fixtures.js';
 import * as ts from 'typescript';
-import {
-	getRippleLanguagePlugin,
-	invalidateCompilerResolutionCaches,
-	TSRXVirtualCode,
-	_reset_for_test,
-} from '../src/language.js';
+import { getRippleLanguagePlugin, TSRXVirtualCode, _reset_for_test } from '../src/language.js';
 
 /**
  * @param {string} source
@@ -89,33 +83,6 @@ describe('typescript-plugin language plugin integration', () => {
 		expect(virtual_code).toBeInstanceOf(TSRXVirtualCode);
 		expect(virtual_code.generatedCode).toContain('compiler:ripple');
 		expect(virtual_code.generatedCode).toContain(file_name);
-	});
-
-	it('reloads an already-required compiler entry after package invalidation', () => {
-		const workspace = create_fixture_workspace('ripple-only');
-		const file_name = path.join(workspace, 'src', 'App.tsrx');
-		const compiler_entry = path.join(
-			workspace,
-			'node_modules',
-			'@tsrx',
-			'ripple',
-			'src',
-			'index.js',
-		);
-
-		const first = create_virtual_code(create_plugin(), file_name, '<div>Hello</div>');
-		expect(first.generatedCode).toContain('compiler:ripple');
-
-		const compiler_source = fs.readFileSync(compiler_entry, 'utf8');
-		fs.writeFileSync(
-			compiler_entry,
-			compiler_source.replace('compiler:ripple', 'compiler:updated'),
-		);
-
-		invalidateCompilerResolutionCaches();
-
-		const second = create_virtual_code(create_plugin(), file_name, '<div>Hello</div>');
-		expect(second.generatedCode).toContain('compiler:updated');
 	});
 
 	it('creates virtual code with the react compiler in a react project when both compilers exist', () => {

--- a/packages/typescript-plugin/tests/plugin-integration.test.js
+++ b/packages/typescript-plugin/tests/plugin-integration.test.js
@@ -1,8 +1,14 @@
+import fs from 'node:fs';
 import path from 'path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { cleanup_fixture_workspaces, create_fixture_workspace } from './workspace-fixtures.js';
 import * as ts from 'typescript';
-import { getRippleLanguagePlugin, TSRXVirtualCode, _reset_for_test } from '../src/language.js';
+import {
+	getRippleLanguagePlugin,
+	invalidateCompilerResolutionCaches,
+	TSRXVirtualCode,
+	_reset_for_test,
+} from '../src/language.js';
 
 /**
  * @param {string} source
@@ -83,6 +89,33 @@ describe('typescript-plugin language plugin integration', () => {
 		expect(virtual_code).toBeInstanceOf(TSRXVirtualCode);
 		expect(virtual_code.generatedCode).toContain('compiler:ripple');
 		expect(virtual_code.generatedCode).toContain(file_name);
+	});
+
+	it('reloads an already-required compiler entry after package invalidation', () => {
+		const workspace = create_fixture_workspace('ripple-only');
+		const file_name = path.join(workspace, 'src', 'App.tsrx');
+		const compiler_entry = path.join(
+			workspace,
+			'node_modules',
+			'@tsrx',
+			'ripple',
+			'src',
+			'index.js',
+		);
+
+		const first = create_virtual_code(create_plugin(), file_name, '<div>Hello</div>');
+		expect(first.generatedCode).toContain('compiler:ripple');
+
+		const compiler_source = fs.readFileSync(compiler_entry, 'utf8');
+		fs.writeFileSync(
+			compiler_entry,
+			compiler_source.replace('compiler:ripple', 'compiler:updated'),
+		);
+
+		invalidateCompilerResolutionCaches();
+
+		const second = create_virtual_code(create_plugin(), file_name, '<div>Hello</div>');
+		expect(second.generatedCode).toContain('compiler:updated');
 	});
 
 	it('creates virtual code with the react compiler in a react project when both compilers exist', () => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes language-server project lifecycle, process restarts, and shared plugin caches; behavior is covered by new tests but incorrect classification could cause unnecessary restarts or stale diagnostics until reload.
> 
> **Overview**
> **Workspace file watching** now classifies changes and applies the right recovery: **Volar project reload** (plus diagnostic refresh) when nested/shared TypeScript configs change—including configs discovered via `extends` and project references, not only `tsconfig.json` names; **process restart** when lockfiles or `package.json` change so a new compiler ESM graph can load; **targeted invalidation** of `.d.ts` caches when declaration files change.
> 
> The language server registers broader watch patterns (including `**/*.tsrx`, `**/*.json`, and package-manager lockfiles), records config dependency paths as projects start up, and creates a fresh Ripple language plugin per Volar project instead of reusing one global instance.
> 
> In the TypeScript plugin, **type-definition caches** are keyed by normalized paths, refreshed when `mtime`/`size` change, and type-name matches are scoped per definition file. **`invalidateCompilerResolutionCaches`** and **`invalidateTypeDefinitionCaches`** expose explicit clears (restart vs in-process). Go-to-definition passes the types file path into match lookup so caches stay correct per source.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 749224eccf62ea4dc5a7dad19b3e5d3d472a85cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->