### PR TITLE
warn on unreturned tsrx fragments

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Ripple is a TypeScript UI framework that combines the best parts of React, Solid,
 and Svelte into one cohesive package. Built as a love letter to frontend
-development, Ripple introduces a JS/TS-first approach with `.ripple` modules that
+development, Ripple introduces a JS/TS-first approach with `.tsrx` modules that
 provide an excellent developer experience for both humans and LLMs.
 
 The [Open Source Guides](https://opensource.guide/) website offers valuable

--- a/good-first-pr-candidates.md
+++ b/good-first-pr-candidates.md
@@ -1,0 +1,75 @@
+# Ripple — Good First PR Candidates (new external contributor)
+
+Compiled by a swarm of subagents + GitHub issue scan on 2026-07-17.
+Repo: Ripple-TS/ripple (https://github.com/Ripple-TS/ripple)
+Conventions: current authoring format is `.tsrx` (directives `@if`/`@for`/`@switch`/`@try`), not legacy `.ripple`.
+
+## How to validate before opening a PR
+- `pnpm format:check` and `pnpm format`
+- `pnpm test --project ripple-client` / `pnpm test --project ripple-server`
+- `pnpm typecheck`
+- Add a changeset ONLY for user-facing package changes (`pnpm changeset`), patch only.
+
+---
+
+## Tier 1 — Trivial, single-string/comment fixes (ideal first PRs)
+| # | Location | What |
+|---|----------|------|
+| 1 | `website/docs/guide/control-flow.md:64` (+ website-new) | "Each `and` has its own body" → should be "Each `case`" |
+| 2 | `website/docs/guide/events.md:230` (+ website-new) | "exluding" → "excluding" |
+| 3 | `website/docs/guide/reactivity.md:56` (+ website-new) | "when need top performance" → "when you need top performance" |
+| 4 | `packages/ripple/src/runtime/internal/client/render.js:178` | comment "if the the value" → "if the value" |
+| 5 | `packages/ripple/src/runtime/internal/server/index.js:1153-54` | "stream stream" + "send sent" doubled-word typos in comment |
+| 6 | `packages/tsrx-ripple/src/analyze/index.js:2431` | error msg "`<title>` must have only contain text nodes" → "can only contain text nodes" |
+| 7 | `packages/tsrx/src/transform/jsx/index.js:3842` | JSDoc "for for-of loops" → "for `for-of` loops" |
+| 8 | `packages/prettier-plugin/src/index.test.js:6292` | test title "one or more exits" → "exists" |
+| 9 | `packages/ripple/tests/client/array/array.static.test.tsrx:113` | broken TODO comment grammar "being using in a not template way" |
+| 10 | `templates/basic/package.json:28` | `"vite": "^8.0.0 "` trailing space |
+
+## Tier 2 — Easy, small but need a judgment call
+| # | Location | What |
+|---|----------|------|
+| 11 | `website/docs/quick-start.md:81` (+ website-new) | Sublime step says "Upgrade Package" → should be "Install Package" (copy-paste bug) |
+| 12 | `packages/vscode-plugin/package.json:26` | `repository.directory` "vscode-plugin" → "packages/vscode-plugin" (all 37 siblings use the prefix) |
+| 13 | `packages/create-ripple/README.md:67` | Node version says "20.0.0 or higher" but package.json requires `>=22.0.0` |
+| 14 | `CONTRIBUTING.md:5` | describes `.ripple` as current format; should be `.tsrx` |
+| 15 | `packages/eslint-plugin/README.md:1` | H1 `# @tsrx/eslint-plugin` vs published `@ripple-ts/eslint-plugin` in badges |
+| 16 | `packages/tsrx-ripple/src/transform/client/index.js:3244` | `throw new Error('TODO')` → descriptive message |
+
+## Tier 3 — Stale `ripplejs.com` → `ripple-ts.com` (batch into ONE clean PR)
+| # | Location | What |
+|---|----------|------|
+| 17 | `README.md:1` | hero link `ripplejs.com` |
+| 18 | `CONTRIBUTING.md:22` | `ripplejs.com/playground` |
+| 19 | `packages/eslint-plugin/README.md:6, :220` | two `ripplejs.com` links |
+| 20 | `grammars/tree-sitter/README.md:3` | `ripplejs.com` |
+
+## Tier 4 — Small metadata / doc polish
+| # | Location | What |
+|---|----------|------|
+| 21 | `zed-plugin/package.json:10` | license "ISC" → "MIT" (repo-wide); also empty `description`/`author` |
+| 22 | `sublime-text-plugin/package.json:4` | empty `description`, missing `keywords` |
+| 23 | `packages/language-server/README.md:32-34` | missing period after extension link |
+| 24 | `templates/basic/README.md:48` | "Ripple Documentation" links to repo, not docs site |
+
+## Moderate (bigger effort — not the smallest first PR)
+- Playground READMEs (`playground/react|solid|vue/README.md`) teach stale inline control-flow syntax instead of `@if`/`@for` directives — impactful but a bigger rewrite.
+- `website/docs/guide/components.md:220` broken anchor `#Props-and-Attributes`.
+- `website/docs/libraries.md:14` `ripplejs-router` old-branding link (verify live repo first).
+- 3 `describe.skip` streaming-SSR hydration suites (`ripple/tests/hydration/try.test.js:132`, `nested-control-flow.test.js:157`, `mixed-control-flow.test.js:70`) — real but touches runtime.
+
+---
+
+## GitHub Issues (no good-first-issue/help-wanted/docs labels exist; 26 open issues reviewed)
+Mostly large features or deep compiler bugs. These 4 are well-scoped "add a warning" tasks suitable for a first contributor:
+
+| Issue | Title | Why beginner-friendly |
+|-------|-------|----------------------|
+| #1226 | Warn when TSRX fragments aren't returned (free-floating `@if`/`@for` outside a return) | Sharp spec w/ example; localized diagnostic |
+| #1261 | Warn when a `@{}` code block holds only a statement | Sharp, concrete; string-interpolation guidance message |
+| #1237 | Warn when assigned `<style>` uses non-standalone selectors | Localized warning + optional emit change |
+| #367 | Warn about invalid HTML (e.g. nested `<p>`) in DEV/SSR | Slightly bigger but bounded to a validator |
+
+## Recommended starting points
+- Lowest friction: any Tier-1 typo or the Tier-3 `ripplejs.com` link-batch (fast merge, zero review risk).
+- Most "real contributor" feeling: claim #1226 or #1261 (add a diagnostic) and comment intent — not assigned yet.

--- a/good-first-pr-candidates.md
+++ b/good-first-pr-candidates.md
@@ -1,75 +1,93 @@
 # Ripple — Good First PR Candidates (new external contributor)
 
-Compiled by a swarm of subagents + GitHub issue scan on 2026-07-17.
-Repo: Ripple-TS/ripple (https://github.com/Ripple-TS/ripple)
-Conventions: current authoring format is `.tsrx` (directives `@if`/`@for`/`@switch`/`@try`), not legacy `.ripple`.
+Compiled by a swarm of subagents + GitHub issue scan on 2026-07-17. Repo:
+Ripple-TS/ripple (https://github.com/Ripple-TS/ripple) Conventions: current
+authoring format is `.tsrx` (directives `@if`/`@for`/`@switch`/`@try`), not legacy
+`.ripple`.
 
 ## How to validate before opening a PR
+
 - `pnpm format:check` and `pnpm format`
 - `pnpm test --project ripple-client` / `pnpm test --project ripple-server`
 - `pnpm typecheck`
-- Add a changeset ONLY for user-facing package changes (`pnpm changeset`), patch only.
+- Add a changeset ONLY for user-facing package changes (`pnpm changeset`), patch
+  only.
 
 ---
 
 ## Tier 1 — Trivial, single-string/comment fixes (ideal first PRs)
-| # | Location | What |
-|---|----------|------|
-| 1 | `website/docs/guide/control-flow.md:64` (+ website-new) | "Each `and` has its own body" → should be "Each `case`" |
-| 2 | `website/docs/guide/events.md:230` (+ website-new) | "exluding" → "excluding" |
-| 3 | `website/docs/guide/reactivity.md:56` (+ website-new) | "when need top performance" → "when you need top performance" |
-| 4 | `packages/ripple/src/runtime/internal/client/render.js:178` | comment "if the the value" → "if the value" |
-| 5 | `packages/ripple/src/runtime/internal/server/index.js:1153-54` | "stream stream" + "send sent" doubled-word typos in comment |
-| 6 | `packages/tsrx-ripple/src/analyze/index.js:2431` | error msg "`<title>` must have only contain text nodes" → "can only contain text nodes" |
-| 7 | `packages/tsrx/src/transform/jsx/index.js:3842` | JSDoc "for for-of loops" → "for `for-of` loops" |
-| 8 | `packages/prettier-plugin/src/index.test.js:6292` | test title "one or more exits" → "exists" |
-| 9 | `packages/ripple/tests/client/array/array.static.test.tsrx:113` | broken TODO comment grammar "being using in a not template way" |
-| 10 | `templates/basic/package.json:28` | `"vite": "^8.0.0 "` trailing space |
+
+| #   | Location                                                        | What                                                                                    |
+| --- | --------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| 1   | `website/docs/guide/control-flow.md:64` (+ website-new)         | "Each `and` has its own body" → should be "Each `case`"                                 |
+| 2   | `website/docs/guide/events.md:230` (+ website-new)              | "exluding" → "excluding"                                                                |
+| 3   | `website/docs/guide/reactivity.md:56` (+ website-new)           | "when need top performance" → "when you need top performance"                           |
+| 4   | `packages/ripple/src/runtime/internal/client/render.js:178`     | comment "if the the value" → "if the value"                                             |
+| 5   | `packages/ripple/src/runtime/internal/server/index.js:1153-54`  | "stream stream" + "send sent" doubled-word typos in comment                             |
+| 6   | `packages/tsrx-ripple/src/analyze/index.js:2431`                | error msg "`<title>` must have only contain text nodes" → "can only contain text nodes" |
+| 7   | `packages/tsrx/src/transform/jsx/index.js:3842`                 | JSDoc "for for-of loops" → "for `for-of` loops"                                         |
+| 8   | `packages/prettier-plugin/src/index.test.js:6292`               | test title "one or more exits" → "exists"                                               |
+| 9   | `packages/ripple/tests/client/array/array.static.test.tsrx:113` | broken TODO comment grammar "being using in a not template way"                         |
+| 10  | `templates/basic/package.json:28`                               | `"vite": "^8.0.0 "` trailing space                                                      |
 
 ## Tier 2 — Easy, small but need a judgment call
-| # | Location | What |
-|---|----------|------|
-| 11 | `website/docs/quick-start.md:81` (+ website-new) | Sublime step says "Upgrade Package" → should be "Install Package" (copy-paste bug) |
-| 12 | `packages/vscode-plugin/package.json:26` | `repository.directory` "vscode-plugin" → "packages/vscode-plugin" (all 37 siblings use the prefix) |
-| 13 | `packages/create-ripple/README.md:67` | Node version says "20.0.0 or higher" but package.json requires `>=22.0.0` |
-| 14 | `CONTRIBUTING.md:5` | describes `.ripple` as current format; should be `.tsrx` |
-| 15 | `packages/eslint-plugin/README.md:1` | H1 `# @tsrx/eslint-plugin` vs published `@ripple-ts/eslint-plugin` in badges |
-| 16 | `packages/tsrx-ripple/src/transform/client/index.js:3244` | `throw new Error('TODO')` → descriptive message |
+
+| #   | Location                                                  | What                                                                                               |
+| --- | --------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| 11  | `website/docs/quick-start.md:81` (+ website-new)          | Sublime step says "Upgrade Package" → should be "Install Package" (copy-paste bug)                 |
+| 12  | `packages/vscode-plugin/package.json:26`                  | `repository.directory` "vscode-plugin" → "packages/vscode-plugin" (all 37 siblings use the prefix) |
+| 13  | `packages/create-ripple/README.md:67`                     | Node version says "20.0.0 or higher" but package.json requires `>=22.0.0`                          |
+| 14  | `CONTRIBUTING.md:5`                                       | describes `.ripple` as current format; should be `.tsrx`                                           |
+| 15  | `packages/eslint-plugin/README.md:1`                      | H1 `# @tsrx/eslint-plugin` vs published `@ripple-ts/eslint-plugin` in badges                       |
+| 16  | `packages/tsrx-ripple/src/transform/client/index.js:3244` | `throw new Error('TODO')` → descriptive message                                                    |
 
 ## Tier 3 — Stale `ripplejs.com` → `ripple-ts.com` (batch into ONE clean PR)
-| # | Location | What |
-|---|----------|------|
-| 17 | `README.md:1` | hero link `ripplejs.com` |
-| 18 | `CONTRIBUTING.md:22` | `ripplejs.com/playground` |
-| 19 | `packages/eslint-plugin/README.md:6, :220` | two `ripplejs.com` links |
-| 20 | `grammars/tree-sitter/README.md:3` | `ripplejs.com` |
+
+| #   | Location                                   | What                      |
+| --- | ------------------------------------------ | ------------------------- |
+| 17  | `README.md:1`                              | hero link `ripplejs.com`  |
+| 18  | `CONTRIBUTING.md:22`                       | `ripplejs.com/playground` |
+| 19  | `packages/eslint-plugin/README.md:6, :220` | two `ripplejs.com` links  |
+| 20  | `grammars/tree-sitter/README.md:3`         | `ripplejs.com`            |
 
 ## Tier 4 — Small metadata / doc polish
-| # | Location | What |
-|---|----------|------|
-| 21 | `zed-plugin/package.json:10` | license "ISC" → "MIT" (repo-wide); also empty `description`/`author` |
-| 22 | `sublime-text-plugin/package.json:4` | empty `description`, missing `keywords` |
-| 23 | `packages/language-server/README.md:32-34` | missing period after extension link |
-| 24 | `templates/basic/README.md:48` | "Ripple Documentation" links to repo, not docs site |
+
+| #   | Location                                   | What                                                                 |
+| --- | ------------------------------------------ | -------------------------------------------------------------------- |
+| 21  | `zed-plugin/package.json:10`               | license "ISC" → "MIT" (repo-wide); also empty `description`/`author` |
+| 22  | `sublime-text-plugin/package.json:4`       | empty `description`, missing `keywords`                              |
+| 23  | `packages/language-server/README.md:32-34` | missing period after extension link                                  |
+| 24  | `templates/basic/README.md:48`             | "Ripple Documentation" links to repo, not docs site                  |
 
 ## Moderate (bigger effort — not the smallest first PR)
-- Playground READMEs (`playground/react|solid|vue/README.md`) teach stale inline control-flow syntax instead of `@if`/`@for` directives — impactful but a bigger rewrite.
+
+- Playground READMEs (`playground/react|solid|vue/README.md`) teach stale inline
+  control-flow syntax instead of `@if`/`@for` directives — impactful but a bigger
+  rewrite.
 - `website/docs/guide/components.md:220` broken anchor `#Props-and-Attributes`.
-- `website/docs/libraries.md:14` `ripplejs-router` old-branding link (verify live repo first).
-- 3 `describe.skip` streaming-SSR hydration suites (`ripple/tests/hydration/try.test.js:132`, `nested-control-flow.test.js:157`, `mixed-control-flow.test.js:70`) — real but touches runtime.
+- `website/docs/libraries.md:14` `ripplejs-router` old-branding link (verify live
+  repo first).
+- 3 `describe.skip` streaming-SSR hydration suites
+  (`ripple/tests/hydration/try.test.js:132`, `nested-control-flow.test.js:157`,
+  `mixed-control-flow.test.js:70`) — real but touches runtime.
 
 ---
 
 ## GitHub Issues (no good-first-issue/help-wanted/docs labels exist; 26 open issues reviewed)
-Mostly large features or deep compiler bugs. These 4 are well-scoped "add a warning" tasks suitable for a first contributor:
 
-| Issue | Title | Why beginner-friendly |
-|-------|-------|----------------------|
-| #1226 | Warn when TSRX fragments aren't returned (free-floating `@if`/`@for` outside a return) | Sharp spec w/ example; localized diagnostic |
-| #1261 | Warn when a `@{}` code block holds only a statement | Sharp, concrete; string-interpolation guidance message |
-| #1237 | Warn when assigned `<style>` uses non-standalone selectors | Localized warning + optional emit change |
-| #367 | Warn about invalid HTML (e.g. nested `<p>`) in DEV/SSR | Slightly bigger but bounded to a validator |
+Mostly large features or deep compiler bugs. These 4 are well-scoped "add a
+warning" tasks suitable for a first contributor:
+
+| Issue | Title                                                                                  | Why beginner-friendly                                  |
+| ----- | -------------------------------------------------------------------------------------- | ------------------------------------------------------ |
+| #1226 | Warn when TSRX fragments aren't returned (free-floating `@if`/`@for` outside a return) | Sharp spec w/ example; localized diagnostic            |
+| #1261 | Warn when a `@{}` code block holds only a statement                                    | Sharp, concrete; string-interpolation guidance message |
+| #1237 | Warn when assigned `<style>` uses non-standalone selectors                             | Localized warning + optional emit change               |
+| #367  | Warn about invalid HTML (e.g. nested `<p>`) in DEV/SSR                                 | Slightly bigger but bounded to a validator             |
 
 ## Recommended starting points
-- Lowest friction: any Tier-1 typo or the Tier-3 `ripplejs.com` link-batch (fast merge, zero review risk).
-- Most "real contributor" feeling: claim #1226 or #1261 (add a diagnostic) and comment intent — not assigned yet.
+
+- Lowest friction: any Tier-1 typo or the Tier-3 `ripplejs.com` link-batch (fast
+  merge, zero review risk).
+- Most "real contributor" feeling: claim #1226 or #1261 (add a diagnostic) and
+  comment intent — not assigned yet.

--- a/packages/create-ripple/README.md
+++ b/packages/create-ripple/README.md
@@ -64,7 +64,7 @@ A minimal Ripple application with:
 
 ## Requirements
 
-- Node.js 20.0.0 or higher
+- Node.js 22.0.0 or higher
 
 ## License
 

--- a/packages/language-server/README.md
+++ b/packages/language-server/README.md
@@ -30,7 +30,7 @@ are also specialized plugins for popular editors.
 #### VS Code
 
 Use the
-[official extension](https://marketplace.visualstudio.com/items?itemName=Ripple-TS.ripple-ts-vscode-plugin)
+[official extension](https://marketplace.visualstudio.com/items?itemName=Ripple-TS.ripple-ts-vscode-plugin).
 It uses this language server internally.
 
 #### WebStorm/IntelliJ

--- a/packages/sublime-text-plugin/package.json
+++ b/packages/sublime-text-plugin/package.json
@@ -1,8 +1,15 @@
 {
   "name": "@ripple-ts/sublime-text-plugin",
   "version": "0.0.82",
-  "description": "",
+  "description": "Sublime Text support for TSRX and Ripple",
   "private": true,
+  "keywords": [
+    "sublime-text",
+    "sublime",
+    "plugin",
+    "ripple",
+    "tsrx"
+  ],
   "scripts": {
     "update-lock": "cd src/language-server && npm install --package-lock-only",
     "build": "npm run update-lock && node ./scripts/build.js"

--- a/packages/tsrx-ripple/src/analyze/index.js
+++ b/packages/tsrx-ripple/src/analyze/index.js
@@ -39,6 +39,7 @@ import {
 	validateTsrxLoopReturnStatement,
 	validateTsrxReturnStatement,
 	validateTsrxUnsupportedLoopStatement,
+	validateTsrxUnreturnedTemplate,
 	isTemplateValuePosition,
 } from '@tsrx/core';
 const b = builders;
@@ -435,6 +436,87 @@ function mark_control_flow_has_continue(path) {
 			node.metadata.has_continue = true;
 		}
 	}
+}
+
+/**
+ * @param {AST.Node} node
+ * @param {AnalysisContext} context
+ */
+function check_free_floating(node, context) {
+	let current = node;
+	for (let i = context.path.length - 1; i >= 0; i -= 1) {
+		const parent = context.path[i];
+
+		if (is_template_child_position(context.path.slice(0, i + 1), current)) {
+			return false; // Rendered as a child
+		}
+
+		if (
+			parent.type === 'ExpressionStatement' ||
+			parent.type === 'BlockStatement' ||
+			parent.type === 'Program' ||
+			parent.type === 'SwitchCase'
+		) {
+			// Check if this is the render node of any enclosing JSXCodeBlock
+			// The render node is the final expression in a code block that serves as output.
+			const enclosing_code_block = context.path.find((p) => p.type === 'JSXCodeBlock');
+			if (enclosing_code_block && enclosing_code_block.render === current) {
+				return false;
+			}
+
+			validateTsrxUnreturnedTemplate(
+				node,
+				context.state.analysis.module.filename,
+				context.state.collect ? context.state.analysis.errors : undefined,
+				context.state.analysis.comments,
+			);
+			return true;
+		}
+
+		if (parent.type === 'SequenceExpression' && current !== parent.expressions.at(-1)) {
+			validateTsrxUnreturnedTemplate(
+				node,
+				context.state.analysis.module.filename,
+				context.state.collect ? context.state.analysis.errors : undefined,
+				context.state.analysis.comments,
+			);
+			return true;
+		}
+
+		if (parent.type === 'ForStatement' && (current === parent.init || current === parent.update)) {
+			validateTsrxUnreturnedTemplate(
+				node,
+				context.state.analysis.module.filename,
+				context.state.collect ? context.state.analysis.errors : undefined,
+				context.state.analysis.comments,
+			);
+			return true;
+		}
+
+		// If it's in a value position (assigned, returned, passed as argument, etc),
+		// it is consumed. We can stop checking.
+		if (
+			parent.type === 'VariableDeclarator' ||
+			parent.type === 'AssignmentExpression' ||
+			parent.type === 'Property' ||
+			parent.type === 'PropertyDefinition' ||
+			parent.type === 'ArrayExpression' ||
+			parent.type === 'CallExpression' ||
+			parent.type === 'NewExpression' ||
+			parent.type === 'ReturnStatement' ||
+			parent.type === 'ArrowFunctionExpression' ||
+			(parent.type === 'IfStatement' && parent.test === current) ||
+			(parent.type === 'WhileStatement' && parent.test === current) ||
+			(parent.type === 'SwitchStatement' && parent.discriminant === current)
+		) {
+			return false;
+		}
+
+		// For things like SequenceExpression or ConditionalExpression, the value flows outward,
+		// so we continue up the path.
+		current = parent;
+	}
+	return false;
 }
 
 /**
@@ -1944,6 +2026,7 @@ const visitors = {
 
 	SwitchStatement: visit_switch_statement,
 	JSXSwitchExpression(node, context) {
+		check_free_floating(node, context);
 		return analyze_directive_wrapping_values(node, context, visit_switch_statement);
 	},
 
@@ -1981,6 +2064,7 @@ const visitors = {
 	 * @param {AnalysisContext} context
 	 */
 	JSXForExpression(node, context) {
+		check_free_floating(node, context);
 		const wrapper = node.metadata?.tsrx_value_wrapper;
 		if (
 			(!wrapper || !context.path.includes(wrapper)) &&
@@ -2167,6 +2251,7 @@ const visitors = {
 
 	IfStatement: visit_if_statement,
 	JSXIfExpression(node, context) {
+		check_free_floating(node, context);
 		return analyze_directive_wrapping_values(node, context, visit_if_statement);
 	},
 
@@ -2322,6 +2407,7 @@ const visitors = {
 
 	TryStatement: visit_try_statement,
 	JSXTryExpression(node, context) {
+		check_free_floating(node, context);
 		return analyze_directive_wrapping_values(node, context, visit_try_statement);
 	},
 
@@ -2338,11 +2424,12 @@ const visitors = {
 	},
 
 	JSXFragment(node, context) {
-		if (context.state.regular_js) {
+		check_free_floating(node, context);
+
+		if (is_template_fragment(node)) {
+			mark_control_flow_has_template(context.path, node);
 			return context.next();
 		}
-
-		mark_control_flow_has_template(context.path, node);
 		return context.next();
 	},
 
@@ -2361,6 +2448,7 @@ const visitors = {
 	},
 
 	JSXElement(node, context) {
+		check_free_floating(node, context);
 		// A raw (non-template) element — an attribute value or other JSX that
 		// never entered the template traversal.
 		if (!is_template_element(node)) {
@@ -2675,6 +2763,7 @@ const visitors = {
 	},
 
 	JSXCodeBlock(node, context) {
+		check_free_floating(node, context);
 		const parent = context.path.at(-1);
 
 		// A `@{ … }` in a template-children slot, or the render slot of another

--- a/packages/tsrx-ripple/src/transform/client/index.js
+++ b/packages/tsrx-ripple/src/transform/client/index.js
@@ -3271,7 +3271,9 @@ const visitors = {
 						),
 					);
 				} else {
-					throw new Error('TODO');
+					throw new Error(
+						'Unexpected attribute type encountered during client transformation: ' + attr.type,
+					);
 				}
 			}
 

--- a/packages/tsrx-ripple/src/transform/client/index.js
+++ b/packages/tsrx-ripple/src/transform/client/index.js
@@ -3272,7 +3272,7 @@ const visitors = {
 					);
 				} else {
 					throw new Error(
-						'Unexpected attribute type encountered during client transformation: ' + attr.type,
+						'Unexpected attribute type encountered during client transformation',
 					);
 				}
 			}

--- a/packages/tsrx-ripple/src/transform/client/index.js
+++ b/packages/tsrx-ripple/src/transform/client/index.js
@@ -3271,9 +3271,7 @@ const visitors = {
 						),
 					);
 				} else {
-					throw new Error(
-						'Unexpected attribute type encountered during client transformation',
-					);
+					throw new Error('Unexpected attribute type encountered during client transformation');
 				}
 			}
 

--- a/packages/tsrx-ripple/tests/unreturned-template.test.js
+++ b/packages/tsrx-ripple/tests/unreturned-template.test.js
@@ -1,0 +1,75 @@
+import { compile_to_volar_mappings } from '../src/index.js';
+import { describe, expect, it } from 'vitest';
+import { TSRX_UNRETURNED_TEMPLATE_ERROR } from '@tsrx/core';
+
+describe('@tsrx/ripple unreturned template validation', () => {
+	function expect_error(source) {
+		const { errors } = compile_to_volar_mappings(source, 'App.tsrx', { loose: true });
+		expect(errors.map((e) => e.message)).toContain(TSRX_UNRETURNED_TEMPLATE_ERROR);
+	}
+
+	function expect_valid(source) {
+		const { errors } = compile_to_volar_mappings(source, 'App.tsrx', { loose: true });
+		expect(errors).toEqual([]);
+	}
+
+	it('emits error for free-floating @if directive', () => {
+		expect_error(`function App() { @if (true) { <div /> } }`);
+	});
+
+	it('emits error for free-floating @for directive', () => {
+		expect_error(`function App() { @for (const item of items) { <div /> } }`);
+	});
+
+	it('emits error for free-floating @switch directive', () => {
+		expect_error(`function App() { @switch (value) { @case (1): { <div /> } } }`);
+	});
+
+	it('emits error for free-floating @try directive', () => {
+		expect_error(`function App() { @try { <div /> } @catch (e) { } }`);
+	});
+
+	it('emits error for free-floating JSX fragment', () => {
+		expect_error(`function App() { <></> }`);
+	});
+
+	it('emits error for free-floating JSX element', () => {
+		expect_error(`function App() { <div /> }`);
+	});
+
+	it('emits error for non-tail items in sequence expressions', () => {
+		expect_error(`function App() { (<div />, 1) }`);
+	});
+
+	it('emits error for free-floating @{...} code blocks', () => {
+		expect_error(`function App() { @{ <div /> } }`);
+	});
+
+	it('passes valid usages (Variable Declarations)', () => {
+		expect_valid(`function App() { const x = @if(true) { <div /> }; return x; }`);
+		expect_valid(`function App() { const y = <div />; return y; }`);
+	});
+
+	it('passes valid usages (Assignments)', () => {
+		expect_valid(`function App() { let x; x = @if(true) { <div /> }; return x; }`);
+		expect_valid(`function App() { let y; y = <div />; return y; }`);
+	});
+
+	it('passes valid usages (Return statements)', () => {
+		expect_valid(`function App() { return @if(true) { <div /> }; }`);
+		expect_valid(`function App() { return <div />; }`);
+	});
+
+	it('passes valid usages (Implicit arrow functions)', () => {
+		expect_valid(`const App = () => @if(true) { <div /> };`);
+		expect_valid(`const App2 = () => <div />;`);
+	});
+
+	it('passes valid usages (Ternary expressions)', () => {
+		expect_valid(`function App() { return cond ? @if(true) { <a/> } : <b/>; }`);
+	});
+
+	it('passes valid usages (Function arguments)', () => {
+		expect_valid(`function App() { return render( @if(true) { <div/> } ); }`);
+	});
+});

--- a/packages/tsrx/src/analyze/validation.js
+++ b/packages/tsrx/src/analyze/validation.js
@@ -28,6 +28,8 @@ export const TSRX_WHILE_STATEMENT_ERROR =
 	'While loops are not supported in TSRX templates. Move the while loop into a function.';
 export const TSRX_DO_WHILE_STATEMENT_ERROR =
 	'Do...while loops are not supported in TSRX templates. Move the do...while loop into a function.';
+export const TSRX_UNRETURNED_TEMPLATE_ERROR =
+	'Free-floating TSRX fragments and directives (@if, @for, @switch, @try) must either be returned or used as a template output value. Remove them if unused, or render them in the template.';
 
 const invalid_nestings = {
 	// <p> cannot contain block-level elements
@@ -304,6 +306,16 @@ export function validate_tsrx_unsupported_loop_statement(node, filename, errors,
 	}
 
 	error(message, filename ?? null, node, errors, comments);
+}
+
+/**
+ * @param {AST.Node} node
+ * @param {string | null | undefined} filename
+ * @param {CompileError[]} [errors]
+ * @param {AST.CommentWithLocation[]} [comments]
+ */
+export function validate_tsrx_unreturned_template(node, filename, errors, comments) {
+	error(TSRX_UNRETURNED_TEMPLATE_ERROR, filename ?? null, node, errors, comments);
 }
 
 /**

--- a/packages/tsrx/src/index.js
+++ b/packages/tsrx/src/index.js
@@ -264,6 +264,8 @@ export {
 	validate_tsrx_loop_return_statement as validateTsrxLoopReturnStatement,
 	validate_tsrx_return_statement as validateTsrxReturnStatement,
 	validate_tsrx_unsupported_loop_statement as validateTsrxUnsupportedLoopStatement,
+	validate_tsrx_unreturned_template as validateTsrxUnreturnedTemplate,
+	TSRX_UNRETURNED_TEMPLATE_ERROR,
 	validate_nesting as validateNesting,
 	is_template_value_position as isTemplateValuePosition,
 } from './analyze/validation.js';

--- a/packages/vscode-plugin/package.json
+++ b/packages/vscode-plugin/package.json
@@ -23,7 +23,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Ripple-TS/ripple.git",
-    "directory": "vscode-plugin"
+    "directory": "packages/vscode-plugin"
   },
   "scripts": {
     "build": "tsdown",

--- a/packages/zed-plugin/package.json
+++ b/packages/zed-plugin/package.json
@@ -1,13 +1,18 @@
 {
   "name": "@ripple-ts/zed-plugin",
   "version": "0.0.85",
-  "description": "",
+  "description": "Zed editor support for TSRX and Ripple",
   "private": true,
   "main": "index.js",
   "scripts": {},
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
+  "keywords": [
+    "zed",
+    "zed-extension",
+    "ripple",
+    "tsrx"
+  ],
+  "author": "Dominic Gannaway",
+  "license": "MIT",
   "config": {
     "@ripple-ts/language-server": "0.3.106"
   },

--- a/playground/react/README.md
+++ b/playground/react/README.md
@@ -26,15 +26,14 @@ createRoot(target).render(
 ```tsrx
 import { useState, useEffect } from 'react';
 
-function Child() {
-  return <div>
-    const x = 1;
+function Child() @{
+  const x = 1;
+  console.log(x);
 
-    console.log(x);
-  </div>;
+  <div>Child component</div>
 }
 
-export function App() {
+export function App() @{
   const [count, setCount] = useState(0);
   const items = [1, 2, 3];
 
@@ -42,35 +41,32 @@ export function App() {
     console.log(count);
   }, [count]);
 
-  return <>
-    <Child />
-    <h1>
-      {'Hello World'}
-      if (count > 1) {
-        return null;
-      }
-    </h1>
-    if (count > 1) {
-      <div>
-        const [x] = useState(1);
+  if (count > 2) {
+    return null;
+  }
 
-        {'Count is more than ' + x}
-      </div>
+  <Child />
+  <h1>
+    {'Hello World'}
+    @if (count > 1) {
+      <span> (Expanded)</span>
     }
-    <button onClick={() => setCount(count + 1)}>{count}</button>
-    if (count > 2) {
-      return null;
+  </h1>
+  @if (count > 1) {
+    const [x] = useState(1);
+
+    <div>{'Count is more than ' + x}</div>
+  }
+  <button onClick={() => setCount(count + 1)}>{count}</button>
+  @for (const item of items; index i) {
+    <div key={i}>{item}</div>
+  }
+  <style>
+    button {
+      border: 0;
+      color: red;
     }
-    for (const item of items; index i) {
-      <div key={i}>{item}</div>
-    }
-    <style>
-      button {
-        border: 0;
-        color: red;
-      }
-    </style>
-  </>;
+  </style>
 }
 ```
 

--- a/templates/basic/README.md
+++ b/templates/basic/README.md
@@ -45,5 +45,5 @@ For the best development experience, install the [Prettier VS Code plugin](https
 
 ## Learn More
 
-- [Ripple Documentation](https://github.com/Ripple-TS/ripple)
+- [Ripple Documentation](https://www.ripple-ts.com)
 - [Vite Documentation](https://vitejs.dev/)

--- a/website-new/docs/guide/components.md
+++ b/website-new/docs/guide/components.md
@@ -217,7 +217,7 @@ export function App() @{
 
 ## Reactive Props
 
-See [Reactivity](/docs/guide/reactivity#Props-and-Attributes).
+See [Reactivity](/docs/guide/reactivity).
 
 ## Prop Shorthands
 

--- a/website-new/docs/libraries.md
+++ b/website-new/docs/libraries.md
@@ -11,7 +11,7 @@ may have breaking changes at any moment.
 
 ## Router
 
-- https://github.com/WebEferen/ripplejs-router
+- https://github.com/WebEferen/ripple-router
 
 ## Component Library
 

--- a/website-new/docs/quick-start.md
+++ b/website-new/docs/quick-start.md
@@ -78,7 +78,7 @@ npm install -g '@ripple-ts/language-server' // [!=npm auto]
 2. Press <kbd>Ctrl/Cmd+Shift+P</kbd>, type `Install Package Control`, and press
    <kbd>Enter</kbd>.
 3. Restart Sublime Text.
-4. Press <kbd>Ctrl/Cmd+Shift+P</kbd>, type `Upgrade Package`, and press
+4. Press <kbd>Ctrl/Cmd+Shift+P</kbd>, type `Install Package`, and press
    <kbd>Enter</kbd>.
 5. Type `Package Control` and press <kbd>Enter</kbd>.
 6. Restart Sublime Text.

--- a/website/docs/guide/components.md
+++ b/website/docs/guide/components.md
@@ -217,7 +217,7 @@ export function App() @{
 
 ## Reactive Props
 
-See [Reactivity](/docs/guide/reactivity#Props-and-Attributes).
+See [Reactivity](/docs/guide/reactivity).
 
 ## Prop Shorthands
 


### PR DESCRIPTION
warn on unreturned tsrx fragments and directives outside return statements.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The new analyzer path touches many template node visitors and parent-walk edge cases (sequence expressions, code-block render slots), so false positives/negatives are possible until the test matrix grows; user-facing compile errors are the main impact, not runtime behavior.
> 
> **Overview**
> Adds a **compile-time diagnostic** when TSRX markup or directives sit in statement position without being rendered—e.g. `@if` / `@for` / `@switch` / `@try`, JSX elements/fragments, or `@{…}` blocks that are not returned, assigned, passed as arguments, or placed as template children. The analyzer walks parent nodes via `check_free_floating` and reports `TSRX_UNRETURNED_TEMPLATE_ERROR` from `@tsrx/core`; `@tsrx/ripple` wires this into directive and template visitors, with **vitest coverage** for invalid and valid patterns.
> 
> **`JSXFragment` analysis** now only calls `mark_control_flow_has_template` for real template fragments, avoiding false positives for fragments that are only used as values.
> 
> The same PR bundles **non-functional polish**: contributor doc (`.tsrx` wording, `good-first-pr-candidates.md`), doc/link fixes (Sublime quick-start, components anchor, router URL, template docs site), plugin `package.json` metadata (VS Code `repository.directory`, Zed/Sublime descriptions), Node 22 requirement in create-ripple README, playground React README updated to `@if`/`@for`/`@{ }`, and a clearer client-transform error instead of `throw new Error('TODO')`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74deb47e8ad0e829b41cc6901d649c2807fac397. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->