### PR TITLE
fix(prettier-plugin): break long type parameter lists like vanilla prettier

### DIFF
--- a/.changeset/breezy-parrots-format.md
+++ b/.changeset/breezy-parrots-format.md
@@ -1,0 +1,5 @@
+---
+'@tsrx/prettier-plugin': patch
+---
+
+Break long type parameter lists one per line with a trailing comma, like vanilla prettier, instead of emitting one overlong line. The `<T,>` trailing-comma preservation now only applies to single-param arrow function generics, where the comma is syntactically meaningful. Function signatures group parameters with the return type so the fitter prefers breaking the parameter list, and type reference arguments can now break too, hugging a single object-type argument.

--- a/packages/prettier-plugin/src/index.js
+++ b/packages/prettier-plugin/src/index.js
@@ -2737,12 +2737,8 @@ function printFunctionExpression(node, path, options, print) {
 		parts.push(' ');
 	}
 
-	// Print parameters using shared function
-	const paramsPart = printFunctionParameters(path, options, print);
-	parts.push(group(paramsPart)); // Handle return type annotation
-	if (node.returnType) {
-		parts.push(': ', path.call(print, 'returnType'));
-	}
+	// Print parameters and return type as a single group
+	parts.push(printFunctionSignature(node, path, options, print));
 
 	parts.push(' ');
 	parts.push(path.call(print, 'body'));
@@ -2790,12 +2786,8 @@ function printArrowFunction(node, path, options, print, args) {
 	) {
 		parts.push(path.call(print, 'params', 0));
 	} else {
-		// Print parameters using shared function
-		const paramsPart = printFunctionParameters(path, options, print);
-		parts.push(group(paramsPart));
-	} // Handle return type annotation
-	if (node.returnType) {
-		parts.push(': ', path.call(print, 'returnType'));
+		// Print parameters and return type as a single group
+		parts.push(printFunctionSignature(node, path, options, print));
 	}
 
 	// For block statements, print the body directly to get proper formatting
@@ -2904,8 +2896,48 @@ function shouldHugTheOnlyFunctionParameter(node) {
 			parameter.type === 'ArrayPattern' ||
 			(parameter.type === 'Identifier' &&
 				!!parameter.typeAnnotation &&
-				parameter.typeAnnotation.type === 'TSTypeAnnotation'))
+				parameter.typeAnnotation.type === 'TSTypeAnnotation' &&
+				isHuggableParameterType(parameter.typeAnnotation.typeAnnotation)))
 	);
+}
+
+/**
+ * Check if a type node is an object-like type (object literal or mapped type)
+ * @param {AST.Node | undefined} node - The type node
+ * @returns {boolean}
+ */
+function isObjectType(node) {
+	return !!node && (node.type === 'TSTypeLiteral' || node.type === 'TSMappedType');
+}
+
+/**
+ * Check if a parameter's type annotation should keep the parameter hugged.
+ * Object-like types hug like vanilla prettier; additionally a type reference
+ * wrapping a single object type (`props: Props<{ ... }>`) hugs, since that is
+ * the common TSRX component-props shape. Other references, like a plain
+ * `initialState: State`, leave the parameter list free to break.
+ * @param {AST.Node | undefined} node - The type node
+ * @returns {boolean}
+ */
+function isHuggableParameterType(node) {
+	if (isObjectType(node)) {
+		return true;
+	}
+	if (node?.type === 'TSIntersectionType') {
+		const types = /** @type {AST.TSIntersectionType} */ (node).types;
+		return types?.length > 0 && isHuggableParameterType(types[types.length - 1]);
+	}
+	if (node?.type === 'TSTypeReference') {
+		const typeArguments =
+			/** @type {AST.TSTypeReference & { typeParameters?: AST.TSTypeParameterInstantiation }} */ (
+				node
+			).typeArguments ??
+			/** @type {AST.TSTypeReference & { typeParameters?: AST.TSTypeParameterInstantiation }} */ (
+				node
+			).typeParameters;
+		return typeArguments?.params?.length === 1 && isObjectType(typeArguments.params[0]);
+	}
+	return false;
 }
 
 /**
@@ -2961,6 +2993,56 @@ function printFunctionParameters(path, options, print) {
 		softline,
 		')',
 	];
+}
+
+/**
+ * Check whether the parameter list should be grouped separately from the return
+ * type, so a breaking return type does not force the parameters to break too.
+ * @param {AST.FunctionExpression | AST.ArrowFunctionExpression | AST.TSDeclareFunction | AST.FunctionDeclaration} functionNode - The function node
+ * @param {Doc} returnTypeDoc - The printed return type
+ * @returns {boolean}
+ */
+function shouldGroupFunctionParameters(functionNode, returnTypeDoc) {
+	const returnTypeNode = functionNode.returnType?.typeAnnotation;
+	const typeParameters = functionNode.typeParameters?.params;
+	if (typeParameters) {
+		if (typeParameters.length > 1) {
+			return false;
+		}
+		if (typeParameters.length === 1) {
+			const typeParameter = typeParameters[0];
+			if (typeParameter.constraint || typeParameter.default) {
+				return false;
+			}
+		}
+	}
+	return (
+		getFunctionParameters(functionNode).length === 1 &&
+		(isObjectType(returnTypeNode) || willBreak(returnTypeDoc))
+	);
+}
+
+/**
+ * Print function parameters together with the return type as a single group, so
+ * the fitter breaks the parameter list before type arguments nested in the
+ * return type, matching vanilla prettier's signature layout.
+ * @param {AST.FunctionExpression | AST.ArrowFunctionExpression | AST.TSDeclareFunction | AST.FunctionDeclaration} node - The function node
+ * @param {AstPath<AST.FunctionExpression | AST.ArrowFunctionExpression | AST.TSDeclareFunction | AST.FunctionDeclaration>} path - The function path
+ * @param {RippleFormatOptions} options - Prettier options
+ * @param {PrintFn} print - Print callback
+ * @returns {Doc}
+ */
+function printFunctionSignature(node, path, options, print) {
+	const paramsPart = printFunctionParameters(path, options, print);
+	if (!node.returnType) {
+		return group(paramsPart);
+	}
+	/** @type {Doc[]} */
+	const returnTypeDoc = [': ', path.call(print, 'returnType')];
+	if (shouldGroupFunctionParameters(node, returnTypeDoc)) {
+		return group([group(paramsPart), ...returnTypeDoc]);
+	}
+	return group([...paramsPart, ...returnTypeDoc]);
 }
 
 /**
@@ -3337,14 +3419,8 @@ function printTSDeclareFunction(node, path, options, print) {
 		}
 	}
 
-	// Print parameters using shared function
-	const paramsPart = printFunctionParameters(path, options, print);
-	parts.push(group(paramsPart));
-
-	// Handle return type annotation
-	if (node.returnType) {
-		parts.push(': ', path.call(print, 'returnType'));
-	}
+	// Print parameters and return type as a single group
+	parts.push(printFunctionSignature(node, path, options, print));
 
 	// TSDeclareFunction ends with semicolon, no body
 	parts.push(';');
@@ -3389,14 +3465,8 @@ function printFunctionDeclaration(node, path, options, print) {
 		}
 	}
 
-	// Print parameters using shared function
-	const paramsPart = printFunctionParameters(path, options, print);
-	parts.push(group(paramsPart));
-
-	// Handle return type annotation
-	if (node.returnType) {
-		parts.push(': ', path.call(print, 'returnType'));
-	}
+	// Print parameters and return type as a single group
+	parts.push(printFunctionSignature(node, path, options, print));
 
 	parts.push(' ');
 	parts.push(path.call(print, 'body'));
@@ -4524,19 +4594,28 @@ function printTSTypeParameterDeclaration(node, path, options, print) {
 	if (!node.params || node.params.length === 0) {
 		return '';
 	}
-	/** @type {Doc[]} */
-	const parts = [];
-	parts.push('<');
 	const paramList = path.map(print, 'params');
-	for (let i = 0; i < paramList.length; i++) {
-		if (i > 0) parts.push(', ');
-		parts.push(paramList[i]);
+
+	// In JSX-shaped files a lone `<T>` on an arrow function is ambiguous with a JSX
+	// element, so a source-level trailing comma (`<T,>`) is syntactically meaningful
+	// there. Keep single-param arrow generics flat and preserve that comma; breaking
+	// them would add a trailing comma that flattens back on the next pass.
+	const parent = /** @type {AST.Node | null} */ (path.getParentNode());
+	if (parent?.type === 'ArrowFunctionExpression' && node.params.length === 1) {
+		const trailing = node.extra?.trailingComma !== undefined ? ',' : '';
+		return ['<', paramList[0], trailing, '>'];
 	}
-	if (node.params.length === 1 && node.extra?.trailingComma !== undefined) {
-		parts.push(',');
-	}
-	parts.push('>');
-	return parts;
+
+	return group([
+		'<',
+		indent([
+			softline,
+			join([',', line], paramList),
+			ifBreak(shouldPrintComma(options, 'all') ? ',' : ''),
+		]),
+		softline,
+		'>',
+	]);
 }
 
 /**
@@ -4579,6 +4658,12 @@ function printTSTypeParameterInstantiation(node, path, options, print) {
 	}
 
 	const paramList = path.map(print, 'params');
+
+	// Hug a single object-like type argument: Props<{ ... }> breaks inside the
+	// braces rather than around them, like vanilla prettier
+	if (node.params.length === 1 && isObjectType(node.params[0])) {
+		return ['<', paramList[0], '>'];
+	}
 
 	// Check if any param has line breaks (e.g., contains object types)
 	const hasBreakingParam = paramList.some((param) => willBreak(param));
@@ -5520,26 +5605,16 @@ function printTSTypeReference(node, path, options, print) {
 	/** @type {Doc[]} */
 	const parts = [path.call(print, 'typeName')];
 
-	// Handle both typeArguments and typeParameters (different AST variations)
+	// Handle both typeArguments and typeParameters (different AST variations).
+	// Both are TSTypeParameterInstantiation nodes, whose printer can break the
+	// argument list when it does not fit.
 	if (node.typeArguments) {
-		parts.push('<');
-		const typeArgs = path.map(print, 'typeArguments', 'params');
-		for (let i = 0; i < typeArgs.length; i++) {
-			if (i > 0) parts.push(', ');
-			parts.push(typeArgs[i]);
-		}
-		parts.push('>');
+		parts.push(path.call(print, 'typeArguments'));
 		// @ts-expect-error - acorn-typescript uses typeParameters instead of typeArguments
 		// we normalize it in the analyze phase, but here we get the parser ast
 	} else if (node.typeParameters) {
-		parts.push('<');
 		// @ts-expect-error - acorn-typescript uses typeParameters instead of typeArguments
-		const typeParams = path.map(print, 'typeParameters', 'params');
-		for (let i = 0; i < typeParams.length; i++) {
-			if (i > 0) parts.push(', ');
-			parts.push(typeParams[i]);
-		}
-		parts.push('>');
+		parts.push(path.call(print, 'typeParameters'));
 	}
 
 	return parts;

--- a/packages/prettier-plugin/src/index.test.js
+++ b/packages/prettier-plugin/src/index.test.js
@@ -6493,4 +6493,133 @@ function RowList({ rows, Row }) {
 			expect(result).toBeWithNewline(expected);
 		});
 	});
+
+	describe('type parameter declarations', () => {
+		/**
+		 * Formats twice and asserts the output is stable (idempotent).
+		 * @param {string} code
+		 * @param {import('prettier').Options} [options]
+		 */
+		const formatStable = async (code, options = {}) => {
+			const once = await format(code, options);
+			const twice = await format(once, options);
+			expect(twice).toBe(once);
+			return once;
+		};
+
+		it('breaks long interface type parameter lists one per line with a trailing comma', async () => {
+			const input = `export interface WithFieldGroupProps<TFieldGroupData, TFieldComponents extends Record<string, HookComponentType<any>>, TFormComponents extends Record<string, HookComponentType<any>>, TSubmitMeta, TRenderProps extends object = Record<string, never>> extends BaseFormOptions<TFieldGroupData, TSubmitMeta> {
+	props?: TRenderProps;
+}`;
+			const expected = `export interface WithFieldGroupProps<
+	TFieldGroupData,
+	TFieldComponents extends Record<string, HookComponentType<any>>,
+	TFormComponents extends Record<string, HookComponentType<any>>,
+	TSubmitMeta,
+	TRenderProps extends object = Record<string, never>,
+> extends BaseFormOptions<TFieldGroupData, TSubmitMeta> {
+	props?: TRenderProps;
+}`;
+
+			const result = await formatStable(input, {
+				printWidth: 100,
+				useTabs: true,
+				singleQuote: true,
+			});
+			expect(result).toBeWithNewline(expected);
+		});
+
+		it('prefers breaking the function parameter list over the type parameter list', async () => {
+			const input = `export default function useStateWithCallback<State>(initialState: State): [State, SetStateWithCallback<State>] {
+	return null;
+}`;
+			const expected = `export default function useStateWithCallback<State>(
+	initialState: State,
+): [State, SetStateWithCallback<State>] {
+	return null;
+}`;
+
+			const result = await formatStable(input, {
+				printWidth: 100,
+				useTabs: true,
+				singleQuote: true,
+			});
+			expect(result).toBeWithNewline(expected);
+		});
+
+		it('breaks function type parameter lists that overflow on their own', async () => {
+			const input = `function useAppForm<TFormData, TOnMount extends undefined | FormValidateOrFn<TFormData>, TOnChange extends undefined | FormValidateOrFn<TFormData>, TSubmitMeta>(props: FormOptions<TFormData, TOnMount, TOnChange, TSubmitMeta>): void {
+	return;
+}`;
+			const expected = `function useAppForm<
+	TFormData,
+	TOnMount extends undefined | FormValidateOrFn<TFormData>,
+	TOnChange extends undefined | FormValidateOrFn<TFormData>,
+	TSubmitMeta,
+>(props: FormOptions<TFormData, TOnMount, TOnChange, TSubmitMeta>): void {
+	return;
+}`;
+
+			const result = await formatStable(input, {
+				printWidth: 100,
+				useTabs: true,
+				singleQuote: true,
+			});
+			expect(result).toBeWithNewline(expected);
+		});
+
+		it('stays idempotent when a single type parameter has to break', async () => {
+			const input = `interface Container<TExtremelyLongParameterName extends Record<string, unknown>> {
+	value: TExtremelyLongParameterName;
+}`;
+			const expected = `interface Container<
+  TExtremelyLongParameterName extends Record<string, unknown>,
+> {
+  value: TExtremelyLongParameterName;
+}`;
+
+			const result = await formatStable(input);
+			expect(result).toBeWithNewline(expected);
+		});
+
+		it('preserves the trailing comma of single-param arrow function generics', async () => {
+			const expected = `const identity = <T,>(value: T): T => value;`;
+
+			const result = await formatStable(expected);
+			expect(result).toBeWithNewline(expected);
+		});
+
+		it('keeps single-param arrow function generics without a trailing comma as-is', async () => {
+			const expected = `const identity = <T>(value: T): T => value;`;
+
+			const result = await formatStable(expected);
+			expect(result).toBeWithNewline(expected);
+		});
+
+		it('drops meaningless trailing commas from non-arrow type parameter lists', async () => {
+			const input = `function pick<State,>(value: State): State {
+	return value;
+}`;
+			const expected = `function pick<State>(value: State): State {
+  return value;
+}`;
+
+			const result = await formatStable(input);
+			expect(result).toBeWithNewline(expected);
+		});
+
+		it('omits the trailing comma in broken type parameter lists when trailingComma is none', async () => {
+			const input = `interface Container<TExtremelyLongParameterName extends Record<string, unknown>> {
+	value: TExtremelyLongParameterName;
+}`;
+			const expected = `interface Container<
+  TExtremelyLongParameterName extends Record<string, unknown>
+> {
+  value: TExtremelyLongParameterName;
+}`;
+
+			const result = await formatStable(input, { trailingComma: 'none' });
+			expect(result).toBeWithNewline(expected);
+		});
+	});
 });


### PR DESCRIPTION
## Problem

`printTSTypeParameterDeclaration` printed `<T, U extends V>` lists as a flat comma join with no break opportunities. Long generic declarations (interfaces or functions with several constrained type params) either emitted one overlong line, or broke at awkward points inside nested type references — where vanilla prettier breaks the list one param per line with a trailing comma.

A naive fix (group + softline + ifBreak trailing comma) oscillates: a broken single-param list `<\n\tState,\n>` re-parses with `extra.trailingComma` set, which the single-param special case then flattens to `<State,>` — non-idempotent.

## Changes

- **`printTSTypeParameterDeclaration`** groups with softline breaks (one param per line, `ifBreak` trailing comma gated on `trailingComma: 'all'`). The `<T,>` preservation special case now applies **only** to single-param arrow function generics — the one place the trailing comma is syntactically meaningful in JSX-shaped files. Arrows stay flat, which removes the oscillation.
- **New `printFunctionSignature`** groups the parameter list together with the return type (with a vanilla-style `shouldGroupFunctionParameters` exception), used by function declarations, function expressions, arrows, and `TSDeclareFunction`, so the fitter prefers breaking the function parameter list over the type parameter list, like vanilla prettier.
- **`shouldHugTheOnlyFunctionParameter`** no longer hugs every identifier with a type annotation (which forced overlong one-line signatures). It hugs object types like vanilla, plus the TSRX component-props shapes `props: Props<{ ... }>` and intersections ending in an object type, preserving the repo's committed formatting.
- **`printTSTypeReference`** delegates type arguments to the `TSTypeParameterInstantiation` printer so nested references like `FormOptions<...>` can break, with a hug case for a single object-type argument.

## Validation

- 8 new tests, each asserting double-format idempotence; full prettier-plugin suite passes (363/363), language-server 36/36, `pnpm typecheck` and `pnpm format:check` clean with zero repo file changes, `pnpm changeset:check` passes.
- Real-world corpus (octane tanstack port): `WithFieldGroupProps` and the `useAppForm` signature in `createFormHook.tsrx` now format byte-identically to the vanilla-formatted source; all six files that were non-idempotent under the naive fix are idempotent, their only diff being the intended vanilla-style parameter break.

Pre-existing issue found while validating (not addressed here): `(arrow) as T` loses its required parentheses on print, breaking re-parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formatter-only changes in the prettier plugin with broad test coverage; no runtime, auth, or data-path impact.
> 
> **Overview**
> Aligns TSRX generic and function-signature formatting with vanilla Prettier so long declarations break predictably and stay idempotent.
> 
> **Type parameter lists** (`printTSTypeParameterDeclaration`) now use grouped softline breaks—one parameter per line with an optional trailing comma when `trailingComma: 'all'`. The `<T,>` trailing-comma preservation is limited to **single-parameter arrow function** generics (JSX ambiguity); other contexts no longer keep meaningless trailing commas (e.g. `pick<State,>` → `pick<State>`).
> 
> **Function signatures** route through new `printFunctionSignature`, grouping parameters with the return type so line breaking prefers the parameter list over nested generics in the return type. `shouldGroupFunctionParameters` can split params from the return type when a lone param pairs with a breaking or object-like return type.
> 
> **Parameter hugging** (`shouldHugTheOnlyFunctionParameter` / `isHuggableParameterType`) no longer hugs every typed identifier; it hugs object-like types and TSRX-style `Props<{ ... }>` shapes so plain types like `initialState: State` can break.
> 
> **Type arguments** reuse the `TSTypeParameterInstantiation` printer from type references; single object-type args still hug (`Foo<{ ... }>`).
> 
> Eight new tests assert double-format stability for these cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5507300d235fddc8b5434c3ec8007011eec7e5bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->