### PR TITLE
fix(parser): wrapped directive

### DIFF
--- a/.changeset/plain-doors-attr-directive.md
+++ b/.changeset/plain-doors-attr-directive.md
@@ -1,0 +1,9 @@
+---
+"@tsrx/core": patch
+---
+
+Fix a parse error when an attribute value contains a control-flow directive (`@if`,
+`@for`, `@switch`, `@try`) — either bare or wrapped in a fragment/element — and the
+attribute's element has children, e.g.
+`<ElementA prop={ @if (ok) { <div /> } }><ElementB /></ElementA>` or
+`<ElementA prop={<>@if (ok) { <A /> } @else { <B /> }</>}></ElementA>`.

--- a/packages/tsrx/src/plugin.js
+++ b/packages/tsrx/src/plugin.js
@@ -3411,17 +3411,20 @@ export function TSRXPlugin(config) {
 				let node = /** @type {ESTreeJSX.JSXExpressionContainer} */ (this.startNode());
 				this.#jsxExpressionContainerDepth++;
 				let pushed_context_baseline = false;
-				/** @type {number} */
-				let context_baseline;
+				// The stack depth with the container's `{` brace context on top, taken
+				// before `next()` so the first expression token's own context pushes
+				// (e.g. a fragment's `<` pushing its tag contexts) are not counted.
+				// This is the depth the stack must return to when the container's
+				// closing `}` is the current token.
+				const container_context_depth = this.context.length;
 				try {
 					this.next();
 
-					// Record the context-stack depth now that the container's `{` brace
-					// context is on the stack. A control-flow directive parsed inside this
+					// Record the context-stack depth now that the first expression token
+					// has been read. A control-flow directive parsed inside this
 					// container must not strip anything below this floor (see
 					// `#filterTemplateScriptContexts`).
-					context_baseline = this.context.length;
-					this.#expressionContainerContextBaselines.push(context_baseline);
+					this.#expressionContainerContextBaselines.push(this.context.length);
 					this.#expressionContainerPathBaselines.push(this.#path.length);
 					pushed_context_baseline = true;
 
@@ -3442,13 +3445,14 @@ export function TSRXPlugin(config) {
 						// a snapshot taken inside this container
 						// (`#parseTemplateControlFlowBlock`), so the container's closing `}`
 						// — read while that stale snapshot was active — pops the wrong entry
-						// and leaves stale brace contexts above the enclosing tag's contexts.
-						// Once the `}` has been read the stack must be back at one below the
-						// baseline (the container's own brace context popped); drop anything
-						// above that so the token after `}` (e.g. the `>` finishing the
-						// enclosing opening tag) tokenizes in the right context.
-						if (this.type === tt.braceR && this.context.length >= context_baseline) {
-							this.context.length = context_baseline - 1;
+						// and leaves stale contexts above the enclosing tag's contexts (the
+						// directive's statement brace, or a wrapping fragment's child
+						// context). Once the `}` has been read the stack must be back at one
+						// below the container's depth (its own brace context popped); drop
+						// anything above that so the token after `}` (e.g. the `>` finishing
+						// the enclosing opening tag) tokenizes in the right context.
+						if (this.type === tt.braceR && this.context.length >= container_context_depth) {
+							this.context.length = container_context_depth - 1;
 						}
 						this.expect(tt.braceR);
 					}

--- a/packages/tsrx/tests/utils/parser.test.js
+++ b/packages/tsrx/tests/utils/parser.test.js
@@ -736,6 +736,26 @@ abc
 		expect(element.children).toEqual([]);
 	});
 
+	it('parses a fragment-wrapped directive attribute value on an element with children', () => {
+		// Unlike the bare-directive case, the container's first token here is the
+		// fragment's `<`, whose tag contexts must not count toward the depth the
+		// stack unwinds to when the container closes — otherwise the `>` after
+		// `}` lexes as template text.
+		const element = findElement(
+			`export function FeatureCard() @{
+				<ElementA prop={<>@if (ok) { <div>1</div> } @else { <div>2</div> }</>}></ElementA>
+			}`,
+			'ElementA',
+		);
+
+		const [attribute] = element.openingElement.attributes;
+		expect(attribute.value.type).toBe('JSXExpressionContainer');
+		expect(attribute.value.expression.type).toBe('JSXFragment');
+		const [directive] = attribute.value.expression.children;
+		expect(directive.type).toBe('JSXIfExpression');
+		expect(directive.alternate?.type).toBe('BlockStatement');
+	});
+
 	it('parses an attribute that follows a directive attribute value', () => {
 		const element = findElement(
 			`export function FeatureCard() @{


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Localized parser tokenizer fix in `jsx_parseExpressionContainer` with targeted tests; no runtime or auth/data impact.
> 
> **Overview**
> Fixes a **parse error** when an attribute value uses `@if` / `@for` / `@switch` / `@try` (bare or inside a fragment) on an element that also has child markup, e.g. `prop={ @if (ok) { <div /> } }><Child /></Element>` or `prop={<>@if … @else …</>}>…</Element>`.
> 
> In `jsx_parseExpressionContainer`, the tokenizer context stack is now unwound using a **container depth** recorded **before** the first expression token is read. Fragment openings and other inner JSX contexts no longer skew that depth, so after the attribute’s closing `}` the following `>` is tokenized as tag syntax instead of template text or a stray operator.
> 
> Adds a regression test for the fragment-wrapped directive case; the changeset documents the patch for `@tsrx/core`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2790b7449d4eddcd7cc71629788a46c0ff31741d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->