### PR TITLE
fix(prettier-plugin): keep cast parens, definite assertions, and single-pass idempotent output

### DIFF
--- a/.changeset/prettier-cast-parens-idempotence.md
+++ b/.changeset/prettier-cast-parens-idempotence.md
@@ -1,0 +1,5 @@
+---
+"@tsrx/prettier-plugin": patch
+---
+
+Keep required parentheses around low-precedence `as`/`satisfies` operands (`(a ?? b) as string` no longer loses its cast grouping), print the definite-assignment assertion on variable declarations (`let x!: T`), and make formatting single-pass idempotent: wrap return/throw arguments that carry own-line leading comments in parentheses instead of letting ASI detach them, decide arrow-body and array-element breaking from the printed doc rather than the original source span, and keep simple `as`-cast text holes inline in JSX. The test suite now formats every case twice and asserts byte-equal output.

--- a/packages/prettier-plugin/src/index.js
+++ b/packages/prettier-plugin/src/index.js
@@ -424,6 +424,27 @@ function binaryExpressionNeedsParens(node, parent) {
 }
 
 /**
+ * Check whether the operand of an `as`/`satisfies` cast must stay parenthesized.
+ * The cast binds at relational precedence, so lower-precedence operands parse
+ * differently without their parens: `a ?? b as string` is `a ?? (b as string)`,
+ * and mixing `??` with an unparenthesized cast operand is a TS syntax error.
+ * @param {AST.Node} expression - The cast operand
+ * @returns {boolean} - True if parentheses are required
+ */
+function castOperandNeedsParens(expression) {
+	switch (expression.type) {
+		case 'LogicalExpression':
+		case 'ArrowFunctionExpression':
+		case 'YieldExpression':
+			return true;
+		case 'BinaryExpression':
+			return getPrecedence(expression.operator) < PRECEDENCE['<'];
+		default:
+			return false;
+	}
+}
+
+/**
  * Check if a parenthesized AssignmentExpression needs its parentheses preserved.
  * @param {AST.AssignmentExpression} node - The expression node
  * @param {AST.Node | null} parent - The parent node
@@ -1413,7 +1434,10 @@ function printRippleNode(node, path, options, print, args) {
 				}
 
 				const trailingDoc = shouldUseTrailingComma ? ifBreak(',', '') : '';
-				nodeContent = group(['[', indent([softline, fill(fillParts), trailingDoc]), softline, ']']);
+				// All-or-nothing group instead of fill(): packing several elements
+				// per wrapped line is never a fixpoint — the repacked output reparses
+				// as a multiline array and would then break one element per line.
+				nodeContent = group(['[', indent([softline, fillParts, trailingDoc]), softline, ']']);
 				break;
 			}
 
@@ -1688,10 +1712,14 @@ function printRippleNode(node, path, options, print, args) {
 				(typePath) => print(typePath, { preferInlineSimpleUnionType: true }),
 				'typeAnnotation',
 			);
+			const expressionDoc = path.call(print, 'expression');
+			const operand = castOperandNeedsParens(node.expression)
+				? ['(', expressionDoc, ')']
+				: expressionDoc;
 			nodeContent =
 				node.typeAnnotation.type !== 'TSTypeLiteral' && willBreak(typeAnnotation)
-					? [path.call(print, 'expression'), ' as', indent([line, typeAnnotation])]
-					: [path.call(print, 'expression'), ' as ', typeAnnotation];
+					? [operand, ' as', indent([line, typeAnnotation])]
+					: [operand, ' as ', typeAnnotation];
 			break;
 		}
 
@@ -1700,10 +1728,14 @@ function printRippleNode(node, path, options, print, args) {
 				(typePath) => print(typePath, { preferInlineSimpleUnionType: true }),
 				'typeAnnotation',
 			);
+			const expressionDoc = path.call(print, 'expression');
+			const operand = castOperandNeedsParens(node.expression)
+				? ['(', expressionDoc, ')']
+				: expressionDoc;
 			nodeContent =
 				node.typeAnnotation.type !== 'TSTypeLiteral' && willBreak(typeAnnotation)
-					? [path.call(print, 'expression'), ' satisfies', indent([line, typeAnnotation])]
-					: [path.call(print, 'expression'), ' satisfies ', typeAnnotation];
+					? [operand, ' satisfies', indent([line, typeAnnotation])]
+					: [operand, ' satisfies ', typeAnnotation];
 			break;
 		}
 
@@ -1892,17 +1924,28 @@ function printRippleNode(node, path, options, print, args) {
 		}
 		case 'Identifier': {
 			// Simple case - just return the name directly like Prettier core
+			const parent = path.getParentNode();
+			// The definite-assignment assertion (`let x!: T`) lives on the declarator
+			const definiteMarker =
+				parent && parent.type === 'VariableDeclarator' && parent.id === node && parent.definite
+					? '!'
+					: '';
 			let identifierContent;
 			if (node.typeAnnotation) {
 				const optionalMarker = node.optional ? '?' : '';
-				identifierContent = [node.name, optionalMarker, ': ', path.call(print, 'typeAnnotation')];
+				identifierContent = [
+					node.name,
+					definiteMarker,
+					optionalMarker,
+					': ',
+					path.call(print, 'typeAnnotation'),
+				];
 			} else {
-				identifierContent = node.name;
+				identifierContent = definiteMarker ? [node.name, definiteMarker] : node.name;
 			}
 			// Preserve parentheses for type-cast identifiers, but only if:
 			// 1. The identifier itself is marked as parenthesized
 			// 2. The parent is NOT handling parentheses itself (MemberExpression, AssignmentExpression, etc.)
-			const parent = path.getParentNode();
 			const parentHandlesParens =
 				parent &&
 				(parent.type === 'MemberExpression' ||
@@ -2068,8 +2111,14 @@ function printRippleNode(node, path, options, print, args) {
 			/** @type {Doc[]} */
 			const parts = ['return'];
 			if (node.argument) {
-				parts.push(' ');
-				parts.push(path.call(print, 'argument'));
+				if (argumentHasOwnLineLeadingComment(node.argument)) {
+					// The comment prints on its own line, which would separate `return`
+					// from its argument and trigger ASI — keep the argument in parens.
+					parts.push(' (', indent([hardline, path.call(print, 'argument')]), hardline, ')');
+				} else {
+					parts.push(' ');
+					parts.push(path.call(print, 'argument'));
+				}
 			}
 			parts.push(semi(options));
 			nodeContent = parts;
@@ -2808,7 +2857,6 @@ function printArrowFunction(node, path, options, print, args) {
 		// to avoid ambiguity with block statements or to clarify intent
 		const bodyDoc = path.call(print, 'body');
 		const groupId = Symbol('arrow');
-		const shouldBreakBody = shouldBreakArrowExpressionBody(node.body, options, args);
 		/** @type {Doc | Doc[]} */
 		let bodyContent;
 		if (
@@ -2820,21 +2868,24 @@ function printArrowFunction(node, path, options, print, args) {
 		} else {
 			bodyContent = bodyDoc;
 		}
-		if (shouldBreakBody) {
-			parts.push(' =>', indent([hardline, bodyContent]));
-		} else {
-			if (isTemplateExpression(node.body)) {
-				return conditionalGroup([
-					group([...parts, ' => ', bodyContent]),
-					group([...parts, ' =>', indent([hardline, bodyContent])]),
-				]);
-			}
-			parts.push(
-				' =>',
-				group(indent(line), { id: groupId }),
-				indentIfBreak(bodyContent, { groupId }),
-			);
+		if (
+			isTemplateExpression(node.body) ||
+			node.body.type === 'BinaryExpression' ||
+			node.body.type === 'LogicalExpression'
+		) {
+			// Try the body inline; otherwise break right after `=>` so the body
+			// starts on its own line. Deciding this from the printed doc (instead
+			// of the original source span) keeps formatting idempotent.
+			return conditionalGroup([
+				group([...parts, ' => ', bodyContent]),
+				group([...parts, ' =>', indent([hardline, bodyContent])]),
+			]);
 		}
+		parts.push(
+			' =>',
+			group(indent(line), { id: groupId }),
+			indentIfBreak(bodyContent, { groupId }),
+		);
 	}
 
 	return group(parts);
@@ -2847,25 +2898,6 @@ function printArrowFunction(node, path, options, print, args) {
  */
 function isTemplateExpression(node) {
 	return node.type === 'JSXElement' || node.type === 'JSXFragment';
-}
-
-/**
- * Check whether a braced attribute expression should close on its own line.
- * @param {AST.Node} node - The expression inside the attribute braces
- * @param {RippleFormatOptions} options
- * @param {AST.Node} [attributeNode]
- * @returns {boolean}
- */
-function shouldBreakAttributeExpressionClosingBrace(node, options, attributeNode = node) {
-	return (
-		node.type === 'ArrowFunctionExpression' &&
-		node.body &&
-		isTemplateExpression(node.body) &&
-		sourceSpanExceedsPrintWidth(
-			/** @type {AST.NodeWithLocation} */ (/** @type {unknown} */ (attributeNode ?? node)),
-			options,
-		)
-	);
 }
 
 /**
@@ -3058,34 +3090,6 @@ function shouldHugArrowFunctions(args) {
 	}
 
 	return firstBlockIndex === 0;
-}
-
-/**
- * Check whether a node's original source span exceeds the configured print width.
- * @param {AST.NodeWithLocation} node - The node to check
- * @param {RippleFormatOptions} options - Prettier options
- * @returns {boolean}
- */
-function sourceSpanExceedsPrintWidth(node, options) {
-	const printWidth = options.printWidth ?? 80;
-	if (!options.originalText || node.start === undefined || node.end === undefined) {
-		return false;
-	}
-	return options.originalText.slice(node.start, node.end).length > printWidth;
-}
-
-/**
- * Check if an arrow expression body should break immediately after `=>`.
- * @param {AST.Expression} node - The arrow body expression
- * @param {RippleFormatOptions} options - Prettier options
- * @param {PrintArgs} [args] - Additional context arguments
- * @returns {boolean}
- */
-function shouldBreakArrowExpressionBody(node, options, args) {
-	return (
-		(node.type === 'BinaryExpression' || node.type === 'LogicalExpression') &&
-		sourceSpanExceedsPrintWidth(/** @type {AST.NodeWithLocation} */ (node), options)
-	);
 }
 
 /**
@@ -4323,10 +4327,39 @@ function printTaggedTemplateExpression(node, path, options, print) {
 function printThrowStatement(node, path, options, print) {
 	/** @type {Doc[]} */
 	const parts = [];
-	parts.push('throw ');
-	parts.push(path.call(print, 'argument'));
+	if (argumentHasOwnLineLeadingComment(node.argument)) {
+		// Same ASI hazard as `return`: keep the argument attached via parens.
+		parts.push('throw (', indent([hardline, path.call(print, 'argument')]), hardline, ')');
+	} else {
+		parts.push('throw ');
+		parts.push(path.call(print, 'argument'));
+	}
 	parts.push(semi(options));
 	return parts;
+}
+
+/**
+ * Check whether a return/throw argument has a leading comment that prints on
+ * its own line (line comments always do; block comments only when they did not
+ * share a line with the argument in the source).
+ * @param {AST.Node | null | undefined} argument - The statement argument
+ * @returns {boolean}
+ */
+function argumentHasOwnLineLeadingComment(argument) {
+	if (!argument) {
+		return false;
+	}
+	const comments = /** @type {AST.NodeWithMaybeComments} */ (argument).leadingComments;
+	if (!comments) {
+		return false;
+	}
+	return comments.some(
+		(comment) =>
+			comment.type === 'Line' ||
+			!comment.loc ||
+			!argument.loc ||
+			comment.loc.end.line !== argument.loc.start.line,
+	);
 }
 
 /**
@@ -5829,7 +5862,9 @@ function isSimpleJSXExpressionChild(child) {
 		expression?.type === 'MemberExpression' ||
 		expression?.type === 'CallExpression' ||
 		expression?.type === 'BinaryExpression' ||
-		expression?.type === 'LogicalExpression'
+		expression?.type === 'LogicalExpression' ||
+		// Text holes like `{expr as string}` are as simple as their operand
+		expression?.type === 'TSAsExpression'
 	);
 }
 
@@ -6548,9 +6583,6 @@ function printJSXAttribute(attr, path, options, print) {
 			'value',
 			'expression',
 		);
-		if (shouldBreakAttributeExpressionClosingBrace(expression, options, attr)) {
-			return [name, '={', exprDoc, hardline, '}'];
-		}
 		return [name, '={', exprDoc, '}'];
 	}
 

--- a/packages/prettier-plugin/src/index.js
+++ b/packages/prettier-plugin/src/index.js
@@ -16,7 +16,7 @@
 
 /** @typedef {Partial<Pick<ParserOptions, 'singleQuote' | 'jsxSingleQuote' | 'semi' | 'trailingComma' | 'useTabs' | 'tabWidth' | 'singleAttributePerLine' | 'bracketSameLine' | 'bracketSpacing' | 'arrowParens' | 'originalText' | 'printWidth'>> & { locStart: (node: AST.NodeWithLocation) => number, locEnd: (node: AST.NodeWithLocation) => number }} RippleFormatOptions */
 
-/** @typedef {{ isInAttribute?: boolean, isInArray?: boolean, allowInlineObject?: boolean, isConditionalTest?: boolean, isNestedConditional?: boolean, suppressLeadingComments?: boolean, suppressExpressionLeadingComments?: boolean, isInlineContext?: boolean, isStatement?: boolean, isLogicalAndOr?: boolean, allowShorthandProperty?: boolean, isFirstChild?: boolean, noBreakInside?: boolean, expandLastArg?: boolean, preferInlineSimpleUnionType?: boolean }} PrintArgs */
+/** @typedef {{ isInAttribute?: boolean, isInArray?: boolean, allowInlineObject?: boolean, isConditionalTest?: boolean, isNestedConditional?: boolean, suppressLeadingComments?: boolean, suppressExpressionLeadingComments?: boolean, suppressOwnParens?: boolean, isInlineContext?: boolean, isStatement?: boolean, isLogicalAndOr?: boolean, allowShorthandProperty?: boolean, isFirstChild?: boolean, noBreakInside?: boolean, expandLastArg?: boolean, preferInlineSimpleUnionType?: boolean }} PrintArgs */
 
 import { parseModule } from '@tsrx/core';
 import { doc } from 'prettier';
@@ -1602,7 +1602,7 @@ function printRippleNode(node, path, options, print, args) {
 		}
 
 		case 'MemberExpression':
-			nodeContent = printMemberExpression(node, path, options, print);
+			nodeContent = printMemberExpression(node, path, options, print, args);
 			break;
 
 		case 'MetaProperty':
@@ -1664,7 +1664,7 @@ function printRippleNode(node, path, options, print, args) {
 
 			// Preserve parentheses for type-annotated call expressions
 			// When parenthesized with leading comments, use grouping to allow breaking
-			if (node.metadata?.parenthesized) {
+			if (node.metadata?.parenthesized && !args?.suppressOwnParens) {
 				const hasLeadingComments = node.leadingComments && node.leadingComments.length > 0;
 				if (hasLeadingComments) {
 					// Group with softline to allow breaking after opening paren
@@ -1950,7 +1950,8 @@ function printRippleNode(node, path, options, print, args) {
 				parent &&
 				(parent.type === 'MemberExpression' ||
 					(parent.type === 'AssignmentExpression' && parent.left === node));
-			const shouldAddParens = node.metadata?.parenthesized && !parentHandlesParens;
+			const shouldAddParens =
+				node.metadata?.parenthesized && !parentHandlesParens && !args?.suppressOwnParens;
 			if (shouldAddParens) {
 				nodeContent = ['(', identifierContent, ')'];
 			} else {
@@ -2114,7 +2115,19 @@ function printRippleNode(node, path, options, print, args) {
 				if (argumentHasOwnLineLeadingComment(node.argument)) {
 					// The comment prints on its own line, which would separate `return`
 					// from its argument and trigger ASI — keep the argument in parens.
-					parts.push(' (', indent([hardline, path.call(print, 'argument')]), hardline, ')');
+					// These parens replace any the argument would print for itself.
+					parts.push(
+						' (',
+						indent([
+							hardline,
+							path.call(
+								(argumentPath) => print(argumentPath, { suppressOwnParens: true }),
+								'argument',
+							),
+						]),
+						hardline,
+						')',
+					);
 				} else {
 					parts.push(' ');
 					parts.push(path.call(print, 'argument'));
@@ -2296,7 +2309,7 @@ function printRippleNode(node, path, options, print, args) {
 			}
 
 			// Wrap in parentheses if metadata indicates they were present
-			if (node.metadata?.parenthesized) {
+			if (node.metadata?.parenthesized && !args?.suppressOwnParens) {
 				result = ['(', result, ')'];
 			}
 
@@ -2320,7 +2333,7 @@ function printRippleNode(node, path, options, print, args) {
 		}
 
 		case 'MemberExpression':
-			nodeContent = printMemberExpression(node, path, options, print);
+			nodeContent = printMemberExpression(node, path, options, print, args);
 			break;
 
 		case 'ObjectPattern':
@@ -4123,9 +4136,10 @@ function printMethodDefinition(node, path, options, print) {
  * @param {AstPath<AST.MemberExpression>} path - The AST path
  * @param {RippleFormatOptions} options - Prettier options
  * @param {PrintFn} print - Print callback
+ * @param {PrintArgs} [args] - Additional context arguments
  * @returns {Doc}
  */
-function printMemberExpression(node, path, options, print) {
+function printMemberExpression(node, path, options, print, args) {
 	let objectPart = path.call(print, 'object');
 	// Preserve parentheses around the object when present
 	if (node.object.metadata?.parenthesized) {
@@ -4143,7 +4157,7 @@ function printMemberExpression(node, path, options, print) {
 	}
 
 	// Preserve parentheses around the entire member expression when present
-	if (node.metadata?.parenthesized) {
+	if (node.metadata?.parenthesized && !args?.suppressOwnParens) {
 		// Check if there are leading comments - if so, use group with softlines to allow breaking
 		const hasLeadingComments = node.leadingComments && node.leadingComments.length > 0;
 		if (hasLeadingComments) {
@@ -4329,7 +4343,16 @@ function printThrowStatement(node, path, options, print) {
 	const parts = [];
 	if (argumentHasOwnLineLeadingComment(node.argument)) {
 		// Same ASI hazard as `return`: keep the argument attached via parens.
-		parts.push('throw (', indent([hardline, path.call(print, 'argument')]), hardline, ')');
+		// These parens replace any the argument would print for itself.
+		parts.push(
+			'throw (',
+			indent([
+				hardline,
+				path.call((argumentPath) => print(argumentPath, { suppressOwnParens: true }), 'argument'),
+			]),
+			hardline,
+			')',
+		);
 	} else {
 		parts.push('throw ');
 		parts.push(path.call(print, 'argument'));

--- a/packages/prettier-plugin/src/index.js
+++ b/packages/prettier-plugin/src/index.js
@@ -2881,18 +2881,20 @@ function printArrowFunction(node, path, options, print, args) {
 		} else {
 			bodyContent = bodyDoc;
 		}
-		if (
-			isTemplateExpression(node.body) ||
-			node.body.type === 'BinaryExpression' ||
-			node.body.type === 'LogicalExpression'
-		) {
-			// Try the body inline; otherwise break right after `=>` so the body
-			// starts on its own line. Deciding this from the printed doc (instead
-			// of the original source span) keeps formatting idempotent.
+		if (isTemplateExpression(node.body)) {
 			return conditionalGroup([
 				group([...parts, ' => ', bodyContent]),
 				group([...parts, ' =>', indent([hardline, bodyContent])]),
 			]);
+		}
+		if (node.body.type === 'BinaryExpression' || node.body.type === 'LogicalExpression') {
+			// Keep the body inline when it fits; otherwise break right after `=>`
+			// so the body starts on its own line. An inner group scoped to the body
+			// makes that call from the printed doc (not the original source span,
+			// which kept the two passes disagreeing) and still works when the
+			// parameter list itself breaks.
+			parts.push(' =>', group(indent([line, bodyContent])));
+			return group(parts);
 		}
 		parts.push(
 			' =>',
@@ -5405,9 +5407,16 @@ function printTSTypeLiteral(node, path, options, print) {
 		'}',
 	]);
 
-	return conditionalGroup(
-		wasOriginallySingleLine(node) ? [inlineDoc, multilineDoc] : [multilineDoc, inlineDoc],
-	);
+	if (!wasOriginallySingleLine(node)) {
+		// A hardline-first conditionalGroup always picks that state (fits()
+		// short-circuits to true on hardlines) while hiding the hardlines from
+		// enclosing groups' break propagation — ancestors then stay flat and
+		// print following siblings past printWidth. The multiline doc alone is
+		// equivalent and propagates its breaks correctly.
+		return multilineDoc;
+	}
+
+	return conditionalGroup([inlineDoc, multilineDoc]);
 }
 
 /**

--- a/packages/prettier-plugin/src/index.test.js
+++ b/packages/prettier-plugin/src/index.test.js
@@ -6601,6 +6601,30 @@ function g() {
 			expect(result).toBeWithNewline(input);
 		});
 
+		it('breaks long logical arrow bodies after multiline type-literal params', async () => {
+			const input = `function f() {
+	const mapping = result.mappings.find(
+		(mapping: {
+			sourceOffsets: number[];
+			generatedOffsets: number[];
+		}) =>
+			mapping.sourceOffsets[0] === source_offset &&
+				mapping.generatedOffsets[0] === generated_offset &&
+				mapping.lengths[0] === identifier.length,
+	);
+}`;
+
+			// The multiline param type used to hide its hardlines from enclosing
+			// groups (fits() short-circuits on hardlines inside conditionalGroup
+			// states), so the body printed flat past printWidth.
+			const result = await format(input, {
+				useTabs: true,
+				singleQuote: true,
+				printWidth: 100,
+			});
+			expect(result).toBeWithNewline(input);
+		});
+
 		it('stabilizes long arrow bodies with logical expressions in one pass', async () => {
 			const input = `function useStack() {
 	return horizontal

--- a/packages/prettier-plugin/src/index.test.js
+++ b/packages/prettier-plugin/src/index.test.js
@@ -6582,6 +6582,25 @@ function RowList({ rows, Row }) {
 			expect(once).not.toMatch(/return[;\s]*\/\//);
 		});
 
+		it('does not double-wrap self-parenthesizing return and throw arguments', async () => {
+			const input = `function f() {
+  return (
+    // pick the fallback
+    cond ? a : b
+  );
+}
+
+function g() {
+  throw (
+    // wrap the cause
+    makeError(cause)
+  );
+}`;
+
+			const result = await format(input);
+			expect(result).toBeWithNewline(input);
+		});
+
 		it('stabilizes long arrow bodies with logical expressions in one pass', async () => {
 			const input = `function useStack() {
 	return horizontal

--- a/packages/prettier-plugin/src/index.test.js
+++ b/packages/prettier-plugin/src/index.test.js
@@ -55,15 +55,23 @@ describe('prettier-plugin', () => {
 	});
 
 	/**
+	 * Format tsrx source. Every call also verifies the output is a fixpoint:
+	 * formatting must be single-pass idempotent (a second pass may not change
+	 * a single byte), so the whole suite doubles as an idempotence corpus.
 	 * @param {string} code
 	 * @param {import('prettier').Options} [options]
 	 */
 	const format = async (code, options = {}) => {
-		return await prettier.format(code, {
+		/** @type {import('prettier').Options} */
+		const resolvedOptions = {
 			parser: 'tsrx',
 			plugins: [join(__dirname, 'index.js')],
 			...options,
-		});
+		};
+		const once = await prettier.format(code, resolvedOptions);
+		const twice = await prettier.format(once, resolvedOptions);
+		expect(twice, 'formatting must be idempotent (second pass changed the output)').toBe(once);
+		return once;
 	};
 
 	it('formats functions that return native elements', async () => {
@@ -888,8 +896,7 @@ const items=[1,2,3];
   <List
     items={props.items}
     renderItem={(item) =>
-      <><ItemView {item} onSelect={props.onSelect} /></>
-    }
+      <><ItemView {item} onSelect={props.onSelect} /></>}
   />
 }`;
 		const result = await format(input, { singleQuote: true, printWidth: 60 });
@@ -1243,7 +1250,8 @@ const items=[1,2,3];
 		it('should format destructured dynamic import() in Promise.all', async () => {
 			const input = `const [{ EditorState }, { oneDark }] = await Promise.all([import('@codemirror/state'), import('@codemirror/theme-one-dark')]);`;
 			const expected = `const [{ EditorState }, { oneDark }] = await Promise.all([
-  import("@codemirror/state"), import("@codemirror/theme-one-dark"),
+  import("@codemirror/state"),
+  import("@codemirror/theme-one-dark"),
 ]);`;
 			const result = await format(input);
 			expect(result).toBeWithNewline(expected);
@@ -3377,7 +3385,8 @@ function test() {
 
 			const expected = `const arr = [
   1, /* comment 1 */
-  2, 3,
+  2,
+  3,
   // comment 2
 ];`;
 
@@ -6491,6 +6500,127 @@ function RowList({ rows, Row }) {
 				printWidth: 100,
 			});
 			expect(result).toBeWithNewline(expected);
+		});
+	});
+
+	describe('parens around as-cast operands', () => {
+		it('keeps parens around a nullish coalescing operand of an as-cast', async () => {
+			const input = `function App() {
+  return <span>{(activeAuthor ?? "All authors") as string}</span>;
+}`;
+
+			const result = await format(input);
+			expect(result).toBeWithNewline(input);
+		});
+
+		it('keeps parens around logical and equality operands of as-casts', async () => {
+			const input = `function App() {
+  const a = (x || y) as string;
+  const b = (x == y) as boolean;
+  const c = (x ?? y) satisfies string;
+  return <div>{a}</div>;
+}`;
+
+			const result = await format(input);
+			expect(result).toBeWithNewline(input);
+		});
+
+		it('does not add parens around higher-precedence operands of as-casts', async () => {
+			const input = `function App() {
+  const a = x + y as string;
+  const b = x < y as unknown;
+  return <div>{a}</div>;
+}`;
+
+			const result = await format(input);
+			expect(result).toBeWithNewline(input);
+		});
+	});
+
+	describe('definite assignment assertions', () => {
+		it('keeps the definite assignment assertion on variable declarations', async () => {
+			const input = `function App() {
+  let cleanup!: () => void;
+  var count!: number;
+  return <div />;
+}`;
+
+			const result = await format(input);
+			expect(result).toBeWithNewline(input);
+		});
+	});
+
+	describe('idempotence', () => {
+		/**
+		 * @param {string} code
+		 * @param {import('prettier').Options} [options]
+		 */
+		const expectStable = async (code, options = {}) => {
+			const once = await format(code, options);
+			const twice = await format(once, options);
+			expect(twice).toBe(once);
+			return once;
+		};
+
+		it('keeps a return argument with leading line comments after the return keyword', async () => {
+			const input = `function isXOrYInValid(xOrY: string | number | undefined) {
+	return (
+		// number that is not NaN or Infinity
+		(typeof xOrY === 'number' && Number.isFinite(xOrY)) ||
+		// for percentage
+		typeof xOrY === 'string'
+	);
+}`;
+
+			const once = await expectStable(input, {
+				useTabs: true,
+				singleQuote: true,
+				printWidth: 100,
+			});
+			// The argument must stay attached to the return; printing the comment
+			// between `return` and the expression triggers ASI and returns undefined.
+			expect(once).not.toMatch(/return[;\s]*\/\//);
+		});
+
+		it('stabilizes long arrow bodies with logical expressions in one pass', async () => {
+			const input = `function useStack() {
+	return horizontal
+		? {
+				defined: (d: AreaStackDatum<XScale, YScale>) =>
+					isValidNumber(yScale(getStackValue(d.data))) && isValidNumber(xScale(getSecondItem(d))),
+			}
+		: null;
+}`;
+
+			await expectStable(input, {
+				useTabs: true,
+				singleQuote: true,
+				printWidth: 100,
+			});
+		});
+
+		it('stabilizes deeply nested JSX attribute arrows returning JSX in one pass', async () => {
+			const input = `function Parent() {
+	return <div>
+		<section>
+			<article>
+				<fieldset>
+					<group.Subscribe
+						children={(state) => (
+							<span data-testid="state-lastName">{state.values.lastName}</span>
+						)}
+					/>
+				</fieldset>
+			</article>
+		</section>
+	</div>;
+}`;
+
+			await expectStable(input, {
+				useTabs: true,
+				singleQuote: true,
+				printWidth: 100,
+			});
 		});
 	});
 });


### PR DESCRIPTION
Fixes three bugs found while porting tanstack.com to Octane (octane PR #214), all in `@tsrx/prettier-plugin` (observed around 0.3.104).

## 1. Parens dropped around `as`-cast operands

`<span>{(activeAuthor ?? 'All authors') as string}</span>` reformatted to `<span>{activeAuthor ?? 'All authors' as string}</span>`. `as` binds at relational precedence, so dropping the parens changes the parse tree (the cast moves onto the right operand), demotes a top-level tsrx text hole to a renderable hole, and `??` mixed with an unparenthesized cast operand is a TS grammar hazard. Same family as the `a - (b - c)` paren drop fixed in #1335. `TSAsExpression`/`TSSatisfiesExpression` now parenthesize logical, low-precedence binary, arrow, and yield operands. Simple `as`-cast text holes are also treated as simple JSX children so they stay inline like the identifier/member holes they wrap.

## 2. Definite-assignment assertion dropped

`let x!: () => void;` reformatted to `let x: () => void;` — runtime-neutral but strict TS then reports "used before being assigned". The parser already records `definite` on the declarator; the printer now emits the `!`.

## 3. Formatting was not single-pass idempotent

Several real-world files needed two `prettier --write` passes to satisfy `--check`, intermittently breaking `format:check` CI gates. Root causes fixed:

- **`return`/`throw` with own-line leading comments on the argument** printed the comment between the keyword and the expression; ASI then turned `return (expr)` into a bare `return` plus dead code — a semantic break, not just churn. Such arguments now keep wrapping parens.
- **Arrow expression bodies** (binary/logical) chose their layout from the *original source span* length, so pass 1 and pass 2 disagreed — a true 2-cycle that never converged. The decision now comes from the printed doc via `conditionalGroup`, matching the existing JSX-body path.
- **Arrow-with-JSX-body attributes** used the same source-span check to dangle the closing `}`; the special case is removed and the brace always hugs (the convention 2 of 3 existing goldens already encoded).
- **Originally-single-line arrays** that wrapped were `fill()`-packed several elements per line; the packed output reparses as a multiline array and then breaks one element per line, so packing was never a fixpoint. Wrapped arrays now break all-or-nothing (matching Prettier core for non-numeric arrays); two goldens updated accordingly.

### Idempotence harness

The shared `format` test helper now formats every input twice and asserts byte-equal output, so all 362 existing cases double as an idempotence corpus. As extra validation the fixed plugin was swept over a 1255-file `.tsrx` corpus (the octane tanstack-com port): the previously affected files all converge in one pass now. One unrelated remaining case (comment scrambling in broken generic type-argument lists, `printTSTypeParameterInstantiation`) converges on pass 2 and is left as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect core printer behavior (casts, returns, arrays, arrows) where mistakes could alter parse meaning or layout, but scope is limited to the prettier plugin with broad idempotence test coverage.
> 
> **Overview**
> **`@tsrx/prettier-plugin`** fixes three formatting bugs and tightens idempotence so one `prettier --write` pass matches `--check`.
> 
> **Casts and TypeScript syntax:** `as` / `satisfies` now keep parentheses on low-precedence operands (e.g. `(activeAuthor ?? "All authors") as string`) via `castOperandNeedsParens`. Variable declarators emit the definite-assignment `!` (`let x!: T`). Simple `TSAsExpression` holes in JSX stay inline like other simple expressions.
> 
> **Single-pass idempotence:** `return` / `throw` arguments with leading comments that print on their own line are wrapped in parens (with `suppressOwnParens` to avoid double-wrapping) so ASI cannot detach the expression. Arrow bodies with binary/logical expressions break from the printed doc instead of original source span; source-span-based JSX attribute `}` breaking is removed. Wrapped single-line arrays use an all-or-nothing group instead of `fill()` packing. Multiline type literals that were originally multi-line return only the multiline doc so breaks propagate to parents.
> 
> **Tests:** The shared `format` helper formats twice and asserts byte-equal output; new cases cover cast parens, definite `!`, and targeted idempotence scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88cfb5554c5c4b48d75aae99ea59916ff517a3ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->