### PR TITLE
fix(prettier-plugin): keep comments attached to their type arguments

### DIFF
--- a/.changeset/prettier-type-arg-comments.md
+++ b/.changeset/prettier-type-arg-comments.md
@@ -1,0 +1,5 @@
+---
+'@tsrx/prettier-plugin': patch
+---
+
+Keep comments attached to their TypeScript type arguments. `TSTypeReference` printed `<...>` type arguments as a flat comma join, which jammed a param's leading and trailing comments together inline (in reversed order) and needed two passes to converge. Type arguments now print through `printTSTypeParameterInstantiation`, so the list breaks like standard prettier: trailing comments stay on their param's line, own-line leading comments stay above their param, and a lone object-type argument still hugs the angle brackets (`Foo<{ ... }>`).

--- a/packages/prettier-plugin/src/index.js
+++ b/packages/prettier-plugin/src/index.js
@@ -4580,17 +4580,17 @@ function printTSTypeParameterInstantiation(node, path, options, print) {
 
 	const paramList = path.map(print, 'params');
 
+	// Hug a lone object-type argument against the brackets: Foo<{ ... }>
+	if (
+		node.params.length === 1 &&
+		(node.params[0].type === 'TSTypeLiteral' || node.params[0].type === 'TSMappedType') &&
+		!hasComment(/** @type {AST.Node & AST.NodeWithMaybeComments} */ (node.params[0]))
+	) {
+		return ['<', paramList[0], '>'];
+	}
+
 	// Check if any param has line breaks (e.g., contains object types)
 	const hasBreakingParam = paramList.some((param) => willBreak(param));
-
-	// Build inline version: <T, U>
-	/** @type {Doc[]} */
-	const inlineParts = ['<'];
-	for (let i = 0; i < paramList.length; i++) {
-		if (i > 0) inlineParts.push(', ');
-		inlineParts.push(paramList[i]);
-	}
-	inlineParts.push('>');
 
 	// If any param breaks, use the breaking version with proper indentation
 	if (hasBreakingParam) {
@@ -5522,24 +5522,12 @@ function printTSTypeReference(node, path, options, print) {
 
 	// Handle both typeArguments and typeParameters (different AST variations)
 	if (node.typeArguments) {
-		parts.push('<');
-		const typeArgs = path.map(print, 'typeArguments', 'params');
-		for (let i = 0; i < typeArgs.length; i++) {
-			if (i > 0) parts.push(', ');
-			parts.push(typeArgs[i]);
-		}
-		parts.push('>');
+		parts.push(path.call(print, 'typeArguments'));
 		// @ts-expect-error - acorn-typescript uses typeParameters instead of typeArguments
 		// we normalize it in the analyze phase, but here we get the parser ast
 	} else if (node.typeParameters) {
-		parts.push('<');
 		// @ts-expect-error - acorn-typescript uses typeParameters instead of typeArguments
-		const typeParams = path.map(print, 'typeParameters', 'params');
-		for (let i = 0; i < typeParams.length; i++) {
-			if (i > 0) parts.push(', ');
-			parts.push(typeParams[i]);
-		}
-		parts.push('>');
+		parts.push(path.call(print, 'typeParameters'));
 	}
 
 	return parts;

--- a/packages/prettier-plugin/src/index.test.js
+++ b/packages/prettier-plugin/src/index.test.js
@@ -3763,6 +3763,45 @@ const deleteButton = container.querySelector(
 			expect(result).toBeWithNewline(expected);
 		});
 
+		it('should keep comments attached to their type arguments and stay idempotent', async () => {
+			const input = `interface Props {
+	form: AppFieldExtendedReactFormApi<
+		unknown,
+		| undefined
+		| FormAsyncValidateOrFn<unknown>, // this types it as 'never' in the render prop. It should prevent any
+		// untyped meta passed to the handleSubmit by accident.
+		NoInfer<TSubmitMeta>
+	>;
+}`;
+			// Matches vanilla prettier's typescript parser output for the same input.
+			const expected = `interface Props {
+	form: AppFieldExtendedReactFormApi<
+		unknown,
+		undefined | FormAsyncValidateOrFn<unknown>, // this types it as 'never' in the render prop. It should prevent any
+		// untyped meta passed to the handleSubmit by accident.
+		NoInfer<TSubmitMeta>
+	>;
+}`;
+			const options = { useTabs: true, tabWidth: 2, singleQuote: true, printWidth: 100 };
+			const result = await format(input, options);
+			expect(result).toBeWithNewline(expected);
+			expect(await format(result, options)).toBe(result);
+		});
+
+		it('should hug a lone object type argument against the angle brackets', async () => {
+			const input = `function Button(props: PropsWithExtras<{
+	variant: string;
+	label: string;
+	onClick: EventListener;
+}>) @{
+	<button class={props.variant} onClick={props.onClick}>{props.label}</button>
+}`;
+			const options = { useTabs: true, tabWidth: 2, singleQuote: true, printWidth: 100 };
+			const result = await format(input, options);
+			expect(result).toBeWithNewline(input);
+			expect(await format(result, options)).toBe(result);
+		});
+
 		it('should not overindent multiline object type aliases', async () => {
 			const input = `type ModuleShape = {
   default: ComponentType<{ value: string }>;


### PR DESCRIPTION
## Problem

`TSTypeReference` printed `<...>` type arguments as a flat comma join with no break structure. When a type argument carried comments, the printer jammed the param's leading and trailing comments together inline — in reversed order — and formatting needed two passes to converge (with the comments still scrambled after the second pass):

```ts
interface Props {
	form: AppFieldExtendedReactFormApi<
		unknown,
		| undefined
		| FormAsyncValidateOrFn<unknown>, // this types it as 'never' in the render prop. It should prevent any
		// untyped meta passed to the handleSubmit by accident.
		NoInfer<TSubmitMeta>
	>;
}
```

formatted to:

```ts
interface Props {
	form: AppFieldExtendedReactFormApi<unknown, | undefined
	| FormAsyncValidateOrFn<unknown>, // untyped meta passed to the handleSubmit by accident. // this types it as 'never' in the render prop. It should prevent any
	NoInfer<TSubmitMeta>>;
}
```

## Fix

- `printTSTypeReference` now delegates its type arguments to `printTSTypeParameterInstantiation` (both the `typeArguments` and acorn `typeParameters` AST variants) instead of a hand-rolled flat join. The list breaks one-param-per-line when a param must break, so trailing comments stay on their param's line and own-line leading comments stay above their param. The output matches vanilla prettier's `typescript` parser for the same input and is a single-pass fixpoint.
- Added a hug case in `printTSTypeParameterInstantiation` for a lone comment-free `TSTypeLiteral`/`TSMappedType` argument so `Foo<{ ... }>` keeps hugging the angle brackets like vanilla prettier.

## Verification

- New tests: the repro (with double-format idempotence assertion) and the object-argument hug case. Full prettier-plugin suite (357) and language-server suite pass; `pnpm typecheck`, `pnpm format:check`, `pnpm changeset:check` pass.
- Swept a 1255-file real-world `.tsrx` corpus: identical failure set to the unmodified plugin (all pre-existing, unrelated causes), so no regressions; the real-world construct that motivated this fix now formats to a byte-identical fixpoint.

Patch changeset included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized prettier-plugin TypeScript printing change with targeted tests; no auth, data, or runtime behavior impact.
> 
> **Overview**
> Fixes **TypeScript generic type argument** printing so comments and line breaks behave like vanilla Prettier instead of collapsing into a single scrambled line.
> 
> **`printTSTypeReference`** no longer hand-joins `typeArguments` / `typeParameters` with commas; it delegates to **`printTSTypeParameterInstantiation`**, which already handles per-argument breaks and comment attachment.
> 
> **`printTSTypeParameterInstantiation`** gains a **hug** path for a single comment-free **`TSTypeLiteral`** or **`TSMappedType`** so output stays `Foo<{ ... }>`.
> 
> New tests cover the commented multi-arg repro (with **double-format idempotence**) and the lone object-type hug case. Patch changeset for `@tsrx/prettier-plugin`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83b8befb96fe6eacbd9cddb8abce064ea844feb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->