### PR TITLE
fix(tsrx): tokenize a slash in JSX text inside an expression container as text

### DIFF
--- a/.changeset/lazy-donuts-repeat.md
+++ b/.changeset/lazy-donuts-repeat.md
@@ -1,0 +1,5 @@
+---
+'@tsrx/core': patch
+---
+
+Tokenize a `/` in JSX text as literal text when the element is nested inside a `{ … }` expression container. Previously `{cond && (<a>x/y</a>)}` and adjacent expression children separated by a slash (`{a}/{b}`) inside a nested element failed to parse with "Invalid regular expression flag" or "Unterminated regular expression", because the tokenizer left raw-text mode and read the slash as the start of a regular expression.

--- a/packages/tsrx/src/plugin.js
+++ b/packages/tsrx/src/plugin.js
@@ -4153,7 +4153,12 @@ export function TSRXPlugin(config) {
 								chunkStart = this.pos;
 								break;
 							}
-							if (this.#shouldReadTemplateRawTextToken()) {
+							// Like the default case below, a slash joins the raw text run even
+							// when the element is nested inside a `{ … }` expression container
+							// (`{cond && (<a>x/y</a>)}`, `{a}/{b}` between child expressions).
+							// Bailing to JS tokenization here would read the `/` as the start
+							// of a regular expression.
+							if (this.#shouldReadTemplateRawTextToken(true)) {
 								++this.pos;
 								break;
 							}

--- a/packages/tsrx/tests/utils/parser.test.js
+++ b/packages/tsrx/tests/utils/parser.test.js
@@ -409,6 +409,108 @@ abc
 		expect(wrapped.children[0].value).toBe(bare.children[0].value);
 	});
 
+	// A `/` in element text must stay literal text — never the start of a regular
+	// expression — including when the element is nested inside a `{ … }`
+	// expression container.
+
+	it('treats a slash in element text as literal text for bare and expression-container elements', () => {
+		const bare = findElement(`function App() { return <a>x/y</a>; }`, 'a');
+		const wrapped = findElement(`function App(p) { return <div>{p.c && <a>x/y</a>}</div>; }`, 'a');
+
+		expect(bare.children.map((child) => child.type)).toEqual(['JSXText']);
+		expect(bare.children[0].value).toBe('x/y');
+		expect(wrapped.children.map((child) => child.type)).toEqual(['JSXText']);
+		expect(wrapped.children[0].value).toBe('x/y');
+	});
+
+	it('treats a slash in element text inside a parenthesized expression container as literal text', () => {
+		const a = findElement(`export function A(p) { return <div>{p.c && (<a>x/y</a>)}</div>; }`, 'a');
+
+		expect(a.children.map((child) => child.type)).toEqual(['JSXText']);
+		expect(a.children[0].value).toBe('x/y');
+	});
+
+	it('parses a slash between adjacent expression children at the top level', () => {
+		const span = findElement(`export function C(p) { return <span>{p.x}/{p.y}</span>; }`, 'span');
+
+		expect(span.children.map((child) => child.type)).toEqual([
+			'JSXExpressionContainer',
+			'JSXText',
+			'JSXExpressionContainer',
+		]);
+		expect(span.children[1].value).toBe('/');
+	});
+
+	it('parses a slash between adjacent expression children in a nested element', () => {
+		const span = findElement(
+			`export function B(p) { return <div><span>{p.x}/{p.y}</span></div>; }`,
+			'span',
+		);
+
+		expect(span.children.map((child) => child.type)).toEqual([
+			'JSXExpressionContainer',
+			'JSXText',
+			'JSXExpressionContainer',
+		]);
+		expect(span.children[1].value).toBe('/');
+	});
+
+	it('parses a slash between adjacent expression children inside an expression container', () => {
+		const span = findElement(
+			`export function B(p) { return <div>{p.c && <span>{p.x}/{p.y}</span>}</div>; }`,
+			'span',
+		);
+
+		expect(span.children.map((child) => child.type)).toEqual([
+			'JSXExpressionContainer',
+			'JSXText',
+			'JSXExpressionContainer',
+		]);
+		expect(span.children[1].value).toBe('/');
+	});
+
+	it('parses a slash between adjacent expression children in a parenthesized expression container', () => {
+		const b = findElement(
+			`export function E(p) { return <div>{p.a && (<b>{p.x}/{p.y}</b>)}</div>; }`,
+			'b',
+		);
+
+		expect(b.children.map((child) => child.type)).toEqual([
+			'JSXExpressionContainer',
+			'JSXText',
+			'JSXExpressionContainer',
+		]);
+		expect(b.children[1].value).toBe('/');
+	});
+
+	it('parses slashes in element text at deeper expression-container nesting', () => {
+		const em = findElement(
+			`export function F(p) {
+				return <div>{p.a && (<section>{p.b ? (<em>{p.x}/{p.y} m/s</em>) : null}</section>)}</div>;
+			}`,
+			'em',
+		);
+
+		expect(em.children.map((child) => child.type)).toEqual([
+			'JSXExpressionContainer',
+			'JSXText',
+			'JSXExpressionContainer',
+			'JSXText',
+		]);
+		expect(em.children[1].value).toBe('/');
+		expect(em.children[3].value).toBe(' m/s');
+	});
+
+	it('still parses division inside an expression container after a nested element', () => {
+		const container = findNode(
+			`export function G(p) { return <div>{p.c ? (<a>x</a>) : p.a / p.b}</div>; }`,
+			'ConditionalExpression',
+		);
+
+		expect(container.alternate.type).toBe('BinaryExpression');
+		expect(container.alternate.operator).toBe('/');
+	});
+
 	const inExpressionContainer = (body) => `function App() {
 			return <>{<div>${body}</div>}</>;
 		}`;


### PR DESCRIPTION
## Bug

A `/` inside JSX text was tokenized as the start of a regular expression when the enclosing element was nested inside a `{ … }` expression container, producing parse errors on valid JSX (observed at `@tsrx/core@0.1.44`):

```tsx
export function A(p) { return <div>{p.c && (<a>x/y</a>)}</div>; }
// Invalid regular expression flag

export function B(p) { return <div>{p.c && <span>{p.x}/{p.y}</span>}</div>; }
// Unterminated regular expression
```

The same source parses fine when the element sits at top level rather than inside a container. Found while porting tanstack.com (its React source renders `{state.owner}/{state.repoName}`, which currently cannot be spelled faithfully and needs a template-literal workaround).

## Cause

The custom `jsx_readToken` text loop in `packages/tsrx/src/plugin.js` already lets ordinary characters join the raw text run inside an expression container — its `default` case passes `allow_inside_expression_container` to `#shouldReadTemplateRawTextToken`. The `case CharCode.slash` branch called the check **without** the flag, so inside a container it bailed out of raw-text mode, pushed `b_stat`, set `exprAllowed = true`, and handed the `/` to the plain JS tokenizer, which scanned it as a regex.

## Fix

Pass `allow_inside_expression_container` in the slash case, mirroring the default case. Every other bail-out condition still applies unchanged: `//` and `/*` comments, closing tags, self-closing `/>`, control-flow directive headers/keywords, and the container-expression-level baseline check (so `{cond ? (<a>x</a>) : a / b}` still parses the `/` as division — covered by a new test).

## Tests

Failing-first tests in `packages/tsrx/tests/utils/parser.test.js` covering:
- `x/y` text in a container-nested element, with and without parentheses
- `{a}/{b}` adjacent expression children at top level, in a nested element, and inside (parenthesized) expression containers
- deeper nesting (`{… ? (<em>{x}/{y} m/s</em>) : null}` inside another container) including whitespace preservation
- division after a parenthesized element inside a container (guard against over-matching)

Validated with `tsrx-utils`, `ripple-client`, `ripple-server`, `tsrx-{ripple,react,solid,preact,vue}`, `prettier-plugin`, `eslint-{parser,plugin}`, `language-server`, and `typescript-plugin` vitest projects, plus `tsgo --noEmit` for `packages/tsrx`. The Prettier plugin formats all the fixed constructs idempotently and preserves the two-hole `{a}/{b}` form.

Includes a patch changeset for `@tsrx/core`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow tokenizer change in one `jsx_readToken` branch with broad test coverage; low risk aside from edge cases around `/` in nested expression containers.
> 
> **Overview**
> Fixes **parse failures** when `/` appears in JSX text or between expression children inside a `{ … }` container (e.g. `{p.c && <a>x/y</a>}`, `{p.x}/{p.y}`), which previously surfaced as invalid or unterminated regular expression errors.
> 
> In `jsx_readToken`, the **`/` branch** now passes `allow_inside_expression_container` into `#shouldReadTemplateRawTextToken`, matching the default raw-text path so `/` stays **JSX text** instead of bailing to JS tokenization. **Division** in real JS after a nested element (e.g. `{cond ? (<a>x</a>) : p.a / p.b}`) is unchanged.
> 
> Adds **parser tests** for bare vs wrapped elements, `{a}/{b}`, deeper nesting, and a division guard; includes a **patch changeset** for `@tsrx/core`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 456b71e617b9136b3128f27aec54700709494c55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->