### PR TITLE
fix(prettier-plugin): keep JSX children glued across whitespace-free text

### DIFF
--- a/.changeset/spicy-donkeys-grin.md
+++ b/.changeset/spicy-donkeys-grin.md
@@ -1,0 +1,5 @@
+---
+'@tsrx/prettier-plugin': patch
+---
+
+Keep JSX children glued across a whitespace-free text boundary, matching vanilla Prettier. `{state.owner}/{state.repoName}` and `{a}some text{b}` now stay on one line instead of each child being split onto its own line, while whitespace-separated siblings and directly adjacent expressions or elements (`{a} / {b}`, `{a}{b}`, `</p><p>`) still get their own lines.

--- a/packages/prettier-plugin/src/index.js
+++ b/packages/prettier-plugin/src/index.js
@@ -5938,6 +5938,70 @@ function printJSXTextChild(raw) {
 }
 
 /**
+ * True when two consecutive printed JSX children stay glued on one line:
+ * a text child directly adjacent (no whitespace) to its neighbor, as in
+ * `{a}/{b}` or `<span>x</span>text`. Matches vanilla Prettier, which only
+ * keeps siblings together across a whitespace-free text boundary — adjacent
+ * expressions or elements (`{a}{b}`, `</p><p>`) still get their own lines.
+ * @param {any} prevNode - Last source node of the previous printed child
+ * @param {any} nextNode - First source node of the next printed child
+ * @returns {boolean}
+ */
+function isGluedJSXPair(prevNode, nextNode) {
+	if (prevNode?.type !== 'JSXText' && nextNode?.type !== 'JSXText') {
+		return false;
+	}
+	if (typeof prevNode?.end !== 'number' || prevNode.end !== nextNode?.start) {
+		return false;
+	}
+	if (hasComment(prevNode) || hasComment(nextNode)) {
+		return false;
+	}
+	if (prevNode.type === 'JSXText' && /\s$/u.test(prevNode.value)) {
+		return false;
+	}
+	if (nextNode.type === 'JSXText' && /^\s/u.test(nextNode.value)) {
+		return false;
+	}
+	return true;
+}
+
+/**
+ * Print a run of glued JSX children as one unit. Words inside text entries can
+ * still wrap at their own spaces, but glued boundaries get no break opportunity.
+ * @param {(Doc | string)[]} entries
+ * @returns {Doc}
+ */
+function printGluedJSXChildren(entries) {
+	/** @type {Doc[]} */
+	const parts = [];
+	/** @type {Doc[]} */
+	let current = [];
+	const flush = () => {
+		if (current.length > 0) {
+			parts.push(current.length === 1 ? current[0] : current);
+			current = [];
+		}
+	};
+	for (const entry of entries) {
+		if (typeof entry === 'string') {
+			const words = entry.trim().split(/\s+/u);
+			for (let i = 0; i < words.length; i++) {
+				if (i > 0) {
+					flush();
+					parts.push(line);
+				}
+				current.push(words[i]);
+			}
+		} else {
+			current.push(entry);
+		}
+	}
+	flush();
+	return parts.length === 1 ? parts[0] : fill(parts);
+}
+
+/**
  * @param {string} raw
  * @returns {string}
  */
@@ -6113,11 +6177,14 @@ function printJSXElement(node, path, options, print) {
 
 	// Format children - filter out empty text nodes and merge adjacent text nodes.
 	// childNodes tracks the source node behind each doc (a text run is a single
-	// JSXText) so the join can preserve authored blank lines.
+	// JSXText) so the join can preserve authored blank lines; childEndNodes tracks
+	// the last source node so glued neighbors can be detected by position.
 	const childrenDocs = [];
 	const childNodes = [];
+	const childEndNodes = [];
 	let currentText = '';
 	let currentTextNode = null;
+	let currentTextEndNode = null;
 
 	for (let i = 0; i < node.children.length; i++) {
 		const child = node.children[i];
@@ -6127,13 +6194,16 @@ function printJSXElement(node, path, options, print) {
 				if (currentText) {
 					childrenDocs.push(currentText);
 					childNodes.push(currentTextNode);
+					childEndNodes.push(currentTextEndNode);
 					currentText = '';
 					currentTextNode = null;
+					currentTextEndNode = null;
 				}
 				const printedChild = path.call(print, 'children', i);
 				if (printedChild !== '') {
 					childrenDocs.push(printedChild);
 					childNodes.push(child);
+					childEndNodes.push(child);
 				}
 				continue;
 			}
@@ -6152,11 +6222,14 @@ function printJSXElement(node, path, options, print) {
 					if (currentText) {
 						childrenDocs.push(currentText);
 						childNodes.push(currentTextNode);
+						childEndNodes.push(currentTextEndNode);
 						currentText = '';
 						currentTextNode = null;
+						currentTextEndNode = null;
 					}
 					childrenDocs.push([text.trim(), ' ', path.call(print, 'children', i + 1), ';']);
 					childNodes.push(child);
+					childEndNodes.push(afterNextChild);
 					i += 2;
 					continue;
 				}
@@ -6167,14 +6240,17 @@ function printJSXElement(node, path, options, print) {
 					currentText = text;
 					currentTextNode = child;
 				}
+				currentTextEndNode = child;
 			}
 		} else {
 			// If we have accumulated text, push it before the non-text node
 			if (currentText) {
 				childrenDocs.push(currentText);
 				childNodes.push(currentTextNode);
+				childEndNodes.push(currentTextEndNode);
 				currentText = '';
 				currentTextNode = null;
+				currentTextEndNode = null;
 			}
 
 			if (child.type === 'JSXExpressionContainer') {
@@ -6187,10 +6263,12 @@ function printJSXElement(node, path, options, print) {
 					...printTemplateChildTrailingComments(child),
 				]);
 				childNodes.push(child);
+				childEndNodes.push(child);
 			} else {
 				// Handle nested JSX elements
 				childrenDocs.push(path.call(print, 'children', i));
 				childNodes.push(child);
+				childEndNodes.push(child);
 			}
 		}
 	}
@@ -6199,6 +6277,7 @@ function printJSXElement(node, path, options, print) {
 	if (currentText) {
 		childrenDocs.push(currentText);
 		childNodes.push(currentTextNode);
+		childEndNodes.push(currentTextEndNode);
 	}
 
 	// A child with leading comments must break onto its own line, so the comment
@@ -6270,11 +6349,21 @@ function printJSXElement(node, path, options, print) {
 	}
 
 	// Multiple children or complex children - format with line breaks. Text runs
-	// fill/wrap to printWidth.
+	// fill/wrap to printWidth. Children with no whitespace between them in the
+	// source (`{a}/{b}`) stay glued as a single unit.
 	const formattedChildren = [];
 	for (let i = 0; i < childrenDocs.length; i++) {
-		const childDoc = childrenDocs[i];
-		formattedChildren.push(typeof childDoc === 'string' ? printRawText(childDoc) : childDoc);
+		const unitEntries = [childrenDocs[i]];
+		while (i < childrenDocs.length - 1 && isGluedJSXPair(childEndNodes[i], childNodes[i + 1])) {
+			i++;
+			unitEntries.push(childrenDocs[i]);
+		}
+		if (unitEntries.length === 1) {
+			const childDoc = unitEntries[0];
+			formattedChildren.push(typeof childDoc === 'string' ? printRawText(childDoc) : childDoc);
+		} else {
+			formattedChildren.push(printGluedJSXChildren(unitEntries));
+		}
 		if (i < childrenDocs.length - 1) {
 			// Preserve a single authored blank line between children (2+ collapse to 1).
 			const blank = getBlankLinesBetweenNodes(childNodes[i], leadingAnchor(childNodes[i + 1])) > 0;
@@ -6391,10 +6480,19 @@ function printJSXFragment(node, path, options, print) {
 		]);
 	}
 
-	// Multiple children or complex children - format with line breaks
+	// Multiple children or complex children - format with line breaks. Children
+	// with no whitespace between them in the source (`{a}/{b}`) stay glued as a
+	// single unit.
 	const formattedChildren = [];
 	for (let i = 0; i < childrenDocs.length; i++) {
-		formattedChildren.push(childrenDocs[i]);
+		const unitEntries = [childrenDocs[i]];
+		while (i < childrenDocs.length - 1 && isGluedJSXPair(childNodes[i], childNodes[i + 1])) {
+			i++;
+			unitEntries.push(childrenDocs[i]);
+		}
+		formattedChildren.push(
+			unitEntries.length === 1 ? unitEntries[0] : printGluedJSXChildren(unitEntries),
+		);
 		if (i < childrenDocs.length - 1) {
 			// Preserve a single authored blank line between children (2+ collapse to 1).
 			const blank = getBlankLinesBetweenNodes(childNodes[i], leadingAnchor(childNodes[i + 1])) > 0;

--- a/packages/prettier-plugin/src/index.test.js
+++ b/packages/prettier-plugin/src/index.test.js
@@ -501,6 +501,83 @@ const items=[1,2,3];
 		expect(result).toBeWithNewline(expected);
 	});
 
+	it('keeps expression children glued across whitespace-free text', async () => {
+		const input = `function Test() {
+  return <a href={x}>
+    {state.owner}/{state.repoName}
+    <ExternalLink className="w-3 h-3" />
+  </a>;
+}`;
+		const expected = `function Test() {
+  return <a href={x}>
+    {state.owner}/{state.repoName}
+    <ExternalLink className="w-3 h-3" />
+  </a>;
+}`;
+
+		const result = await format(input);
+		expect(result).toBeWithNewline(expected);
+	});
+
+	it('keeps expression siblings glued across multi-word text', async () => {
+		const input = `function Test() {
+  return <div>
+    {a}some words here{b}
+    <Foo />
+  </div>;
+}`;
+		const expected = `function Test() {
+  return <div>
+    {a}some words here{b}
+    <Foo />
+  </div>;
+}`;
+
+		const result = await format(input);
+		expect(result).toBeWithNewline(expected);
+	});
+
+	it('keeps whitespace-separated and directly adjacent expressions on their own lines', async () => {
+		const input = `function Test() {
+  return <div>
+    {a} / {b}
+    {c}{d}
+    <Foo />
+  </div>;
+}`;
+		const expected = `function Test() {
+  return <div>
+    {a}
+    /
+    {b}
+    {c}
+    {d}
+    <Foo />
+  </div>;
+}`;
+
+		const result = await format(input);
+		expect(result).toBeWithNewline(expected);
+	});
+
+	it('keeps fragment expression children glued across whitespace-free text', async () => {
+		const input = `function Test() {
+  return <>
+    {state.owner}/{state.repoName}
+    <Foo />
+  </>;
+}`;
+		const expected = `function Test() {
+  return <>
+    {state.owner}/{state.repoName}
+    <Foo />
+  </>;
+}`;
+
+		const result = await format(input);
+		expect(result).toBeWithNewline(expected);
+	});
+
 	it('formats text line breaks properly', async () => {
 		const input = `function Test() {
   return <div>


### PR DESCRIPTION
## Summary

`@tsrx/prettier-plugin` 0.3.106 splits adjacent JSX children with no whitespace between them onto separate lines:

```jsx
{state.owner}
/
{state.repoName}
```

Vanilla Prettier keeps `{state.owner}/{state.repoName}` on one line. This code path only recently became reachable: before #1368, a literal `/` in JSX text inside an expression container failed to parse, so the plugin never saw such input.

The multi-child layouts in `printJSXElement` and `printJSXFragment` joined every printed child with a hardline. This PR merges children that must stay together into a single unit before the hardline join, matching vanilla Prettier's rule (verified empirically against the TypeScript parser): siblings stay glued only across a **whitespace-free text boundary** —

- `{a}/{b}`, `{a}some text{b}`, `<span>x</span>text` → stay on one line
- `{a} / {b}` (whitespace-separated), `{a}{b}` (adjacent expressions), `</p><p>` (adjacent elements) → still get their own lines

Glue detection uses source positions (`prev.end === next.start`; reliable because the parser drops whitespace-only text nodes) plus edge whitespace of the raw text, and bails when either node carries comments. Glued runs print as one `fill` unit, so multi-word glued text can still wrap at its own internal spaces but never at a glued boundary.

## Changes

- `isGluedJSXPair` + `printGluedJSXChildren` helpers; glued-run merging in both element and fragment child-join loops
- Element printer now tracks the last source node behind each merged text run so adjacency is checked against the correct node
- 4 new format tests (`{expr}/{expr}`, `{expr}text{expr}`, negative cases, fragment variant); each doubles as an idempotency check
- Patch changeset for `@tsrx/prettier-plugin`

## Testing

- `pnpm vitest run --project prettier-plugin` — 378 passed
- `pnpm vitest run --project tsrx-mcp` (plugin consumer) — 68 passed
- `pnpm typecheck`, `pnpm format:check`, `pnpm changeset:check` — clean
- Real-world `DeployDialog.tsrx` now formats `{state.owner}/{state.repoName}` inline and is idempotent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to JSX/fragment pretty-printing layout with regression tests; no auth, data, or API surface changes.
> 
> **Overview**
> **Fixes JSX child line breaks** so `@tsrx/prettier-plugin` matches vanilla Prettier when siblings touch with no whitespace in the source.
> 
> Previously, multi-child elements and fragments joined every printed child with a hardline, so patterns like `{state.owner}/{state.repoName}` were split across lines. The printer now **merges “glued” runs** before inserting breaks: `isGluedJSXPair` (source adjacency via `prev.end === next.start`, text-boundary rules, no comments) and `printGluedJSXChildren` (single `fill` unit, internal word wrap only). Element printing also tracks **`childEndNodes`** so merged text runs pair correctly with the next sibling.
> 
> Whitespace-separated text (`{a} / {b}`), adjacent expressions (`{a}{b}`), and adjacent elements still break onto separate lines. Four format tests and a patch changeset cover the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e5e412fe8e232dfb239ba64dc2a343037364a93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->