### PR TITLE
chore: no free-floating jsx w/o return; new tsrx analysis stage

### DIFF
--- a/.changeset/warm-otters-render.md
+++ b/.changeset/warm-otters-render.md
@@ -9,4 +9,4 @@
 '@tsrx/mcp': patch
 ---
 
-Add shared TSRX semantic analysis and report free-floating template output in normal function bodies. Runtime builds now fail when output would be discarded, while type-only and Volar compilation collect the diagnostic and continue. Return or retain template values, or use an `@{}` function body for implicit output.
+Add shared TSRX semantic analysis and report free-floating template output in normal function bodies and ordinary setup sections of `@{}` blocks. Runtime builds now fail when output would be discarded, while type-only and Volar compilation collect the diagnostic and continue. Return or retain template values, or make them part of a function's rendered output.

--- a/.changeset/warm-otters-render.md
+++ b/.changeset/warm-otters-render.md
@@ -1,0 +1,12 @@
+---
+'@tsrx/core': patch
+'@tsrx/ripple': patch
+'@tsrx/react': patch
+'@tsrx/preact': patch
+'@tsrx/solid': patch
+'@tsrx/vue': patch
+'@tsrx/eslint-parser': patch
+'@tsrx/mcp': patch
+---
+
+Add shared TSRX semantic analysis and report free-floating template output in normal function bodies. Runtime builds now fail when output would be discarded, while type-only and Volar compilation collect the diagnostic and continue. Return or retain template values, or use an `@{}` function body for implicit output.

--- a/packages/eslint-parser/src/index.ts
+++ b/packages/eslint-parser/src/index.ts
@@ -1,6 +1,10 @@
 import type { Program } from 'estree';
 import type { Linter } from 'eslint';
-import { DIAGNOSTIC_CODES, parseModule as parse_module } from '@tsrx/core';
+import {
+	analyzeTsrx as analyze_tsrx,
+	DIAGNOSTIC_CODES,
+	parseModule as parse_module,
+} from '@tsrx/core';
 
 interface ParseResult {
 	ast: Program;
@@ -151,14 +155,21 @@ function to_eslint_parse_error(error: any): SyntaxError {
 export function parseForESLint(code: string, options?: Linter.ParserOptions): ParseResult {
 	try {
 		const errors: any[] = [];
+		const comments: any[] = [];
 		// Parse the TSRX source code using the shared TSRX parser. ESLint passes
 		// `<input>` for in-memory sources (e.g. RuleTester), so a real filename is
 		// only missing when the parser is invoked directly.
 		const ast = parse_module(code, options?.filePath || 'ESLintParser.tsrx', {
 			collect: true,
 			errors,
+			comments,
 		}) as any;
 		if (!ast) throw new Error('Parser returned null or undefined AST');
+		analyze_tsrx(ast, options?.filePath || 'ESLintParser.tsrx', {
+			collect: true,
+			errors,
+			comments,
+		});
 
 		const fatal_error = errors.find(is_fatal_parser_diagnostic);
 		if (fatal_error) {

--- a/packages/ripple/tests/client/for.test.tsrx
+++ b/packages/ripple/tests/client/for.test.tsrx
@@ -20,10 +20,11 @@ describe('for statements', () => {
 			() => compile(
 				`function App() @{
 					const items = [1, 2, 3];
+					const content = [];
 					for (const item of items) {
-						<div class="selected">{item}</div>
+						content.push(<div class="selected">{item}</div>);
 					}
-					<></>
+					<>{content}</>
 				}`,
 				'App.tsrx',
 				{ mode: 'client' },
@@ -49,7 +50,7 @@ describe('for statements', () => {
 
 	it('renders an empty fallback', () => {
 		function App() @{
-			const items = [];
+			const items: string[] = [];
 			@for (const item of items) {
 				<div class="item">{item}</div>
 			} @empty {

--- a/packages/ripple/tests/client/return.test.tsrx
+++ b/packages/ripple/tests/client/return.test.tsrx
@@ -92,14 +92,15 @@ describe('function returns in client components', () => {
 		expect(
 			() => compile(
 				`
-					function App() @{
-						const items = [1, 2, 3];
+						function App() @{
+							const items = [1, 2, 3];
+							const content = [];
 							for (const item of items) {
-								<div>{item}</div>
+								content.push(<div>{item}</div>);
 							}
-							<></>
-					}
-				`,
+							<>{content}</>
+						}
+					`,
 				'test.tsrx',
 				{ mode: 'client' },
 			),

--- a/packages/ripple/tests/server/compiler.test.tsrx
+++ b/packages/ripple/tests/server/compiler.test.tsrx
@@ -199,7 +199,7 @@ export default function A() @{
 	});
 
 	it('does not merge adjacent call-containing children into stringified text in SSR output', () => {
-		const setup = `function child(label) {
+		const setup = `function child(label) @{
 	<span>{label}</span>
 }
 function Constructed(label) {

--- a/packages/ripple/tests/server/for.test.tsrx
+++ b/packages/ripple/tests/server/for.test.tsrx
@@ -18,9 +18,11 @@ describe('for statements in SSR', () => {
 			() => compile(
 				`function App() @{
 					const items = [1, 2, 3];
+					const content = [];
 					for (const item of items) {
-						<div class="selected">{item}</div>
+						content.push(<div class="selected">{item}</div>);
 					}
+					<>{content}</>
 				}`,
 				'App.tsrx',
 				{ mode: 'server' },

--- a/packages/ripple/tests/server/return.test.tsrx
+++ b/packages/ripple/tests/server/return.test.tsrx
@@ -59,13 +59,15 @@ describe('function returns in SSR components', () => {
 		expect(
 			() => compile(
 				`
-					function App() @{
+						function App() @{
 							const items = [1, 2, 3];
+							const content = [];
 							for (const item of items) {
-								<div>{item}</div>
+								content.push(<div>{item}</div>);
 							}
-					}
-				`,
+							<>{content}</>
+						}
+					`,
 				'test.tsrx',
 				{ mode: 'server' },
 			),

--- a/packages/tsrx-mcp/src/analyze.js
+++ b/packages/tsrx-mcp/src/analyze.js
@@ -91,9 +91,9 @@ function create_advice(input) {
 		advice.push({
 			kind: 'forgotten-statement-container',
 			severity: 'error',
-			title: 'Add @ before statement-container braces',
+			title: 'Render or retain template output',
 			message:
-				'A function body with TypeScript setup followed by bare TSRX output must use a JSX statement container. Change the opening `{` to `@{`, or use an ordinary `return` when the function only returns JSX.',
+				'Free-floating TSRX output in a normal function body is discarded. Return it, assign it to a value that is later rendered, or change the function body opening `{` to `@{` for implicit output.',
 			documentation: ['tsrx://docs/components.md', 'tsrx://docs/expression-values.md'],
 		});
 	}

--- a/packages/tsrx-mcp/src/analyze.js
+++ b/packages/tsrx-mcp/src/analyze.js
@@ -93,7 +93,7 @@ function create_advice(input) {
 			severity: 'error',
 			title: 'Render or retain template output',
 			message:
-				'Free-floating TSRX output in a normal function body is discarded. Return it, assign it to a value that is later rendered, or change the function body opening `{` to `@{` for implicit output.',
+				'Free-floating TSRX output in ordinary setup is discarded. Return it, assign it to a value that is later rendered, or make it part of the rendered output of a function `@{...}` body.',
 			documentation: ['tsrx://docs/components.md', 'tsrx://docs/expression-values.md'],
 		});
 	}

--- a/packages/tsrx-preact/src/index.js
+++ b/packages/tsrx-preact/src/index.js
@@ -3,7 +3,7 @@
 /** @import { NonEmptyString } from '@tsrx/core/types/helpers' */
 /** @import { CompileOptions } from './transform.js' */
 
-import { createVolarMappingsResult, dedupeMappings, parseModule } from '@tsrx/core';
+import { analyzeTsrx, createVolarMappingsResult, dedupeMappings, parseModule } from '@tsrx/core';
 import { DEFAULT_SUSPENSE_SOURCE, transform } from './transform.js';
 
 export { DEFAULT_SUSPENSE_SOURCE };
@@ -40,6 +40,18 @@ export function compile(source, filename, compile_options) {
 		filename,
 		collect ? { collect: true, loose: !!compile_options?.loose, errors, comments } : undefined,
 	);
+	analyzeTsrx(
+		ast,
+		filename,
+		collect
+			? {
+					collect: true,
+					loose: !!compile_options?.loose,
+					errors,
+					comments,
+				}
+			: undefined,
+	);
 	const { ast: _ast, ...result } = transform(
 		ast,
 		source,
@@ -69,6 +81,13 @@ export function compile_to_volar_mappings(source, filename, options) {
 		loose: !!options?.loose,
 		preserveParens: true,
 		keywordTokens: true,
+		errors,
+		comments,
+	});
+	analyzeTsrx(ast, filename, {
+		collect: true,
+		loose: !!options?.loose,
+		typeOnly: true,
 		errors,
 		comments,
 	});

--- a/packages/tsrx-react/src/index.js
+++ b/packages/tsrx-react/src/index.js
@@ -2,7 +2,7 @@
 /** @import { CompileError, ParseOptions } from '@tsrx/core/types' */
 /** @import { NonEmptyString } from '@tsrx/core/types/helpers' */
 
-import { createVolarMappingsResult, dedupeMappings, parseModule } from '@tsrx/core';
+import { analyzeTsrx, createVolarMappingsResult, dedupeMappings, parseModule } from '@tsrx/core';
 import { transform } from './transform.js';
 
 export { isRefProp } from './ref.js';
@@ -38,6 +38,11 @@ export function compile(source, filename, options) {
 		filename,
 		collect ? { collect: true, loose: !!options?.loose, errors, comments } : undefined,
 	);
+	analyzeTsrx(
+		ast,
+		filename,
+		collect ? { collect: true, loose: !!options?.loose, errors, comments } : undefined,
+	);
 	const { ast: _ast, ...result } = transform(
 		ast,
 		source,
@@ -65,6 +70,13 @@ export function compile_to_volar_mappings(source, filename, options) {
 		loose: !!options?.loose,
 		preserveParens: true,
 		keywordTokens: true,
+		errors,
+		comments,
+	});
+	analyzeTsrx(ast, filename, {
+		collect: true,
+		loose: !!options?.loose,
+		typeOnly: true,
 		errors,
 		comments,
 	});

--- a/packages/tsrx-ripple/src/analyze/index.js
+++ b/packages/tsrx-ripple/src/analyze/index.js
@@ -40,6 +40,7 @@ import {
 	validateTsrxReturnStatement,
 	validateTsrxUnsupportedLoopStatement,
 	isTemplateValuePosition,
+	isFunctionOrClassNode as is_function_or_class_boundary,
 } from '@tsrx/core';
 const b = builders;
 import { walk } from 'zimmerframe';
@@ -300,20 +301,6 @@ function mark_control_flow_has_template(path, node) {
  */
 function is_script_only_control_flow_body(node) {
 	return node?.metadata?.script_only === true;
-}
-
-/**
- * @param {AST.Node} node
- * @returns {boolean}
- */
-function is_function_or_class_boundary(node) {
-	return (
-		node.type === 'FunctionExpression' ||
-		node.type === 'ArrowFunctionExpression' ||
-		node.type === 'FunctionDeclaration' ||
-		node.type === 'ClassExpression' ||
-		node.type === 'ClassDeclaration'
-	);
 }
 
 /**

--- a/packages/tsrx-ripple/src/index.js
+++ b/packages/tsrx-ripple/src/index.js
@@ -2,7 +2,7 @@
 /** @import { CompileOptions, CompileError, ParseOptions } from '../types/index' */
 /** @import { NonEmptyString } from '@tsrx/core/types/helpers' */
 
-import { createVolarMappingsResult, parseModule } from '@tsrx/core';
+import { analyzeTsrx, createVolarMappingsResult, parseModule } from '@tsrx/core';
 import { analyze } from './analyze/index.js';
 import { transform_client } from './transform/client/index.js';
 import { transform_server } from './transform/server/index.js';
@@ -34,6 +34,11 @@ export function compile(source, filename, options = {}) {
 		source,
 		filename,
 		collect ? { ...options, collect, errors, comments } : undefined,
+	);
+	analyzeTsrx(
+		ast,
+		filename,
+		collect ? { collect, loose: !!options.loose, errors, comments } : undefined,
 	);
 	const analysis = analyze(
 		ast,
@@ -85,6 +90,13 @@ export function compile_to_volar_mappings(source, filename, options = {}) {
 		loose: !!options?.loose,
 		preserveParens: true,
 		keywordTokens: true,
+		errors,
+		comments,
+	});
+	analyzeTsrx(ast, filename, {
+		collect: true,
+		loose: !!options?.loose,
+		to_ts: true,
 		errors,
 		comments,
 	});

--- a/packages/tsrx-ripple/src/template-ast.js
+++ b/packages/tsrx-ripple/src/template-ast.js
@@ -11,8 +11,10 @@
  * transforms — which walk the same tree — always agree on node identity.
  */
 
-import { builders } from '@tsrx/core';
+import { builders, isTemplateDirective as is_template_directive } from '@tsrx/core';
 const b = builders;
+
+export { is_template_directive };
 
 /**
  * @param {string} value
@@ -132,23 +134,6 @@ export function get_template_expression(node, to_ts) {
  */
 export function is_empty_expression_container(node) {
 	return node.type === 'JSXExpressionContainer' && node.expression?.type === 'JSXEmptyExpression';
-}
-
-/**
- * A `@if`/`@for`/`@switch`/`@try` template control-flow directive — the
- * parser's expression-form nodes. Directives keep these forms end to end; a
- * plain `IfStatement`/`ForOfStatement`/… is always ordinary JavaScript, except
- * the `@else if` chain links detected by {@link is_template_else_if}.
- * @param {AST.Node | null | undefined} node
- * @returns {node is AST.JSXTemplateDirective}
- */
-export function is_template_directive(node) {
-	return (
-		node?.type === 'JSXIfExpression' ||
-		node?.type === 'JSXForExpression' ||
-		node?.type === 'JSXSwitchExpression' ||
-		node?.type === 'JSXTryExpression'
-	);
 }
 
 /**

--- a/packages/tsrx-ripple/src/utils.js
+++ b/packages/tsrx-ripple/src/utils.js
@@ -15,6 +15,7 @@ import {
 	isDomProperty,
 	isNonDelegated,
 	isVoidElement,
+	isCodeBlockFunctionBody,
 	normalizeEventName,
 	setLocation,
 	simpleHash,
@@ -43,6 +44,7 @@ export const is_boolean_attribute = isBooleanAttribute;
 export const is_dom_property = isDomProperty;
 export const simple_hash = simpleHash;
 export const strong_hash = strongHash;
+export const is_code_block_function_body = isCodeBlockFunctionBody;
 
 /**
  * @param {AST.Node | null | undefined} node
@@ -365,20 +367,6 @@ export function unwrap_single_return_iife(call) {
 		}
 	}
 	return call;
-}
-
-/**
- * @param {AST.JSXCodeBlock} node
- * @param {AST.Node | undefined} parent
- * @returns {boolean}
- */
-export function is_code_block_function_body(node, parent) {
-	return (
-		(parent?.type === 'ArrowFunctionExpression' ||
-			parent?.type === 'FunctionDeclaration' ||
-			parent?.type === 'FunctionExpression') &&
-		parent.body === node
-	);
 }
 
 /**

--- a/packages/tsrx-ripple/tests/basic.test.js
+++ b/packages/tsrx-ripple/tests/basic.test.js
@@ -21,7 +21,7 @@ runSharedComponentParamsTests({
 describe('@tsrx/ripple faithful text output', () => {
 	it("keeps a single `@` text child as `<>@</>` instead of `{'@'}` in type-only output", () => {
 		const { code, errors } = compile_to_volar_mappings(
-			`export function App() {
+			`export function App() @{
 				<>@</>
 			}`,
 			'App.tsrx',
@@ -35,7 +35,7 @@ describe('@tsrx/ripple faithful text output', () => {
 
 	it('does not promote ordinary single-text output into a string literal', () => {
 		const { code, errors } = compile_to_volar_mappings(
-			`export function App() {
+			`export function App() @{
 				<>Hello</>
 			}`,
 			'App.tsrx',
@@ -49,7 +49,7 @@ describe('@tsrx/ripple faithful text output', () => {
 
 	it('lowers a single `@` text child to a faithful runtime text node', () => {
 		const { code } = compile(
-			`export function App() {
+			`export function App() @{
 				<>@</>
 			}`,
 			'App.tsrx',
@@ -1788,20 +1788,6 @@ describe('@tsrx/ripple unified function and component compilation', () => {
 			if (flag === 'undefined') return undefined;
 			return alt;
 		}`);
-	});
-
-	it('preserves plain ASI returns without component return guards', () => {
-		const source = `function Test() {
-			return;
-			<div>{"should not render"}</div>
-		}`;
-		const client = compile(source, 'App.tsrx');
-		const server = compile(source, 'App.tsrx', { mode: 'server' });
-
-		expect(client.code).toContain('return;');
-		expect(client.code).not.toContain('return_guard');
-		expect(server.code).toContain('return;');
-		expect(server.code).not.toContain('return_guard');
 	});
 
 	it('guards regular statements after conditional component returns', () => {

--- a/packages/tsrx-solid/src/index.js
+++ b/packages/tsrx-solid/src/index.js
@@ -2,7 +2,7 @@
 /** @import { CompileError, ParseOptions } from '@tsrx/core/types' */
 /** @import { NonEmptyString } from '@tsrx/core/types/helpers' */
 
-import { createVolarMappingsResult, dedupeMappings, parseModule } from '@tsrx/core';
+import { analyzeTsrx, createVolarMappingsResult, dedupeMappings, parseModule } from '@tsrx/core';
 import { transform } from './transform.js';
 
 export { isRefProp } from './ref.js';
@@ -38,6 +38,11 @@ export function compile(source, filename, options) {
 		filename,
 		collect ? { collect: true, loose: !!options?.loose, errors, comments } : undefined,
 	);
+	analyzeTsrx(
+		ast,
+		filename,
+		collect ? { collect: true, loose: !!options?.loose, errors, comments } : undefined,
+	);
 	const { ast: _ast, ...result } = transform(
 		ast,
 		source,
@@ -65,6 +70,13 @@ export function compile_to_volar_mappings(source, filename, options) {
 		loose: !!options?.loose,
 		preserveParens: true,
 		keywordTokens: true,
+		errors,
+		comments,
+	});
+	analyzeTsrx(ast, filename, {
+		collect: true,
+		loose: !!options?.loose,
+		typeOnly: true,
 		errors,
 		comments,
 	});

--- a/packages/tsrx-solid/src/transform.js
+++ b/packages/tsrx-solid/src/transform.js
@@ -36,6 +36,7 @@ import {
 	isTemplateForOfNode as is_template_for_of_node,
 	isTemplateSwitchNode as is_template_switch_node,
 	isTemplateTryNode as is_template_try_node,
+	isFunctionOrClassNode as is_function_or_class_boundary,
 } from '@tsrx/core';
 
 import { builders as b } from '@tsrx/core';
@@ -446,20 +447,6 @@ function get_if_consequent_body(node) {
 function body_has_loop_skip(body_nodes) {
 	return body_nodes.some(
 		(node) => is_bare_return_statement(node) || get_returning_if_info(node) !== null,
-	);
-}
-
-/**
- * @param {any} node
- * @returns {boolean}
- */
-function is_function_or_class_boundary(node) {
-	return (
-		node?.type === 'FunctionDeclaration' ||
-		node?.type === 'FunctionExpression' ||
-		node?.type === 'ArrowFunctionExpression' ||
-		node?.type === 'ClassDeclaration' ||
-		node?.type === 'ClassExpression'
 	);
 }
 

--- a/packages/tsrx-vue/src/index.js
+++ b/packages/tsrx-vue/src/index.js
@@ -2,7 +2,7 @@
 /** @import { CompileError, ParseOptions } from '@tsrx/core/types' */
 /** @import { NonEmptyString } from '@tsrx/core/types/helpers' */
 
-import { createVolarMappingsResult, dedupeMappings, parseModule } from '@tsrx/core';
+import { analyzeTsrx, createVolarMappingsResult, dedupeMappings, parseModule } from '@tsrx/core';
 import { transform } from './transform.js';
 
 export { isRefProp } from './ref.js';
@@ -38,6 +38,11 @@ export function compile(source, filename, options) {
 		filename,
 		collect ? { collect: true, loose: !!options?.loose, errors, comments } : undefined,
 	);
+	analyzeTsrx(
+		ast,
+		filename,
+		collect ? { collect: true, loose: !!options?.loose, errors, comments } : undefined,
+	);
 	const { ast: _ast, ...result } = transform(
 		ast,
 		source,
@@ -65,6 +70,13 @@ export function compile_to_volar_mappings(source, filename, options) {
 		loose: !!options?.loose,
 		preserveParens: true,
 		keywordTokens: true,
+		errors,
+		comments,
+	});
+	analyzeTsrx(ast, filename, {
+		collect: true,
+		loose: !!options?.loose,
+		typeOnly: true,
 		errors,
 		comments,
 	});

--- a/packages/tsrx/README.md
+++ b/packages/tsrx/README.md
@@ -27,9 +27,10 @@ pnpm add @tsrx/core
 ## Usage
 
 ```js
-import { parseModule } from '@tsrx/core';
+import { analyzeTsrx, parseModule } from '@tsrx/core';
 
 const ast = parseModule(source, 'App.tsrx');
+const analysis = analyzeTsrx(ast, 'App.tsrx');
 ```
 
 The parser produces an ESTree-compatible AST, augmented with the TSRX node types
@@ -54,6 +55,10 @@ here and keeps package docs focused on the core parser API.
 
 - **`parseModule(source, filename, options?)`** — parse a TSRX module into an
   ESTree AST.
+- **`analyzeTsrx(ast, filename, options?)`** — run target-neutral semantic
+  validation before framework analysis or transformation. Pass `collect: true`,
+  `typeOnly: true`, or `to_ts: true` to collect non-fatal diagnostics for
+  editor/type-only output.
 - **Scope analysis** — `createScopes`, `Scope`, `ScopeRoot`, binding tracking
   (`import`, `prop`, `let`, `const`, `function`, `for_pattern`, …).
 - **AST utilities** — pattern walkers, identifier extraction, builders, location

--- a/packages/tsrx/src/analyze/index.js
+++ b/packages/tsrx/src/analyze/index.js
@@ -4,7 +4,11 @@
  */
 
 import { walk } from 'zimmerframe';
-import { is_code_block_function_body, is_tsrx_render_output_node } from '../utils/ast.js';
+import {
+	is_code_block_function_body,
+	is_statement_position,
+	is_tsrx_render_output_node,
+} from '../utils/ast.js';
 import { validate_forgotten_statement_container } from './validation.js';
 
 /**
@@ -53,17 +57,7 @@ function is_free_floating_template(node, path) {
 			return true;
 		}
 
-		if (
-			parent.type === 'BlockStatement' &&
-			parent.body.includes(/** @type {AST.Statement} */ (child))
-		) {
-			return true;
-		}
-
-		if (
-			parent.type === 'SwitchCase' &&
-			parent.consequent.includes(/** @type {AST.Statement} */ (child))
-		) {
+		if (is_statement_position(parent, child)) {
 			return true;
 		}
 

--- a/packages/tsrx/src/analyze/index.js
+++ b/packages/tsrx/src/analyze/index.js
@@ -98,7 +98,7 @@ function visit_render_output(node, { next, path, state }) {
 
 	if (
 		state.function &&
-		!state.function_body_is_code_block &&
+		!(state.function_body_is_code_block && state.function.body === node) &&
 		!state.inside_template_output &&
 		is_free_floating_template(node, path)
 	) {
@@ -110,7 +110,12 @@ function visit_render_output(node, { next, path, state }) {
 		);
 	}
 
-	next({ ...state, inside_template_output: true });
+	// A JSXCodeBlock contains ordinary setup statements in `body` as well as
+	// the retained output in `render`. Reset the template context while walking
+	// both fields so free-floating output in setup is still diagnosed. The
+	// render node itself is retained by the code block, and establishes template
+	// context for its own descendants when this visitor reaches it.
+	next({ ...state, inside_template_output: node.type !== 'JSXCodeBlock' });
 }
 
 /**

--- a/packages/tsrx/src/analyze/index.js
+++ b/packages/tsrx/src/analyze/index.js
@@ -1,0 +1,178 @@
+/**
+@import * as AST from 'estree';
+@import { TSRXAnalysisOptions, TSRXAnalysisResult, TSRXAnalysisState } from '../../types/index';
+ */
+
+import { walk } from 'zimmerframe';
+import { is_code_block_function_body, is_tsrx_render_output_node } from '../utils/ast.js';
+import { validate_forgotten_statement_container } from './validation.js';
+
+/**
+ * Wrappers that preserve an expression's value and therefore do not turn a
+ * template into a used value on their own. Looking through them keeps strict
+ * builds and `preserveParens` type-only builds on the same diagnostic path.
+ *
+ * @param {AST.Node} parent
+ * @param {AST.Node} child
+ * @returns {boolean}
+ */
+function is_transparent_expression_wrapper(parent, child) {
+	return (
+		(parent.type === 'ParenthesizedExpression' ||
+			parent.type === 'TSAsExpression' ||
+			parent.type === 'TSSatisfiesExpression' ||
+			parent.type === 'TSNonNullExpression' ||
+			parent.type === 'TSInstantiationExpression' ||
+			parent.type === 'TSTypeAssertion' ||
+			parent.type === 'ChainExpression') &&
+		/** @type {{ expression?: AST.Node }} */ (parent).expression === child
+	);
+}
+
+/**
+ * A template is unused only when it is itself the statement being executed.
+ * Templates nested in assignments, returns, arguments, operands, or other
+ * value-producing expressions may be consumed later and are valid.
+ *
+ * @param {AST.Node} node
+ * @param {AST.Node[]} path
+ * @returns {boolean}
+ */
+function is_free_floating_template(node, path) {
+	let child = node;
+
+	for (let i = path.length - 1; i >= 0; i -= 1) {
+		const parent = path[i];
+
+		if (is_transparent_expression_wrapper(parent, child)) {
+			child = parent;
+			continue;
+		}
+
+		if (parent.type === 'ExpressionStatement' && parent.expression === child) {
+			return true;
+		}
+
+		if (
+			parent.type === 'BlockStatement' &&
+			parent.body.includes(/** @type {AST.Statement} */ (child))
+		) {
+			return true;
+		}
+
+		if (
+			parent.type === 'SwitchCase' &&
+			parent.consequent.includes(/** @type {AST.Statement} */ (child))
+		) {
+			return true;
+		}
+
+		return false;
+	}
+
+	return false;
+}
+
+/**
+ * @param {AST.Function} node
+ * @param {{ next: (state?: TSRXAnalysisState) => unknown, state: TSRXAnalysisState }} context
+ */
+function visit_function(node, { next, state }) {
+	next({
+		...state,
+		function: node,
+		function_body_is_code_block: is_code_block_function_body(node.body, node),
+		inside_template_output: false,
+	});
+}
+
+/**
+ * @param {AST.Node} node
+ * @param {{ next: (state?: TSRXAnalysisState) => unknown, path: AST.Node[], state: TSRXAnalysisState }} context
+ */
+function visit_render_output(node, { next, path, state }) {
+	if (!is_tsrx_render_output_node(node)) {
+		next();
+		return;
+	}
+
+	if (
+		state.function &&
+		!state.function_body_is_code_block &&
+		!state.inside_template_output &&
+		is_free_floating_template(node, path)
+	) {
+		validate_forgotten_statement_container(
+			node,
+			state.filename,
+			state.collect ? state.errors : undefined,
+			state.comments,
+		);
+	}
+
+	next({ ...state, inside_template_output: true });
+}
+
+/**
+ * @param {AST.ClassDeclaration | AST.ClassExpression} _node
+ * @param {{ next: (state?: TSRXAnalysisState) => unknown, state: TSRXAnalysisState }} context
+ */
+function visit_class(_node, { next, state }) {
+	next({
+		...state,
+		function: null,
+		function_body_is_code_block: false,
+		inside_template_output: false,
+	});
+}
+
+const visitors = {
+	FunctionDeclaration: visit_function,
+	FunctionExpression: visit_function,
+	ArrowFunctionExpression: visit_function,
+
+	// A class body is not part of the surrounding function's execution context.
+	// Method/function nodes establish their own context when reached.
+	ClassDeclaration: visit_class,
+	ClassExpression: visit_class,
+
+	JSXElement: visit_render_output,
+	JSXFragment: visit_render_output,
+	JSXStyleElement: visit_render_output,
+	JSXCodeBlock: visit_render_output,
+	JSXIfExpression: visit_render_output,
+	JSXForExpression: visit_render_output,
+	JSXSwitchExpression: visit_render_output,
+	JSXTryExpression: visit_render_output,
+};
+
+/**
+ * Run target-neutral semantic validation over a parsed TSRX module. Parsing
+ * remains syntax-only; every target invokes this pass before target analysis or
+ * transformation. Type-only/Volar callers collect diagnostics and continue.
+ *
+ * @param {AST.Program} ast
+ * @param {string | null | undefined} filename
+ * @param {TSRXAnalysisOptions} [options]
+ * @returns {TSRXAnalysisResult}
+ */
+export function analyze_tsrx(ast, filename, options = {}) {
+	const errors = options.errors ?? [];
+	const comments = options.comments ?? [];
+	const collect = !!(options.collect || options.loose || options.typeOnly || options.to_ts);
+
+	/** @type {TSRXAnalysisState} */
+	const state = {
+		filename: filename ?? null,
+		collect,
+		errors,
+		comments,
+		function: null,
+		function_body_is_code_block: false,
+		inside_template_output: false,
+	};
+
+	walk(ast, state, visitors);
+
+	return { ast, errors, comments };
+}

--- a/packages/tsrx/src/analyze/validation.js
+++ b/packages/tsrx/src/analyze/validation.js
@@ -29,7 +29,7 @@ export const TSRX_WHILE_STATEMENT_ERROR =
 export const TSRX_DO_WHILE_STATEMENT_ERROR =
 	'Do...while loops are not supported in TSRX templates. Move the do...while loop into a function.';
 export const TSRX_FORGOTTEN_STATEMENT_CONTAINER_ERROR =
-	"This TSRX template output is unused because its function has a normal JavaScript body. Return it, assign it to a value that is rendered, or add '@' before the function body's opening brace.";
+	"This TSRX template output is unused. Return it, assign it to a value that is rendered, or make it part of the rendered output of a function '@{...}' body.";
 
 const invalid_nestings = {
 	// <p> cannot contain block-level elements

--- a/packages/tsrx/src/analyze/validation.js
+++ b/packages/tsrx/src/analyze/validation.js
@@ -28,6 +28,8 @@ export const TSRX_WHILE_STATEMENT_ERROR =
 	'While loops are not supported in TSRX templates. Move the while loop into a function.';
 export const TSRX_DO_WHILE_STATEMENT_ERROR =
 	'Do...while loops are not supported in TSRX templates. Move the do...while loop into a function.';
+export const TSRX_FORGOTTEN_STATEMENT_CONTAINER_ERROR =
+	"This TSRX template output is unused because its function has a normal JavaScript body. Return it, assign it to a value that is rendered, or add '@' before the function body's opening brace.";
 
 const invalid_nestings = {
 	// <p> cannot contain block-level elements
@@ -198,6 +200,23 @@ export function validate_tsrx_return_statement(node, filename, errors, comments)
 		errors,
 		comments,
 		DIAGNOSTIC_CODES.TEMPLATE_RETURN_STATEMENT,
+	);
+}
+
+/**
+ * @param {AST.Node} node
+ * @param {string | null | undefined} filename
+ * @param {CompileError[]} [errors]
+ * @param {AST.CommentWithLocation[]} [comments]
+ */
+export function validate_forgotten_statement_container(node, filename, errors, comments) {
+	error(
+		TSRX_FORGOTTEN_STATEMENT_CONTAINER_ERROR,
+		filename ?? null,
+		node,
+		errors,
+		comments,
+		DIAGNOSTIC_CODES.FORGOTTEN_STATEMENT_CONTAINER,
 	);
 }
 

--- a/packages/tsrx/src/index.js
+++ b/packages/tsrx/src/index.js
@@ -93,6 +93,7 @@ export {
 	is_template_directive as isTemplateDirective,
 	is_tsrx_render_output_node as isTsrxRenderOutputNode,
 	is_code_block_function_body as isCodeBlockFunctionBody,
+	is_statement_position as isStatementPosition,
 } from './utils/ast.js';
 
 // Shared TSRX semantic analysis

--- a/packages/tsrx/src/index.js
+++ b/packages/tsrx/src/index.js
@@ -87,9 +87,16 @@ export {
 	build_assignment_value as buildAssignmentValue,
 	is_class_node as isClassNode,
 	is_function_node as isFunctionNode,
+	is_function_or_class_node as isFunctionOrClassNode,
 	is_function_or_component_node as isFunctionOrComponentNode,
 	is_inside_component as isInsideComponent,
+	is_template_directive as isTemplateDirective,
+	is_tsrx_render_output_node as isTsrxRenderOutputNode,
+	is_code_block_function_body as isCodeBlockFunctionBody,
 } from './utils/ast.js';
+
+// Shared TSRX semantic analysis
+export { analyze_tsrx as analyzeTsrx } from './analyze/index.js';
 
 // Builders (namespace re-export — members mirror AST node kinds)
 export * as builders from './utils/builders.js';
@@ -244,6 +251,7 @@ export { analyze_css as analyzeCss } from './analyze/css-analyze.js';
 export { prune_css as pruneCss } from './analyze/prune.js';
 export {
 	TSRX_DO_WHILE_STATEMENT_ERROR,
+	TSRX_FORGOTTEN_STATEMENT_CONTAINER_ERROR,
 	TSRX_FOR_IN_STATEMENT_ERROR,
 	TSRX_FOR_STATEMENT_ERROR,
 	TSRX_IF_BREAK_ERROR,
@@ -264,6 +272,7 @@ export {
 	validate_tsrx_loop_return_statement as validateTsrxLoopReturnStatement,
 	validate_tsrx_return_statement as validateTsrxReturnStatement,
 	validate_tsrx_unsupported_loop_statement as validateTsrxUnsupportedLoopStatement,
+	validate_forgotten_statement_container as validateForgottenStatementContainer,
 	validate_nesting as validateNesting,
 	is_template_value_position as isTemplateValuePosition,
 } from './analyze/validation.js';

--- a/packages/tsrx/src/plugin.js
+++ b/packages/tsrx/src/plugin.js
@@ -11,8 +11,7 @@ import { regex_newline_characters } from './utils/patterns.js';
 import { error } from './errors.js';
 import { DIAGNOSTIC_CODES } from './diagnostics.js';
 import { TSRX_RETURN_STATEMENT_ERROR } from './analyze/validation.js';
-const FORGOTTEN_STATEMENT_CONTAINER_ERROR =
-	"This function body contains TSRX template output, but it is a normal JavaScript block. Add '@' before the opening brace to use a TSRX statement container.";
+import { is_tsrx_render_output_node } from './utils/ast.js';
 
 const CharCode = Object.freeze({
 	tab: 9,
@@ -1163,104 +1162,6 @@ export function TSRXPlugin(config) {
 			}
 
 			/**
-			 * @param {AST.Node | null | undefined} node
-			 */
-			#isRenderOutputNode(node) {
-				if (!node) return false;
-				switch (node.type) {
-					case 'JSXElement':
-					case 'JSXFragment':
-					case 'JSXStyleElement':
-					case 'JSXCodeBlock':
-					case 'JSXIfExpression':
-					case 'JSXForExpression':
-					case 'JSXSwitchExpression':
-					case 'JSXTryExpression':
-						return true;
-				}
-				return false;
-			}
-
-			/**
-			 * @param {AST.Node | null | undefined} node
-			 */
-			#isForgottenStatementContainerOutputNode(node) {
-				return this.#isRenderOutputNode(node) && node?.type !== 'JSXCodeBlock';
-			}
-
-			/**
-			 * @param {AST.Node | null | undefined} node
-			 */
-			#isIgnoredForgottenStatementContainerStatement(node) {
-				return !node || node.type === 'EmptyStatement';
-			}
-
-			/**
-			 * A normal function body that directly contains a bare JSX/control-flow node
-			 * almost always means the author wrote `{ ... <div /> }` but intended
-			 * `@{ ... <div /> }`. Only report when adding `@` would produce a valid
-			 * statement container: setup statements first, followed by one final render
-			 * output. Report only direct body children so ordinary nested callbacks/branches
-			 * are diagnosed by their own function body, not their parent.
-			 * @param {AST.Node} node
-			 */
-			#reportForgottenStatementContainerBody(node) {
-				if (!this.#collect) {
-					return;
-				}
-
-				const body = /** @type {{ body?: AST.Node }} */ (node).body;
-				if (body?.type !== 'BlockStatement') {
-					return;
-				}
-
-				const statements = /** @type {AST.BlockStatement} */ (body).body || [];
-				const has_return_type = Boolean(/** @type {{ returnType?: AST.Node }} */ (node).returnType);
-				if (!has_return_type) {
-					return;
-				}
-
-				let target = null;
-				let target_index = -1;
-				for (let index = 0; index < statements.length; index++) {
-					const statement = statements[index];
-					const output =
-						this.#isForgottenStatementContainerOutputNode(statement) ||
-						(statement.type === 'ExpressionStatement' &&
-							this.#isForgottenStatementContainerOutputNode(statement.expression))
-							? statement
-							: null;
-
-					if (!output) {
-						continue;
-					}
-
-					if (target_index !== -1) {
-						return;
-					}
-					target_index = index;
-					target = output;
-				}
-
-				if (!target) {
-					return;
-				}
-
-				for (const statement of statements.slice(target_index + 1)) {
-					if (!this.#isIgnoredForgottenStatementContainerStatement(statement)) {
-						return;
-					}
-				}
-
-				this.#report_recoverable_error_range(
-					/** @type {number} */ (target.start),
-					/** @type {number} */ (target.end),
-					FORGOTTEN_STATEMENT_CONTAINER_ERROR,
-					DIAGNOSTIC_CODES.FORGOTTEN_STATEMENT_CONTAINER,
-				);
-			}
-
-			/**
 			 * Inside a code block (`@{ … }` or a directive's `{ }`), decides whether the
 			 * next thing is the single bare render node (`<tag …>`, `<>…</>`, or an
 			 * `@if`/`@for`/`@switch`/`@try` directive) rather than a setup statement.
@@ -1500,7 +1401,7 @@ export function TSRXPlugin(config) {
 				}
 
 				const last = flat[flat.length - 1];
-				if (this.#isRenderOutputNode(last)) {
+				if (is_tsrx_render_output_node(last)) {
 					node.render = last;
 					node.body = /** @type {AST.Statement[]} */ (flat.slice(0, -1));
 				} else {
@@ -3455,9 +3356,7 @@ export function TSRXPlugin(config) {
 						this.exitScope();
 						return node;
 					}
-					const parsed = super.parseFunctionBody(node, isArrowFunction, isMethod, forInit, ...args);
-					this.#reportForgottenStatementContainerBody(parsed);
-					return parsed;
+					return super.parseFunctionBody(node, isArrowFunction, isMethod, forInit, ...args);
 				} finally {
 					this.#functionBodyDepth--;
 				}

--- a/packages/tsrx/src/transform/jsx/index.js
+++ b/packages/tsrx/src/transform/jsx/index.js
@@ -61,6 +61,10 @@ import {
 } from '../jsx-interleave.js';
 import { is_hoist_safe_jsx_node } from '../jsx-hoist.js';
 import { lower_server_module_for_types } from './server-module.js';
+import {
+	is_function_or_class_node as is_function_or_class_boundary,
+	is_template_directive as is_jsx_control_flow_expression,
+} from '../../utils/ast.js';
 
 const TEMPLATE_FRAGMENT_ERROR =
 	'JSX fragment syntax is not needed in TSRX templates. TSRX renders in immediate mode, so everything is already a fragment. Use `<>...</>` only in expression position.';
@@ -113,20 +117,6 @@ function report_jsx_fragment_in_tsrx_error(node, transform_context) {
 /**
  * @typedef {{ source_name: string, read: () => any }} LazyBinding
  */
-
-/**
- * @param {any} node
- * @returns {boolean}
- */
-function is_function_or_class_boundary(node) {
-	return (
-		node?.type === 'FunctionDeclaration' ||
-		node?.type === 'FunctionExpression' ||
-		node?.type === 'ArrowFunctionExpression' ||
-		node?.type === 'ClassDeclaration' ||
-		node?.type === 'ClassExpression'
-	);
-}
 
 /**
  * @param {any} node
@@ -262,22 +252,6 @@ function expand_child_code_blocks(node, seen = new Set()) {
 	}
 
 	return out;
-}
-
-/**
- * A `@`-prefixed JSX control-flow expression (`@if`/`@for`/`@switch`/`@try`).
- * These are the only control-flow nodes that can appear in expression position;
- * the plain statement forms (`IfStatement`, `SwitchStatement`, …) never do.
- * @param {any} node
- * @returns {boolean}
- */
-function is_jsx_control_flow_expression(node) {
-	return (
-		node?.type === 'JSXIfExpression' ||
-		node?.type === 'JSXForExpression' ||
-		node?.type === 'JSXSwitchExpression' ||
-		node?.type === 'JSXTryExpression'
-	);
 }
 
 /**

--- a/packages/tsrx/src/transform/style-ref.js
+++ b/packages/tsrx/src/transform/style-ref.js
@@ -1,6 +1,7 @@
 /** @import * as AST from 'estree' */
 
 import * as b from '../utils/builders.js';
+import { is_function_or_class_node as is_function_or_class_boundary } from '../utils/ast.js';
 import { clone_expression_node, clone_identifier } from './jsx/ast-builders.js';
 
 const regex_backslash_and_following_character = /\\(.)/g;
@@ -234,20 +235,6 @@ function is_ref_attribute(attr) {
  */
 function is_style_element(node) {
 	return !!node && node.type === 'JSXStyleElement';
-}
-
-/**
- * @param {any} node
- * @returns {boolean}
- */
-function is_function_or_class_boundary(node) {
-	return (
-		node?.type === 'FunctionDeclaration' ||
-		node?.type === 'FunctionExpression' ||
-		node?.type === 'ArrowFunctionExpression' ||
-		node?.type === 'ClassDeclaration' ||
-		node?.type === 'ClassExpression'
-	);
 }
 
 /**

--- a/packages/tsrx/src/utils/ast.js
+++ b/packages/tsrx/src/utils/ast.js
@@ -105,6 +105,39 @@ export function is_code_block_function_body(node, parent) {
 }
 
 /**
+ * Returns whether `child` directly occupies a statement slot of `parent`.
+ * Parser-native TSRX output nodes can appear in these slots without an
+ * `ExpressionStatement` wrapper, notably as braceless control-flow bodies.
+ *
+ * @param {AST.Node} parent
+ * @param {AST.Node} child
+ * @returns {boolean}
+ */
+export function is_statement_position(parent, child) {
+	switch (parent.type) {
+		case 'Program':
+		case 'BlockStatement':
+			return parent.body.includes(/** @type {AST.Statement} */ (child));
+		case 'SwitchCase':
+			return parent.consequent.includes(/** @type {AST.Statement} */ (child));
+		case 'JSXCodeBlock':
+			return parent.body.includes(/** @type {AST.Statement} */ (child));
+		case 'IfStatement':
+			return parent.consequent === child || parent.alternate === child;
+		case 'ForStatement':
+		case 'ForInStatement':
+		case 'ForOfStatement':
+		case 'WhileStatement':
+		case 'DoWhileStatement':
+		case 'LabeledStatement':
+		case 'WithStatement':
+			return parent.body === child;
+		default:
+			return false;
+	}
+}
+
+/**
  * Returns the closest native TSRX function in an ancestry path. By default,
  * function and class boundaries stop the search so callers only match direct
  * native TSRX function body/control-flow nodes.

--- a/packages/tsrx/src/utils/ast.js
+++ b/packages/tsrx/src/utils/ast.js
@@ -22,7 +22,7 @@ import * as b from './builders.js';
 
 /**
  * @param {AST.Node} node
- * @returns {boolean}
+ * @returns {node is AST.Function}
  */
 export function is_function_node(node) {
 	return (
@@ -30,6 +30,14 @@ export function is_function_node(node) {
 		node.type === 'ArrowFunctionExpression' ||
 		node.type === 'FunctionDeclaration'
 	);
+}
+
+/**
+ * @param {AST.Node | null | undefined} node
+ * @returns {node is AST.Function | AST.ClassDeclaration | AST.ClassExpression}
+ */
+export function is_function_or_class_node(node) {
+	return !!node && (is_function_node(node) || is_class_node(node));
 }
 
 /**
@@ -46,6 +54,54 @@ export function is_function_or_component_node(node) {
  */
 export function is_class_node(node) {
 	return node.type === 'ClassExpression' || node.type === 'ClassDeclaration';
+}
+
+/**
+ * A parsed `@if`/`@for`/`@switch`/`@try` control-flow directive.
+ *
+ * @param {AST.Node | null | undefined} node
+ * @returns {node is AST.JSXTemplateDirective}
+ */
+export function is_template_directive(node) {
+	return (
+		node?.type === 'JSXIfExpression' ||
+		node?.type === 'JSXForExpression' ||
+		node?.type === 'JSXSwitchExpression' ||
+		node?.type === 'JSXTryExpression'
+	);
+}
+
+/**
+ * Any source AST node that can be the rendered output of a TSRX template or
+ * statement container.
+ *
+ * @param {AST.Node | null | undefined} node
+ * @returns {node is AST.TSRXRenderOutput}
+ */
+export function is_tsrx_render_output_node(node) {
+	return !!(
+		node &&
+		(node.type === 'JSXElement' ||
+			node.type === 'JSXFragment' ||
+			node.type === 'JSXStyleElement' ||
+			node.type === 'JSXCodeBlock' ||
+			is_template_directive(node))
+	);
+}
+
+/**
+ * @param {AST.Node | null | undefined} node
+ * @param {AST.Node | null | undefined} parent
+ * @returns {node is AST.JSXCodeBlock}
+ */
+export function is_code_block_function_body(node, parent) {
+	return !!(
+		node &&
+		node.type === 'JSXCodeBlock' &&
+		parent &&
+		is_function_node(parent) &&
+		parent.body === node
+	);
 }
 
 /**

--- a/packages/tsrx/tests/analyze/analyze.test.js
+++ b/packages/tsrx/tests/analyze/analyze.test.js
@@ -1,0 +1,172 @@
+import { describe, expect, it } from 'vitest';
+import { analyzeTsrx, DIAGNOSTIC_CODES, parseModule } from '../../src/index.js';
+import { TSRX_FORGOTTEN_STATEMENT_CONTAINER_ERROR } from '../../src/analyze/validation.js';
+
+const filename = 'App.tsrx';
+
+/**
+ * Parse and run the target-neutral analysis in diagnostic-collection mode.
+ * Keeping this below the target compilers ensures the semantic rules are
+ * exercised once rather than repeated by every lowering target.
+ *
+ * @param {string} source
+ * @param {import('../../types/index.d.ts').TSRXAnalysisOptions} [options]
+ */
+function analyze(source, options = { collect: true }) {
+	const parse_errors = [];
+	const comments = [];
+	const ast = parseModule(source, filename, {
+		collect: true,
+		errors: parse_errors,
+		comments,
+	});
+
+	expect(parse_errors).toEqual([]);
+
+	return analyzeTsrx(ast, filename, { ...options, comments });
+}
+
+/** @param {ReturnType<typeof analyze>} result */
+function forgotten_output_errors(result) {
+	return result.errors.filter(
+		(error) => error.code === DIAGNOSTIC_CODES.FORGOTTEN_STATEMENT_CONTAINER,
+	);
+}
+
+describe('target-neutral TSRX analysis', () => {
+	describe('unused template output', () => {
+		it('reports free-floating output in every ordinary function form', () => {
+			for (const source of [
+				'function Test() { <div /> }',
+				'const Test = () => { <div /> };',
+				'const Test = function () { <div /> };',
+				'consume(function () { <div /> });',
+				'const object = { render() { <div /> } };',
+				'class Test { render() { <div /> } }',
+			]) {
+				const errors = forgotten_output_errors(analyze(source));
+
+				expect(errors, source).toHaveLength(1);
+				expect(errors[0].message).toBe(TSRX_FORGOTTEN_STATEMENT_CONTAINER_ERROR);
+			}
+		});
+
+		it('reports every free-floating TSRX output shape once', () => {
+			for (const output of [
+				'<div />',
+				'<><div /></>',
+				'<style>div { color: red; }</style>',
+				'@if (ok) { <div /> } @else { <span /> }',
+				'@for (const item of items) { <div>{item}</div> }',
+				'@switch (value) { @case 1: { <div /> } @default: { <span /> } }',
+				'@try { <div /> } @catch (error) { <span /> }',
+				'@{ <div /> }',
+			]) {
+				const errors = forgotten_output_errors(
+					analyze(`function Test() {
+						${output}
+					}`),
+				);
+
+				expect(errors, output).toHaveLength(1);
+			}
+		});
+
+		it('reports output nested in ordinary JavaScript blocks and output followed by setup', () => {
+			const result = analyze(`function Test() {
+				if (ready) {
+					<div />
+				}
+
+				<span />;
+				const value = 1;
+				console.log(value);
+			}`);
+
+			expect(forgotten_output_errors(result)).toHaveLength(2);
+		});
+
+		it('looks through value-transparent expression wrappers', () => {
+			const result = analyze(`function Test() {
+				(<div />);
+				(<span /> as JSX.Element);
+			}`);
+
+			expect(forgotten_output_errors(result)).toHaveLength(2);
+		});
+
+		it('throws during strict analysis', () => {
+			const ast = parseModule('function Test() { <div /> }', filename);
+
+			expect(() => analyzeTsrx(ast, filename)).toThrow(TSRX_FORGOTTEN_STATEMENT_CONTAINER_ERROR);
+		});
+
+		it('collects and continues for editor and type-only analysis modes', () => {
+			for (const options of [
+				{ collect: true },
+				{ loose: true },
+				{ typeOnly: true },
+				{ to_ts: true },
+			]) {
+				const result = analyze('function Test() { <div /> }', options);
+
+				expect(forgotten_output_errors(result), options).toHaveLength(1);
+			}
+		});
+	});
+
+	describe('rendered or retained template output', () => {
+		it('allows every function form to use a direct @{...} body', () => {
+			for (const source of [
+				'function Test() @{ <div /> }',
+				'const Test = () => @{ <div /> };',
+				'const Test = function () @{ <div /> };',
+				'consume(function () @{ <div /> });',
+				'const object = { render() @{ <div /> } };',
+				'class Test { render() @{ <div /> } }',
+			]) {
+				expect(forgotten_output_errors(analyze(source)), source).toEqual([]);
+			}
+		});
+
+		it('still checks ordinary nested functions inside a function @{...} body', () => {
+			const result = analyze(`function App() @{
+				const render = function () {
+					<span />
+				};
+
+				<div>{render()}</div>
+			}`);
+
+			expect(forgotten_output_errors(result)).toHaveLength(1);
+		});
+
+		it('allows returned, retained, passed, and expression-bodied output', () => {
+			for (const source of [
+				'function Test() { return <div />; }',
+				'function Test() { const view = <div />; return view; }',
+				'function Test() { render(<div />); }',
+				'function Test() { return ready && <div />; }',
+				'const Test = () => <div />;',
+				'function Test() { const view = @if (ready) { <div /> }; return view; }',
+				'function Test() { const view = @{ <div /> }; return view; }',
+			]) {
+				expect(forgotten_output_errors(analyze(source)), source).toEqual([]);
+			}
+		});
+
+		it('does not report nested output that belongs to another template', () => {
+			const result = analyze(`function Test() {
+				return <section>
+					@if (ready) { <div /> } @else { <span /> }
+				</section>;
+			}`);
+
+			expect(forgotten_output_errors(result)).toEqual([]);
+		});
+
+		it('does not apply function-body semantics at module scope', () => {
+			expect(forgotten_output_errors(analyze('<div />'))).toEqual([]);
+		});
+	});
+});

--- a/packages/tsrx/tests/analyze/analyze.test.js
+++ b/packages/tsrx/tests/analyze/analyze.test.js
@@ -120,6 +120,25 @@ describe('target-neutral TSRX analysis', () => {
 			expect(forgotten_output_errors(result)).toHaveLength(1);
 		});
 
+		it('reports every braceless statement-position template', () => {
+			const result = analyze(
+				`function Test(a, b, object, items, ready) @{
+					if (a) <div />;
+					if (b) run(); else <span />;
+					for (;;) <p />;
+					for (const key in object) <section />;
+					for (const item of items) <article />;
+					while (ready) <aside />;
+					output: <footer />;
+
+					<main />
+				}`,
+				{ collect: true },
+			);
+
+			expect(forgotten_output_errors(result)).toHaveLength(7);
+		});
+
 		it('reports free-floating setup output in retained and nested @{...} expressions', () => {
 			const result = analyze(
 				`function Retained(enabled) {
@@ -233,6 +252,16 @@ describe('target-neutral TSRX analysis', () => {
 				} @else {
 					<main />
 				}
+			}`);
+
+			expect(forgotten_output_errors(result)).toEqual([]);
+		});
+
+		it('allows templates used as ordinary control-flow values', () => {
+			const result = analyze(`function Test() {
+				if (<Condition />) run();
+				for (; <Condition />; ) run();
+				while (<Condition />) run();
 			}`);
 
 			expect(forgotten_output_errors(result)).toEqual([]);

--- a/packages/tsrx/tests/analyze/analyze.test.js
+++ b/packages/tsrx/tests/analyze/analyze.test.js
@@ -36,40 +36,39 @@ function forgotten_output_errors(result) {
 describe('target-neutral TSRX analysis', () => {
 	describe('unused template output', () => {
 		it('reports free-floating output in every ordinary function form', () => {
-			for (const source of [
-				'function Test() { <div /> }',
-				'const Test = () => { <div /> };',
-				'const Test = function () { <div /> };',
-				'consume(function () { <div /> });',
-				'const object = { render() { <div /> } };',
-				'class Test { render() { <div /> } }',
-			]) {
-				const errors = forgotten_output_errors(analyze(source));
+			const result = analyze(
+				`function Declaration() { <div /> }
+				const Arrow = () => { <div /> };
+				const Expression = function () { <div /> };
+				consume(function () { <div /> });
+				const object = { render() { <div /> } };
+				class Component { render() { <div /> } }`,
+				{ collect: true },
+			);
+			const errors = forgotten_output_errors(result);
 
-				expect(errors, source).toHaveLength(1);
-				expect(errors[0].message).toBe(TSRX_FORGOTTEN_STATEMENT_CONTAINER_ERROR);
-			}
+			expect(errors).toHaveLength(6);
+			expect(
+				errors.every((error) => error.message === TSRX_FORGOTTEN_STATEMENT_CONTAINER_ERROR),
+			).toBe(true);
 		});
 
 		it('reports every free-floating TSRX output shape once', () => {
-			for (const output of [
-				'<div />',
-				'<><div /></>',
-				'<style>div { color: red; }</style>',
-				'@if (ok) { <div /> } @else { <span /> }',
-				'@for (const item of items) { <div>{item}</div> }',
-				'@switch (value) { @case 1: { <div /> } @default: { <span /> } }',
-				'@try { <div /> } @catch (error) { <span /> }',
-				'@{ <div /> }',
-			]) {
-				const errors = forgotten_output_errors(
-					analyze(`function Test() {
-						${output}
-					}`),
-				);
+			const result = analyze(
+				`function Test(ok, items, value) {
+					<div />;
+					<><div /></>;
+					<style>div { color: red; }</style>;
+					@if (ok) { <div /> } @else { <span /> };
+					@for (const item of items) { <div>{item}</div> };
+					@switch (value) { @case 1: { <div /> } @default: { <span /> } };
+					@try { <div /> } @catch (error) { <span /> };
+					@{ <div /> };
+				}`,
+				{ collect: true },
+			);
 
-				expect(errors, output).toHaveLength(1);
-			}
+			expect(forgotten_output_errors(result)).toHaveLength(8);
 		});
 
 		it('reports output nested in ordinary JavaScript blocks and output followed by setup', () => {
@@ -82,6 +81,72 @@ describe('target-neutral TSRX analysis', () => {
 				const value = 1;
 				console.log(value);
 			}`);
+
+			expect(forgotten_output_errors(result)).toHaveLength(2);
+		});
+
+		it('reports free-floating output in the setup portion of a function @{...} body', () => {
+			const result = analyze(
+				`function Test(enabled, ready, items, value) @{
+					if (enabled) {
+						<div />;
+						<><div /></>;
+						<style>div { color: red; }</style>;
+						@if (ready) { <div /> } @else { <span /> };
+						@for (const item of items) { <div>{item}</div> };
+						@switch (value) { @case 1: { <div /> } @default: { <span /> } };
+						@try { <div /> } @catch (error) { <span /> };
+						@{ <div /> };
+					}
+
+					<main />
+				}`,
+				{ collect: true },
+			);
+
+			expect(forgotten_output_errors(result)).toHaveLength(8);
+		});
+
+		it('reports free-floating output in ordinary setup loops', () => {
+			const result = analyze(`function Test() @{
+				const items = [1, 2, 3];
+				for (const item of items) {
+					<div>{item}</div>
+				}
+
+				<main />
+			}`);
+
+			expect(forgotten_output_errors(result)).toHaveLength(1);
+		});
+
+		it('reports free-floating setup output in retained and nested @{...} expressions', () => {
+			const result = analyze(
+				`function Retained(enabled) {
+					const content = @{
+						if (enabled) {
+							<aside />
+						}
+
+						<main />
+					};
+
+					return content;
+				}
+
+				function Nested(enabled) {
+					return <section>
+						@{
+							if (enabled) {
+								<aside />
+							}
+
+							<main />
+						}
+					</section>;
+				}`,
+				{ collect: true },
+			);
 
 			expect(forgotten_output_errors(result)).toHaveLength(2);
 		});
@@ -153,6 +218,24 @@ describe('target-neutral TSRX analysis', () => {
 			]) {
 				expect(forgotten_output_errors(analyze(source)), source).toEqual([]);
 			}
+		});
+
+		it('allows retained setup output before the rendered value of a function @{...} body', () => {
+			const result = analyze(`function Test(enabled) @{
+				let content = null;
+				if (enabled) {
+					content = <aside /> as JSX.Element;
+					renderPreview(<small />);
+				}
+
+				@if (content) {
+					<main>{content}</main>
+				} @else {
+					<main />
+				}
+			}`);
+
+			expect(forgotten_output_errors(result)).toEqual([]);
 		});
 
 		it('does not report nested output that belongs to another template', () => {

--- a/packages/tsrx/tests/shared/compile.js
+++ b/packages/tsrx/tests/shared/compile.js
@@ -37,8 +37,6 @@ function diagnostic_codes(result) {
 
 const TSRX_TEMPLATE_RETURN_ERROR =
 	'Return statements are not allowed inside TSRX templates. Move the return before the TSRX return value, or use conditional rendering instead.';
-const TSRX_FORGOTTEN_STATEMENT_CONTAINER_ERROR =
-	"This function body contains TSRX template output, but it is a normal JavaScript block. Add '@' before the opening brace to use a TSRX statement container.";
 
 /**
  * Shared compile/editor diagnostics. These do not assert source-map structure;
@@ -59,13 +57,13 @@ export function runSharedCompileDiagnosticsTests({ compile_to_volar_mappings, na
 			);
 
 			expect(result.errors).toEqual([]);
-			expect(result.code).toContain('{a} {a}');
+			expect(count_substring(result.code, '{a}')).toBeGreaterThanOrEqual(2);
 			expect(result.code).not.toContain('<>{a}a</>');
 		});
 
 		it('keeps a single text child faithful instead of promoting it to a string literal', () => {
 			const result = compile_to_volar_mappings(
-				`export function App() {
+				`export function App() @{
 					<>@</>
 				}`,
 				'App.tsrx',
@@ -80,7 +78,7 @@ export function runSharedCompileDiagnosticsTests({ compile_to_volar_mappings, na
 
 		it('does not promote ordinary single-text output into a string literal', () => {
 			const result = compile_to_volar_mappings(
-				`export function App() {
+				`export function App() @{
 					<>Hello</>
 				}`,
 				'App.tsrx',
@@ -195,87 +193,6 @@ export function runSharedCompileDiagnosticsTests({ compile_to_volar_mappings, na
 			expect(result.code).toContain('return [<>Delete</>, <>Edit</>];');
 			expect(result.code).toContain('return [<>View</>];');
 			expect(result.code).toContain('bySwitch: (role) => {');
-		});
-
-		it('reports function bodies that look like forgotten statement containers', () => {
-			const result = compile_to_volar_mappings(
-				`export function UserBadge({ user }: UserBadgeProps): JSX.Element {
-					if (!user) {
-						return <span class="muted">Signed out</span>;
-					}
-
-					const initials = user.name.slice(0, 2).toUpperCase();
-
-					<button title={user.name}>{initials}</button>
-				}`,
-				'App.tsrx',
-			);
-
-			expect(diagnostic_codes(result)).toContain(DIAGNOSTIC_CODES.FORGOTTEN_STATEMENT_CONTAINER);
-			expect(result.errors.map((error) => error.message)).toContain(
-				TSRX_FORGOTTEN_STATEMENT_CONTAINER_ERROR,
-			);
-		});
-
-		it('reports arrow function bodies that look like forgotten statement containers', () => {
-			const result = compile_to_volar_mappings(
-				`const UserBadge = ({ user }: UserBadgeProps): JSX.Element => {
-					const initials = user.name.slice(0, 2).toUpperCase();
-
-					<button title={user.name}>{initials}</button>
-				};`,
-				'App.tsrx',
-			);
-
-			expect(diagnostic_codes(result)).toContain(DIAGNOSTIC_CODES.FORGOTTEN_STATEMENT_CONTAINER);
-		});
-
-		it('does not report forgotten statement containers when setup follows template output', () => {
-			const result = compile_to_volar_mappings(
-				`export function UserBadge({ user }: UserBadgeProps): JSX.Element {
-					<span>{user.name}</span>;
-
-					const initials = user.name.slice(0, 2).toUpperCase();
-					console.log(initials);
-				}`,
-				'App.tsrx',
-			);
-
-			expect(diagnostic_codes(result)).not.toContain(
-				DIAGNOSTIC_CODES.FORGOTTEN_STATEMENT_CONTAINER,
-			);
-		});
-
-		it('does not report ordinary returned JSX', () => {
-			const result = compile_to_volar_mappings(
-				`export function UserBadge({ user }: UserBadgeProps): JSX.Element {
-					return <span>{user.name}</span>;
-				}`,
-				'App.tsrx',
-			);
-
-			expect(diagnostic_codes(result)).not.toContain(
-				DIAGNOSTIC_CODES.FORGOTTEN_STATEMENT_CONTAINER,
-			);
-		});
-
-		it('does not report explicit nested statement containers in ordinary function bodies', () => {
-			const result = compile_to_volar_mappings(
-				`export function UserBadge({ user }: UserBadgeProps): JSX.Element {
-					const badge = @{
-						const initials = user.name.slice(0, 2).toUpperCase();
-
-						<button title={user.name}>{initials}</button>
-					};
-
-					return badge;
-				}`,
-				'App.tsrx',
-			);
-
-			expect(diagnostic_codes(result)).not.toContain(
-				DIAGNOSTIC_CODES.FORGOTTEN_STATEMENT_CONTAINER,
-			);
 		});
 
 		it('allows return statements in localized setup before a template fence', () => {
@@ -710,73 +627,6 @@ export function runSharedTsxExpressionTsrxTests({ compile, name, classAttrName }
 			expect(code).toContain('const count = 2;');
 			expect(code).toContain('<span>{count}</span>');
 			expect(code).not.toContain('JSXCodeBlock');
-		});
-
-		it('lowers a dangling @if expression statement', () => {
-			const { code } = compile(
-				`function StatusBadge({ status }: { status: string }) {
-							@if (status === 'active') {
-								<span class="badge active">Online</span>
-							} @else if (status === 'idle') {
-								<span class="badge idle">Away</span>
-							} @else {
-								<span class="badge">Offline</span>
-							}
-						}`,
-				'App.tsrx',
-			);
-			expect(code).toContain('Online');
-			expect(code).toContain('Away');
-			expect(code).toContain('Offline');
-			expect(code).not.toContain('@if');
-			expect(code).not.toContain('JSXIfExpression');
-		});
-
-		it('lowers dangling @ control expressions and code blocks as expression statements', () => {
-			const cases = [
-				[
-					`function App() {
-								@for (const item of items) {
-									<li>{item}</li>
-								}
-							}`,
-					['<li>', '@for', 'JSXForExpression'],
-				],
-				[
-					`function App() {
-								@switch (status) {
-									@case 'loading': { <p>Loading...</p> }
-									@default: { <p>Unknown status.</p> }
-								}
-							}`,
-					['Loading...', '@switch', 'JSXSwitchExpression'],
-				],
-				[
-					`function App() {
-								@try {
-									<p>Loaded</p>
-								} @catch (error) {
-									<p>Failed</p>
-								}
-							}`,
-					['Loaded', '@try', 'JSXTryExpression'],
-				],
-				[
-					`function App() {
-								@{
-									const count = 2;
-									<span>{count}</span>
-								}
-							}`,
-					['const count = 2;', 'JSXCodeBlock', 'JSXCodeBlock'],
-				],
-			];
-			for (const [source, [expected, rawSyntax, rawNode]] of cases) {
-				const { code } = compile(source, 'App.tsrx');
-				expect(code, source).toContain(expected);
-				expect(code, source).not.toContain(rawSyntax);
-				expect(code, source).not.toContain(rawNode);
-			}
 		});
 
 		it('lowers @if as the left operand of a logical expression', () => {

--- a/packages/tsrx/tests/shared/compile.js
+++ b/packages/tsrx/tests/shared/compile.js
@@ -2277,7 +2277,7 @@ export function runSharedCompileTests({
 			const { code } = compile(
 				`export function App(disabled: boolean) @{
 						if (disabled) {
-							<span>disabled</span>
+							return <span>disabled</span>;
 						}
 
 						<span>enabled</span>

--- a/packages/tsrx/tests/utils/parser.test.js
+++ b/packages/tsrx/tests/utils/parser.test.js
@@ -2585,7 +2585,7 @@ foo();`;
 		).toThrow();
 	});
 
-	it('does not throw forgotten statement-container hints during strict parsing', () => {
+	it('leaves forgotten statement-container validation to semantic analysis', () => {
 		const source = `export function UserBadge({ user }: UserBadgeProps): JSX.Element {
 			const initials = user.name.slice(0, 2).toUpperCase();
 
@@ -2596,9 +2596,7 @@ foo();`;
 
 		const errors = [];
 		parseModule(source, 'App.tsrx', { collect: true, errors });
-		expect(errors.map((error) => error.message)).toContain(
-			"This function body contains TSRX template output, but it is a normal JavaScript block. Add '@' before the opening brace to use a TSRX statement container.",
-		);
+		expect(errors).toEqual([]);
 	});
 
 	it('keeps node locations in sync after re-reading a setup statement mis-read as JSX text', () => {

--- a/packages/tsrx/types/index.d.ts
+++ b/packages/tsrx/types/index.d.ts
@@ -445,6 +445,14 @@ declare module 'estree' {
 		| JSXSwitchExpression
 		| JSXTryExpression;
 
+	/** Any node that can be the rendered output of a TSRX template or statement container. */
+	type TSRXRenderOutput =
+		| ESTreeJSX.JSXElement
+		| ESTreeJSX.JSXFragment
+		| JSXStyleElement
+		| JSXCodeBlock
+		| JSXTemplateDirective;
+
 	interface ParenthesizedExpression extends AST.BaseNode {
 		type: 'ParenthesizedExpression';
 		expression: AST.Expression;
@@ -1267,6 +1275,30 @@ export interface ParseOptions {
 export interface AnalyzeOptions extends ParseOptions, Pick<CompileOptions, 'mode'> {
 	errors?: CompileError[];
 	to_ts?: boolean;
+}
+
+/** Options for the target-neutral TSRX semantic analysis pass. */
+export interface TSRXAnalysisOptions extends ParseOptions {
+	typeOnly?: boolean;
+	to_ts?: boolean;
+}
+
+/** Traversal state used by the target-neutral TSRX semantic analysis pass. */
+export interface TSRXAnalysisState {
+	filename: string | null;
+	collect: boolean;
+	errors: CompileError[];
+	comments: AST.CommentWithLocation[];
+	function: AST.Function | null;
+	function_body_is_code_block: boolean;
+	inside_template_output: boolean;
+}
+
+/** Result of target-neutral TSRX semantic analysis. */
+export interface TSRXAnalysisResult {
+	ast: AST.Program;
+	errors: CompileError[];
+	comments: AST.CommentWithLocation[];
 }
 
 /**

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -433,6 +433,15 @@ export default defineConfig({
 			},
 			{
 				test: {
+					name: 'tsrx-analyze',
+					include: ['packages/tsrx/tests/analyze/**/*.test.js'],
+					environment: 'node',
+					globals: true,
+				},
+				plugins: [],
+			},
+			{
+				test: {
 					name: 'ripple-hydration',
 					include: ['packages/ripple/tests/hydration/**/*.test.js'],
 					environment: 'jsdom',


### PR DESCRIPTION
closes #1226 
superseds #1373 

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the compile pipeline for every target and turns previously compilable (but no-op) template statements into errors at runtime, which may break existing code until authors return or retain output.
> 
> **Overview**
> Adds a **target-neutral `analyzeTsrx` pass** in `@tsrx/core` that runs after `parseModule` and before each framework’s own analysis/transform. Parsing stays syntax-only; the new pass walks functions and flags **free-floating** template nodes (elements, fragments, `@if`/`@for`, etc.) that sit in statement position without being returned, assigned for later render, or part of a function `@{...}` body’s rendered output—including setup inside `@{...}` and braceless control-flow bodies.
> 
> The old parser heuristic that suggested “add `@` before `{`” when a typed function body ended with JSX is **removed**; diagnosis now uses `FORGOTTEN_STATEMENT_CONTAINER` with messaging to **render or retain** the value. **Strict compiles throw** on this diagnostic; **loose / type-only / Volar** paths collect it and continue. `@tsrx/eslint-parser`, React/Preact/Solid/Vue/Ripple `compile` and `compile_to_volar_mappings`, and MCP advice are updated to call the shared pass. Several AST helpers (`isTsrxRenderOutputNode`, `isStatementPosition`, `isTemplateDirective`, etc.) are **centralized in core** to avoid duplicate logic. Tests now build lists in ordinary `for` loops via `content.push(...)` plus a final fragment instead of relying on silent discarded JSX inside loops.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55e842ac246be094f285620965c56880e025a745. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->