### PR TITLE
multiple fixes: parser expressions, white space, text handling, ripple fixes

### DIFF
--- a/.changeset/directive-in-attribute-element.md
+++ b/.changeset/directive-in-attribute-element.md
@@ -1,0 +1,18 @@
+---
+'@tsrx/core': patch
+---
+
+fix(parser): recognize control-flow directives inside element-valued attribute expressions
+
+JSX inside an attribute-value `{ … }` container now parses through the TSRX
+template path, so `prop={<h1>@if (ok) { … } @else { … }</h1>}` behaves the same
+as assigning the element to a variable first. Previously the directive was
+either kept as literal text or — when no whitespace preceded the `@` — re-parsed
+into an untransformed directive node that crashed the printer.
+
+Also fixes template text loss around directives: text (and significant inline
+whitespace) preceding a directive or an `=` was silently dropped in
+container-nested elements, and inline spaces between a sibling element and a
+directive were dropped inside `@switch` bodies and value-position directives
+(`const v = @if …`). Sibling whitespace now survives uniformly, matching how
+the browser renders it; newline-containing layout indentation is still removed.

--- a/.changeset/element-values-in-expression-position.md
+++ b/.changeset/element-values-in-expression-position.md
@@ -1,0 +1,27 @@
+---
+'@tsrx/ripple': patch
+---
+
+fix(transform): lower template elements in expression-container and attribute-value positions
+
+An element inside a child expression container (`<div>{<h1>…</h1>}</div>`) or
+an attribute value (`prop={<h1>…</h1>}`) now lowers to a `tsrx_element` value
+in both client and server output — matching what the same element assigned to
+a variable produces. Previously the client leaked raw JSX into the compiled
+output (broken at runtime) and both modes crashed the printer when the element
+contained control-flow directives. Ternary and directive-valued attributes on
+the server are fixed by the same change.
+
+Expression children are now classified by provable type: an expression that
+provably evaluates to a text primitive (string, number, boolean, bigint,
+null/undefined — literals, operators, `String()`/`Number()`/`Boolean()`, `as`
+casts, typed bindings and members) keeps the inline text fast paths, and
+everything else renders through the value-aware expression paths — so an
+element passed as a prop and rendered via `{props.header}` produces its markup
+instead of `[object Object]`. `<title>` expression children always use the
+escaping text path, keeping hydration markers out of `document.title`.
+
+Also fixes a latent client codegen crash: a text expression following inlined
+text in the same template text run (e.g. `<div>label: {String(f())}</div>`)
+anchored past the end of the coalesced text node; such expressions now render
+through a comment-anchored `_$_.expression`.

--- a/.changeset/flatten-fragment-children.md
+++ b/.changeset/flatten-fragment-children.md
@@ -1,0 +1,17 @@
+---
+'@tsrx/ripple': patch
+---
+
+fix: render fragment children inline with zero extra DOM
+
+An authored `<>…</>` in children position previously compiled to a comment
+anchor plus a runtime `tsrx_element` expression on the client while the server
+inlined its content bare — an extra comment node and render unit per fragment,
+and a client/server DOM shape mismatch that broke hydration of fragment
+children. Template fragments in children position now flatten during child
+normalization: their children render inline in the parent template (text runs
+merge across the former fragment boundary), adding no DOM nodes at all.
+Code-block chain fragments, generated value wrappers, and component root
+render fragments keep their existing lowering; the to_ts view keeps authored
+fragments verbatim. `<head>` extraction and value-position classification look
+through flattened fragments.

--- a/.changeset/text-run-merge-primitives.md
+++ b/.changeset/text-run-merge-primitives.md
@@ -1,0 +1,17 @@
+---
+'@tsrx/ripple': patch
+'ripple': patch
+---
+
+fix: merge provably-primitive call-containing expressions into text runs
+
+Adjacent text and expression children previously refused to merge whenever the
+expression contained a call, leaving shapes like `<div>label: {String(f())}</div>`
+split into a text run plus a separate anchor — which crashed client rendering
+(the text anchor coalesced with the preceding template text) and could not
+hydrate against the server's inlined output. An expression that provably
+evaluates to a text primitive now merges into the run, so both targets render
+one shared text node; a provably-string child concatenates bare instead of
+being double-wrapped in `String(… ?? '')`. The client runtime's non-hydrating
+text-anchor lookup also creates the expected text node when the template text
+coalesced, matching its hydrating behavior.

--- a/.changeset/text-run-merge-primitives.md
+++ b/.changeset/text-run-merge-primitives.md
@@ -1,6 +1,5 @@
 ---
 '@tsrx/ripple': patch
-'ripple': patch
 ---
 
 fix: merge provably-primitive call-containing expressions into text runs
@@ -11,7 +10,6 @@ split into a text run plus a separate anchor — which crashed client rendering
 (the text anchor coalesced with the preceding template text) and could not
 hydrate against the server's inlined output. An expression that provably
 evaluates to a text primitive now merges into the run, so both targets render
-one shared text node; a provably-string child concatenates bare instead of
-being double-wrapped in `String(… ?? '')`. The client runtime's non-hydrating
-text-anchor lookup also creates the expected text node when the template text
-coalesced, matching its hydrating behavior.
+one shared text node. Merged operands are nullish-guarded (`String(v ?? '')`)
+so nullish values contribute nothing, except provably-string operands and
+non-nullish primitive literals, which concatenate bare.

--- a/packages/ripple/src/runtime/internal/client/operations.js
+++ b/packages/ripple/src/runtime/internal/client/operations.js
@@ -66,7 +66,20 @@ export function get_last_child(node) {
  */
 export function first_child(node, is_text) {
 	if (!hydrating) {
-		return get_first_child(node);
+		var first = get_first_child(node);
+		// A text anchor may have coalesced with preceding template text into a
+		// single text node (or be missing entirely) — the caller expects a text
+		// node of its own, so create one.
+		if (is_text && first?.nodeType !== TEXT_NODE) {
+			var created = create_text();
+			if (first === null) {
+				/** @type {Element} */ (node).append(created);
+			} else {
+				/** @type {Element | Text | Comment} */ (first).before(created);
+			}
+			return created;
+		}
+		return first;
 	}
 	var child = get_first_child(/** @type {Node} */ (hydrate_node));
 

--- a/packages/ripple/src/runtime/internal/client/operations.js
+++ b/packages/ripple/src/runtime/internal/client/operations.js
@@ -66,20 +66,7 @@ export function get_last_child(node) {
  */
 export function first_child(node, is_text) {
 	if (!hydrating) {
-		var first = get_first_child(node);
-		// A text anchor may have coalesced with preceding template text into a
-		// single text node (or be missing entirely) — the caller expects a text
-		// node of its own, so create one.
-		if (is_text && first?.nodeType !== TEXT_NODE) {
-			var created = create_text();
-			if (first === null) {
-				/** @type {Element} */ (node).append(created);
-			} else {
-				/** @type {Element | Text | Comment} */ (first).before(created);
-			}
-			return created;
-		}
-		return first;
+		return get_first_child(node);
 	}
 	var child = get_first_child(/** @type {Node} */ (hydrate_node));
 

--- a/packages/ripple/tests/client/basic/basic.rendering.test.tsrx
+++ b/packages/ripple/tests/client/basic/basic.rendering.test.tsrx
@@ -647,6 +647,24 @@ second
 		expect(container.querySelector('div h1 span').textContent).toEqual('no');
 	});
 
+	it('renders a call-containing text expression after inlined text', () => {
+		// The `' '` text anchor for the expression used to coalesce with the
+		// preceding inlined text into a single template text node, leaving
+		// `sibling(…, true)` nothing to anchor to — a runtime crash. (Only
+		// call-containing expressions hit this: call-free ones merge with the
+		// preceding text upstream instead.)
+		function fetchCount() {
+			return 42;
+		}
+
+		function App() @{
+			<div>count: {String(fetchCount())}</div>
+		}
+
+		render(App);
+		expect(container.querySelector('div').textContent).toEqual('count: 42');
+	});
+
 	it('should handle multiple consecutive text expressions', () => {
 		function App() @{
 			let name = 'World';

--- a/packages/ripple/tests/client/basic/basic.rendering.test.tsrx
+++ b/packages/ripple/tests/client/basic/basic.rendering.test.tsrx
@@ -607,6 +607,46 @@ second
 		expect(div.textContent).toEqual('a Hello');
 	});
 
+	it('renders a template element inside an expression container child', () => {
+		function App() @{
+			<div>
+				{<h1>inline</h1>}
+			</div>
+		}
+
+		render(App);
+		expect(container.querySelector('div h1').textContent).toEqual('inline');
+	});
+
+	it('updates control flow inside an element in an expression container child', () => {
+		function App() @{
+			let &[ok] = track(true);
+			<>
+				<button
+					onClick={() => {
+						ok = !ok;
+					}}
+				>{'toggle'}</button>
+				<div>
+					{<h1>
+						@if (ok) {
+							<span>{'yes'}</span>
+						} @else {
+							<span>{'no'}</span>
+						}
+					</h1>}
+				</div>
+			</>
+		}
+
+		render(App);
+		expect(container.querySelector('div h1 span').textContent).toEqual('yes');
+
+		container.querySelector('button').click();
+		flushSync();
+		expect(container.querySelector('div h1 span').textContent).toEqual('no');
+	});
+
 	it('should handle multiple consecutive text expressions', () => {
 		function App() @{
 			let name = 'World';

--- a/packages/ripple/tests/client/compiler/compiler.basic.test.tsrx
+++ b/packages/ripple/tests/client/compiler/compiler.basic.test.tsrx
@@ -143,6 +143,10 @@ function tag() {
 const values = { member: 0 };`;
 
 		const cases = [
+			// Call-containing but provably-text-primitive expressions — `empty() + ''`,
+			// `\`${empty()}\``, `void empty()`, `values[getKey()]++` — are NOT in this
+			// list: they cannot hold an element, so they DO merge into the text run
+			// (see 'merges provably-primitive call-containing children').
 			{ name: 'call expression', expression: 'child(\'call\')' },
 			{ name: 'new expression', expression: 'new Constructed(\'new\')' },
 			{ name: 'chain expression', expression: 'factory?.(\'chain\')' },
@@ -156,7 +160,6 @@ const values = { member: 0 };`;
 			},
 			{ name: 'array expression', expression: '[child(\'array\')]' },
 			{ name: 'assignment expression', expression: 'assigned = child(\'assignment\')' },
-			{ name: 'binary expression', expression: 'empty() + \'\'' },
 			{ name: 'logical expression', expression: 'true && child(\'logical\')' },
 			{ name: 'conditional expression', expression: 'true ? child(\'conditional\') : \'\'' },
 			{ name: 'member expression', expression: 'lookup[getKey()]' },
@@ -166,9 +169,6 @@ const values = { member: 0 };`;
 			},
 			{ name: 'sequence expression', expression: '(touch(), child(\'sequence\'))' },
 			{ name: 'tagged template expression', expression: 'tag`tagged`' },
-			{ name: 'template literal', expression: '`${empty()}`' },
-			{ name: 'unary expression', expression: 'void empty()' },
-			{ name: 'update expression', expression: 'values[getKey()]++' },
 		];
 
 		for (const test_case of cases) {
@@ -183,6 +183,38 @@ export function App() @{
 				throw new Error(`${test_case.name} was merged into a stringified text expression:\n${code}`);
 			}
 		}
+	});
+
+	it('merges provably-primitive call-containing children into the text run', () => {
+		const source = `function empty() {
+	return null;
+}
+export function App() @{
+		<div>{'label:'}{void empty()}</div>
+}`;
+
+		const { code } = compile(source, 'primitive-merge.tsrx', { mode: 'client' });
+
+		// One merged text expression — no separate comment-anchored expression.
+		expect(code).toContain('\'label:\' + _$_.with_scope');
+		expect(code).toContain('String(void');
+		expect(code).not.toContain('_$_.expression(');
+	});
+
+	it('concatenates provably-string merge children bare', () => {
+		const source = `function fetchLabel() {
+	return 'fetched';
+}
+export function App() @{
+		<div>{'label:'}{String(fetchLabel())}</div>
+}`;
+
+		const { code } = compile(source, 'string-merge.tsrx', { mode: 'client' });
+
+		// Already a string: no String(… ?? '') double wrap around it.
+		expect(code).toContain('String(fetchLabel())');
+		expect(code).not.toContain('String(String(');
+		expect(code).not.toContain('?? \'\'');
 	});
 
 	it('parses backtick expressions inside TSRX fragments as template literals', () => {

--- a/packages/ripple/tests/client/composite/composite.props.test.tsrx
+++ b/packages/ripple/tests/client/composite/composite.props.test.tsrx
@@ -195,4 +195,50 @@ describe('composite > props', () => {
 		expect(container.querySelector('p').textContent).toBe('Description 1');
 		expect(container.querySelector('price').textContent).toBe('15');
 	});
+
+	it('renders a template element passed inline as a prop', () => {
+		function Child(props: { header: unknown }) @{
+			<div>{props.header}</div>
+		}
+
+		function App() @{
+			<Child header={<h1>{'hello'}</h1>} />
+		}
+
+		render(App);
+		expect(container.querySelector('div h1').textContent).toBe('hello');
+	});
+
+	it('updates control flow inside an element passed inline as a prop', () => {
+		function Child(props: { header: unknown }) @{
+			<div>{props.header}</div>
+		}
+
+		function App() @{
+			let &[ok] = track(true);
+			<>
+				<button
+					onClick={() => {
+						ok = !ok;
+					}}
+				>{'toggle'}</button>
+				<Child
+					header={<h1>
+						@if (ok) {
+							<span>{'yes'}</span>
+						} @else {
+							<span>{'no'}</span>
+						}
+					</h1>}
+				/>
+			</>
+		}
+
+		render(App);
+		expect(container.querySelector('div h1 span').textContent).toBe('yes');
+
+		container.querySelector('button').click();
+		flushSync();
+		expect(container.querySelector('div h1 span').textContent).toBe('no');
+	});
 });

--- a/packages/ripple/tests/hydration/basic.test.js
+++ b/packages/ripple/tests/hydration/basic.test.js
@@ -277,4 +277,20 @@ describe('hydration > text runs with call-containing primitives', () => {
 		await hydrateComponent(ServerComponents.FragmentChildOnly, ClientComponents.FragmentChildOnly);
 		expect(container.textContent).toBe('frag-tail');
 	});
+
+	it('hydrates a fragment leading with an opaque value', async () => {
+		await hydrateComponent(
+			ServerComponents.FragmentLeadsWithOpaqueValue,
+			ClientComponents.FragmentLeadsWithOpaqueValue,
+		);
+		expect(container.textContent).toBe('Hafter-opaque');
+	});
+
+	it('hydrates a fragment leading with a call-containing primitive', async () => {
+		await hydrateComponent(
+			ServerComponents.FragmentLeadsWithPrimitiveCall,
+			ClientComponents.FragmentLeadsWithPrimitiveCall,
+		);
+		expect(container.textContent).toBe('fetchedafter-call');
+	});
 });

--- a/packages/ripple/tests/hydration/basic.test.js
+++ b/packages/ripple/tests/hydration/basic.test.js
@@ -255,3 +255,26 @@ describe('hydration > basic', () => {
 		expect(container.querySelector('.inner .last-child')?.textContent).toBe('I am the last child');
 	});
 });
+
+describe('hydration > text runs with call-containing primitives', () => {
+	it('hydrates a text expression that follows inlined text', async () => {
+		await hydrateComponent(
+			ServerComponents.TextTailExpression,
+			ClientComponents.TextTailExpression,
+		);
+		expect(container.textContent).toBe('label: fetched');
+	});
+
+	it('hydrates a text expression that follows a fragment ending in text', async () => {
+		await hydrateComponent(
+			ServerComponents.FragmentTailExpression,
+			ClientComponents.FragmentTailExpression,
+		);
+		expect(container.textContent).toBe('frag-fetched');
+	});
+
+	it('hydrates an authored fragment child', async () => {
+		await hydrateComponent(ServerComponents.FragmentChildOnly, ClientComponents.FragmentChildOnly);
+		expect(container.textContent).toBe('frag-tail');
+	});
+});

--- a/packages/ripple/tests/hydration/compiled/client/basic.js
+++ b/packages/ripple/tests/hydration/compiled/client/basic.js
@@ -218,9 +218,9 @@ export function ExpressionContent() {
 			var div_6 = _$_.first_child_frag(fragment_7);
 
 			{
-				var expression_1 = _$_.child(div_6);
+				var expression_1 = _$_.child(div_6, true);
 
-				_$_.expression(expression_1, () => value);
+				expression_1.nodeValue = value;
 				_$_.pop(div_6);
 			}
 
@@ -246,9 +246,9 @@ function NestedHelperItem({ item }) {
 		var div_7 = root_15();
 
 		{
-			var expression_3 = _$_.child(div_7);
+			var expression_3 = _$_.child(div_7, true);
 
-			_$_.expression(expression_3, () => item);
+			expression_3.nodeValue = item;
 			_$_.pop(div_7);
 		}
 

--- a/packages/ripple/tests/hydration/compiled/client/basic.js
+++ b/packages/ripple/tests/hydration/compiled/client/basic.js
@@ -71,6 +71,9 @@ var root_66 = _$_.template(`<footer class="last-child">I am the last child</foot
 var root_67 = _$_.template(`<div class="wrapper"><h1>Header</h1><p>Some content</p><!></div>`, 0);
 var root_68 = _$_.template(`<div class="inner"><span>Inner text</span><!></div>`, 0);
 var root_69 = _$_.template(`<section class="outer"><h2>Section title</h2><!></section>`, 0);
+var root_70 = _$_.template(`<div> </div>`, 0);
+var root_71 = _$_.template(`<div> </div>`, 0);
+var root_72 = _$_.template(`<div>frag-<span>tail</span></div>`, 0);
 
 import { track } from 'ripple';
 
@@ -193,7 +196,7 @@ export function Greeting(props) {
 		}
 
 		_$_.render(() => {
-			_$_.set_text(expression, 'Hello ' + _$_.with_scope(__block, () => String(props.name ?? '')));
+			_$_.set_text(expression, 'Hello ' + props.name);
 		});
 
 		_$_.append(__anchor, div_5);
@@ -914,6 +917,58 @@ export function NestedComponentAsLastSibling() {
 		}
 
 		_$_.append(__anchor, section_1);
+	});
+}
+
+function fetchLabel() {
+	return 'fetched';
+}
+
+export function TextTailExpression() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		var div_27 = root_70();
+
+		{
+			var text = _$_.child(div_27, true);
+
+			_$_.pop(div_27);
+		}
+
+		_$_.render(() => {
+			_$_.set_text(text, "label: " + _$_.with_scope(__block, () => String(fetchLabel())));
+		});
+
+		_$_.append(__anchor, div_27);
+	});
+}
+
+export function FragmentTailExpression() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		var div_28 = root_71();
+
+		{
+			var expression_29 = _$_.child(div_28, true);
+
+			_$_.pop(div_28);
+		}
+
+		_$_.render(() => {
+			_$_.set_text(expression_29, 'frag-' + _$_.with_scope(__block, () => String(fetchLabel())));
+		});
+
+		_$_.append(__anchor, div_28);
+	});
+}
+
+export function FragmentChildOnly() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		var div_29 = root_72();
+
+		{
+			_$_.pop(div_29);
+		}
+
+		_$_.append(__anchor, div_29);
 	});
 }
 

--- a/packages/ripple/tests/hydration/compiled/client/basic.js
+++ b/packages/ripple/tests/hydration/compiled/client/basic.js
@@ -74,6 +74,12 @@ var root_69 = _$_.template(`<section class="outer"><h2>Section title</h2><!></se
 var root_70 = _$_.template(`<div> </div>`, 0);
 var root_71 = _$_.template(`<div> </div>`, 0);
 var root_72 = _$_.template(`<div>frag-<span>tail</span></div>`, 0);
+var root_74 = _$_.template(`<!><p>after-opaque</p>`, 1, 2);
+var root_73 = _$_.template(`<!>`, 1, 1);
+var root_75 = _$_.template(`<div></div>`, 0);
+var root_77 = _$_.template(` <p>after-call</p>`, 1, 2);
+var root_76 = _$_.template(`<!>`, 1, 1);
+var root_78 = _$_.template(`<div></div>`, 0);
 
 import { track } from 'ripple';
 
@@ -969,6 +975,73 @@ export function FragmentChildOnly() {
 		}
 
 		_$_.append(__anchor, div_29);
+	});
+}
+
+function OpaqueLead(props) {
+	return _$_.tsrx_element((__anchor, __block) => {
+		var fragment_30 = root_73();
+		var node_26 = _$_.first_child_frag(fragment_30);
+
+		_$_.expression(node_26, () => _$_.tsrx_element((__anchor, __block) => {
+			var fragment_31 = root_74();
+			var expression_30 = _$_.first_child_frag(fragment_31);
+
+			_$_.expression(expression_30, () => props.header);
+			_$_.append(__anchor, fragment_31);
+		}));
+
+		_$_.append(__anchor, fragment_30);
+	});
+}
+
+export function FragmentLeadsWithOpaqueValue() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		var div_30 = root_75();
+
+		{
+			var append_anchor_1 = _$_.append_into(div_30);
+
+			_$_.render_component(OpaqueLead, append_anchor_1, { header: 'H' });
+			_$_.pop(div_30);
+		}
+
+		_$_.append(__anchor, div_30);
+	});
+}
+
+function PrimitiveCallLead() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		var fragment_32 = root_76();
+		var node_27 = _$_.first_child_frag(fragment_32);
+
+		_$_.expression(node_27, () => _$_.tsrx_element((__anchor, __block) => {
+			var fragment_33 = root_77();
+			var expression_31 = _$_.first_child_frag(fragment_33, true);
+
+			_$_.render(() => {
+				_$_.set_text(expression_31, _$_.with_scope(__block, () => String(fetchLabel())));
+			});
+
+			_$_.append(__anchor, fragment_33);
+		}));
+
+		_$_.append(__anchor, fragment_32);
+	});
+}
+
+export function FragmentLeadsWithPrimitiveCall() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		var div_31 = root_78();
+
+		{
+			var append_anchor_2 = _$_.append_into(div_31);
+
+			_$_.render_component(PrimitiveCallLead, append_anchor_2, {});
+			_$_.pop(div_31);
+		}
+
+		_$_.append(__anchor, div_31);
 	});
 }
 

--- a/packages/ripple/tests/hydration/compiled/client/if-fragment-controlflow.js
+++ b/packages/ripple/tests/hydration/compiled/client/if-fragment-controlflow.js
@@ -1,38 +1,32 @@
 // @ts-nocheck
 import * as _$_ from 'ripple/internal/client';
 
-var root_3 = _$_.template(`<p class="muze"> </p>`, 0);
-var root_2 = _$_.template(`<!><span class="after">after</span>`, 1, 2);
-var root_1 = _$_.template(`<!>`, 1, 1);
+var root_2 = _$_.template(`<p class="muze"> </p>`, 0);
+var root_1 = _$_.template(`<!><span class="after">after</span>`, 1, 2);
 var root = _$_.template(`<div class="feed-c"><!></div>`, 0);
-var root_7 = _$_.template(`<p class="muze"> </p>`, 0);
-var root_8 = _$_.template(`<span class="has-items">has items</span>`, 0);
-var root_9 = _$_.template(`<span class="empty">empty</span>`, 0);
-var root_6 = _$_.template(`<!><!><!>`, 1, 3);
-var root_5 = _$_.template(`<!>`, 1, 1);
-var root_4 = _$_.template(`<div class="feed"><!></div>`, 0);
-var root_12 = _$_.template(`<p class="muze">b</p><p class="muze">c</p>`, 1, 2);
-var root_11 = _$_.template(`<!>`, 1, 1);
-var root_10 = _$_.template(`<div class="feed-b"><!></div>`, 0);
-var root_15 = _$_.template(`<p class="muze"> </p>`, 0);
-var root_14 = _$_.template(`<!><span class="after">after</span>`, 1, 2);
+var root_5 = _$_.template(`<p class="muze"> </p>`, 0);
+var root_6 = _$_.template(`<span class="has-items">has items</span>`, 0);
+var root_7 = _$_.template(`<span class="empty">empty</span>`, 0);
+var root_4 = _$_.template(`<!><!><!>`, 1, 3);
+var root_3 = _$_.template(`<div class="feed"><!></div>`, 0);
+var root_9 = _$_.template(`<p class="muze">b</p><p class="muze">c</p>`, 1, 2);
+var root_8 = _$_.template(`<div class="feed-b"><!></div>`, 0);
+var root_12 = _$_.template(`<p class="muze"> </p>`, 0);
+var root_11 = _$_.template(`<!><span class="after">after</span>`, 1, 2);
+var root_10 = _$_.template(`<!>`, 1, 1);
+var root_14 = _$_.template(`<p class="muze"> </p>`, 0);
+var root_15 = _$_.template(`<!><span class="after">after</span>`, 1, 2);
 var root_13 = _$_.template(`<!>`, 1, 1);
 var root_17 = _$_.template(`<p class="muze"> </p>`, 0);
 var root_18 = _$_.template(`<!><span class="after">after</span>`, 1, 2);
-var root_16 = _$_.template(`<!>`, 1, 1);
-var root_21 = _$_.template(`<p class="muze"> </p>`, 0);
-var root_22 = _$_.template(`<!><span class="after">after</span>`, 1, 2);
-var root_20 = _$_.template(`<!>`, 1, 1);
-var root_19 = _$_.template(`<div class="feed-f"><!></div>`, 0);
-var root_24 = _$_.template(`<span class="loading">loading</span>`, 0);
-var root_27 = _$_.template(`<p class="muze"> </p>`, 0);
-var root_26 = _$_.template(`<!><span class="after">after</span>`, 1, 2);
-var root_25 = _$_.template(`<!>`, 1, 1);
-var root_23 = _$_.template(`<div class="feed-d"><!></div>`, 0);
-var root_31 = _$_.template(`<p class="muze"> </p>`, 0);
-var root_30 = _$_.template(`<!><span class="after">after</span>`, 1, 2);
-var root_29 = _$_.template(`<section><!></section>`, 0);
-var root_28 = _$_.template(`<div class="feed-e"><!></div>`, 0);
+var root_16 = _$_.template(`<div class="feed-f"><!></div>`, 0);
+var root_20 = _$_.template(`<span class="loading">loading</span>`, 0);
+var root_22 = _$_.template(`<p class="muze"> </p>`, 0);
+var root_21 = _$_.template(`<!><span class="after">after</span>`, 1, 2);
+var root_19 = _$_.template(`<div class="feed-d"><!></div>`, 0);
+var root_25 = _$_.template(`<p class="muze"> </p>`, 0);
+var root_24 = _$_.template(`<section><!><span class="after">after</span></section>`, 0);
+var root_23 = _$_.template(`<div class="feed-e"><!></div>`, 0);
 
 export function IfFragmentForElement() {
 	return _$_.tsrx_element((__anchor, __block) => {
@@ -46,33 +40,26 @@ export function IfFragmentForElement() {
 			{
 				var consequent = (__anchor) => {
 					var fragment = root_1();
-					var node_2 = _$_.first_child_frag(fragment);
+					var node_1 = _$_.first_child_frag(fragment);
 
-					_$_.expression(node_2, () => _$_.tsrx_element((__anchor, __block) => {
-						var fragment_1 = root_2();
-						var node_1 = _$_.first_child_frag(fragment_1);
+					_$_.for_keyed(
+						node_1,
+						() => muzes,
+						(__anchor, pattern) => {
+							var p = root_2();
 
-						_$_.for_keyed(
-							node_1,
-							() => muzes,
-							(__anchor, pattern) => {
-								var p = root_3();
+							{
+								var expression = _$_.child(p);
 
-								{
-									var expression = _$_.child(p);
+								_$_.expression(expression, () => _$_.get(pattern).muzeId);
+								_$_.pop(p);
+							}
 
-									_$_.expression(expression, () => _$_.get(pattern).muzeId);
-									_$_.pop(p);
-								}
-
-								_$_.append(__anchor, p);
-							},
-							0,
-							(pattern) => _$_.get(pattern).muzeId
-						);
-
-						_$_.append(__anchor, fragment_1);
-					}));
+							_$_.append(__anchor, p);
+						},
+						0,
+						(pattern) => _$_.get(pattern).muzeId
+					);
 
 					_$_.append(__anchor, fragment);
 				};
@@ -93,74 +80,67 @@ export function IfFragmentForIfIf() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		const muzes = [{ muzeId: 'b' }, { muzeId: 'c' }];
 		const hasLoaded = true;
-		var div_1 = root_4();
+		var div_1 = root_3();
 
 		{
-			var node_3 = _$_.child(div_1);
+			var node_2 = _$_.child(div_1);
 
 			{
 				var consequent_3 = (__anchor) => {
-					var fragment_2 = root_5();
-					var node_7 = _$_.first_child_frag(fragment_2);
+					var fragment_1 = root_4();
+					var node_3 = _$_.first_child_frag(fragment_1);
 
-					_$_.expression(node_7, () => _$_.tsrx_element((__anchor, __block) => {
-						var fragment_3 = root_6();
-						var node_4 = _$_.first_child_frag(fragment_3);
+					_$_.for_keyed(
+						node_3,
+						() => muzes,
+						(__anchor, pattern_1) => {
+							var p_1 = root_5();
 
-						_$_.for_keyed(
-							node_4,
-							() => muzes,
-							(__anchor, pattern_1) => {
-								var p_1 = root_7();
+							{
+								var expression_1 = _$_.child(p_1);
 
-								{
-									var expression_1 = _$_.child(p_1);
+								_$_.expression(expression_1, () => _$_.get(pattern_1).muzeId);
+								_$_.pop(p_1);
+							}
 
-									_$_.expression(expression_1, () => _$_.get(pattern_1).muzeId);
-									_$_.pop(p_1);
-								}
+							_$_.append(__anchor, p_1);
+						},
+						0,
+						(pattern_1) => _$_.get(pattern_1).muzeId
+					);
 
-								_$_.append(__anchor, p_1);
-							},
-							0,
-							(pattern_1) => _$_.get(pattern_1).muzeId
-						);
+					var node_4 = _$_.sibling(node_3);
 
-						var node_5 = _$_.sibling(node_4);
+					{
+						var consequent_1 = (__anchor) => {
+							var span = root_6();
 
-						{
-							var consequent_1 = (__anchor) => {
-								var span = root_8();
+							_$_.append(__anchor, span);
+						};
 
-								_$_.append(__anchor, span);
-							};
+						_$_.if(node_4, (__render) => {
+							if (muzes.length > 0) __render(consequent_1);
+						});
+					}
 
-							_$_.if(node_5, (__render) => {
-								if (muzes.length > 0) __render(consequent_1);
-							});
-						}
+					var node_5 = _$_.sibling(node_4);
 
-						var node_6 = _$_.sibling(node_5);
+					{
+						var consequent_2 = (__anchor) => {
+							var span_1 = root_7();
 
-						{
-							var consequent_2 = (__anchor) => {
-								var span_1 = root_9();
+							_$_.append(__anchor, span_1);
+						};
 
-								_$_.append(__anchor, span_1);
-							};
+						_$_.if(node_5, (__render) => {
+							if (muzes.length === 0) __render(consequent_2);
+						});
+					}
 
-							_$_.if(node_6, (__render) => {
-								if (muzes.length === 0) __render(consequent_2);
-							});
-						}
-
-						_$_.append(__anchor, fragment_3);
-					}));
-
-					_$_.append(__anchor, fragment_2);
+					_$_.append(__anchor, fragment_1);
 				};
 
-				_$_.if(node_3, (__render) => {
+				_$_.if(node_2, (__render) => {
 					if (hasLoaded) __render(consequent_3);
 				});
 			}
@@ -175,26 +155,19 @@ export function IfFragmentForIfIf() {
 export function IfFragmentElements() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		const hasLoaded = true;
-		var div_2 = root_10();
+		var div_2 = root_8();
 
 		{
-			var node_8 = _$_.child(div_2);
+			var node_6 = _$_.child(div_2);
 
 			{
 				var consequent_4 = (__anchor) => {
-					var fragment_4 = root_11();
-					var node_9 = _$_.first_child_frag(fragment_4);
+					var fragment_2 = root_9();
 
-					_$_.expression(node_9, () => _$_.tsrx_element((__anchor, __block) => {
-						var fragment_5 = root_12();
-
-						_$_.append(__anchor, fragment_5);
-					}));
-
-					_$_.append(__anchor, fragment_4);
+					_$_.append(__anchor, fragment_2);
 				};
 
-				_$_.if(node_8, (__render) => {
+				_$_.if(node_6, (__render) => {
 					if (hasLoaded) __render(consequent_4);
 				});
 			}
@@ -209,18 +182,18 @@ export function IfFragmentElements() {
 export function ComponentBodyFragmentControlFlow() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		const muzes = [{ muzeId: 'b' }, { muzeId: 'c' }];
-		var fragment_6 = root_13();
-		var node_11 = _$_.first_child_frag(fragment_6);
+		var fragment_3 = root_10();
+		var node_8 = _$_.first_child_frag(fragment_3);
 
-		_$_.expression(node_11, () => _$_.tsrx_element((__anchor, __block) => {
-			var fragment_7 = root_14();
-			var node_10 = _$_.first_child_frag(fragment_7);
+		_$_.expression(node_8, () => _$_.tsrx_element((__anchor, __block) => {
+			var fragment_4 = root_11();
+			var node_7 = _$_.first_child_frag(fragment_4);
 
 			_$_.for_keyed(
-				node_10,
+				node_7,
 				() => muzes,
 				(__anchor, pattern_2) => {
-					var p_2 = root_15();
+					var p_2 = root_12();
 
 					{
 						var expression_2 = _$_.child(p_2);
@@ -235,22 +208,22 @@ export function ComponentBodyFragmentControlFlow() {
 				(pattern_2) => _$_.get(pattern_2).muzeId
 			);
 
-			_$_.append(__anchor, fragment_7);
+			_$_.append(__anchor, fragment_4);
 		}));
 
-		_$_.append(__anchor, fragment_6);
+		_$_.append(__anchor, fragment_3);
 	});
 }
 
 export function ComponentBodyCodeBlockControlFlow() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		const muzes = [{ muzeId: 'b' }, { muzeId: 'c' }];
-		var fragment_8 = root_16();
-		var node_12 = _$_.first_child_frag(fragment_8);
+		var fragment_5 = root_13();
+		var node_9 = _$_.first_child_frag(fragment_5);
 
-		_$_.expression(node_12, () => _$_.tsrx_element((__anchor, __block) => {
-			var fragment_9 = root_18();
-			var expression_4 = _$_.first_child_frag(fragment_9);
+		_$_.expression(node_9, () => _$_.tsrx_element((__anchor, __block) => {
+			var fragment_6 = root_15();
+			var expression_4 = _$_.first_child_frag(fragment_6);
 
 			_$_.expression(expression_4, () => _$_.tsrx_element((__anchor, __block) => {
 				const rows = muzes;
@@ -259,7 +232,7 @@ export function ComponentBodyCodeBlockControlFlow() {
 					__anchor,
 					() => rows,
 					(__anchor, pattern_3) => {
-						var p_3 = root_17();
+						var p_3 = root_14();
 
 						{
 							var expression_3 = _$_.child(p_3);
@@ -275,10 +248,10 @@ export function ComponentBodyCodeBlockControlFlow() {
 				);
 			}));
 
-			_$_.append(__anchor, fragment_9);
+			_$_.append(__anchor, fragment_6);
 		}));
 
-		_$_.append(__anchor, fragment_8);
+		_$_.append(__anchor, fragment_5);
 	});
 }
 
@@ -286,50 +259,43 @@ export function IfCodeBlockControlFlow() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		const muzes = [{ muzeId: 'b' }, { muzeId: 'c' }];
 		const hasLoaded = true;
-		var div_3 = root_19();
+		var div_3 = root_16();
 
 		{
-			var node_13 = _$_.child(div_3);
+			var node_10 = _$_.child(div_3);
 
 			{
 				var consequent_5 = (__anchor) => {
-					var fragment_10 = root_20();
-					var node_14 = _$_.first_child_frag(fragment_10);
+					var fragment_7 = root_18();
+					var expression_6 = _$_.first_child_frag(fragment_7);
 
-					_$_.expression(node_14, () => _$_.tsrx_element((__anchor, __block) => {
-						var fragment_11 = root_22();
-						var expression_6 = _$_.first_child_frag(fragment_11);
+					_$_.expression(expression_6, () => _$_.tsrx_element((__anchor, __block) => {
+						const rows = muzes;
 
-						_$_.expression(expression_6, () => _$_.tsrx_element((__anchor, __block) => {
-							const rows = muzes;
+						_$_.for_keyed(
+							__anchor,
+							() => rows,
+							(__anchor, pattern_4) => {
+								var p_4 = root_17();
 
-							_$_.for_keyed(
-								__anchor,
-								() => rows,
-								(__anchor, pattern_4) => {
-									var p_4 = root_21();
+								{
+									var expression_5 = _$_.child(p_4);
 
-									{
-										var expression_5 = _$_.child(p_4);
+									_$_.expression(expression_5, () => _$_.get(pattern_4).muzeId);
+									_$_.pop(p_4);
+								}
 
-										_$_.expression(expression_5, () => _$_.get(pattern_4).muzeId);
-										_$_.pop(p_4);
-									}
-
-									_$_.append(__anchor, p_4);
-								},
-								16,
-								(pattern_4) => _$_.get(pattern_4).muzeId
-							);
-						}));
-
-						_$_.append(__anchor, fragment_11);
+								_$_.append(__anchor, p_4);
+							},
+							16,
+							(pattern_4) => _$_.get(pattern_4).muzeId
+						);
 					}));
 
-					_$_.append(__anchor, fragment_10);
+					_$_.append(__anchor, fragment_7);
 				};
 
-				_$_.if(node_13, (__render) => {
+				_$_.if(node_10, (__render) => {
 					if (hasLoaded) __render(consequent_5);
 				});
 			}
@@ -345,52 +311,45 @@ export function IfElseFragment() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		const muzes = [{ muzeId: 'b' }, { muzeId: 'c' }];
 		const hasLoaded = false;
-		var div_4 = root_23();
+		var div_4 = root_19();
 
 		{
-			var node_15 = _$_.child(div_4);
+			var node_11 = _$_.child(div_4);
 
 			{
 				var consequent_6 = (__anchor) => {
-					var span_2 = root_24();
+					var span_2 = root_20();
 
 					_$_.append(__anchor, span_2);
 				};
 
 				var alternate = (__anchor) => {
-					var fragment_12 = root_25();
-					var node_17 = _$_.first_child_frag(fragment_12);
+					var fragment_8 = root_21();
+					var node_12 = _$_.first_child_frag(fragment_8);
 
-					_$_.expression(node_17, () => _$_.tsrx_element((__anchor, __block) => {
-						var fragment_13 = root_26();
-						var node_16 = _$_.first_child_frag(fragment_13);
+					_$_.for_keyed(
+						node_12,
+						() => muzes,
+						(__anchor, pattern_5) => {
+							var p_5 = root_22();
 
-						_$_.for_keyed(
-							node_16,
-							() => muzes,
-							(__anchor, pattern_5) => {
-								var p_5 = root_27();
+							{
+								var expression_7 = _$_.child(p_5);
 
-								{
-									var expression_7 = _$_.child(p_5);
+								_$_.expression(expression_7, () => _$_.get(pattern_5).muzeId);
+								_$_.pop(p_5);
+							}
 
-									_$_.expression(expression_7, () => _$_.get(pattern_5).muzeId);
-									_$_.pop(p_5);
-								}
+							_$_.append(__anchor, p_5);
+						},
+						0,
+						(pattern_5) => _$_.get(pattern_5).muzeId
+					);
 
-								_$_.append(__anchor, p_5);
-							},
-							0,
-							(pattern_5) => _$_.get(pattern_5).muzeId
-						);
-
-						_$_.append(__anchor, fragment_13);
-					}));
-
-					_$_.append(__anchor, fragment_12);
+					_$_.append(__anchor, fragment_8);
 				};
 
-				_$_.if(node_15, (__render) => {
+				_$_.if(node_11, (__render) => {
 					if (hasLoaded) __render(consequent_6); else __render(alternate, false);
 				});
 			}
@@ -406,43 +365,36 @@ export function IfDivFragment() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		const muzes = [{ muzeId: 'b' }, { muzeId: 'c' }];
 		const hasLoaded = true;
-		var div_5 = root_28();
+		var div_5 = root_23();
 
 		{
-			var node_18 = _$_.child(div_5);
+			var node_13 = _$_.child(div_5);
 
 			{
 				var consequent_7 = (__anchor) => {
-					var section = root_29();
+					var section = root_24();
 
 					{
-						var node_20 = _$_.child(section);
+						var node_14 = _$_.child(section);
 
-						_$_.expression(node_20, () => _$_.tsrx_element((__anchor, __block) => {
-							var fragment_14 = root_30();
-							var node_19 = _$_.first_child_frag(fragment_14);
+						_$_.for_keyed(
+							node_14,
+							() => muzes,
+							(__anchor, pattern_6) => {
+								var p_6 = root_25();
 
-							_$_.for_keyed(
-								node_19,
-								() => muzes,
-								(__anchor, pattern_6) => {
-									var p_6 = root_31();
+								{
+									var expression_8 = _$_.child(p_6);
 
-									{
-										var expression_8 = _$_.child(p_6);
+									_$_.expression(expression_8, () => _$_.get(pattern_6).muzeId);
+									_$_.pop(p_6);
+								}
 
-										_$_.expression(expression_8, () => _$_.get(pattern_6).muzeId);
-										_$_.pop(p_6);
-									}
-
-									_$_.append(__anchor, p_6);
-								},
-								0,
-								(pattern_6) => _$_.get(pattern_6).muzeId
-							);
-
-							_$_.append(__anchor, fragment_14);
-						}));
+								_$_.append(__anchor, p_6);
+							},
+							0,
+							(pattern_6) => _$_.get(pattern_6).muzeId
+						);
 
 						_$_.pop(section);
 					}
@@ -450,7 +402,7 @@ export function IfDivFragment() {
 					_$_.append(__anchor, section);
 				};
 
-				_$_.if(node_18, (__render) => {
+				_$_.if(node_13, (__render) => {
 					if (hasLoaded) __render(consequent_7);
 				});
 			}

--- a/packages/ripple/tests/hydration/compiled/client/streaming.js
+++ b/packages/ripple/tests/hydration/compiled/client/streaming.js
@@ -2,33 +2,30 @@
 import * as _$_ from 'ripple/internal/client';
 
 var root = _$_.template(`<div class="resolved"><span class="value"> </span><button class="inc">inc</button></div>`, 0);
-var root_4 = _$_.template(`<!><footer class="after-async">after-async</footer>`, 1, 2);
-var root_3 = _$_.template(`<!>`, 1, 1);
-var root_5 = _$_.template(`<p class="loading">loading...</p>`, 0);
+var root_3 = _$_.template(`<!><footer class="after-async">after-async</footer>`, 1, 2);
+var root_4 = _$_.template(`<p class="loading">loading...</p>`, 0);
 var root_2 = _$_.template(`<span class="before">before</span><!><span class="sibling-after">sibling-after</span>`, 1, 3);
 var root_1 = _$_.template(`<!>`, 1, 1);
-var root_6 = _$_.template(`<p class="resolved"> </p>`, 0);
-var root_9 = _$_.template(`<em class="caught"> </em>`, 0);
-var root_8 = _$_.template(`<span class="before">before</span><!>`, 1, 2);
-var root_7 = _$_.template(`<!>`, 1, 1);
-var root_10 = _$_.template(`<p class="resolved"> </p>`, 0);
-var root_11 = _$_.template(`<em class="caught"> </em>`, 0);
-var root_12 = _$_.template(`<p class="loading">loading...</p>`, 0);
-var root_13 = _$_.template(`<p class="resolved"> </p>`, 0);
-var root_14 = _$_.template(`<p class="loading">loading...</p>`, 0);
-var root_15 = _$_.template(`<section class="root-catch"> </section>`, 0);
-var root_16 = _$_.template(`<p class="root-pending">root-loading</p>`, 0);
-var root_19 = _$_.template(`<p class="head-content"> </p>`, 0);
-var root_18 = _$_.template(`<!>`, 1, 1);
-var root_17 = _$_.template(`<!>`, 1, 1);
-var root_20 = _$_.template(`<p class="loading">loading...</p>`, 0);
-var root_21 = _$_.template(`<p class="root-async"> </p>`, 0);
-var root_22 = _$_.template(`<p class="outer"> </p>`, 0);
-var root_23 = _$_.template(`<p class="inner"> </p>`, 0);
-var root_26 = _$_.template(`<p class="inner-loading">inner-loading</p>`, 0);
-var root_25 = _$_.template(`<!><!>`, 1, 2);
-var root_24 = _$_.template(`<!>`, 1, 1);
-var root_27 = _$_.template(`<p class="outer-loading">outer-loading</p>`, 0);
+var root_5 = _$_.template(`<p class="resolved"> </p>`, 0);
+var root_8 = _$_.template(`<em class="caught"> </em>`, 0);
+var root_7 = _$_.template(`<span class="before">before</span><!>`, 1, 2);
+var root_6 = _$_.template(`<!>`, 1, 1);
+var root_9 = _$_.template(`<p class="resolved"> </p>`, 0);
+var root_10 = _$_.template(`<em class="caught"> </em>`, 0);
+var root_11 = _$_.template(`<p class="loading">loading...</p>`, 0);
+var root_12 = _$_.template(`<p class="resolved"> </p>`, 0);
+var root_13 = _$_.template(`<p class="loading">loading...</p>`, 0);
+var root_14 = _$_.template(`<section class="root-catch"> </section>`, 0);
+var root_15 = _$_.template(`<p class="root-pending">root-loading</p>`, 0);
+var root_17 = _$_.template(`<p class="head-content"> </p>`, 0);
+var root_16 = _$_.template(`<!>`, 1, 1);
+var root_18 = _$_.template(`<p class="loading">loading...</p>`, 0);
+var root_19 = _$_.template(`<p class="root-async"> </p>`, 0);
+var root_20 = _$_.template(`<p class="outer"> </p>`, 0);
+var root_21 = _$_.template(`<p class="inner"> </p>`, 0);
+var root_23 = _$_.template(`<p class="inner-loading">inner-loading</p>`, 0);
+var root_22 = _$_.template(`<!><!>`, 1, 2);
+var root_24 = _$_.template(`<p class="outer-loading">outer-loading</p>`, 0);
 
 import { track, trackAsync } from 'ripple';
 
@@ -92,9 +89,9 @@ function BasicContent() {
 export function StreamPending() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		var fragment = root_1();
-		var node_3 = _$_.first_child_frag(fragment);
+		var node_2 = _$_.first_child_frag(fragment);
 
-		_$_.expression(node_3, () => _$_.tsrx_element((__anchor, __block) => {
+		_$_.expression(node_2, () => _$_.tsrx_element((__anchor, __block) => {
 			var fragment_1 = root_2();
 			var span_1 = _$_.first_child_frag(fragment_1);
 			var node = _$_.sibling(span_1);
@@ -103,21 +100,14 @@ export function StreamPending() {
 				node,
 				(__anchor) => {
 					var fragment_2 = root_3();
-					var node_2 = _$_.first_child_frag(fragment_2);
+					var node_1 = _$_.first_child_frag(fragment_2);
 
-					_$_.expression(node_2, () => _$_.tsrx_element((__anchor, __block) => {
-						var fragment_3 = root_4();
-						var node_1 = _$_.first_child_frag(fragment_3);
-
-						_$_.render_component(BasicContent, node_1, {});
-						_$_.append(__anchor, fragment_3);
-					}));
-
+					_$_.render_component(BasicContent, node_1, {});
 					_$_.append(__anchor, fragment_2);
 				},
 				null,
 				(__anchor) => {
-					var p = root_5();
+					var p = root_4();
 
 					_$_.append(__anchor, p);
 				}
@@ -133,7 +123,7 @@ export function StreamPending() {
 function CatchOnlyContent() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		let lazy_2 = _$_.track_async(() => controls.catchOnly.promise, __block, '50f939c6');
-		var p_1 = root_6();
+		var p_1 = root_5();
 
 		{
 			var expression_1 = _$_.child(p_1);
@@ -148,21 +138,21 @@ function CatchOnlyContent() {
 
 export function StreamCatchOnly() {
 	return _$_.tsrx_element((__anchor, __block) => {
-		var fragment_4 = root_7();
-		var node_5 = _$_.first_child_frag(fragment_4);
+		var fragment_3 = root_6();
+		var node_4 = _$_.first_child_frag(fragment_3);
 
-		_$_.expression(node_5, () => _$_.tsrx_element((__anchor, __block) => {
-			var fragment_5 = root_8();
-			var span_2 = _$_.first_child_frag(fragment_5);
-			var node_4 = _$_.sibling(span_2);
+		_$_.expression(node_4, () => _$_.tsrx_element((__anchor, __block) => {
+			var fragment_4 = root_7();
+			var span_2 = _$_.first_child_frag(fragment_4);
+			var node_3 = _$_.sibling(span_2);
 
 			_$_.try(
-				node_4,
+				node_3,
 				(__anchor) => {
 					_$_.render_component(CatchOnlyContent, __anchor, {});
 				},
 				(__anchor, e) => {
-					var em = root_9();
+					var em = root_8();
 
 					{
 						var expression_2 = _$_.child(em);
@@ -175,17 +165,17 @@ export function StreamCatchOnly() {
 				}
 			);
 
-			_$_.append(__anchor, fragment_5);
+			_$_.append(__anchor, fragment_4);
 		}));
 
-		_$_.append(__anchor, fragment_4);
+		_$_.append(__anchor, fragment_3);
 	});
 }
 
 function RejectContent() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		let lazy_3 = _$_.track_async(() => controls.rejects.promise, __block, '96452a54');
-		var p_2 = root_10();
+		var p_2 = root_9();
 
 		{
 			var expression_3 = _$_.child(p_2);
@@ -206,7 +196,7 @@ export function StreamRejects() {
 				_$_.render_component(RejectContent, __anchor, {});
 			},
 			(__anchor, e) => {
-				var em_1 = root_11();
+				var em_1 = root_10();
 
 				{
 					var expression_4 = _$_.child(em_1);
@@ -218,7 +208,7 @@ export function StreamRejects() {
 				_$_.append(__anchor, em_1);
 			},
 			(__anchor) => {
-				var p_3 = root_12();
+				var p_3 = root_11();
 
 				_$_.append(__anchor, p_3);
 			},
@@ -230,7 +220,7 @@ export function StreamRejects() {
 function NoCatchContent() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		let lazy_4 = _$_.track_async(() => controls.noCatch.promise, __block, '6baa716b');
-		var p_4 = root_13();
+		var p_4 = root_12();
 
 		{
 			var expression_5 = _$_.child(p_4);
@@ -252,7 +242,7 @@ export function StreamNoCatch() {
 			},
 			null,
 			(__anchor) => {
-				var p_5 = root_14();
+				var p_5 = root_13();
 
 				_$_.append(__anchor, p_5);
 			},
@@ -263,7 +253,7 @@ export function StreamNoCatch() {
 
 export function RootCatch({ error, reset }) {
 	return _$_.tsrx_element((__anchor, __block) => {
-		var section = root_15();
+		var section = root_14();
 
 		_$_.event('Click', section, reset);
 
@@ -280,7 +270,7 @@ export function RootCatch({ error, reset }) {
 
 export function RootPending() {
 	return _$_.tsrx_element((__anchor, __block) => {
-		var p_6 = root_16();
+		var p_6 = root_15();
 
 		_$_.append(__anchor, p_6);
 	});
@@ -289,35 +279,28 @@ export function RootPending() {
 function HeadContent() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		let lazy_5 = _$_.track_async(() => controls.head.promise, __block, '9cd3c3cd');
-		var fragment_6 = root_17();
-		var node_7 = _$_.first_child_frag(fragment_6);
+		var fragment_5 = root_16();
+		var node_5 = _$_.first_child_frag(fragment_5);
 
-		_$_.expression(node_7, () => _$_.tsrx_element((__anchor, __block) => {
+		_$_.expression(node_5, () => _$_.tsrx_element((__anchor, __block) => {
 			{
 				var consequent = (__anchor) => {
-					var fragment_7 = root_18();
-					var node_6 = _$_.first_child_frag(fragment_7);
+					var p_7 = root_17();
 
-					_$_.expression(node_6, () => _$_.tsrx_element((__anchor, __block) => {
-						var p_7 = root_19();
+					{
+						var expression_7 = _$_.child(p_7);
 
-						{
-							var expression_7 = _$_.child(p_7);
+						_$_.expression(expression_7, () => lazy_5.value);
+						_$_.pop(p_7);
+					}
 
-							_$_.expression(expression_7, () => lazy_5.value);
-							_$_.pop(p_7);
-						}
-
-						_$_.head('814bacd9', (__anchor) => {
-							_$_.render(() => {
-								_$_.document.title = 'title:' + lazy_5.value;
-							});
+					_$_.head('814bacd9', (__anchor) => {
+						_$_.render(() => {
+							_$_.document.title = 'title:' + lazy_5.value;
 						});
+					});
 
-						_$_.append(__anchor, p_7);
-					}));
-
-					_$_.append(__anchor, fragment_7);
+					_$_.append(__anchor, p_7);
 				};
 
 				_$_.if(
@@ -330,7 +313,7 @@ function HeadContent() {
 			}
 		}));
 
-		_$_.append(__anchor, fragment_6);
+		_$_.append(__anchor, fragment_5);
 	});
 }
 
@@ -343,7 +326,7 @@ export function StreamHead() {
 			},
 			null,
 			(__anchor) => {
-				var p_8 = root_20();
+				var p_8 = root_18();
 
 				_$_.append(__anchor, p_8);
 			},
@@ -355,7 +338,7 @@ export function StreamHead() {
 export function StreamRootDirect() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		let lazy_6 = _$_.track_async(() => controls.rootDirect.promise, __block, 'bc9e61da');
-		var p_9 = root_21();
+		var p_9 = root_19();
 
 		{
 			var expression_8 = _$_.child(p_9);
@@ -371,7 +354,7 @@ export function StreamRootDirect() {
 function OuterContent() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		let lazy_7 = _$_.track_async(() => controls.outer.promise, __block, '35931cce');
-		var p_10 = root_22();
+		var p_10 = root_20();
 
 		{
 			var expression_9 = _$_.child(p_10);
@@ -387,7 +370,7 @@ function OuterContent() {
 function InnerContent() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		let lazy_8 = _$_.track_async(() => controls.inner.promise, __block, '6c7d38ed');
-		var p_11 = root_23();
+		var p_11 = root_21();
 
 		{
 			var expression_10 = _$_.child(p_11);
@@ -405,38 +388,31 @@ export function StreamNested() {
 		_$_.try(
 			__anchor,
 			(__anchor) => {
-				var fragment_8 = root_24();
-				var node_10 = _$_.first_child_frag(fragment_8);
+				var fragment_6 = root_22();
+				var node_6 = _$_.first_child_frag(fragment_6);
 
-				_$_.expression(node_10, () => _$_.tsrx_element((__anchor, __block) => {
-					var fragment_9 = root_25();
-					var node_8 = _$_.first_child_frag(fragment_9);
+				_$_.render_component(OuterContent, node_6, {});
 
-					_$_.render_component(OuterContent, node_8, {});
+				var node_7 = _$_.sibling(node_6);
 
-					var node_9 = _$_.sibling(node_8);
+				_$_.try(
+					node_7,
+					(__anchor) => {
+						_$_.render_component(InnerContent, __anchor, {});
+					},
+					null,
+					(__anchor) => {
+						var p_12 = root_23();
 
-					_$_.try(
-						node_9,
-						(__anchor) => {
-							_$_.render_component(InnerContent, __anchor, {});
-						},
-						null,
-						(__anchor) => {
-							var p_12 = root_26();
+						_$_.append(__anchor, p_12);
+					}
+				);
 
-							_$_.append(__anchor, p_12);
-						}
-					);
-
-					_$_.append(__anchor, fragment_9);
-				}));
-
-				_$_.append(__anchor, fragment_8);
+				_$_.append(__anchor, fragment_6);
 			},
 			null,
 			(__anchor) => {
-				var p_13 = root_27();
+				var p_13 = root_24();
 
 				_$_.append(__anchor, p_13);
 			},

--- a/packages/ripple/tests/hydration/compiled/server/basic.js
+++ b/packages/ripple/tests/hydration/compiled/server/basic.js
@@ -215,7 +215,15 @@ export function NestedTsxTsrxExpressionValues() {
 			__out += '<div class="nested-expression-values"><!--[-->';
 
 			for (const item of [1, 2, 3]) {
-				__out += '<div class="app-item">' + _$_.escape(item) + '</div>';
+				__out += '<div class="app-item">';
+
+				{
+					_$_.output_push(__out);
+					__out = '';
+					_$_.render_expression(item);
+				}
+
+				__out += '</div>';
 			}
 
 			__out += '<!--]-->';

--- a/packages/ripple/tests/hydration/compiled/server/basic.js
+++ b/packages/ripple/tests/hydration/compiled/server/basic.js
@@ -131,7 +131,7 @@ export function Greeting(props) {
 		_$_.regular_block(() => {
 			let __out = '';
 
-			__out += '<div>' + _$_.escape('Hello ' + String(props.name ?? '')) + '</div>';
+			__out += '<div>' + _$_.escape('Hello ' + props.name) + '</div>';
 			_$_.output_push(__out);
 		});
 	});
@@ -908,6 +908,43 @@ export function NestedComponentAsLastSibling() {
 			}
 
 			__out += '</section>';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+function fetchLabel() {
+	return 'fetched';
+}
+
+export function TextTailExpression() {
+	return _$_.tsrx_element(() => {
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<div>' + _$_.escape("label: " + String(fetchLabel())) + '</div>';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function FragmentTailExpression() {
+	return _$_.tsrx_element(() => {
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<div>' + _$_.escape('frag-' + String(fetchLabel())) + '</div>';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function FragmentChildOnly() {
+	return _$_.tsrx_element(() => {
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<div>frag-<span>tail</span></div>';
 			_$_.output_push(__out);
 		});
 	});

--- a/packages/ripple/tests/hydration/compiled/server/basic.js
+++ b/packages/ripple/tests/hydration/compiled/server/basic.js
@@ -949,3 +949,77 @@ export function FragmentChildOnly() {
 		});
 	});
 }
+
+function OpaqueLead(props) {
+	return _$_.tsrx_element(() => {
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<!--[-->';
+			_$_.output_push(__out);
+			__out = '';
+			_$_.render_expression(props.header);
+			__out += '<p>after-opaque</p><!--]-->';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function FragmentLeadsWithOpaqueValue() {
+	return _$_.tsrx_element(() => {
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<div>';
+
+			{
+				{
+					const comp = OpaqueLead;
+					const args = [{ header: 'H' }];
+
+					_$_.output_push(__out);
+					__out = '';
+					_$_.render_component(comp, ...args);
+				}
+			}
+
+			__out += '</div>';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+function PrimitiveCallLead() {
+	return _$_.tsrx_element(() => {
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += _$_.escape(String(fetchLabel())) + '<p>after-call</p>';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function FragmentLeadsWithPrimitiveCall() {
+	return _$_.tsrx_element(() => {
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<div>';
+
+			{
+				{
+					const comp = PrimitiveCallLead;
+					const args = [{}];
+
+					_$_.output_push(__out);
+					__out = '';
+					_$_.render_component(comp, ...args);
+				}
+			}
+
+			__out += '</div>';
+			_$_.output_push(__out);
+		});
+	});
+}

--- a/packages/ripple/tests/hydration/compiled/server/events.js
+++ b/packages/ripple/tests/hydration/compiled/server/events.js
@@ -10,7 +10,15 @@ export function ClickCounter() {
 		_$_.regular_block(() => {
 			let __out = '';
 
-			__out += '<div><button class="increment">Increment</button><span class="count">' + _$_.escape(lazy.value) + '</span></div>';
+			__out += '<div><button class="increment">Increment</button><span class="count">';
+
+			{
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_expression(lazy.value);
+			}
+
+			__out += '</span></div>';
 			_$_.output_push(__out);
 		});
 	});
@@ -23,7 +31,15 @@ export function IncrementDecrement() {
 		_$_.regular_block(() => {
 			let __out = '';
 
-			__out += '<div><button class="decrement">-</button><span class="count">' + _$_.escape(lazy_1.value) + '</span><button class="increment">+</button></div>';
+			__out += '<div><button class="decrement">-</button><span class="count">';
+
+			{
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_expression(lazy_1.value);
+			}
+
+			__out += '</span><button class="increment">+</button></div>';
 			_$_.output_push(__out);
 		});
 	});
@@ -37,7 +53,23 @@ export function MultipleEvents() {
 		_$_.regular_block(() => {
 			let __out = '';
 
-			__out += '<div><button class="target">Target</button><span class="clicks">' + _$_.escape(lazy_2.value) + '</span><span class="hovers">' + _$_.escape(lazy_3.value) + '</span></div>';
+			__out += '<div><button class="target">Target</button><span class="clicks">';
+
+			{
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_expression(lazy_2.value);
+			}
+
+			__out += '</span><span class="hovers">';
+
+			{
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_expression(lazy_3.value);
+			}
+
+			__out += '</span></div>';
 			_$_.output_push(__out);
 		});
 	});
@@ -56,7 +88,23 @@ export function MultiStateUpdate() {
 		_$_.regular_block(() => {
 			let __out = '';
 
-			__out += '<div><button class="btn">Click</button><span class="count">' + _$_.escape(lazy_4.value) + '</span><span class="action">' + _$_.escape(lazy_5.value) + '</span></div>';
+			__out += '<div><button class="btn">Click</button><span class="count">';
+
+			{
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_expression(lazy_4.value);
+			}
+
+			__out += '</span><span class="action">';
+
+			{
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_expression(lazy_5.value);
+			}
+
+			__out += '</span></div>';
 			_$_.output_push(__out);
 		});
 	});
@@ -112,7 +160,15 @@ export function ParentWithChildButton() {
 				_$_.render_component(comp, ...args);
 			}
 
-			__out += '<span class="count">' + _$_.escape(lazy_7.value) + '</span></div>';
+			__out += '<span class="count">';
+
+			{
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_expression(lazy_7.value);
+			}
+
+			__out += '</span></div>';
 			_$_.output_push(__out);
 		});
 	});

--- a/packages/ripple/tests/hydration/compiled/server/for.js
+++ b/packages/ripple/tests/hydration/compiled/server/for.js
@@ -13,7 +13,15 @@ export function StaticForLoop() {
 			__out += '<ul><!--[-->';
 
 			for (const item of items) {
-				__out += '<li>' + _$_.escape(item) + '</li>';
+				__out += '<li>';
+
+				{
+					_$_.output_push(__out);
+					__out = '';
+					_$_.render_expression(item);
+				}
+
+				__out += '</li>';
 			}
 
 			__out += '<!--]--></ul>';
@@ -64,7 +72,15 @@ export function KeyedForLoop() {
 			__out += '<ul><!--[-->';
 
 			for (const item of items) {
-				__out += '<li>' + _$_.escape(item.name) + '</li>';
+				__out += '<li>';
+
+				{
+					_$_.output_push(__out);
+					__out = '';
+					_$_.render_expression(item.name);
+				}
+
+				__out += '</li>';
 			}
 
 			__out += '<!--]--></ul>';
@@ -83,7 +99,15 @@ export function ReactiveForLoopAdd() {
 			__out += '<button class="add">Add</button><ul><!--[-->';
 
 			for (const item of lazy.value) {
-				__out += '<li>' + _$_.escape(item) + '</li>';
+				__out += '<li>';
+
+				{
+					_$_.output_push(__out);
+					__out = '';
+					_$_.render_expression(item);
+				}
+
+				__out += '</li>';
 			}
 
 			__out += '<!--]--></ul>';
@@ -102,7 +126,15 @@ export function ReactiveForLoopRemove() {
 			__out += '<button class="remove">Remove</button><ul><!--[-->';
 
 			for (const item of lazy_1.value) {
-				__out += '<li>' + _$_.escape(item) + '</li>';
+				__out += '<li>';
+
+				{
+					_$_.output_push(__out);
+					__out = '';
+					_$_.render_expression(item);
+				}
+
+				__out += '</li>';
 			}
 
 			__out += '<!--]--></ul>';
@@ -126,7 +158,15 @@ export function ForLoopInteractive() {
 				var i = 0;
 
 				for (const count of lazy_2.value) {
-					__out += '<div' + _$_.attr('class', `item-${i}`) + '><span class="value">' + _$_.escape(count) + '</span><button class="increment">+</button></div>';
+					__out += '<div' + _$_.attr('class', `item-${i}`) + '><span class="value">';
+
+					{
+						_$_.output_push(__out);
+						__out = '';
+						_$_.render_expression(count);
+					}
+
+					__out += '</span><button class="increment">+</button></div>';
 					i++;
 				}
 
@@ -162,7 +202,15 @@ export function NestedForLoop() {
 						var colIndex = 0;
 
 						for (const cell of row) {
-							__out += '<span' + _$_.attr('class', `cell-${rowIndex}-${colIndex}`) + '>' + _$_.escape(cell) + '</span>';
+							__out += '<span' + _$_.attr('class', `cell-${rowIndex}-${colIndex}`) + '>';
+
+							{
+								_$_.output_push(__out);
+								__out = '';
+								_$_.render_expression(cell);
+							}
+
+							__out += '</span>';
 							colIndex++;
 						}
 
@@ -192,7 +240,15 @@ export function EmptyForLoop() {
 			__out += '<div class="container"><!--[-->';
 
 			for (const item of items) {
-				__out += '<span>' + _$_.escape(item) + '</span>';
+				__out += '<span>';
+
+				{
+					_$_.output_push(__out);
+					__out = '';
+					_$_.render_expression(item);
+				}
+
+				__out += '</span>';
 			}
 
 			__out += '<!--]--></div>';
@@ -214,7 +270,23 @@ export function ForLoopComplexObjects() {
 			__out += '<div><!--[-->';
 
 			for (const user of users) {
-				__out += '<div' + _$_.attr('class', `user-${user.id}`) + '><span class="name">' + _$_.escape(user.name) + '</span><span class="role">' + _$_.escape(user.role) + '</span></div>';
+				__out += '<div' + _$_.attr('class', `user-${user.id}`) + '><span class="name">';
+
+				{
+					_$_.output_push(__out);
+					__out = '';
+					_$_.render_expression(user.name);
+				}
+
+				__out += '</span><span class="role">';
+
+				{
+					_$_.output_push(__out);
+					__out = '';
+					_$_.render_expression(user.role);
+				}
+
+				__out += '</span></div>';
 			}
 
 			__out += '<!--]--></div>';
@@ -240,7 +312,15 @@ export function KeyedForLoopReorder() {
 			__out += '<button class="reorder">Reorder</button><ul><!--[-->';
 
 			for (const item of lazy_3.value) {
-				__out += '<li' + _$_.attr('class', `item-${item.id}`) + '>' + _$_.escape(item.name) + '</li>';
+				__out += '<li' + _$_.attr('class', `item-${item.id}`) + '>';
+
+				{
+					_$_.output_push(__out);
+					__out = '';
+					_$_.render_expression(item.name);
+				}
+
+				__out += '</li>';
 			}
 
 			__out += '<!--]--></ul>';
@@ -259,7 +339,15 @@ export function KeyedForLoopUpdate() {
 			__out += '<button class="update">Update</button><ul><!--[-->';
 
 			for (const item of lazy_4.value) {
-				__out += '<li' + _$_.attr('class', `item-${item.id}`) + '>' + _$_.escape(item.name) + '</li>';
+				__out += '<li' + _$_.attr('class', `item-${item.id}`) + '>';
+
+				{
+					_$_.output_push(__out);
+					__out = '';
+					_$_.render_expression(item.name);
+				}
+
+				__out += '</li>';
 			}
 
 			__out += '<!--]--></ul>';
@@ -278,7 +366,15 @@ export function ForLoopMixedOperations() {
 			__out += '<button class="shuffle">Shuffle</button><ul><!--[-->';
 
 			for (const item of lazy_5.value) {
-				__out += '<li' + _$_.attr('class', `item-${item}`) + '>' + _$_.escape(item) + '</li>';
+				__out += '<li' + _$_.attr('class', `item-${item}`) + '>';
+
+				{
+					_$_.output_push(__out);
+					__out = '';
+					_$_.render_expression(item);
+				}
+
+				__out += '</li>';
 			}
 
 			__out += '<!--]--></ul>';
@@ -301,7 +397,15 @@ export function ForLoopInsideIf() {
 				__out += '<ul class="list"><!--[-->';
 
 				for (const item of lazy_7.value) {
-					__out += '<li>' + _$_.escape(item) + '</li>';
+					__out += '<li>';
+
+					{
+						_$_.output_push(__out);
+						__out = '';
+						_$_.render_expression(item);
+					}
+
+					__out += '</li>';
 				}
 
 				__out += '<!--]--></ul>';
@@ -323,7 +427,15 @@ export function ForLoopEmptyToPopulated() {
 			__out += '<button class="populate">Populate</button><ul class="list"><!--[-->';
 
 			for (const item of lazy_8.value) {
-				__out += '<li>' + _$_.escape(item) + '</li>';
+				__out += '<li>';
+
+				{
+					_$_.output_push(__out);
+					__out = '';
+					_$_.render_expression(item);
+				}
+
+				__out += '</li>';
 			}
 
 			__out += '<!--]--></ul>';
@@ -342,7 +454,15 @@ export function ForLoopPopulatedToEmpty() {
 			__out += '<button class="clear">Clear</button><ul class="list"><!--[-->';
 
 			for (const item of lazy_9.value) {
-				__out += '<li>' + _$_.escape(item) + '</li>';
+				__out += '<li>';
+
+				{
+					_$_.output_push(__out);
+					__out = '';
+					_$_.render_expression(item);
+				}
+
+				__out += '</li>';
 			}
 
 			__out += '<!--]--></ul>';
@@ -374,7 +494,15 @@ export function NestedForLoopReactive() {
 						var colIndex = 0;
 
 						for (const cell of row) {
-							__out += '<span' + _$_.attr('class', `cell-${rowIndex}-${colIndex}`) + '>' + _$_.escape(cell) + '</span>';
+							__out += '<span' + _$_.attr('class', `cell-${rowIndex}-${colIndex}`) + '>';
+
+							{
+								_$_.output_push(__out);
+								__out = '';
+								_$_.render_expression(cell);
+							}
+
+							__out += '</span>';
 							colIndex++;
 						}
 
@@ -419,13 +547,37 @@ export function ForLoopDeeplyNested() {
 			__out += '<div class="org"><!--[-->';
 
 			for (const dept of departments) {
-				__out += '<div' + _$_.attr('class', `dept-${dept.id}`) + '><h2 class="dept-name">' + _$_.escape(dept.name) + '</h2><!--[-->';
+				__out += '<div' + _$_.attr('class', `dept-${dept.id}`) + '><h2 class="dept-name">';
+
+				{
+					_$_.output_push(__out);
+					__out = '';
+					_$_.render_expression(dept.name);
+				}
+
+				__out += '</h2><!--[-->';
 
 				for (const team of dept.teams) {
-					__out += '<div' + _$_.attr('class', `team-${team.id}`) + '><h3 class="team-name">' + _$_.escape(team.name) + '</h3><ul><!--[-->';
+					__out += '<div' + _$_.attr('class', `team-${team.id}`) + '><h3 class="team-name">';
+
+					{
+						_$_.output_push(__out);
+						__out = '';
+						_$_.render_expression(team.name);
+					}
+
+					__out += '</h3><ul><!--[-->';
 
 					for (const member of team.members) {
-						__out += '<li class="member">' + _$_.escape(member) + '</li>';
+						__out += '<li class="member">';
+
+						{
+							_$_.output_push(__out);
+							__out = '';
+							_$_.render_expression(member);
+						}
+
+						__out += '</li>';
 					}
 
 					__out += '<!--]--></ul></div>';
@@ -513,7 +665,15 @@ export function ForLoopWithSiblings() {
 			__out += '<div class="wrapper"><header class="before">Before</header><!--[-->';
 
 			for (const item of lazy_13.value) {
-				__out += '<div' + _$_.attr('class', `item-${item}`) + '>' + _$_.escape(item) + '</div>';
+				__out += '<div' + _$_.attr('class', `item-${item}`) + '>';
+
+				{
+					_$_.output_push(__out);
+					__out = '';
+					_$_.render_expression(item);
+				}
+
+				__out += '</div>';
 			}
 
 			__out += '<!--]--><footer class="after">After</footer></div><button class="add">Add</button>';
@@ -575,7 +735,15 @@ export function ForLoopSingleItem() {
 			__out += '<ul><!--[-->';
 
 			for (const item of items) {
-				__out += '<li class="single">' + _$_.escape(item) + '</li>';
+				__out += '<li class="single">';
+
+				{
+					_$_.output_push(__out);
+					__out = '';
+					_$_.render_expression(item);
+				}
+
+				__out += '</li>';
 			}
 
 			__out += '<!--]--></ul>';
@@ -594,7 +762,15 @@ export function ForLoopAddAtBeginning() {
 			__out += '<button class="prepend">Prepend A</button><ul><!--[-->';
 
 			for (const item of lazy_15.value) {
-				__out += '<li' + _$_.attr('class', `item-${item}`) + '>' + _$_.escape(item) + '</li>';
+				__out += '<li' + _$_.attr('class', `item-${item}`) + '>';
+
+				{
+					_$_.output_push(__out);
+					__out = '';
+					_$_.render_expression(item);
+				}
+
+				__out += '</li>';
 			}
 
 			__out += '<!--]--></ul>';
@@ -613,7 +789,15 @@ export function ForLoopAddInMiddle() {
 			__out += '<button class="insert">Insert B</button><ul><!--[-->';
 
 			for (const item of lazy_16.value) {
-				__out += '<li' + _$_.attr('class', `item-${item}`) + '>' + _$_.escape(item) + '</li>';
+				__out += '<li' + _$_.attr('class', `item-${item}`) + '>';
+
+				{
+					_$_.output_push(__out);
+					__out = '';
+					_$_.render_expression(item);
+				}
+
+				__out += '</li>';
 			}
 
 			__out += '<!--]--></ul>';
@@ -632,7 +816,15 @@ export function ForLoopRemoveFromMiddle() {
 			__out += '<button class="remove-middle">Remove B</button><ul><!--[-->';
 
 			for (const item of lazy_17.value) {
-				__out += '<li' + _$_.attr('class', `item-${item}`) + '>' + _$_.escape(item) + '</li>';
+				__out += '<li' + _$_.attr('class', `item-${item}`) + '>';
+
+				{
+					_$_.output_push(__out);
+					__out = '';
+					_$_.render_expression(item);
+				}
+
+				__out += '</li>';
 			}
 
 			__out += '<!--]--></ul>';
@@ -656,7 +848,15 @@ export function ForLoopLargeList() {
 				var i = 0;
 
 				for (const item of items) {
-					__out += '<li' + _$_.attr('class', `item-${i}`) + '>' + _$_.escape(item) + '</li>';
+					__out += '<li' + _$_.attr('class', `item-${i}`) + '>';
+
+					{
+						_$_.output_push(__out);
+						__out = '';
+						_$_.render_expression(item);
+					}
+
+					__out += '</li>';
 					i++;
 				}
 
@@ -679,7 +879,15 @@ export function ForLoopSwap() {
 			__out += '<button class="swap">Swap First and Last</button><ul><!--[-->';
 
 			for (const item of lazy_18.value) {
-				__out += '<li' + _$_.attr('class', `item-${item}`) + '>' + _$_.escape(item) + '</li>';
+				__out += '<li' + _$_.attr('class', `item-${item}`) + '>';
+
+				{
+					_$_.output_push(__out);
+					__out = '';
+					_$_.render_expression(item);
+				}
+
+				__out += '</li>';
 			}
 
 			__out += '<!--]--></ul>';
@@ -698,7 +906,15 @@ export function ForLoopReverse() {
 			__out += '<button class="reverse">Reverse</button><ul><!--[-->';
 
 			for (const item of lazy_19.value) {
-				__out += '<li' + _$_.attr('class', `item-${item}`) + '>' + _$_.escape(item) + '</li>';
+				__out += '<li' + _$_.attr('class', `item-${item}`) + '>';
+
+				{
+					_$_.output_push(__out);
+					__out = '';
+					_$_.render_expression(item);
+				}
+
+				__out += '</li>';
 			}
 
 			__out += '<!--]--></ul>';

--- a/packages/ripple/tests/hydration/compiled/server/head.js
+++ b/packages/ripple/tests/hydration/compiled/server/head.js
@@ -28,7 +28,15 @@ export function ReactiveTitle() {
 		_$_.regular_block(() => {
 			let __out = '';
 
-			__out += '<div><span>' + _$_.escape(lazy.value) + '</span></div>';
+			__out += '<div><span>';
+
+			{
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_expression(lazy.value);
+			}
+
+			__out += '</span></div>';
 			_$_.output_push(__out);
 			__out = '';
 			_$_.set_output_target('head');
@@ -66,7 +74,15 @@ export function ReactiveMetaTags() {
 		_$_.regular_block(() => {
 			let __out = '';
 
-			__out += '<div>' + _$_.escape(lazy_1.value) + '</div>';
+			__out += '<div>';
+
+			{
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_expression(lazy_1.value);
+			}
+
+			__out += '</div>';
 			_$_.output_push(__out);
 			__out = '';
 			_$_.set_output_target('head');
@@ -86,7 +102,15 @@ export function TitleWithTemplate() {
 		_$_.regular_block(() => {
 			let __out = '';
 
-			__out += '<div>' + _$_.escape(lazy_2.value) + '</div>';
+			__out += '<div>';
+
+			{
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_expression(lazy_2.value);
+			}
+
+			__out += '</div>';
 			_$_.output_push(__out);
 			__out = '';
 			_$_.set_output_target('head');
@@ -125,7 +149,15 @@ export function ConditionalTitle() {
 		_$_.regular_block(() => {
 			let __out = '';
 
-			__out += '<div>' + _$_.escape(lazy_4.value) + '</div>';
+			__out += '<div>';
+
+			{
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_expression(lazy_4.value);
+			}
+
+			__out += '</div>';
 			_$_.output_push(__out);
 			__out = '';
 			_$_.set_output_target('head');
@@ -146,7 +178,15 @@ export function ComputedTitle() {
 		_$_.regular_block(() => {
 			let __out = '';
 
-			__out += '<div><span>' + _$_.escape(lazy_5.value) + '</span></div>';
+			__out += '<div><span>';
+
+			{
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_expression(lazy_5.value);
+			}
+
+			__out += '</span></div>';
 			_$_.output_push(__out);
 			__out = '';
 			_$_.set_output_target('head');

--- a/packages/ripple/tests/hydration/compiled/server/html.js
+++ b/packages/ripple/tests/hydration/compiled/server/html.js
@@ -321,7 +321,7 @@ export function DocLayout(__props) {
 					_$_.output_push('>');
 
 					{
-						_$_.output_push(_$_.escape(_$_.fallback(__props.nextLink, null).text));
+						_$_.render_expression(_$_.fallback(__props.nextLink, null).text);
 					}
 
 					_$_.output_push('</a>');
@@ -367,7 +367,7 @@ export function DocLayout(__props) {
 								_$_.output_push('>');
 
 								{
-									_$_.output_push(_$_.escape(item.text));
+									_$_.render_expression(item.text);
 								}
 
 								_$_.output_push('</a>');
@@ -711,7 +711,15 @@ function ForList({ items }) {
 			__out += '<!--[-->';
 
 			for (const item of items) {
-				__out += '<span class="for-item">' + _$_.escape(item) + '</span>';
+				__out += '<span class="for-item">';
+
+				{
+					_$_.output_push(__out);
+					__out = '';
+					_$_.render_expression(item);
+				}
+
+				__out += '</span>';
 			}
 
 			__out += '<!--]-->';
@@ -957,7 +965,15 @@ function NavItem(__props) {
 				_$_.output_push('</div>');
 			}
 
-			__out += '<!--]--><a' + _$_.attr('href', __props.href, false) + '><span>' + _$_.escape(__props.text) + '</span></a></div>';
+			__out += '<!--]--><a' + _$_.attr('href', __props.href, false) + '><span>';
+
+			{
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_expression(__props.text);
+			}
+
+			__out += '</span></a></div>';
 			_$_.output_push(__out);
 		});
 	});
@@ -1482,7 +1498,7 @@ function DocsLayoutInner(__props) {
 					_$_.output_push('>');
 
 					{
-						_$_.output_push(_$_.escape(_$_.fallback(__props.nextLink, null).text));
+						_$_.render_expression(_$_.fallback(__props.nextLink, null).text);
 					}
 
 					_$_.output_push('</a>');
@@ -1647,7 +1663,7 @@ function DocsLayoutExact(__props) {
 							_$_.output_push('>');
 
 							{
-								_$_.output_push(_$_.escape(_$_.fallback(__props.prevLink, null).text));
+								_$_.render_expression(_$_.fallback(__props.prevLink, null).text);
 							}
 
 							_$_.output_push('</span>');
@@ -1675,7 +1691,7 @@ function DocsLayoutExact(__props) {
 							_$_.output_push('>');
 
 							{
-								_$_.output_push(_$_.escape(_$_.fallback(__props.nextLink, null).text));
+								_$_.render_expression(_$_.fallback(__props.nextLink, null).text);
 							}
 
 							_$_.output_push('</span>');
@@ -1724,7 +1740,7 @@ function DocsLayoutExact(__props) {
 							_$_.output_push('>');
 
 							{
-								_$_.output_push(_$_.escape(item.text));
+								_$_.render_expression(item.text);
 							}
 
 							_$_.output_push('</a>');

--- a/packages/ripple/tests/hydration/compiled/server/if-fragment-controlflow.js
+++ b/packages/ripple/tests/hydration/compiled/server/if-fragment-controlflow.js
@@ -15,7 +15,15 @@ export function IfFragmentForElement() {
 				__out += '<!--[--><!--[-->';
 
 				for (const muze of muzes) {
-					__out += '<p class="muze">' + _$_.escape(muze.muzeId) + '</p>';
+					__out += '<p class="muze">';
+
+					{
+						_$_.output_push(__out);
+						__out = '';
+						_$_.render_expression(muze.muzeId);
+					}
+
+					__out += '</p>';
 				}
 
 				__out += '<!--]--><span class="after">after</span><!--]-->';
@@ -41,7 +49,15 @@ export function IfFragmentForIfIf() {
 				__out += '<!--[--><!--[-->';
 
 				for (const muze of muzes) {
-					__out += '<p class="muze">' + _$_.escape(muze.muzeId) + '</p>';
+					__out += '<p class="muze">';
+
+					{
+						_$_.output_push(__out);
+						__out = '';
+						_$_.render_expression(muze.muzeId);
+					}
+
+					__out += '</p>';
 				}
 
 				__out += '<!--]--><!--[-->';
@@ -94,7 +110,15 @@ export function ComponentBodyFragmentControlFlow() {
 			__out += '<!--[--><!--[-->';
 
 			for (const muze of muzes) {
-				__out += '<p class="muze">' + _$_.escape(muze.muzeId) + '</p>';
+				__out += '<p class="muze">';
+
+				{
+					_$_.output_push(__out);
+					__out = '';
+					_$_.render_expression(muze.muzeId);
+				}
+
+				__out += '</p>';
 			}
 
 			__out += '<!--]--><span class="after">after</span><!--]-->';
@@ -121,7 +145,15 @@ export function ComponentBodyCodeBlockControlFlow() {
 				__out += '<!--[-->';
 
 				for (const muze of rows) {
-					__out += '<p class="muze">' + _$_.escape(muze.muzeId) + '</p>';
+					__out += '<p class="muze">';
+
+					{
+						_$_.output_push(__out);
+						__out = '';
+						_$_.render_expression(muze.muzeId);
+					}
+
+					__out += '</p>';
 				}
 
 				__out += '<!--]-->';
@@ -156,7 +188,15 @@ export function IfCodeBlockControlFlow() {
 					__out += '<!--[-->';
 
 					for (const muze of rows) {
-						__out += '<p class="muze">' + _$_.escape(muze.muzeId) + '</p>';
+						__out += '<p class="muze">';
+
+						{
+							_$_.output_push(__out);
+							__out = '';
+							_$_.render_expression(muze.muzeId);
+						}
+
+						__out += '</p>';
 					}
 
 					__out += '<!--]-->';
@@ -188,7 +228,15 @@ export function IfElseFragment() {
 				__out += '<!--[--><!--[-->';
 
 				for (const muze of muzes) {
-					__out += '<p class="muze">' + _$_.escape(muze.muzeId) + '</p>';
+					__out += '<p class="muze">';
+
+					{
+						_$_.output_push(__out);
+						__out = '';
+						_$_.render_expression(muze.muzeId);
+					}
+
+					__out += '</p>';
 				}
 
 				__out += '<!--]--><span class="after">after</span><!--]-->';
@@ -214,7 +262,15 @@ export function IfDivFragment() {
 				__out += '<section><!--[--><!--[-->';
 
 				for (const muze of muzes) {
-					__out += '<p class="muze">' + _$_.escape(muze.muzeId) + '</p>';
+					__out += '<p class="muze">';
+
+					{
+						_$_.output_push(__out);
+						__out = '';
+						_$_.render_expression(muze.muzeId);
+					}
+
+					__out += '</p>';
 				}
 
 				__out += '<!--]--><span class="after">after</span><!--]--></section>';

--- a/packages/ripple/tests/hydration/compiled/server/if-fragment-controlflow.js
+++ b/packages/ripple/tests/hydration/compiled/server/if-fragment-controlflow.js
@@ -12,7 +12,7 @@ export function IfFragmentForElement() {
 			__out += '<div class="feed-c"><!--[-->';
 
 			if (hasLoaded) {
-				__out += '<!--[--><!--[-->';
+				__out += '<!--[-->';
 
 				for (const muze of muzes) {
 					__out += '<p class="muze">';
@@ -26,7 +26,7 @@ export function IfFragmentForElement() {
 					__out += '</p>';
 				}
 
-				__out += '<!--]--><span class="after">after</span><!--]-->';
+				__out += '<!--]--><span class="after">after</span>';
 			}
 
 			__out += '<!--]--></div>';
@@ -46,7 +46,7 @@ export function IfFragmentForIfIf() {
 			__out += '<div class="feed"><!--[-->';
 
 			if (hasLoaded) {
-				__out += '<!--[--><!--[-->';
+				__out += '<!--[-->';
 
 				for (const muze of muzes) {
 					__out += '<p class="muze">';
@@ -72,7 +72,7 @@ export function IfFragmentForIfIf() {
 					__out += '<span class="empty">empty</span>';
 				}
 
-				__out += '<!--]--><!--]-->';
+				__out += '<!--]-->';
 			}
 
 			__out += '<!--]--></div>';
@@ -91,7 +91,7 @@ export function IfFragmentElements() {
 			__out += '<div class="feed-b"><!--[-->';
 
 			if (hasLoaded) {
-				__out += '<!--[--><p class="muze">b</p><p class="muze">c</p><!--]-->';
+				__out += '<p class="muze">b</p><p class="muze">c</p>';
 			}
 
 			__out += '<!--]--></div>';
@@ -177,7 +177,6 @@ export function IfCodeBlockControlFlow() {
 			__out += '<div class="feed-f"><!--[-->';
 
 			if (hasLoaded) {
-				__out += '<!--[-->';
 				_$_.output_push(__out);
 				__out = '';
 
@@ -203,7 +202,7 @@ export function IfCodeBlockControlFlow() {
 					_$_.output_push(__out);
 				}));
 
-				__out += '<span class="after">after</span><!--]-->';
+				__out += '<span class="after">after</span>';
 			}
 
 			__out += '<!--]--></div>';
@@ -225,7 +224,7 @@ export function IfElseFragment() {
 			if (hasLoaded) {
 				__out += '<span class="loading">loading</span>';
 			} else {
-				__out += '<!--[--><!--[-->';
+				__out += '<!--[-->';
 
 				for (const muze of muzes) {
 					__out += '<p class="muze">';
@@ -239,7 +238,7 @@ export function IfElseFragment() {
 					__out += '</p>';
 				}
 
-				__out += '<!--]--><span class="after">after</span><!--]-->';
+				__out += '<!--]--><span class="after">after</span>';
 			}
 
 			__out += '<!--]--></div>';
@@ -259,7 +258,7 @@ export function IfDivFragment() {
 			__out += '<div class="feed-e"><!--[-->';
 
 			if (hasLoaded) {
-				__out += '<section><!--[--><!--[-->';
+				__out += '<section><!--[-->';
 
 				for (const muze of muzes) {
 					__out += '<p class="muze">';
@@ -273,7 +272,7 @@ export function IfDivFragment() {
 					__out += '</p>';
 				}
 
-				__out += '<!--]--><span class="after">after</span><!--]--></section>';
+				__out += '<!--]--><span class="after">after</span></section>';
 			}
 
 			__out += '<!--]--></div>';

--- a/packages/ripple/tests/hydration/compiled/server/mixed-control-flow.js
+++ b/packages/ripple/tests/hydration/compiled/server/mixed-control-flow.js
@@ -219,7 +219,15 @@ function AsyncRow({ label }) {
 		_$_.regular_block(() => {
 			let __out = '';
 
-			__out += '<div class="resolved-row">' + _$_.escape(lazy_3.value) + '</div>';
+			__out += '<div class="resolved-row">';
+
+			{
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_expression(lazy_3.value);
+			}
+
+			__out += '</div>';
 			_$_.output_push(__out);
 		});
 	});

--- a/packages/ripple/tests/hydration/compiled/server/nested-control-flow.js
+++ b/packages/ripple/tests/hydration/compiled/server/nested-control-flow.js
@@ -18,7 +18,15 @@ export function ForIf() {
 				__out += '<!--[-->';
 
 				if (item.show) {
-					__out += '<li' + _$_.attr('class', `item item-${item.id}`) + '>' + _$_.escape(item.label) + '</li>';
+					__out += '<li' + _$_.attr('class', `item item-${item.id}`) + '>';
+
+					{
+						_$_.output_push(__out);
+						__out = '';
+						_$_.render_expression(item.label);
+					}
+
+					__out += '</li>';
 				}
 
 				__out += '<!--]-->';

--- a/packages/ripple/tests/hydration/compiled/server/reactivity.js
+++ b/packages/ripple/tests/hydration/compiled/server/reactivity.js
@@ -10,7 +10,15 @@ export function TrackedState() {
 		_$_.regular_block(() => {
 			let __out = '';
 
-			__out += '<div class="count">' + _$_.escape(lazy.value) + '</div>';
+			__out += '<div class="count">';
+
+			{
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_expression(lazy.value);
+			}
+
+			__out += '</div>';
 			_$_.output_push(__out);
 		});
 	});
@@ -23,7 +31,15 @@ export function CounterWithInitial(props) {
 		_$_.regular_block(() => {
 			let __out = '';
 
-			__out += '<div><span class="count">' + _$_.escape(lazy_1.value) + '</span></div>';
+			__out += '<div><span class="count">';
+
+			{
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_expression(lazy_1.value);
+			}
+
+			__out += '</span></div>';
 			_$_.output_push(__out);
 		});
 	});
@@ -74,7 +90,31 @@ export function MultipleTracked() {
 		_$_.regular_block(() => {
 			let __out = '';
 
-			__out += '<div class="multiple-tracked"><div class="x">' + _$_.escape(lazy_4.value) + '</div><div class="y">' + _$_.escape(lazy_5.value) + '</div><div class="z">' + _$_.escape(lazy_6.value) + '</div></div>';
+			__out += '<div class="multiple-tracked"><div class="x">';
+
+			{
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_expression(lazy_4.value);
+			}
+
+			__out += '</div><div class="y">';
+
+			{
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_expression(lazy_5.value);
+			}
+
+			__out += '</div><div class="z">';
+
+			{
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_expression(lazy_6.value);
+			}
+
+			__out += '</div></div>';
 			_$_.output_push(__out);
 		});
 	});

--- a/packages/ripple/tests/hydration/compiled/server/streaming.js
+++ b/packages/ripple/tests/hydration/compiled/server/streaming.js
@@ -350,7 +350,7 @@ function HeadContent() {
 			__out += '<!--[--><!--[-->';
 
 			if (lazy_5.value) {
-				__out += '<!--[--><p class="head-content">';
+				__out += '<p class="head-content">';
 
 				{
 					_$_.output_push(__out);
@@ -366,7 +366,6 @@ function HeadContent() {
 				_$_.output_push(__out);
 				__out = '';
 				_$_.set_output_target(null);
-				__out += '<!--]-->';
 			}
 
 			__out += '<!--]--><!--]-->';
@@ -494,41 +493,55 @@ export function StreamNested() {
 
 				_$_.regular_block(() => {
 					{
-						{
-							const comp = OuterContent;
-							const args = [{}];
+						const comp = OuterContent;
+						const args = [{}];
 
-							_$_.render_component(comp, ...args);
-						}
-
-						_$_.try_block(
-							() => {
-								let __out = '';
-
-								__out += '<!--[-->';
-
-								{
-									const comp = InnerContent;
-									const args = [{}];
-
-									_$_.output_push(__out);
-									__out = '';
-									_$_.render_component(comp, ...args);
-								}
-
-								__out += '<!--]-->';
-								_$_.output_push(__out);
-							},
-							null,
-							() => {
-								let __out = '';
-
-								__out += '<!--[--><p class="inner-loading">inner-loading</p><!--]-->';
-								_$_.output_push(__out);
-							}
-						);
+						_$_.render_component(comp, ...args);
 					}
 				});
+
+				_$_.output_push(__out);
+				__out = '';
+
+				_$_.try_block(
+					() => {
+						let __out = '';
+
+						__out += '<!--[-->';
+						_$_.output_push(__out);
+						__out = '';
+
+						_$_.regular_block(() => {
+							{
+								const comp = InnerContent;
+								const args = [{}];
+
+								_$_.render_component(comp, ...args);
+							}
+						});
+
+						__out += '<!--]-->';
+						_$_.output_push(__out);
+					},
+					null,
+					() => {
+						let __out = '';
+
+						__out += '<!--[-->';
+						_$_.output_push(__out);
+						__out = '';
+
+						_$_.regular_block(() => {
+							let __out = '';
+
+							__out += '<p class="inner-loading">inner-loading</p>';
+							_$_.output_push(__out);
+						});
+
+						__out += '<!--]-->';
+						_$_.output_push(__out);
+					}
+				);
 
 				__out += '<!--]-->';
 				_$_.output_push(__out);

--- a/packages/ripple/tests/hydration/compiled/server/streaming.js
+++ b/packages/ripple/tests/hydration/compiled/server/streaming.js
@@ -93,7 +93,15 @@ function CatchOnlyContent() {
 		_$_.regular_block(() => {
 			let __out = '';
 
-			__out += '<p class="resolved">' + _$_.escape(lazy_2.value) + '</p>';
+			__out += '<p class="resolved">';
+
+			{
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_expression(lazy_2.value);
+			}
+
+			__out += '</p>';
 			_$_.output_push(__out);
 		});
 	});
@@ -129,7 +137,15 @@ export function StreamCatchOnly() {
 				(e) => {
 					let __out = '';
 
-					__out += '<!--[--><em class="caught">' + _$_.escape(e.message) + '</em><!--]-->';
+					__out += '<!--[--><em class="caught">';
+
+					{
+						_$_.output_push(__out);
+						__out = '';
+						_$_.render_expression(e.message);
+					}
+
+					__out += '</em><!--]-->';
 					_$_.output_push(__out);
 				},
 				null
@@ -147,7 +163,15 @@ function RejectContent() {
 		_$_.regular_block(() => {
 			let __out = '';
 
-			__out += '<p class="resolved">' + _$_.escape(lazy_3.value) + '</p>';
+			__out += '<p class="resolved">';
+
+			{
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_expression(lazy_3.value);
+			}
+
+			__out += '</p>';
 			_$_.output_push(__out);
 		});
 	});
@@ -185,7 +209,15 @@ export function StreamRejects() {
 				_$_.regular_block(() => {
 					let __out = '';
 
-					__out += '<em class="caught">' + _$_.escape(e.message) + '</em>';
+					__out += '<em class="caught">';
+
+					{
+						_$_.output_push(__out);
+						__out = '';
+						_$_.render_expression(e.message);
+					}
+
+					__out += '</em>';
 					_$_.output_push(__out);
 				});
 
@@ -220,7 +252,15 @@ function NoCatchContent() {
 		_$_.regular_block(() => {
 			let __out = '';
 
-			__out += '<p class="resolved">' + _$_.escape(lazy_4.value) + '</p>';
+			__out += '<p class="resolved">';
+
+			{
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_expression(lazy_4.value);
+			}
+
+			__out += '</p>';
 			_$_.output_push(__out);
 		});
 	});
@@ -275,7 +315,15 @@ export function RootCatch({ error, reset }) {
 		_$_.regular_block(() => {
 			let __out = '';
 
-			__out += '<section class="root-catch">' + _$_.escape(error.message) + '</section>';
+			__out += '<section class="root-catch">';
+
+			{
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_expression(error.message);
+			}
+
+			__out += '</section>';
 			_$_.output_push(__out);
 		});
 	});
@@ -302,7 +350,15 @@ function HeadContent() {
 			__out += '<!--[--><!--[-->';
 
 			if (lazy_5.value) {
-				__out += '<!--[--><p class="head-content">' + _$_.escape(lazy_5.value) + '</p>';
+				__out += '<!--[--><p class="head-content">';
+
+				{
+					_$_.output_push(__out);
+					__out = '';
+					_$_.render_expression(lazy_5.value);
+				}
+
+				__out += '</p>';
 				_$_.output_push(__out);
 				__out = '';
 				_$_.set_output_target('head');
@@ -370,7 +426,15 @@ export function StreamRootDirect() {
 		_$_.regular_block(() => {
 			let __out = '';
 
-			__out += '<p class="root-async">' + _$_.escape(lazy_6.value) + '</p>';
+			__out += '<p class="root-async">';
+
+			{
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_expression(lazy_6.value);
+			}
+
+			__out += '</p>';
 			_$_.output_push(__out);
 		});
 	});
@@ -383,7 +447,15 @@ function OuterContent() {
 		_$_.regular_block(() => {
 			let __out = '';
 
-			__out += '<p class="outer">' + _$_.escape(lazy_7.value) + '</p>';
+			__out += '<p class="outer">';
+
+			{
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_expression(lazy_7.value);
+			}
+
+			__out += '</p>';
 			_$_.output_push(__out);
 		});
 	});
@@ -396,7 +468,15 @@ function InnerContent() {
 		_$_.regular_block(() => {
 			let __out = '';
 
-			__out += '<p class="inner">' + _$_.escape(lazy_8.value) + '</p>';
+			__out += '<p class="inner">';
+
+			{
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_expression(lazy_8.value);
+			}
+
+			__out += '</p>';
 			_$_.output_push(__out);
 		});
 	});

--- a/packages/ripple/tests/hydration/compiled/server/track-async-serialization.js
+++ b/packages/ripple/tests/hydration/compiled/server/track-async-serialization.js
@@ -24,7 +24,15 @@ function ServerCallResult({ count }) {
 		_$_.regular_block(() => {
 			let __out = '';
 
-			__out += '<p class="result">' + _$_.escape(lazy.value) + '</p>';
+			__out += '<p class="result">';
+
+			{
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_expression(lazy.value);
+			}
+
+			__out += '</p>';
 			_$_.output_push(__out);
 		});
 	});
@@ -89,7 +97,15 @@ export function AsyncSimpleValue() {
 				_$_.regular_block(() => {
 					let __out = '';
 
-					__out += '<p class="result">' + _$_.escape(lazy_2.value) + '</p>';
+					__out += '<p class="result">';
+
+					{
+						_$_.output_push(__out);
+						__out = '';
+						_$_.render_expression(lazy_2.value);
+					}
+
+					__out += '</p>';
 					_$_.output_push(__out);
 				});
 
@@ -134,7 +150,15 @@ export function AsyncNumericValue() {
 				_$_.regular_block(() => {
 					let __out = '';
 
-					__out += '<span class="count">' + _$_.escape(lazy_3.value) + '</span>';
+					__out += '<span class="count">';
+
+					{
+						_$_.output_push(__out);
+						__out = '';
+						_$_.render_expression(lazy_3.value);
+					}
+
+					__out += '</span>';
 					_$_.output_push(__out);
 				});
 
@@ -179,7 +203,23 @@ export function AsyncObjectValue() {
 				_$_.regular_block(() => {
 					let __out = '';
 
-					__out += '<div class="user"><span class="name">' + _$_.escape(lazy_4.value.name) + '</span><span class="age">' + _$_.escape(lazy_4.value.age) + '</span></div>';
+					__out += '<div class="user"><span class="name">';
+
+					{
+						_$_.output_push(__out);
+						__out = '';
+						_$_.render_expression(lazy_4.value.name);
+					}
+
+					__out += '</span><span class="age">';
+
+					{
+						_$_.output_push(__out);
+						__out = '';
+						_$_.render_expression(lazy_4.value.age);
+					}
+
+					__out += '</span></div>';
 					_$_.output_push(__out);
 				});
 
@@ -225,7 +265,23 @@ export function AsyncMultipleValues() {
 				_$_.regular_block(() => {
 					let __out = '';
 
-					__out += '<div class="multi"><span class="first">' + _$_.escape(lazy_5.value) + '</span><span class="second">' + _$_.escape(lazy_6.value) + '</span></div>';
+					__out += '<div class="multi"><span class="first">';
+
+					{
+						_$_.output_push(__out);
+						__out = '';
+						_$_.render_expression(lazy_5.value);
+					}
+
+					__out += '</span><span class="second">';
+
+					{
+						_$_.output_push(__out);
+						__out = '';
+						_$_.render_expression(lazy_6.value);
+					}
+
+					__out += '</span></div>';
 					_$_.output_push(__out);
 				});
 
@@ -270,7 +326,15 @@ export function AsyncWithCatch() {
 				_$_.regular_block(() => {
 					let __out = '';
 
-					__out += '<p class="result">' + _$_.escape(lazy_7.value) + '</p>';
+					__out += '<p class="result">';
+
+					{
+						_$_.output_push(__out);
+						__out = '';
+						_$_.render_expression(lazy_7.value);
+					}
+
+					__out += '</p>';
 					_$_.output_push(__out);
 				});
 
@@ -287,7 +351,15 @@ export function AsyncWithCatch() {
 				_$_.regular_block(() => {
 					let __out = '';
 
-					__out += '<p class="error">' + _$_.escape(e.message) + '</p>';
+					__out += '<p class="error">';
+
+					{
+						_$_.output_push(__out);
+						__out = '';
+						_$_.render_expression(e.message);
+					}
+
+					__out += '</p>';
 					_$_.output_push(__out);
 				});
 
@@ -331,7 +403,15 @@ export function ChildWithError() {
 				_$_.regular_block(() => {
 					let __out = '';
 
-					__out += '<p class="result">' + _$_.escape(lazy_8.value) + '</p>';
+					__out += '<p class="result">';
+
+					{
+						_$_.output_push(__out);
+						__out = '';
+						_$_.render_expression(lazy_8.value);
+					}
+
+					__out += '</p>';
 					_$_.output_push(__out);
 				});
 
@@ -392,7 +472,15 @@ export function ParentWithCatch() {
 				_$_.regular_block(() => {
 					let __out = '';
 
-					__out += '<p class="parent-error">' + _$_.escape(e.message) + '</p>';
+					__out += '<p class="parent-error">';
+
+					{
+						_$_.output_push(__out);
+						__out = '';
+						_$_.render_expression(e.message);
+					}
+
+					__out += '</p>';
 					_$_.output_push(__out);
 				});
 
@@ -411,7 +499,15 @@ function ReactiveDependencyResult({ count }) {
 		_$_.regular_block(() => {
 			let __out = '';
 
-			__out += '<p class="result">' + _$_.escape(lazy_9.value) + '</p>';
+			__out += '<p class="result">';
+
+			{
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_expression(lazy_9.value);
+			}
+
+			__out += '</p>';
 			_$_.output_push(__out);
 		});
 	});

--- a/packages/ripple/tests/hydration/compiled/server/try.js
+++ b/packages/ripple/tests/hydration/compiled/server/try.js
@@ -19,7 +19,15 @@ export function RootCatch({ error, reset }) {
 		_$_.regular_block(() => {
 			let __out = '';
 
-			__out += '<section class="root-catch"><p class="root-error">' + _$_.escape(error.message) + '</p><button class="root-reset">retry</button></section>';
+			__out += '<section class="root-catch"><p class="root-error">';
+
+			{
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_expression(error.message);
+			}
+
+			__out += '</p><button class="root-reset">retry</button></section>';
 			_$_.output_push(__out);
 		});
 	});
@@ -45,7 +53,15 @@ export function RootAsyncDirect() {
 		_$_.regular_block(() => {
 			let __out = '';
 
-			__out += '<p class="root-async-value">' + _$_.escape(lazy.value) + '</p>';
+			__out += '<p class="root-async-value">';
+
+			{
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_expression(lazy.value);
+			}
+
+			__out += '</p>';
 			_$_.output_push(__out);
 		});
 	});
@@ -58,7 +74,15 @@ export function RootAsyncRejects() {
 		_$_.regular_block(() => {
 			let __out = '';
 
-			__out += '<p class="root-async-value">' + _$_.escape(lazy_1.value) + '</p>';
+			__out += '<p class="root-async-value">';
+
+			{
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_expression(lazy_1.value);
+			}
+
+			__out += '</p>';
 			_$_.output_push(__out);
 		});
 	});
@@ -118,7 +142,15 @@ function AsyncList() {
 			__out += '<ul class="items"><!--[-->';
 
 			for (let item of lazy_2.value) {
-				__out += '<li>' + _$_.escape(item) + '</li>';
+				__out += '<li>';
+
+				{
+					_$_.output_push(__out);
+					__out = '';
+					_$_.render_expression(item);
+				}
+
+				__out += '</li>';
 			}
 
 			__out += '<!--]--></ul>';
@@ -175,7 +207,15 @@ function AsyncContent() {
 		_$_.regular_block(() => {
 			let __out = '';
 
-			__out += '<div class="resolved">' + _$_.escape(lazy_3.value) + '</div>';
+			__out += '<div class="resolved">';
+
+			{
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_expression(lazy_3.value);
+			}
+
+			__out += '</div>';
 			_$_.output_push(__out);
 		});
 	});

--- a/packages/ripple/tests/hydration/components/basic.tsrx
+++ b/packages/ripple/tests/hydration/components/basic.tsrx
@@ -338,9 +338,11 @@ export function TextTailExpression() @{
 }
 
 export function FragmentTailExpression() @{
+	// prettier-ignore
 	<div><>{'frag-'}</>{String(fetchLabel())}</div>
 }
 
 export function FragmentChildOnly() @{
+	// prettier-ignore
 	<div><>{'frag-'}</><span>{'tail'}</span></div>
 }

--- a/packages/ripple/tests/hydration/components/basic.tsrx
+++ b/packages/ripple/tests/hydration/components/basic.tsrx
@@ -326,3 +326,21 @@ export function NestedComponentAsLastSibling() @{
 		<InnerContent />
 	</section>
 }
+
+// A call-containing but provably-text-primitive expression following inlined
+// text: client and server must agree on the DOM shape for the text run.
+function fetchLabel() {
+	return 'fetched';
+}
+
+export function TextTailExpression() @{
+	<div>label: {String(fetchLabel())}</div>
+}
+
+export function FragmentTailExpression() @{
+	<div><>{'frag-'}</>{String(fetchLabel())}</div>
+}
+
+export function FragmentChildOnly() @{
+	<div><>{'frag-'}</><span>{'tail'}</span></div>
+}

--- a/packages/ripple/tests/hydration/components/basic.tsrx
+++ b/packages/ripple/tests/hydration/components/basic.tsrx
@@ -346,3 +346,26 @@ export function FragmentChildOnly() @{
 	// prettier-ignore
 	<div><>{'frag-'}</><span>{'tail'}</span></div>
 }
+
+// Fragment-boundary marker prediction: the fragment brackets itself only when
+// its first renderable child emits its own markers — the prediction must match
+// what the expression visitor actually emits.
+function OpaqueLead(props: { header: unknown }) @{
+	// prettier-ignore
+	<>{props.header}<p>{'after-opaque'}</p></>
+}
+
+export function FragmentLeadsWithOpaqueValue() @{
+	// prettier-ignore
+	<div><OpaqueLead header={'H'} /></div>
+}
+
+function PrimitiveCallLead() @{
+	// prettier-ignore
+	<>{String(fetchLabel())}<p>{'after-call'}</p></>
+}
+
+export function FragmentLeadsWithPrimitiveCall() @{
+	// prettier-ignore
+	<div><PrimitiveCallLead /></div>
+}

--- a/packages/ripple/tests/server/basic.test.tsrx
+++ b/packages/ripple/tests/server/basic.test.tsrx
@@ -598,4 +598,23 @@ second
 			'<div class="block-function">function inner / function outer</div><div class="block-arrow">22</div><div class="block-method">method inner / method outer</div>',
 		);
 	});
+
+	it('renders a template element inside an expression container child', async () => {
+		function App() @{
+			<div>
+				{<h1>
+					@if (true) {
+						<span>{'yes'}</span>
+					} @else {
+						<span>{'no'}</span>
+					}
+				</h1>}
+			</div>
+		}
+
+		const { body } = await render(App);
+		expect(body).toContain('<h1>');
+		expect(body).toContain('<span>yes</span>');
+		expect(body).not.toContain('<span>no</span>');
+	});
 });

--- a/packages/ripple/tests/server/compiler.test.tsrx
+++ b/packages/ripple/tests/server/compiler.test.tsrx
@@ -226,6 +226,10 @@ function tag() {
 const values = { member: 0 };`;
 
 		const cases = [
+			// Call-containing but provably-text-primitive expressions — `empty() + ''`,
+			// `\`${empty()}\``, `void empty()`, `values[getKey()]++` — are NOT in this
+			// list: they cannot hold an element, so they DO merge into the text run
+			// (see 'merges provably-primitive call-containing children').
 			{ name: 'call expression', expression: 'child(\'call\')' },
 			{ name: 'new expression', expression: 'new Constructed(\'new\')' },
 			{ name: 'chain expression', expression: 'factory?.(\'chain\')' },
@@ -239,7 +243,6 @@ const values = { member: 0 };`;
 			},
 			{ name: 'array expression', expression: '[child(\'array\')]' },
 			{ name: 'assignment expression', expression: 'assigned = child(\'assignment\')' },
-			{ name: 'binary expression', expression: 'empty() + \'\'' },
 			{ name: 'logical expression', expression: 'true && child(\'logical\')' },
 			{ name: 'conditional expression', expression: 'true ? child(\'conditional\') : \'\'' },
 			{ name: 'member expression', expression: 'lookup[getKey()]' },
@@ -249,9 +252,6 @@ const values = { member: 0 };`;
 			},
 			{ name: 'sequence expression', expression: '(touch(), child(\'sequence\'))' },
 			{ name: 'tagged template expression', expression: 'tag`tagged`' },
-			{ name: 'template literal', expression: '`${empty()}`' },
-			{ name: 'unary expression', expression: 'void empty()' },
-			{ name: 'update expression', expression: 'values[getKey()]++' },
 		];
 
 		for (const test_case of cases) {
@@ -267,6 +267,31 @@ export function App() @{
 			}
 		}
 	});
+
+	it(
+		'merges provably-primitive call-containing children into one escaped text run in SSR output',
+		() => {
+			const source = `function empty() {
+	return null;
+}
+function fetchLabel() {
+	return 'fetched';
+}
+export function App() @{
+		<div>{'label:'}{void empty()}{String(fetchLabel())}</div>
+}`;
+
+			const { code } = compile(source, 'primitive-merge.tsrx', { mode: 'server' });
+
+			// One escaped text run — no render_expression, no hydration markers; a
+			// provably-string child concatenates bare (no String(… ?? '') wrap).
+			expect(code).toContain(
+				'_$_.escape(\'label:\' + (String(void empty() ?? \'\') + String(fetchLabel())))',
+			);
+			expect(code).not.toContain('render_expression');
+			expect(code).not.toContain('String(String(');
+		},
+	);
 
 	it('decodes JSX-style entities before server text escaping', () => {
 		const result = compile(

--- a/packages/ripple/tests/server/composite.props.test.tsrx
+++ b/packages/ripple/tests/server/composite.props.test.tsrx
@@ -164,4 +164,30 @@ describe('composite > props', () => {
 		expect(document.querySelector('p').textContent).toBe('Description 1');
 		expect(document.querySelector('price').textContent).toBe('15');
 	});
+
+	it('renders a template element passed inline as a prop', async () => {
+		// `props.header` is not provably a string, so it renders through
+		// `render_expression`, which recognizes template-element values —
+		// inline escaping would stringify the element to `[object Object]`.
+		function Child(props: { header: unknown }) @{
+			<div>{props.header}</div>
+		}
+
+		function App() @{
+			<Child
+				header={<h1>
+					@if (true) {
+						<span>{'yes'}</span>
+					} @else {
+						<span>{'no'}</span>
+					}
+				</h1>}
+			/>
+		}
+
+		const { body } = await render(App);
+		expect(body).toContain('<h1>');
+		expect(body).toContain('<span>yes</span>');
+		expect(body).not.toContain('<span>no</span>');
+	});
 });

--- a/packages/ripple/tests/server/streaming-ssr.test.tsrx
+++ b/packages/ripple/tests/server/streaming-ssr.test.tsrx
@@ -203,7 +203,7 @@ describe('streaming try/pending boundaries', () => {
 		const id = slot_match![1];
 		const chunk = chunks[1];
 		expect(chunk).toContain(`<template data-ripple-chunk="${id}">`);
-		expect(chunk).toContain('<p>async-data</p>');
+		expect(chunk).toContain('<p><!--[-->async-data<!--]--></p>');
 		// static markup after the suspension point belongs to the chunk
 		// (regression: it used to be lost when the boundary cleared its buffer)
 		expect(chunk).toContain('<footer>static-after</footer>');
@@ -242,7 +242,7 @@ describe('streaming try/pending boundaries', () => {
 		await result;
 
 		const chunk = chunks[chunks.length - 1];
-		expect(chunk).toContain('<p>body</p>');
+		expect(chunk).toContain('<p><!--[-->body<!--]--></p>');
 		expect(chunk).not.toContain('failed');
 	});
 
@@ -272,7 +272,7 @@ describe('streaming try/pending boundaries', () => {
 
 		const all = chunks.join('');
 		const chunk = chunks[chunks.length - 1];
-		expect(chunk).toContain('<em>boom</em>');
+		expect(chunk).toContain('<em><!--[-->boom<!--]--></em>');
 		expect(chunk).toContain('<template data-ripple-chunk=');
 		// the rejected trackAsync envelope reaches the wire before the chunk
 		// that hydrates the catch branch from it
@@ -380,8 +380,8 @@ describe('streaming nested and sibling boundaries', () => {
 
 		expect(chunks).toHaveLength(2);
 		const chunk = chunks[1];
-		expect(chunk).toContain('<p class="outer">outer-done</p>');
-		expect(chunk).toContain('<p class="inner">inner-done</p>');
+		expect(chunk).toContain('<p class="outer"><!--[-->outer-done<!--]--></p>');
+		expect(chunk).toContain('<p class="inner"><!--[-->inner-done<!--]--></p>');
 		// coalesced: the inner boundary is inlined, no open slot, no fallback
 		expect(chunk).not.toContain('inner-loading');
 		expect(chunk).not.toMatch(SLOT_OPEN_RE);
@@ -402,7 +402,7 @@ describe('streaming nested and sibling boundaries', () => {
 
 		expect(chunks).toHaveLength(2);
 		const parent_chunk = chunks[1];
-		expect(parent_chunk).toContain('<p class="outer">outer-done</p>');
+		expect(parent_chunk).toContain('<p class="outer"><!--[-->outer-done<!--]--></p>');
 		// the child is still pending: its slot (wrapper + fallback) ships
 		// inside the parent chunk
 		expect(parent_chunk).toContain('inner-loading');
@@ -412,7 +412,7 @@ describe('streaming nested and sibling boundaries', () => {
 		await result;
 
 		expect(chunks).toHaveLength(3);
-		expect(chunks[2]).toContain('<p class="inner">inner-done</p>');
+		expect(chunks[2]).toContain('<p class="inner"><!--[-->inner-done<!--]--></p>');
 	});
 
 	it('streams sibling boundaries out of order, as each settles', async () => {
@@ -603,7 +603,7 @@ describe('streaming with a document template', () => {
 		expect(isClosed()).toBe(true);
 		// the suffix is the final push, after the last chunk
 		expect(chunks[chunks.length - 1]).toBe('</div></body></html>');
-		expect(chunks[chunks.length - 2]).toContain('<p>done</p>');
+		expect(chunks[chunks.length - 2]).toContain('<p><!--[-->done<!--]--></p>');
 	});
 });
 
@@ -647,7 +647,7 @@ describe('streaming head content', () => {
 		expect(chunk).toMatch(
 			/<template data-ripple-head="\d+">[\s\S]*?<title>title:late<\/title>[\s\S]*?<\/template>/,
 		);
-		expect(chunk).toContain('<p class="has-head">late</p>');
+		expect(chunk).toContain('<p class="has-head"><!--[-->late<!--]--></p>');
 		// the head template precedes the content template
 		expect(chunk.indexOf('data-ripple-head')).toBeLessThan(chunk.indexOf('data-ripple-chunk'));
 	});

--- a/packages/ripple/tests/server/track-async-serialization.test.tsrx
+++ b/packages/ripple/tests/server/track-async-serialization.test.tsrx
@@ -66,7 +66,7 @@ describe('trackAsync serialization (server)', () => {
 		}
 
 		const { body } = await render(App);
-		expect(body).toContain('<li>a</li>');
+		expect(body).toContain('<li><!--[-->a<!--]--></li>');
 		expect(body).toContain('__ripple_ta_');
 	});
 
@@ -84,7 +84,7 @@ describe('trackAsync serialization (server)', () => {
 
 		const { body } = await render(App);
 		const public_message = DEV ? 'fetch failed' : TRACK_ASYNC_PUBLIC_ERROR_MESSAGE;
-		expect(body).toContain(`<p class="error">${public_message}</p>`);
+		expect(body).toContain(`<p class="error"><!--[-->${public_message}<!--]--></p>`);
 		expect(body).toContain('__ripple_ta_');
 		expect(body).toContain('"ok":false');
 		expect(body).toContain(`"message":"${public_message}"`);
@@ -110,7 +110,7 @@ describe('trackAsync serialization (server)', () => {
 
 		const { body } = await render(Parent);
 		const public_message = DEV ? 'child error' : TRACK_ASYNC_PUBLIC_ERROR_MESSAGE;
-		expect(body).toContain(`<p class="parent-error">${public_message}</p>`);
+		expect(body).toContain(`<p class="parent-error"><!--[-->${public_message}<!--]--></p>`);
 		expect(body).toContain('__ripple_ta_');
 		expect(body).toContain('"ok":false');
 		expect(body).toContain(`"message":"${public_message}"`);
@@ -132,7 +132,7 @@ describe('trackAsync serialization (server)', () => {
 
 		const { body } = await render(App);
 		const public_message = DEV ? 'sync failure' : TRACK_ASYNC_PUBLIC_ERROR_MESSAGE;
-		expect(body).toContain(`<p class="error">${public_message}</p>`);
+		expect(body).toContain(`<p class="error"><!--[-->${public_message}<!--]--></p>`);
 		expect(body).toContain('__ripple_ta_');
 		expect(body).toContain('"ok":false');
 		expect(body).toContain(`"message":"${public_message}"`);

--- a/packages/tsrx-ripple/src/transform/client/index.js
+++ b/packages/tsrx-ripple/src/transform/client/index.js
@@ -112,6 +112,7 @@ import {
 	get_code_block_render,
 	get_code_block_template_child,
 	lower_code_block_children,
+	is_text_primitive_expression,
 } from '../../utils.js';
 import {
 	get_attribute_name,
@@ -322,233 +323,6 @@ function insert_style_ref_setup_statements(body, setup, scopes) {
 		return result;
 	}
 	return [...setup, ...body];
-}
-
-/**
- * @param {AST.TypeNode | undefined | null} type_annotation
- * @returns {AST.TypeNode | undefined}
- */
-function unwrap_type_annotation(type_annotation) {
-	/** @type {AST.TypeNode | undefined | null} */
-	let annotation = type_annotation;
-
-	while (annotation) {
-		if (annotation.type === 'TSTypeAnnotation') {
-			annotation = annotation.typeAnnotation;
-			continue;
-		}
-		if (annotation.type === 'TSParenthesizedType') {
-			annotation = annotation.typeAnnotation;
-			continue;
-		}
-		break;
-	}
-
-	return annotation ?? undefined;
-}
-
-/**
- * @param {AST.TypeNode | undefined | null} type_annotation
- * @returns {boolean}
- */
-function is_string_type_annotation(type_annotation) {
-	const annotation = unwrap_type_annotation(type_annotation);
-	if (!annotation) return false;
-
-	if (annotation.type === 'TSStringKeyword') return true;
-	if (annotation.type === 'TSLiteralType' && annotation.literal.type === 'Literal') {
-		return typeof annotation.literal.value === 'string';
-	}
-	if (annotation.type === 'TSUnionType') {
-		return annotation.types.every((type) => is_string_type_annotation(type));
-	}
-
-	return false;
-}
-
-/**
- * @param {AST.TypeNode | undefined | null} type_annotation
- * @param {string} property_name
- * @returns {AST.TypeNode | undefined}
- */
-function get_property_type_annotation(type_annotation, property_name) {
-	const annotation = unwrap_type_annotation(type_annotation);
-
-	if (annotation?.type === 'TSIntersectionType') {
-		for (const type of annotation.types) {
-			const property_type = get_property_type_annotation(type, property_name);
-			if (property_type) return property_type;
-		}
-		return undefined;
-	}
-
-	if (annotation?.type !== 'TSTypeLiteral') {
-		return undefined;
-	}
-
-	for (const member of annotation.members) {
-		if (member.type !== 'TSPropertySignature' || member.computed) continue;
-
-		const key = member.key;
-		const name =
-			key.type === 'Identifier'
-				? key.name
-				: key.type === 'Literal' && typeof key.value === 'string'
-					? key.value
-					: null;
-
-		if (name === property_name) {
-			return member.typeAnnotation?.typeAnnotation;
-		}
-	}
-
-	return undefined;
-}
-
-/**
- * @param {Binding | null | undefined} binding
- * @returns {AST.TypeNode | undefined}
- */
-function get_binding_type_annotation(binding) {
-	const node = binding?.node;
-	if (!node) return undefined;
-
-	return (
-		/** @type {{ typeAnnotation?: AST.TSTypeAnnotation | AST.TypeNode }} */ (binding.metadata ?? {})
-			.typeAnnotation ??
-		/** @type {{ typeAnnotation?: AST.TSTypeAnnotation }} */ (node).typeAnnotation?.typeAnnotation
-	);
-}
-
-/**
- * @param {AST.Expression} expression
- * @returns {string | null}
- */
-function get_static_property_name(expression) {
-	if (expression.type !== 'MemberExpression' || expression.property.type === 'PrivateIdentifier') {
-		return null;
-	}
-
-	if (!expression.computed && expression.property.type === 'Identifier') {
-		return expression.property.name;
-	}
-
-	if (
-		expression.computed &&
-		expression.property.type === 'Literal' &&
-		typeof expression.property.value === 'string'
-	) {
-		return expression.property.value;
-	}
-
-	return null;
-}
-
-/**
- * @param {AST.Expression | AST.Pattern} expression
- * @returns {boolean}
- */
-function is_string_literal_expression(expression) {
-	return expression.type === 'Literal' && typeof expression.value === 'string';
-}
-
-/**
- * @param {AST.Expression} expression
- * @param {TransformClientState} state
- * @param {Set<Binding>} [visited]
- * @returns {boolean}
- */
-function is_stringish_expression(expression, state, visited = new Set()) {
-	if (expression.type === 'ParenthesizedExpression' || expression.type === 'ChainExpression') {
-		return is_stringish_expression(
-			/** @type {AST.Expression} */ (expression.expression),
-			state,
-			visited,
-		);
-	}
-
-	if (expression.type === 'TSAsExpression' || expression.type === 'TSTypeAssertion') {
-		return (
-			is_string_type_annotation(expression.typeAnnotation) ||
-			is_stringish_expression(/** @type {AST.Expression} */ (expression.expression), state, visited)
-		);
-	}
-
-	if (
-		expression.type === 'TSNonNullExpression' ||
-		expression.type === 'TSInstantiationExpression'
-	) {
-		return is_stringish_expression(
-			/** @type {AST.Expression} */ (expression.expression),
-			state,
-			visited,
-		);
-	}
-
-	if (is_string_literal_expression(expression) || expression.type === 'TemplateLiteral') {
-		return true;
-	}
-
-	if (
-		expression.type === 'CallExpression' &&
-		expression.callee.type === 'Identifier' &&
-		expression.callee.name === 'String'
-	) {
-		return true;
-	}
-
-	if (expression.type === 'BinaryExpression' && expression.operator === '+') {
-		const left = /** @type {AST.Expression} */ (expression.left);
-		const right = /** @type {AST.Expression} */ (expression.right);
-		// `string + anything` (and `anything + string`) always evaluates to a
-		// string in JS, so one provably-stringish operand is enough — the result
-		// can never be an element or collection. (String literals are stringish,
-		// so this subsumes the literal-operand cases.)
-		return (
-			is_stringish_expression(left, state, visited) ||
-			is_stringish_expression(right, state, visited)
-		);
-	}
-
-	if (expression.type === 'ConditionalExpression') {
-		return (
-			is_stringish_expression(expression.consequent, state, visited) &&
-			is_stringish_expression(expression.alternate, state, visited)
-		);
-	}
-
-	if (expression.type === 'Identifier') {
-		const binding = state.scope.get(expression.name);
-		if (!binding || binding.node === expression || visited.has(binding)) {
-			return false;
-		}
-		if (is_string_type_annotation(get_binding_type_annotation(binding))) {
-			return true;
-		}
-		if (binding.initial && !binding.reassigned && !binding.mutated && !binding.updated) {
-			visited.add(binding);
-			return is_stringish_expression(
-				/** @type {AST.Expression} */ (binding.initial),
-				state,
-				visited,
-			);
-		}
-		return false;
-	}
-
-	if (expression.type === 'MemberExpression' && expression.object.type === 'Identifier') {
-		const property_name = get_static_property_name(expression);
-		if (property_name === null) return false;
-
-		const binding = state.scope.get(expression.object.name);
-		const property_type = get_property_type_annotation(
-			get_binding_type_annotation(binding),
-			property_name,
-		);
-		return is_string_type_annotation(property_type);
-	}
-
-	return false;
 }
 
 /**
@@ -2458,7 +2232,7 @@ const visitors = {
 		// from re-wrapping it endlessly.
 		if (
 			!is_code_block_function_body(node, context.path.at(-1)) &&
-			is_native_tsrx_value_position(context.path)
+			is_native_tsrx_value_position(context.path, node)
 		) {
 			return context.visit(wrap_code_block_in_iife(node), context.state);
 		}
@@ -2506,7 +2280,7 @@ const visitors = {
 			if (state.to_ts) {
 				return context.next();
 			}
-			if (state.jsx_to_tsrx_element || is_native_tsrx_value_position(context.path)) {
+			if (state.jsx_to_tsrx_element || is_native_tsrx_value_position(context.path, node)) {
 				return build_jsx_to_tsrx_element(/** @type {AST.TSRXJSXFragment} */ (node), context);
 			}
 			return context.next();
@@ -2579,7 +2353,7 @@ const visitors = {
 
 		if (
 			state.regular_js ||
-			is_native_tsrx_value_position(context.path) ||
+			is_native_tsrx_value_position(context.path, node) ||
 			is_regular_js_statement_position(context.path)
 		) {
 			const expression = build_style_class_map_expression(node, context);
@@ -2622,7 +2396,7 @@ const visitors = {
 			if (state.to_ts) {
 				return context.next();
 			}
-			if (state.jsx_to_tsrx_element || is_native_tsrx_value_position(context.path)) {
+			if (state.jsx_to_tsrx_element || is_native_tsrx_value_position(context.path, node)) {
 				return build_jsx_to_tsrx_element(/** @type {AST.TSRXJSXElement} */ (node), context);
 			}
 			return context.next();
@@ -2660,7 +2434,7 @@ const visitors = {
 			(!state.inside_head &&
 				!state.template_child &&
 				!node.metadata?.returned_tsrx_child &&
-				(is_native_tsrx_value_position(context.path) ||
+				(is_native_tsrx_value_position(context.path, node) ||
 					(context.state.component === undefined &&
 						is_native_tsrx_statement_position(context.path))))
 		) {
@@ -5148,10 +4922,24 @@ function is_native_tsrx_statement_position(path) {
 
 /**
  * @param {AST.Node[]} path
+ * @param {AST.Node} [node] The node being classified. Expression-container and
+ *   attribute values are visited with the container unwrapped (see
+ *   `get_attribute_value` / `get_template_expression`), so their path parent is
+ *   the host template element itself — indistinguishable from a rendered child
+ *   by parent type alone. A rendered child sits in the parent's `children`; a
+ *   value does not, so `<div>{<h1 />}</div>` and `prop={<h1 />}` classify as
+ *   values while `<div><h1 /></div>` stays a template child.
  * @returns {boolean}
  */
-function is_native_tsrx_value_position(path) {
+function is_native_tsrx_value_position(path, node) {
 	const parent = path.at(-1);
+	if (node && (is_template_element(parent) || is_template_fragment(parent))) {
+		return !(
+			/** @type {ESTreeJSX.JSXElement} */ (parent).children?.includes(
+				/** @type {ESTreeJSX.JSXElement} */ (node),
+			)
+		);
+	}
 	return !(
 		is_native_tsrx_statement_position(path) ||
 		is_template_element(parent) ||
@@ -5574,6 +5362,14 @@ function transform_children(children, context) {
 
 	let skipped = 0;
 
+	// Whether the template string currently ends inside text content (inlined
+	// literals, JSXText, a previous text expression's ' ' anchor). A further
+	// ' ' text anchor pushed onto a text tail coalesces with it into a single
+	// DOM text node, so `sibling(…, true)` would find nothing to anchor to —
+	// text expressions must then fall back to a comment-anchored
+	// `_$_.expression` instead. Conservative: fragments leave it set.
+	let template_tail_is_text = false;
+
 	for (let node_idx = 0; node_idx < normalized.length; node_idx++) {
 		const node = normalized[node_idx];
 
@@ -5686,6 +5482,24 @@ function transform_children(children, context) {
 			 * @param {AST.Expression} expr
 			 */
 			const render_text_expression = (identity, expr) => {
+				// A non-literal needs a text node of its own; on a text tail the
+				// ' ' anchor would coalesce with the preceding text into a single
+				// DOM node, so render through a comment-anchored expression
+				// instead. (Inlined literals just extend the text — no anchor.)
+				if (expr.type !== 'Literal' && template_tail_is_text) {
+					skipped = 0;
+					state.template?.push('<!>');
+					template_tail_is_text = false;
+					const id = flush_node(false);
+					const call = b.call('_$_.expression', id, b.thunk(expr));
+					state.init?.push(
+						state.namespace !== DEFAULT_NAMESPACE
+							? b.stmt(b.call('_$_.with_ns', b.literal(state.namespace), b.thunk(call)))
+							: b.stmt(call),
+					);
+					return;
+				}
+				template_tail_is_text = true;
 				if (metadata?.tracking) {
 					skipped = 0;
 					state.template?.push(' ');
@@ -5752,6 +5566,8 @@ function transform_children(children, context) {
 					flush_node: /** @type {TransformClientState['flush_node']} */ (flush_node),
 					namespace: state.namespace,
 				});
+				// An element's markup (or its comment anchor) closes the text run.
+				template_tail_is_text = false;
 
 				// After processing an element's children via child()/sibling() navigation,
 				// hydrate_node is left deep inside the element. If there's a next sibling,
@@ -5830,6 +5646,8 @@ function transform_children(children, context) {
 					flush_node: /** @type {TransformClientState['flush_node']} */ (flush_node),
 					namespace: state.namespace,
 				});
+				// A fragment's children can end in anything — assume a text tail.
+				template_tail_is_text = true;
 			} else if (is_template_expression(node)) {
 				// is_template_expression stays a boolean (its negative would lie
 				// about merged-text containers), so narrow the container once here.
@@ -5842,6 +5660,7 @@ function transform_children(children, context) {
 				);
 
 				if (expr.type === 'Literal') {
+					template_tail_is_text = true;
 					if (normalized.length === 1) {
 						skipped++;
 						if (
@@ -5861,6 +5680,7 @@ function transform_children(children, context) {
 				} else if (is_static_native_tsrx_call) {
 					skipped = 0;
 					state.template?.push('<!>');
+					template_tail_is_text = false;
 					const id = flush_node(false);
 					const call = b.call('_$_.render_tsrx_element', expr, id, b.id('__block'));
 					state.init?.push(
@@ -5870,7 +5690,7 @@ function transform_children(children, context) {
 					);
 				} else if (
 					!is_children_template_expression(container_expression, state.scope) &&
-					is_stringish_expression(container_expression, state)
+					is_text_primitive_expression(container_expression, state)
 				) {
 					render_text_expression(container_expression, expr);
 				} else if (
@@ -5879,6 +5699,7 @@ function transform_children(children, context) {
 				) {
 					skipped++;
 					state.template?.push(' ');
+					template_tail_is_text = true;
 					const id = flush_node(false);
 					const call = b.call('_$_.expression', id, b.thunk(expr));
 					state.init?.push(
@@ -5889,6 +5710,7 @@ function transform_children(children, context) {
 				} else {
 					skipped = 0;
 					state.template?.push('<!>');
+					template_tail_is_text = false;
 					const id = flush_node(false);
 					const call = b.call('_$_.expression', id, b.thunk(expr));
 					state.init?.push(

--- a/packages/tsrx-ripple/src/transform/client/index.js
+++ b/packages/tsrx-ripple/src/transform/client/index.js
@@ -113,6 +113,8 @@ import {
 	get_code_block_template_child,
 	lower_code_block_children,
 	is_text_primitive_expression,
+	collect_head_elements,
+	is_flattenable_template_fragment,
 } from '../../utils.js';
 import {
 	get_attribute_name,
@@ -4921,6 +4923,29 @@ function is_native_tsrx_statement_position(path) {
 }
 
 /**
+ * Whether `node` is one of `parent`'s rendered template children, looking
+ * through fragments that `normalize_child` flattens — their children render
+ * inline in the parent, so they are the parent's children for classification.
+ * @param {AST.Node | undefined} parent
+ * @param {AST.Node} node
+ * @returns {boolean}
+ */
+function is_rendered_template_child(parent, node) {
+	const children = /** @type {ESTreeJSX.JSXElement | undefined} */ (parent)?.children;
+	if (!children) return false;
+	for (const child of children) {
+		if (child === node) return true;
+		if (
+			is_flattenable_template_fragment(/** @type {AST.Node} */ (child), false) &&
+			is_rendered_template_child(/** @type {AST.Node} */ (child), node)
+		) {
+			return true;
+		}
+	}
+	return false;
+}
+
+/**
  * @param {AST.Node[]} path
  * @param {AST.Node} [node] The node being classified. Expression-container and
  *   attribute values are visited with the container unwrapped (see
@@ -4934,11 +4959,7 @@ function is_native_tsrx_statement_position(path) {
 function is_native_tsrx_value_position(path, node) {
 	const parent = path.at(-1);
 	if (node && (is_template_element(parent) || is_template_fragment(parent))) {
-		return !(
-			/** @type {ESTreeJSX.JSXElement} */ (parent).children?.includes(
-				/** @type {ESTreeJSX.JSXElement} */ (node),
-			)
-		);
+		return !is_rendered_template_child(parent, node);
 	}
 	return !(
 		is_native_tsrx_statement_position(path) ||
@@ -5208,11 +5229,7 @@ function transform_children(children, context) {
 		state: { ...state, keep_component_style: state.to_ts ? true : state.keep_component_style },
 	});
 
-	const head_elements = /** @type {ESTreeJSX.JSXElement[]} */ (
-		children.filter(
-			(node) => is_template_element(node) && get_element_identifier(node)?.name === 'head',
-		)
-	);
+	const head_elements = collect_head_elements(children, !!state.to_ts);
 
 	const is_fragment =
 		normalized.some(
@@ -5362,14 +5379,6 @@ function transform_children(children, context) {
 
 	let skipped = 0;
 
-	// Whether the template string currently ends inside text content (inlined
-	// literals, JSXText, a previous text expression's ' ' anchor). A further
-	// ' ' text anchor pushed onto a text tail coalesces with it into a single
-	// DOM text node, so `sibling(…, true)` would find nothing to anchor to —
-	// text expressions must then fall back to a comment-anchored
-	// `_$_.expression` instead. Conservative: fragments leave it set.
-	let template_tail_is_text = false;
-
 	for (let node_idx = 0; node_idx < normalized.length; node_idx++) {
 		const node = normalized[node_idx];
 
@@ -5482,24 +5491,6 @@ function transform_children(children, context) {
 			 * @param {AST.Expression} expr
 			 */
 			const render_text_expression = (identity, expr) => {
-				// A non-literal needs a text node of its own; on a text tail the
-				// ' ' anchor would coalesce with the preceding text into a single
-				// DOM node, so render through a comment-anchored expression
-				// instead. (Inlined literals just extend the text — no anchor.)
-				if (expr.type !== 'Literal' && template_tail_is_text) {
-					skipped = 0;
-					state.template?.push('<!>');
-					template_tail_is_text = false;
-					const id = flush_node(false);
-					const call = b.call('_$_.expression', id, b.thunk(expr));
-					state.init?.push(
-						state.namespace !== DEFAULT_NAMESPACE
-							? b.stmt(b.call('_$_.with_ns', b.literal(state.namespace), b.thunk(call)))
-							: b.stmt(call),
-					);
-					return;
-				}
-				template_tail_is_text = true;
 				if (metadata?.tracking) {
 					skipped = 0;
 					state.template?.push(' ');
@@ -5566,8 +5557,6 @@ function transform_children(children, context) {
 					flush_node: /** @type {TransformClientState['flush_node']} */ (flush_node),
 					namespace: state.namespace,
 				});
-				// An element's markup (or its comment anchor) closes the text run.
-				template_tail_is_text = false;
 
 				// After processing an element's children via child()/sibling() navigation,
 				// hydrate_node is left deep inside the element. If there's a next sibling,
@@ -5646,8 +5635,6 @@ function transform_children(children, context) {
 					flush_node: /** @type {TransformClientState['flush_node']} */ (flush_node),
 					namespace: state.namespace,
 				});
-				// A fragment's children can end in anything — assume a text tail.
-				template_tail_is_text = true;
 			} else if (is_template_expression(node)) {
 				// is_template_expression stays a boolean (its negative would lie
 				// about merged-text containers), so narrow the container once here.
@@ -5660,7 +5647,6 @@ function transform_children(children, context) {
 				);
 
 				if (expr.type === 'Literal') {
-					template_tail_is_text = true;
 					if (normalized.length === 1) {
 						skipped++;
 						if (
@@ -5680,7 +5666,6 @@ function transform_children(children, context) {
 				} else if (is_static_native_tsrx_call) {
 					skipped = 0;
 					state.template?.push('<!>');
-					template_tail_is_text = false;
 					const id = flush_node(false);
 					const call = b.call('_$_.render_tsrx_element', expr, id, b.id('__block'));
 					state.init?.push(
@@ -5699,7 +5684,6 @@ function transform_children(children, context) {
 				) {
 					skipped++;
 					state.template?.push(' ');
-					template_tail_is_text = true;
 					const id = flush_node(false);
 					const call = b.call('_$_.expression', id, b.thunk(expr));
 					state.init?.push(
@@ -5710,7 +5694,6 @@ function transform_children(children, context) {
 				} else {
 					skipped = 0;
 					state.template?.push('<!>');
-					template_tail_is_text = false;
 					const id = flush_node(false);
 					const call = b.call('_$_.expression', id, b.thunk(expr));
 					state.init?.push(

--- a/packages/tsrx-ripple/src/transform/server/index.js
+++ b/packages/tsrx-ripple/src/transform/server/index.js
@@ -81,6 +81,8 @@ import {
 	lower_code_block_children,
 	is_code_block_function_body,
 	is_text_primitive_expression,
+	collect_head_elements,
+	is_flattenable_template_fragment,
 } from '../../utils.js';
 import {
 	get_attribute_name,
@@ -836,6 +838,29 @@ function is_native_tsrx_statement_position(path) {
 }
 
 /**
+ * Whether `node` is one of `parent`'s rendered template children, looking
+ * through fragments that `normalize_child` flattens — their children render
+ * inline in the parent, so they are the parent's children for classification.
+ * @param {AST.Node | undefined} parent
+ * @param {AST.Node} node
+ * @returns {boolean}
+ */
+function is_rendered_template_child(parent, node) {
+	const children = /** @type {ESTreeJSX.JSXElement | undefined} */ (parent)?.children;
+	if (!children) return false;
+	for (const child of children) {
+		if (child === node) return true;
+		if (
+			is_flattenable_template_fragment(/** @type {AST.Node} */ (child), false) &&
+			is_rendered_template_child(/** @type {AST.Node} */ (child), node)
+		) {
+			return true;
+		}
+	}
+	return false;
+}
+
+/**
  * @param {AST.Node[]} path
  * @param {AST.Node} [node] The node being classified. Expression-container and
  *   attribute values are visited with the container unwrapped (see
@@ -849,11 +874,7 @@ function is_native_tsrx_statement_position(path) {
 function is_native_tsrx_value_position(path, node) {
 	const parent = path.at(-1);
 	if (node && (is_template_element(parent) || is_template_fragment(parent))) {
-		return !(
-			/** @type {ESTreeJSX.JSXElement} */ (parent).children?.includes(
-				/** @type {ESTreeJSX.JSXElement} */ (node),
-			)
-		);
+		return !is_rendered_template_child(parent, node);
 	}
 	return !(
 		is_native_tsrx_statement_position(path) ||
@@ -1178,9 +1199,7 @@ function transform_children(children, context) {
 		}
 	}
 
-	const head_elements = /** @type {ESTreeJSX.JSXElement[]} */ (
-		children.filter((node) => is_head_element(node))
-	);
+	const head_elements = collect_head_elements(children, !!state.to_ts);
 
 	if (head_elements.length) {
 		state.init?.push(b.stmt(b.call(b.id('_$_.set_output_target'), b.literal('head'))));

--- a/packages/tsrx-ripple/src/transform/server/index.js
+++ b/packages/tsrx-ripple/src/transform/server/index.js
@@ -80,6 +80,7 @@ import {
 	get_code_block_template_child,
 	lower_code_block_children,
 	is_code_block_function_body,
+	is_text_primitive_expression,
 } from '../../utils.js';
 import {
 	get_attribute_name,
@@ -836,10 +837,24 @@ function is_native_tsrx_statement_position(path) {
 
 /**
  * @param {AST.Node[]} path
+ * @param {AST.Node} [node] The node being classified. Expression-container and
+ *   attribute values are visited with the container unwrapped (see
+ *   `get_attribute_value` / `get_template_expression`), so their path parent is
+ *   the host template element itself — indistinguishable from a rendered child
+ *   by parent type alone. A rendered child sits in the parent's `children`; a
+ *   value does not, so `<div>{<h1 />}</div>` and `prop={<h1 />}` classify as
+ *   values while `<div><h1 /></div>` stays a template child.
  * @returns {boolean}
  */
-function is_native_tsrx_value_position(path) {
+function is_native_tsrx_value_position(path, node) {
 	const parent = path.at(-1);
+	if (node && (is_template_element(parent) || is_template_fragment(parent))) {
+		return !(
+			/** @type {ESTreeJSX.JSXElement} */ (parent).children?.includes(
+				/** @type {ESTreeJSX.JSXElement} */ (node),
+			)
+		);
+	}
 	return !(
 		is_native_tsrx_statement_position(path) ||
 		is_template_element(parent) ||
@@ -1873,7 +1888,7 @@ const visitors = {
 		// body (handled by `transform_native_tsrx_function`).
 		if (
 			!is_code_block_function_body(node, context.path.at(-1)) &&
-			is_native_tsrx_value_position(context.path)
+			is_native_tsrx_value_position(context.path, node)
 		) {
 			return context.visit(wrap_code_block_in_iife(node), context.state);
 		}
@@ -1900,7 +1915,7 @@ const visitors = {
 		// A raw (non-template) fragment — an attribute value or other JSX that
 		// never entered the template traversal.
 		if (!is_template_fragment(node)) {
-			if (context.state.jsx_to_tsrx_element || is_native_tsrx_value_position(context.path)) {
+			if (context.state.jsx_to_tsrx_element || is_native_tsrx_value_position(context.path, node)) {
 				return build_jsx_to_tsrx_element(/** @type {AST.TSRXJSXFragment} */ (node), context);
 			}
 			return context.next();
@@ -2254,7 +2269,7 @@ const visitors = {
 
 		if (
 			state.regular_js ||
-			is_native_tsrx_value_position(context.path) ||
+			is_native_tsrx_value_position(context.path, node) ||
 			is_regular_js_statement_position(context.path)
 		) {
 			const expression = build_style_class_map_expression(node, context);
@@ -2276,7 +2291,7 @@ const visitors = {
 		// A raw (non-template) element — an attribute value or other JSX that
 		// never entered the template traversal.
 		if (!is_template_element(node)) {
-			if (state.jsx_to_tsrx_element || is_native_tsrx_value_position(context.path)) {
+			if (state.jsx_to_tsrx_element || is_native_tsrx_value_position(context.path, node)) {
 				return build_jsx_to_tsrx_element(/** @type {AST.TSRXJSXElement} */ (node), context);
 			}
 			return context.next();
@@ -2292,7 +2307,7 @@ const visitors = {
 			state.regular_js ||
 			(!state.template_child &&
 				!node.metadata?.returned_tsrx_child &&
-				(is_native_tsrx_value_position(context.path) ||
+				(is_native_tsrx_value_position(context.path, node) ||
 					(context.state.component === undefined &&
 						is_native_tsrx_statement_position(context.path))))
 		) {
@@ -2614,12 +2629,17 @@ const visitors = {
 						const attr_name = get_attribute_name(attr);
 						const attr_value = get_attribute_value(attr);
 						const metadata = { tracking: false };
+						// An attribute value is not a template child — clearing the flag
+						// lets template JSX inside it (an element, fragment, or directive,
+						// at any nesting depth) lower to a `tsrx_element` value instead of
+						// leaking to the printer as raw JSX.
 						let property =
 							attr_value === null
 								? b.literal(true)
 								: /** @type {AST.Expression} */ (
 										visit(/** @type {AST.Expression} */ (attr_value), {
 											...state,
+											template_child: false,
 											metadata,
 										})
 									);
@@ -2972,14 +2992,6 @@ const visitors = {
 			contains_template_value_node(/** @type {AST.Node} */ (node.expression)) ||
 			is_template_value_call(/** @type {AST.Expression} */ (node.expression), state.scope) ||
 			is_template_value_binding(node.expression, state.scope);
-		const is_collection_expression = is_collection_value_expression(
-			/** @type {AST.Expression} */ (node.expression),
-			state.scope,
-			context,
-		);
-		const is_runtime_expression = expression_contains_call(
-			/** @type {AST.Expression} */ (node.expression),
-		);
 		let expression = /** @type {AST.Expression} */ (
 			visit(node.expression, {
 				...state,
@@ -2987,13 +2999,33 @@ const visitors = {
 			})
 		);
 
+		// `<title>` holds text only (per spec) — hydration markers must never be
+		// emitted into it (`document.title` would contain them), so its
+		// expression children always render through the escaping text path.
+		const container_parent = context.path.at(-1);
+		const inside_title =
+			is_template_element(container_parent) &&
+			get_element_identifier(/** @type {ESTreeJSX.JSXElement} */ (container_parent))?.name ===
+				'title';
+
 		if (expression.type === 'Literal') {
 			state.init?.push(
 				b.stmt(b.call(b.id('_$_.output_push'), b.literal(escape(expression.value)))),
 			);
 		} else if (is_static_native_tsrx_call) {
 			state.init?.push(b.stmt(b.call('_$_.render_tsrx_element', expression)));
-		} else if (is_children_expression || is_collection_expression || is_runtime_expression) {
+		} else if (
+			!inside_title &&
+			// Only an expression provably evaluating to a text primitive — a
+			// string, number, boolean, bigint, or null/undefined (literals,
+			// operators, `String()`/`Number()`/`Boolean()`, `as` casts, typed
+			// bindings and members) — may use the inline-escape fast path.
+			// Anything else — children props, collections, calls, opaque members
+			// like `{props.header}` — can hold a template value and must go
+			// through `render_expression`, which renders elements and
+			// collections and escapes plain values.
+			!is_text_primitive_expression(/** @type {AST.Expression} */ (node.expression), state)
+		) {
 			state.init?.push(b.stmt(b.call('_$_.render_expression', expression)));
 		} else {
 			state.init?.push(b.stmt(b.call(b.id('_$_.output_push'), b.call('_$_.escape', expression))));

--- a/packages/tsrx-ripple/src/transform/server/index.js
+++ b/packages/tsrx-ripple/src/transform/server/index.js
@@ -69,7 +69,6 @@ import {
 	build_index_read,
 	build_index_write,
 	build_index_update,
-	expression_contains_call,
 	get_indexed_reactive_target,
 	rewrite_lazy_member_base,
 	strip_tsrx_style_elements,
@@ -497,70 +496,6 @@ function is_template_value_binding(expression, scope) {
 }
 
 /**
- * @param {AST.Expression | AST.SpreadElement} expression
- * @param {ScopeInterface} scope
- * @param {TransformServerContext} context
- * @returns {boolean}
- */
-function is_collection_value_expression(expression, scope, context) {
-	if (expression.type === 'ArrayExpression') {
-		return true;
-	}
-
-	if (
-		expression.type === 'TSAsExpression' ||
-		expression.type === 'TSSatisfiesExpression' ||
-		expression.type === 'TSNonNullExpression'
-	) {
-		return is_collection_value_expression(expression.expression, scope, context);
-	}
-
-	if (expression.type === 'ConditionalExpression') {
-		return (
-			is_collection_value_expression(expression.consequent, scope, context) ||
-			is_collection_value_expression(expression.alternate, scope, context)
-		);
-	}
-
-	if (expression.type === 'LogicalExpression') {
-		return (
-			is_collection_value_expression(expression.left, scope, context) ||
-			is_collection_value_expression(expression.right, scope, context)
-		);
-	}
-
-	if (expression.type === 'CallExpression') {
-		if (is_ripple_track_call(expression.callee, context)) {
-			const first_arg = expression.arguments[0];
-			return (
-				first_arg != null &&
-				is_collection_value_expression(
-					/** @type {AST.Expression | AST.SpreadElement} */ (first_arg),
-					scope,
-					context,
-				)
-			);
-		}
-
-		if (expression.callee.type === 'Identifier') {
-			return function_returns_value(scope.get(expression.callee.name)?.initial, (expression) =>
-				is_collection_value_expression(expression, scope, context),
-			);
-		}
-	}
-
-	if (expression.type !== 'Identifier') {
-		return false;
-	}
-
-	const initial = scope.get(expression.name)?.initial;
-	return (
-		initial != null &&
-		is_collection_value_expression(/** @type {AST.Expression} */ (initial), scope, context)
-	);
-}
-
-/**
  * @param {AST.TSRXImportDeclaration} node
  * @returns {string | null}
  */
@@ -704,15 +639,13 @@ function tsrx_expression_emits_marker(node, context) {
 	if (is_static_native_tsrx_function_call(expression, context)) {
 		return false;
 	}
-	const scope = context.state.scope;
-	return (
-		is_children_template_expression(expression, scope) ||
-		contains_template_value_node(/** @type {AST.Node} */ (expression)) ||
-		is_template_value_call(expression, scope) ||
-		is_template_value_binding(expression, scope) ||
-		is_collection_value_expression(expression, scope, context) ||
-		expression_contains_call(expression)
-	);
+	// The single routing truth — the `JSXExpressionContainer` visitor calls
+	// this same function, so the fragment-boundary prediction can never drift
+	// from what SSR actually emits: only an expression that is not provably a
+	// text primitive lowers to `render_expression` (marker-bracketed);
+	// provable primitives — including call-containing ones like `String(f())`
+	// — inline as escaped text with no markers.
+	return !is_text_primitive_expression(expression, context.state);
 }
 
 /**
@@ -3035,15 +2968,11 @@ const visitors = {
 			state.init?.push(b.stmt(b.call('_$_.render_tsrx_element', expression)));
 		} else if (
 			!inside_title &&
-			// Only an expression provably evaluating to a text primitive — a
-			// string, number, boolean, bigint, or null/undefined (literals,
-			// operators, `String()`/`Number()`/`Boolean()`, `as` casts, typed
-			// bindings and members) — may use the inline-escape fast path.
-			// Anything else — children props, collections, calls, opaque members
-			// like `{props.header}` — can hold a template value and must go
-			// through `render_expression`, which renders elements and
-			// collections and escapes plain values.
-			!is_text_primitive_expression(/** @type {AST.Expression} */ (node.expression), state)
+			// Shared routing truth (see `tsrx_expression_emits_marker`): only an
+			// expression that is not provably a text primitive renders through
+			// `render_expression` — which renders elements and collections,
+			// escapes plain values, and brackets with hydration markers.
+			tsrx_expression_emits_marker(node, context)
 		) {
 			state.init?.push(b.stmt(b.call('_$_.render_expression', expression)));
 		} else {

--- a/packages/tsrx-ripple/src/utils.js
+++ b/packages/tsrx-ripple/src/utils.js
@@ -3008,3 +3008,280 @@ export function adopt_raw_template_jsx(node) {
 	mark_raw_template_jsx(node);
 	return node.type === 'JSXFragment' ? node.children : node;
 }
+
+/**
+ * @param {AST.TypeNode | undefined | null} type_annotation
+ * @returns {AST.TypeNode | undefined}
+ */
+export function unwrap_type_annotation(type_annotation) {
+	/** @type {AST.TypeNode | undefined | null} */
+	let annotation = type_annotation;
+
+	while (annotation) {
+		if (annotation.type === 'TSTypeAnnotation') {
+			annotation = annotation.typeAnnotation;
+			continue;
+		}
+		if (annotation.type === 'TSParenthesizedType') {
+			annotation = annotation.typeAnnotation;
+			continue;
+		}
+		break;
+	}
+
+	return annotation ?? undefined;
+}
+
+/**
+ * Whether the type provably describes a text primitive — a string, number,
+ * boolean, or bigint (or null/undefined, which render as ''). Unions qualify
+ * only when every member does.
+ * @param {AST.TypeNode | undefined | null} type_annotation
+ * @returns {boolean}
+ */
+export function is_text_primitive_type_annotation(type_annotation) {
+	const annotation = unwrap_type_annotation(type_annotation);
+	if (!annotation) return false;
+
+	if (
+		annotation.type === 'TSStringKeyword' ||
+		annotation.type === 'TSNumberKeyword' ||
+		annotation.type === 'TSBooleanKeyword' ||
+		annotation.type === 'TSBigIntKeyword' ||
+		annotation.type === 'TSNullKeyword' ||
+		annotation.type === 'TSUndefinedKeyword'
+	) {
+		return true;
+	}
+	if (annotation.type === 'TSLiteralType' && annotation.literal.type === 'Literal') {
+		return is_text_primitive_literal(annotation.literal);
+	}
+	if (annotation.type === 'TSUnionType') {
+		return annotation.types.every((type) => is_text_primitive_type_annotation(type));
+	}
+
+	return false;
+}
+
+/**
+ * @param {AST.TypeNode | undefined | null} type_annotation
+ * @param {string} property_name
+ * @returns {AST.TypeNode | undefined}
+ */
+export function get_property_type_annotation(type_annotation, property_name) {
+	const annotation = unwrap_type_annotation(type_annotation);
+
+	if (annotation?.type === 'TSIntersectionType') {
+		for (const type of annotation.types) {
+			const property_type = get_property_type_annotation(type, property_name);
+			if (property_type) return property_type;
+		}
+		return undefined;
+	}
+
+	if (annotation?.type !== 'TSTypeLiteral') {
+		return undefined;
+	}
+
+	for (const member of annotation.members) {
+		if (member.type !== 'TSPropertySignature' || member.computed) continue;
+
+		const key = member.key;
+		const name =
+			key.type === 'Identifier'
+				? key.name
+				: key.type === 'Literal' && typeof key.value === 'string'
+					? key.value
+					: null;
+
+		if (name === property_name) {
+			return member.typeAnnotation?.typeAnnotation;
+		}
+	}
+
+	return undefined;
+}
+
+/**
+ * @param {Binding | null | undefined} binding
+ * @returns {AST.TypeNode | undefined}
+ */
+export function get_binding_type_annotation(binding) {
+	const node = binding?.node;
+	if (!node) return undefined;
+
+	return (
+		/** @type {{ typeAnnotation?: AST.TSTypeAnnotation | AST.TypeNode }} */ (binding.metadata ?? {})
+			.typeAnnotation ??
+		/** @type {{ typeAnnotation?: AST.TSTypeAnnotation }} */ (node).typeAnnotation?.typeAnnotation
+	);
+}
+
+/**
+ * @param {AST.Expression} expression
+ * @returns {string | null}
+ */
+export function get_static_property_name(expression) {
+	if (expression.type !== 'MemberExpression' || expression.property.type === 'PrivateIdentifier') {
+		return null;
+	}
+
+	if (!expression.computed && expression.property.type === 'Identifier') {
+		return expression.property.name;
+	}
+
+	if (
+		expression.computed &&
+		expression.property.type === 'Literal' &&
+		typeof expression.property.value === 'string'
+	) {
+		return expression.property.value;
+	}
+
+	return null;
+}
+
+/**
+ * A literal whose value is a text primitive. Regex literals are objects and
+ * are excluded (their `value` can also be `null` when unserializable).
+ * @param {AST.Expression | AST.Pattern} expression
+ * @returns {boolean}
+ */
+export function is_text_primitive_literal(expression) {
+	if (expression.type !== 'Literal' || 'regex' in expression) {
+		return false;
+	}
+	const value = expression.value;
+	return (
+		value === null ||
+		typeof value === 'string' ||
+		typeof value === 'number' ||
+		typeof value === 'boolean' ||
+		typeof value === 'bigint'
+	);
+}
+
+/**
+ * Whether the expression provably evaluates to a text primitive — a string,
+ * number, boolean, bigint, null, or undefined. These render as plain escaped
+ * text (`String(value ?? '')` on the server, `value + ''` on the client), so
+ * they may use the inline text fast paths. Anything unproven can hold a
+ * template value — an element or a collection — and must render through the
+ * value-aware expression paths instead.
+ * @param {AST.Expression} expression
+ * @param {{ scope: ScopeInterface }} state
+ * @param {Set<Binding>} [visited]
+ * @returns {boolean}
+ */
+export function is_text_primitive_expression(expression, state, visited = new Set()) {
+	if (expression.type === 'ParenthesizedExpression' || expression.type === 'ChainExpression') {
+		return is_text_primitive_expression(
+			/** @type {AST.Expression} */ (expression.expression),
+			state,
+			visited,
+		);
+	}
+
+	if (expression.type === 'TSAsExpression' || expression.type === 'TSTypeAssertion') {
+		return (
+			is_text_primitive_type_annotation(expression.typeAnnotation) ||
+			is_text_primitive_expression(
+				/** @type {AST.Expression} */ (expression.expression),
+				state,
+				visited,
+			)
+		);
+	}
+
+	if (
+		expression.type === 'TSNonNullExpression' ||
+		expression.type === 'TSInstantiationExpression'
+	) {
+		return is_text_primitive_expression(
+			/** @type {AST.Expression} */ (expression.expression),
+			state,
+			visited,
+		);
+	}
+
+	if (is_text_primitive_literal(expression) || expression.type === 'TemplateLiteral') {
+		return true;
+	}
+
+	if (
+		expression.type === 'CallExpression' &&
+		expression.callee.type === 'Identifier' &&
+		(expression.callee.name === 'String' ||
+			expression.callee.name === 'Number' ||
+			expression.callee.name === 'Boolean')
+	) {
+		return true;
+	}
+
+	// Every binary, unary, and update expression yields a primitive in JS:
+	// `+` returns a string or number (object operands coerce first),
+	// arithmetic/bitwise operators return numbers or bigints, comparisons and
+	// `instanceof`/`in` return booleans, `typeof` returns a string, `void`
+	// returns undefined, `!`/`delete` return booleans.
+	if (
+		expression.type === 'BinaryExpression' ||
+		expression.type === 'UnaryExpression' ||
+		expression.type === 'UpdateExpression'
+	) {
+		return true;
+	}
+
+	// `&&`/`||`/`??` return one of their operands, so both must be proven.
+	if (expression.type === 'LogicalExpression') {
+		return (
+			is_text_primitive_expression(
+				/** @type {AST.Expression} */ (expression.left),
+				state,
+				visited,
+			) && is_text_primitive_expression(expression.right, state, visited)
+		);
+	}
+
+	if (expression.type === 'ConditionalExpression') {
+		return (
+			is_text_primitive_expression(expression.consequent, state, visited) &&
+			is_text_primitive_expression(expression.alternate, state, visited)
+		);
+	}
+
+	if (expression.type === 'Identifier') {
+		if (expression.name === 'undefined') {
+			return true;
+		}
+		const binding = state.scope.get(expression.name);
+		if (!binding || binding.node === expression || visited.has(binding)) {
+			return false;
+		}
+		if (is_text_primitive_type_annotation(get_binding_type_annotation(binding))) {
+			return true;
+		}
+		if (binding.initial && !binding.reassigned && !binding.mutated && !binding.updated) {
+			visited.add(binding);
+			return is_text_primitive_expression(
+				/** @type {AST.Expression} */ (binding.initial),
+				state,
+				visited,
+			);
+		}
+		return false;
+	}
+
+	if (expression.type === 'MemberExpression' && expression.object.type === 'Identifier') {
+		const property_name = get_static_property_name(expression);
+		if (property_name === null) return false;
+
+		const binding = state.scope.get(expression.object.name);
+		const property_type = get_property_type_annotation(
+			get_binding_type_annotation(binding),
+			property_name,
+		);
+		return is_text_primitive_type_annotation(property_type);
+	}
+
+	return false;
+}

--- a/packages/tsrx-ripple/src/utils.js
+++ b/packages/tsrx-ripple/src/utils.js
@@ -2043,25 +2043,42 @@ export function normalize_children(children, context) {
 		) {
 			const child_expression = get_template_expression(child, to_ts);
 			const prev_expression = get_template_expression(prev_child, to_ts);
+			// A call-containing expression must not merge into a stringified text
+			// run when the call could return a template value — but when the whole
+			// expression is provably a text primitive (`String(f())`, `void f()`),
+			// stringifying is exactly its render semantics, and merging keeps the
+			// run a single text node on both client and server (required for
+			// hydration to pair static and dynamic text).
 			if (
 				(is_template_expression(child) &&
 					is_children_template_expression(child_expression, context.state.scope)) ||
 				(is_template_expression(prev_child) &&
 					is_children_template_expression(prev_expression, context.state.scope)) ||
-				expression_contains_call(child_expression) ||
-				expression_contains_call(prev_expression)
+				(expression_contains_call(child_expression) &&
+					!is_text_primitive_expression(child_expression, context.state)) ||
+				(expression_contains_call(prev_expression) &&
+					!is_text_primitive_expression(prev_expression, context.state))
 			) {
 				continue;
 			}
 
+			// Each merged operand renders as `String(value ?? '')` — nullish must
+			// contribute NOTHING (a bare undefined would concat as "undefined").
+			// The wrapper is skipped only when provably unnecessary: a provably-
+			// string operand (never nullish, already a string) or a non-nullish
+			// primitive literal. Both cases guarantee at least one string operand
+			// per pair (a literal-only pair folds below), so `+` always
+			// concatenates.
+			/** @param {AST.Expression} operand */
+			const merge_operand = (operand) =>
+				is_text_primitive_expression(operand, context.state, undefined, true) ||
+				(operand.type === 'Literal' && !('regex' in operand) && operand.value != null)
+					? operand
+					: b.call('String', b.logical('??', operand, b.literal('')));
 			const merged_expression =
 				child_expression.type === 'Literal' && prev_expression.type === 'Literal'
 					? b.literal(prev_expression.value + String(child_expression.value))
-					: b.binary(
-							'+',
-							prev_expression,
-							b.call('String', b.logical('??', child_expression, b.literal(''))),
-						);
+					: b.binary('+', merge_operand(prev_expression), merge_operand(child_expression));
 			const merged = b.jsx_expression_container(
 				merged_expression,
 				/** @type {AST.NodeWithLocation} */ (prev_child),
@@ -2307,6 +2324,48 @@ function is_template_fragment_binding(binding, scope, visited = new Set()) {
 }
 
 /**
+ * A template fragment in children position that renders inline (see
+ * `normalize_child`). Code-block chains are deliberate lexical scopes,
+ * generated value wrappers carry their own lowering, and a component's root
+ * render fragment is the anchor the root-template machinery keys off — only
+ * plain grouping flattens. The to_ts view keeps authored fragments verbatim.
+ * @param {AST.Node} node
+ * @param {boolean} to_ts
+ * @returns {node is ESTreeJSX.JSXFragment}
+ */
+export function is_flattenable_template_fragment(node, to_ts) {
+	return (
+		!to_ts &&
+		is_template_fragment(node) &&
+		node.metadata?.tsrx_code_block_chain !== true &&
+		node.metadata?.tsrx_generated_wrapper !== true &&
+		node.metadata?.returned_tsrx_child !== true &&
+		node.metadata?.tsrx_render_fragment !== true
+	);
+}
+
+/**
+ * Collect the `<head>` elements rendered by a children list, looking through
+ * fragments that `normalize_child` flattens — their children render inline,
+ * so their heads belong to this list too.
+ * @param {AST.Node[]} children
+ * @param {boolean} to_ts
+ * @returns {ESTreeJSX.JSXElement[]}
+ */
+export function collect_head_elements(children, to_ts) {
+	/** @type {ESTreeJSX.JSXElement[]} */
+	const heads = [];
+	for (const node of children) {
+		if (is_template_element(node) && get_element_identifier(node)?.name === 'head') {
+			heads.push(/** @type {ESTreeJSX.JSXElement} */ (node));
+		} else if (is_flattenable_template_fragment(node, to_ts)) {
+			heads.push(...collect_head_elements(/** @type {AST.Node[]} */ (node.children), to_ts));
+		}
+	}
+	return heads;
+}
+
+/**
  * @param {AST.Node} node
  * @param {AST.Node[]} normalized
  * @param {CommonContext} context
@@ -2323,6 +2382,17 @@ function normalize_child(node, normalized, context) {
 		);
 		if (child != null) {
 			normalize_child(child, normalized, context);
+		}
+		return;
+	} else if (is_flattenable_template_fragment(node, !!context.state.to_ts)) {
+		// A template fragment in children position is transparent grouping — its
+		// children render inline, exactly as the same children authored without
+		// the fragment would (and exactly as the server writes them). Flattening
+		// costs zero DOM: no comment anchor, no runtime expression wrapper, and
+		// text runs can merge across the former fragment boundary. The to_ts
+		// view keeps authored fragments verbatim.
+		for (const child of /** @type {ESTreeJSX.JSXFragment} */ (node).children) {
+			normalize_child(/** @type {AST.Node} */ (child), normalized, context);
 		}
 		return;
 	} else if (
@@ -3035,29 +3105,37 @@ export function unwrap_type_annotation(type_annotation) {
 /**
  * Whether the type provably describes a text primitive — a string, number,
  * boolean, or bigint (or null/undefined, which render as ''). Unions qualify
- * only when every member does.
+ * only when every member does. With `strings_only`, only provably-string
+ * types qualify (a plain `+` concatenation and a skipped `?? ''` guard are
+ * then already correct).
  * @param {AST.TypeNode | undefined | null} type_annotation
+ * @param {boolean} [strings_only]
  * @returns {boolean}
  */
-export function is_text_primitive_type_annotation(type_annotation) {
+export function is_text_primitive_type_annotation(type_annotation, strings_only = false) {
 	const annotation = unwrap_type_annotation(type_annotation);
 	if (!annotation) return false;
 
+	if (annotation.type === 'TSStringKeyword') {
+		return true;
+	}
 	if (
-		annotation.type === 'TSStringKeyword' ||
-		annotation.type === 'TSNumberKeyword' ||
-		annotation.type === 'TSBooleanKeyword' ||
-		annotation.type === 'TSBigIntKeyword' ||
-		annotation.type === 'TSNullKeyword' ||
-		annotation.type === 'TSUndefinedKeyword'
+		!strings_only &&
+		(annotation.type === 'TSNumberKeyword' ||
+			annotation.type === 'TSBooleanKeyword' ||
+			annotation.type === 'TSBigIntKeyword' ||
+			annotation.type === 'TSNullKeyword' ||
+			annotation.type === 'TSUndefinedKeyword')
 	) {
 		return true;
 	}
 	if (annotation.type === 'TSLiteralType' && annotation.literal.type === 'Literal') {
-		return is_text_primitive_literal(annotation.literal);
+		return strings_only
+			? typeof annotation.literal.value === 'string'
+			: is_text_primitive_literal(annotation.literal);
 	}
 	if (annotation.type === 'TSUnionType') {
-		return annotation.types.every((type) => is_text_primitive_type_annotation(type));
+		return annotation.types.every((type) => is_text_primitive_type_annotation(type, strings_only));
 	}
 
 	return false;
@@ -3168,27 +3246,40 @@ export function is_text_primitive_literal(expression) {
  * they may use the inline text fast paths. Anything unproven can hold a
  * template value — an element or a collection — and must render through the
  * value-aware expression paths instead.
+ *
+ * With `strings_only`, only provably-STRING expressions qualify: string
+ * literals/templates, `String()`, `typeof`, `+` with a provably-string
+ * operand, `as string`, and string-typed bindings/members. A merged text run
+ * can concatenate those bare — no `String(… ?? '')` wrapper needed.
  * @param {AST.Expression} expression
  * @param {{ scope: ScopeInterface }} state
  * @param {Set<Binding>} [visited]
+ * @param {boolean} [strings_only]
  * @returns {boolean}
  */
-export function is_text_primitive_expression(expression, state, visited = new Set()) {
+export function is_text_primitive_expression(
+	expression,
+	state,
+	visited = new Set(),
+	strings_only = false,
+) {
 	if (expression.type === 'ParenthesizedExpression' || expression.type === 'ChainExpression') {
 		return is_text_primitive_expression(
 			/** @type {AST.Expression} */ (expression.expression),
 			state,
 			visited,
+			strings_only,
 		);
 	}
 
 	if (expression.type === 'TSAsExpression' || expression.type === 'TSTypeAssertion') {
 		return (
-			is_text_primitive_type_annotation(expression.typeAnnotation) ||
+			is_text_primitive_type_annotation(expression.typeAnnotation, strings_only) ||
 			is_text_primitive_expression(
 				/** @type {AST.Expression} */ (expression.expression),
 				state,
 				visited,
+				strings_only,
 			)
 		);
 	}
@@ -3201,19 +3292,26 @@ export function is_text_primitive_expression(expression, state, visited = new Se
 			/** @type {AST.Expression} */ (expression.expression),
 			state,
 			visited,
+			strings_only,
 		);
 	}
 
-	if (is_text_primitive_literal(expression) || expression.type === 'TemplateLiteral') {
+	if (expression.type === 'TemplateLiteral') {
 		return true;
+	}
+
+	if (is_text_primitive_literal(expression)) {
+		return strings_only
+			? typeof (/** @type {AST.Literal} */ (expression).value) === 'string'
+			: true;
 	}
 
 	if (
 		expression.type === 'CallExpression' &&
 		expression.callee.type === 'Identifier' &&
 		(expression.callee.name === 'String' ||
-			expression.callee.name === 'Number' ||
-			expression.callee.name === 'Boolean')
+			(!strings_only &&
+				(expression.callee.name === 'Number' || expression.callee.name === 'Boolean')))
 	) {
 		return true;
 	}
@@ -3222,13 +3320,26 @@ export function is_text_primitive_expression(expression, state, visited = new Se
 	// `+` returns a string or number (object operands coerce first),
 	// arithmetic/bitwise operators return numbers or bigints, comparisons and
 	// `instanceof`/`in` return booleans, `typeof` returns a string, `void`
-	// returns undefined, `!`/`delete` return booleans.
-	if (
-		expression.type === 'BinaryExpression' ||
-		expression.type === 'UnaryExpression' ||
-		expression.type === 'UpdateExpression'
-	) {
-		return true;
+	// returns undefined, `!`/`delete` return booleans. Only `+` with a
+	// provably-string operand and `typeof` prove a STRING.
+	if (expression.type === 'BinaryExpression') {
+		if (!strings_only) return true;
+		return (
+			expression.operator === '+' &&
+			(is_text_primitive_expression(
+				/** @type {AST.Expression} */ (expression.left),
+				state,
+				visited,
+				true,
+			) ||
+				is_text_primitive_expression(expression.right, state, visited, true))
+		);
+	}
+	if (expression.type === 'UnaryExpression') {
+		return strings_only ? expression.operator === 'typeof' : true;
+	}
+	if (expression.type === 'UpdateExpression') {
+		return !strings_only;
 	}
 
 	// `&&`/`||`/`??` return one of their operands, so both must be proven.
@@ -3238,26 +3349,27 @@ export function is_text_primitive_expression(expression, state, visited = new Se
 				/** @type {AST.Expression} */ (expression.left),
 				state,
 				visited,
-			) && is_text_primitive_expression(expression.right, state, visited)
+				strings_only,
+			) && is_text_primitive_expression(expression.right, state, visited, strings_only)
 		);
 	}
 
 	if (expression.type === 'ConditionalExpression') {
 		return (
-			is_text_primitive_expression(expression.consequent, state, visited) &&
-			is_text_primitive_expression(expression.alternate, state, visited)
+			is_text_primitive_expression(expression.consequent, state, visited, strings_only) &&
+			is_text_primitive_expression(expression.alternate, state, visited, strings_only)
 		);
 	}
 
 	if (expression.type === 'Identifier') {
 		if (expression.name === 'undefined') {
-			return true;
+			return !strings_only;
 		}
 		const binding = state.scope.get(expression.name);
 		if (!binding || binding.node === expression || visited.has(binding)) {
 			return false;
 		}
-		if (is_text_primitive_type_annotation(get_binding_type_annotation(binding))) {
+		if (is_text_primitive_type_annotation(get_binding_type_annotation(binding), strings_only)) {
 			return true;
 		}
 		if (binding.initial && !binding.reassigned && !binding.mutated && !binding.updated) {
@@ -3266,6 +3378,7 @@ export function is_text_primitive_expression(expression, state, visited = new Se
 				/** @type {AST.Expression} */ (binding.initial),
 				state,
 				visited,
+				strings_only,
 			);
 		}
 		return false;
@@ -3280,7 +3393,7 @@ export function is_text_primitive_expression(expression, state, visited = new Se
 			get_binding_type_annotation(binding),
 			property_name,
 		);
-		return is_text_primitive_type_annotation(property_type);
+		return is_text_primitive_type_annotation(property_type, strings_only);
 	}
 
 	return false;

--- a/packages/tsrx-ripple/tests/basic.test.js
+++ b/packages/tsrx-ripple/tests/basic.test.js
@@ -2006,3 +2006,68 @@ describe('@tsrx/ripple server expression classification', () => {
 		expect(code).not.toContain('_$_.render_expression');
 	});
 });
+
+describe('@tsrx/ripple fragment children flatten', () => {
+	// A fragment in children position is transparent grouping: it must add
+	// ZERO dom — no comment anchor, no runtime expression wrapper — and its
+	// text merges into the surrounding run.
+	it('renders fragment children inline with no extra nodes', () => {
+		const source = `export function App() @{
+				<div>{'a'}<>{'b'}<span>{'c'}</span></>{'d'}</div>
+			}`;
+
+		const { code } = compile(source, 'App.tsrx');
+		expect(code).toContain('`<div>ab<span>c</span>d</div>`');
+		expect(code).not.toContain('<!>');
+		expect(code).not.toContain('_$_.expression');
+
+		const server = compile(source, 'App.tsrx', { mode: 'server' });
+		expect(server.code).toContain(`'<div>ab<span>c</span>d</div>'`);
+	});
+
+	it('flattens nested fragments recursively', () => {
+		const source = `export function App() @{
+				<div>{'a'}<><>{'b'}</><>{'c'}<span>{'d'}</span></></></div>
+			}`;
+
+		const { code } = compile(source, 'App.tsrx');
+		expect(code).toContain('`<div>abc<span>d</span></div>`');
+		expect(code).not.toContain('<!>');
+
+		const server = compile(source, 'App.tsrx', { mode: 'server' });
+		expect(server.code).toContain(`'<div>abc<span>d</span></div>'`);
+	});
+
+	it('handles control flow inside a flattened fragment at the parent level', () => {
+		const source = `export function App({ ok }) @{
+				<div>{'a'}<>@if (ok) { <b>{'y'}</b> } @else { <i>{'n'}</i> }</>{'z'}</div>
+			}`;
+
+		const { code } = compile(source, 'App.tsrx');
+		// The directive anchors directly in the parent template — exactly one
+		// comment anchor, no fragment wrapper expression around it.
+		expect(code).toContain('_$_.if(');
+		expect((code.match(/<!>/g) || []).length).toBe(1);
+		expect(code).not.toContain('_$_.expression(');
+
+		const server = compile(source, 'App.tsrx', { mode: 'server' });
+		expect(server.code).toContain('if (ok) {');
+	});
+
+	it('extracts head elements from inside flattened fragments in client output', () => {
+		const source = `export function App({ ok }) @{
+				@if (ok) {
+					<>
+						<head>
+							<title>{'late'}</title>
+						</head>
+						<p>{'content'}</p>
+					</>
+				}
+			}`;
+
+		const { code } = compile(source, 'App.tsrx');
+		expect(code).toContain('_$_.head(');
+		expect(code).toContain('_$_.document.title');
+	});
+});

--- a/packages/tsrx-ripple/tests/basic.test.js
+++ b/packages/tsrx-ripple/tests/basic.test.js
@@ -769,11 +769,13 @@ describe('@tsrx/ripple lowers a directive value to a typed value in to_ts (like 
 		const code = ts(
 			`function App({ xs, c }: { xs: number[]; c: any }) @{ const v = @switch (c) { @case 1: { <><a /> @for (const x of xs) { <li>{x}</li> }</> } }; <div>{v}</div> }`,
 		);
+		// The inline space between `<a />` and the directive is significant sibling
+		// whitespace (it would render between inline elements) and stays in the output.
 		expect(code).toMatch(
-			/<><a \/>\{Array\.from\(xs\)\.map\(\(x\) => \{\s*return <li>\{x\}<\/li>;\s*\}\)\}<\/>/,
+			/<><a \/> \{Array\.from\(xs\)\.map\(\(x\) => \{\s*return <li>\{x\}<\/li>;\s*\}\)\}<\/>/,
 		);
 		// not a void IIFE-with-for inside the fragment.
-		expect(code).not.toMatch(/<a \/>\{\(\(\) => \{\s*for \(/);
+		expect(code).not.toMatch(/<a \/> \{\(\(\) => \{\s*for \(/);
 	});
 
 	// The same nested directive in RENDER position (a direct child of the rendered
@@ -1924,5 +1926,83 @@ describe('@tsrx/ripple template comments', () => {
 	it('keeps template comments out of to_ts output', () => {
 		const { code } = compile_to_volar_mappings(source, 'App.tsrx', { loose: true });
 		expect(code).not.toMatch(/world|hello/);
+	});
+});
+
+describe('@tsrx/ripple template elements in expression position', () => {
+	// An element inside an expression container or attribute value is a value,
+	// not a rendered child — it must lower to a `_$_.tsrx_element(…)` handle in
+	// both modes instead of leaking raw JSX (or a raw directive node) to the
+	// printer.
+	const attribute_source = `export function App() @{
+			<Child prop={<h1>@if (true) { <div>1</div> } @else { <div>2</div> }</h1>} />
+		}`;
+	const container_source = `export function App() @{
+			<div>{<h1>@if (true) { <span>1</span> } @else { <span>2</span> }</h1>}</div>
+		}`;
+
+	it('lowers an element-valued attribute with control flow in client and server output', () => {
+		for (const mode of ['client', 'server']) {
+			const { code } = compile(attribute_source, 'App.tsrx', { mode });
+			expect(code).toContain('prop: _$_.tsrx_element(');
+			expect(code).not.toContain('@if');
+			expect(code).not.toContain('<h1>@if');
+		}
+	});
+
+	it('lowers an element inside a child expression container in client and server output', () => {
+		const client = compile(container_source, 'App.tsrx', { mode: 'client' });
+		expect(client.code).toContain('_$_.expression(expression, () => _$_.tsrx_element(');
+		expect(client.code).not.toContain('() => <h1>');
+
+		const server = compile(container_source, 'App.tsrx', { mode: 'server' });
+		expect(server.code).toContain('_$_.render_expression(_$_.tsrx_element(');
+	});
+});
+
+describe('@tsrx/ripple server expression classification', () => {
+	// Only provably-string expressions may use the inline-escape fast path;
+	// anything else can hold a template value and must render through
+	// `render_expression`. `<title>` is text-only per spec, so its expression
+	// children always escape — hydration markers must never reach
+	// `document.title`.
+	it('escapes provably-primitive expressions and defers the rest to render_expression', () => {
+		const { code } = compile(
+			`export function App(props: { n: number, s: string }) @{
+				<>
+					<div>{props.s}</div>
+					<em>{'lit' + props.n}</em>
+					<b>{String(props.n)}</b>
+					<i>{props.n as string}</i>
+					<span>{props.n}</span>
+					<section>{props.anything}</section>
+				</>
+			}`,
+			'App.tsrx',
+			{ mode: 'server', loose: true },
+		);
+
+		expect(code).toContain('_$_.escape(props.s)');
+		expect(code).toContain("_$_.escape('lit' + props.n)");
+		expect(code).toContain('_$_.escape(String(props.n))');
+		// `props.n` is number-typed — provably a text primitive, so it escapes.
+		expect(code).toContain('_$_.escape(props.n)');
+		expect(code).toContain('_$_.render_expression(props.anything)');
+		expect(code).not.toContain('_$_.render_expression(props.s)');
+	});
+
+	it('keeps title expression children on the escaping text path', () => {
+		const { code } = compile(
+			`export function App(props: { anything: unknown }) @{
+				<head>
+					<title>{props.anything}</title>
+				</head>
+			}`,
+			'App.tsrx',
+			{ mode: 'server', loose: true },
+		);
+
+		expect(code).toContain('_$_.escape(props.anything)');
+		expect(code).not.toContain('_$_.render_expression');
 	});
 });

--- a/packages/tsrx-ripple/tests/code-block-children.test.js
+++ b/packages/tsrx-ripple/tests/code-block-children.test.js
@@ -22,7 +22,7 @@ describe('@tsrx/ripple code blocks in template children position', () => {
 		const component = code.search(/_\$_\.tsrx_element\(\(__anchor, __block\) => \{\s*const x = 1;/);
 		expect(component).toBeGreaterThan(-1);
 		expect(code.indexOf('_$_.expression(')).toBeLessThan(component);
-		expect(code).toContain('() => x');
+		expect(code).toContain('.nodeValue = x;');
 		expect(code).not.toContain('(() => {');
 	});
 
@@ -66,7 +66,7 @@ describe('@tsrx/ripple code blocks in template children position', () => {
 		// Shadowed declarations survive because each block is its own scope.
 		expect(code).toContain('const x = 1;');
 		expect(code).toContain('const x = 2;');
-		expect(code).toContain('() => x + y');
+		expect(code).toContain('.nodeValue = x + y;');
 		// Each nesting level becomes its own inline component scope.
 		expect(code.indexOf('const x = 2;')).toBeGreaterThan(code.indexOf('const x = 1;'));
 	});
@@ -203,8 +203,11 @@ describe('@tsrx/ripple code blocks in template children position', () => {
 		expect(errors).toEqual([]);
 		const scoped_decl = code.indexOf('const scoped = 1;');
 		expect(scoped_decl).toBeGreaterThan(-1);
-		expect(code.indexOf('_$_.escape(items.length)')).toBeGreaterThan(scoped_decl);
-		expect(code).not.toContain('render_expression');
+		// `items.length` is not provably a string, so it renders through
+		// `render_expression`; a code-only block still produces no inline
+		// component — the root element is the only `tsrx_element`.
+		expect(code.indexOf('_$_.render_expression(items.length)')).toBeGreaterThan(scoped_decl);
+		expect(code.match(/_\$_\.tsrx_element\(/g)).toHaveLength(1);
 	});
 
 	const nested_function_body = `function App() @{
@@ -224,7 +227,7 @@ describe('@tsrx/ripple code blocks in template children position', () => {
 		expect(anchor).toBeGreaterThan(-1);
 		expect(code.indexOf('const x = 1;')).toBeLessThan(anchor);
 		expect(code.indexOf('const y = 2;')).toBeGreaterThan(anchor);
-		expect(code).toContain('() => x + y');
+		expect(code).toContain('.nodeValue = x + y;');
 	});
 
 	it('scopes a nested code-block render chain in a function body (server)', () => {
@@ -261,6 +264,8 @@ describe('@tsrx/ripple code blocks in template children position', () => {
 		const { code, errors } = compile(inside_if, 'App.tsrx', { mode: 'server' });
 		expect(errors).toEqual([]);
 		expect(code).toContain(`const label = 'shown';`);
+		// `label` is bound to a string literal — provably stringish, so it keeps
+		// the inline-escape fast path.
 		expect(code).toContain('_$_.escape(label)');
 	});
 });

--- a/packages/tsrx-vue/tests/basic.test.js
+++ b/packages/tsrx-vue/tests/basic.test.js
@@ -149,10 +149,8 @@ describe('@tsrx/vue basic', () => {
 			'App.tsrx',
 		);
 
-		expect(code).toContain('fragment={() => <>');
-		expect(code).toContain('<>Delete</>');
-		expect(code).toContain('<>Edit</>');
-		expect(code).toContain('native={() => <>');
+		expect(code).toMatch(/fragment={\(\) => {\s+return <>{\[<>Delete<\/>, <>Edit<\/>\]}<\/>;/);
+		expect(code).toMatch(/native={\(\) => {\s+return <>{\[<>Delete<\/>, <>Edit<\/>\]}<\/>;/);
 	});
 
 	it('emits scoped CSS and applies the scope hash to host elements', () => {

--- a/packages/tsrx/src/plugin.js
+++ b/packages/tsrx/src/plugin.js
@@ -7,7 +7,7 @@
 import * as acorn from 'acorn';
 import { isWhitespaceTextNode, BINDING_TYPES, DestructuringErrors } from './parse/index.js';
 import { parse_style } from './parse/style.js';
-import { regex_newline_characters } from './utils/patterns.js';
+import { regex_newline_characters, regex_not_whitespace } from './utils/patterns.js';
 import { error } from './errors.js';
 import { DIAGNOSTIC_CODES } from './diagnostics.js';
 import { TSRX_RETURN_STATEMENT_ERROR } from './analyze/validation.js';
@@ -926,14 +926,24 @@ export function TSRXPlugin(config) {
 			 *   template-mode element whose text children are raw JSX text; the rest of
 			 *   the directive/comment/boundary checks below still apply, so a directive
 			 *   body inside an expression container is correctly excluded.
+			 * @param {boolean} [ignore_directive_start] Skip the directive-start bail —
+			 *   used to ask whether the position is template text APART from starting a
+			 *   directive, so whitespace directly before the directive can be kept. Also
+			 *   skips the value-position (`#templateScriptParsingDepth`) and `@switch`
+			 *   (JS switch label) bails: those describe the surrounding construct, not
+			 *   this position, and significant whitespace between template siblings must
+			 *   not depend on which construct the template sits in.
 			 */
-			#shouldReadTemplateRawTextToken(allow_inside_expression_container = false) {
+			#shouldReadTemplateRawTextToken(
+				allow_inside_expression_container = false,
+				ignore_directive_start = false,
+			) {
 				if (
 					this.#closingNativeTemplateNode ||
 					this.#readingJSXControlFlowDirectiveKeyword ||
 					this.#readingJSXControlFlowHeader ||
 					this.#parsingJSXSwitchCaseScriptStatementDepth > 0 ||
-					this.#templateScriptParsingDepth > 0 ||
+					(!ignore_directive_start && this.#templateScriptParsingDepth > 0) ||
 					(!allow_inside_expression_container && this.#jsxExpressionContainerDepth > 0)
 				) {
 					return false;
@@ -942,11 +952,14 @@ export function TSRXPlugin(config) {
 				if (current_context_token === '<tag' || current_context_token === '</tag') {
 					return false;
 				}
-				if (this.labels.some((label) => label.kind === 'switch')) {
+				if (!ignore_directive_start && this.labels.some((label) => label.kind === 'switch')) {
 					return false;
 				}
 				const current_template_node = this.#currentNativeTemplateNode();
-				if (!current_template_node || this.#isJSXControlFlowDirectiveAt(this.pos)) {
+				if (
+					!current_template_node ||
+					(!ignore_directive_start && this.#isJSXControlFlowDirectiveAt(this.pos))
+				) {
 					return false;
 				}
 				// Inside an expression container (only reachable with
@@ -1020,6 +1033,26 @@ export function TSRXPlugin(config) {
 					return true;
 				}
 				return true;
+			}
+
+			/**
+			 * At a raw-text bail boundary in `jsx_readToken`, decides whether the
+			 * accumulated run is template text that must be finished as a jsxText
+			 * token rather than silently discarded by the token-start reset. True
+			 * when the run contains non-whitespace (whitespace accumulates without
+			 * consulting the raw-text gate, so a whitespace-only run can be plain JS
+			 * layout — a newline before a `return`, indentation before `: null`), or
+			 * when it is significant whitespace directly before a directive in an
+			 * open template element (`<><a /> @for (…) { … }</>`).
+			 * @param {string} accumulated
+			 */
+			#shouldFinishAccumulatedTemplateText(accumulated) {
+				if (!accumulated) return false;
+				if (regex_not_whitespace.test(accumulated)) return true;
+				return (
+					this.#isJSXControlFlowDirectiveAt(this.pos) &&
+					this.#shouldReadTemplateRawTextToken(true, true)
+				);
 			}
 
 			#readTemplateRawTextToken() {
@@ -1438,7 +1471,10 @@ export function TSRXPlugin(config) {
 			 * @type {Parse.Parser['parseExprAtom']}
 			 */
 			parseExprAtom(refDestructuringErrors, forInit, forNew) {
-				if (this.input.charCodeAt(this.start) === CharCode.at) {
+				// A token already consumed as JSX text (a script-mode element child) must
+				// stay text even when it happens to begin at an `@` — otherwise whether
+				// `@if` parses as a directive would depend on leading whitespace.
+				if (this.input.charCodeAt(this.start) === CharCode.at && this.type !== tstt.jsxText) {
 					if (this.#isCodeBlockStart(this.start)) {
 						return /** @type {any} */ (this.#parseCodeBlock());
 					}
@@ -3731,13 +3767,23 @@ export function TSRXPlugin(config) {
 			/** @type {Parse.Parser['jsx_parseAttributeValue']} */
 			jsx_parseAttributeValue() {
 				switch (this.type) {
-					case tt.braceL:
+					case tt.braceL: {
+						// The host element's `templateMode` is still `'script'` while its
+						// opening tag parses, which would route JSX inside the value
+						// container to the vanilla (non-TSRX) element parser. Clear the
+						// opening node so the container parses exactly like a child-position
+						// `{ … }` container — an inline template value must behave the same
+						// as one assigned to a variable and passed by name.
+						const opening_node = this.#openingNativeTemplateNode;
+						this.#openingNativeTemplateNode = null;
 						this.#jsxAttributeValueExpressionDepth++;
 						try {
 							return this.jsx_parseExpressionContainer();
 						} finally {
 							this.#jsxAttributeValueExpressionDepth--;
+							this.#openingNativeTemplateNode = opening_node;
 						}
+					}
 					case tstt.jsxTagStart:
 					case tt.string:
 						return this.parseExprAtom();
@@ -3996,17 +4042,26 @@ export function TSRXPlugin(config) {
 
 					switch (ch) {
 						case CharCode.equals:
+							// The `allow_inside_expression_container` form keeps `=` (and `=>`)
+							// as text inside a container-nested element's children, matching the
+							// bare-template path — see the default case below.
 							if (
-								!this.#shouldReadTemplateRawTextToken() &&
+								!this.#shouldReadTemplateRawTextToken(true) &&
 								this.input.charCodeAt(this.pos + 1) === CharCode.greaterThan
 							) {
 								this.#resetTokenStartToCurrentPosition();
 								this.pos += 2;
 								return this.finishToken(tt.arrow);
 							}
-							if (this.#shouldReadTemplateRawTextToken()) {
+							if (this.#shouldReadTemplateRawTextToken(true)) {
 								++this.pos;
 								break;
+							}
+							{
+								const accumulated = out + this.input.slice(chunkStart, this.pos);
+								if (this.#shouldFinishAccumulatedTemplateText(accumulated)) {
+									return this.finishToken(tstt.jsxText, accumulated);
+								}
 							}
 							this.#resetTokenStartToCurrentPosition();
 							this.context.push(b_stat);
@@ -4185,6 +4240,16 @@ export function TSRXPlugin(config) {
 								if (this.#shouldReadTemplateRawTextToken(true)) {
 									++this.pos;
 									break;
+								}
+								// Like `<` and `{` above, a bail boundary (e.g. a directive's `@`)
+								// must first finish accumulated template text — resetting the token
+								// start here would silently drop it from the template. See
+								// `#shouldFinishAccumulatedTemplateText` for which runs qualify.
+								{
+									const accumulated = out + this.input.slice(chunkStart, this.pos);
+									if (this.#shouldFinishAccumulatedTemplateText(accumulated)) {
+										return this.finishToken(tstt.jsxText, accumulated);
+									}
 								}
 								this.#resetTokenStartToCurrentPosition();
 								this.context.push(b_stat);

--- a/packages/tsrx/tests/shared/compile.js
+++ b/packages/tsrx/tests/shared/compile.js
@@ -486,6 +486,21 @@ export function runSharedTsxExpressionTsrxTests({ compile, name, classAttrName }
 	});
 
 	describe(`[${name}] control flow in expression position`, () => {
+		it('lowers a directive inside an element-valued attribute', () => {
+			const { code } = compile(
+				`function Child(props) { return null; }
+
+					export function App() @{
+						<Child prop={<h1>@if (true) { <div>1</div> } @else { <div>2</div> }</h1>} />
+					}`,
+				'App.tsrx',
+			);
+			expect(code).toContain('prop={<h1>');
+			expect(code).toContain('<div>1</div>');
+			expect(code).toContain('<div>2</div>');
+			expect(code).not.toContain('@if');
+		});
+
 		it('lowers @switch assigned to a variable', () => {
 			const { code } = compile(
 				`function App({ status }: { status: string }) {
@@ -2883,9 +2898,12 @@ export function optionalFn(bar: string, baz?: string) {
 			);
 
 			expect(code).not.toContain('return;');
-			expect(code).toContain('return <><div>fragment</div></>;');
-			expect(code).toContain('return <><div>tsx</div></>;');
-			expect(code).toContain('return <><div>tsrx</div></>;');
+			expect(code).toMatch(/const App__static\d+ = <div[^>]*>fragment<\/div>;/);
+			expect(code).toMatch(/const App__static\d+ = <div[^>]*>tsx<\/div>;/);
+			expect(code).toMatch(/const App__static\d+ = <div[^>]*>tsrx<\/div>;/);
+			expect(code).toMatch(/fragment={\(\) => {\s+return <>{App__static\d+}<\/>;/);
+			expect(code).toMatch(/tsx={\(\) => {\s+return <>{App__static\d+}<\/>;/);
+			expect(code).toMatch(/tsrx={\(\) => {\s+return <>{App__static\d+}<\/>;/);
 		});
 
 		it('parses semicolon-less JSX returns in component prop arrow functions', () => {
@@ -2919,10 +2937,8 @@ export function optionalFn(bar: string, baz?: string) {
 				'App.tsrx',
 			);
 
-			expect(code).toContain('fragment={() => <>');
-			expect(code).toContain('native={() => <>');
-			expect(code).toContain('<>Delete</>');
-			expect(code).toContain('<>Edit</>');
+			expect(code).toMatch(/fragment={\(\) => {\s+return <>{\[<>Delete<\/>, <>Edit<\/>\]}<\/>;/);
+			expect(code).toMatch(/native={\(\) => {\s+return <>{\[<>Delete<\/>, <>Edit<\/>\]}<\/>;/);
 		});
 	});
 

--- a/packages/tsrx/tests/utils/parser.test.js
+++ b/packages/tsrx/tests/utils/parser.test.js
@@ -756,6 +756,150 @@ abc
 		expect(directive.alternate?.type).toBe('BlockStatement');
 	});
 
+	it('parses an element-wrapped directive attribute value', () => {
+		// The host element's `templateMode` is still `'script'` while its opening
+		// tag parses, which routed the attribute value's element to the vanilla
+		// JSX parser — turning the directive into literal text. An inline template
+		// value must parse the same as one assigned to a variable first.
+		const element = findElement(
+			`export function FeatureCard() @{
+				<ElementA prop={<h1>
+					@if (ok) { <div>1</div> } @else { <div>2</div> }
+				</h1>} />
+			}`,
+			'ElementA',
+		);
+
+		const [attribute] = element.openingElement.attributes;
+		expect(attribute.value.type).toBe('JSXExpressionContainer');
+		expect(attribute.value.expression.type).toBe('JSXElement');
+		const directive = attribute.value.expression.children.find(
+			(child) => child.type === 'JSXIfExpression',
+		);
+		expect(directive.type).toBe('JSXIfExpression');
+		expect(directive.alternate?.type).toBe('BlockStatement');
+	});
+
+	it('parses an element-wrapped directive attribute value with no whitespace around the directive', () => {
+		// With no gap after `<h1>`, the vanilla-parsed text token began exactly at
+		// the `@`, so the at-sign expression intercept re-parsed it as a directive
+		// inside an otherwise untransformed subtree — crashing the printer.
+		// Whether `@if` is a directive must not depend on leading whitespace.
+		const element = findElement(
+			`export function FeatureCard() @{
+				<ElementA prop={<h1>@if (ok) { <div>1</div> } @else { <div>2</div> }</h1>} />
+			}`,
+			'ElementA',
+		);
+
+		const [attribute] = element.openingElement.attributes;
+		expect(attribute.value.expression.type).toBe('JSXElement');
+		const [directive] = attribute.value.expression.children;
+		expect(directive.type).toBe('JSXIfExpression');
+		expect(directive.alternate?.type).toBe('BlockStatement');
+	});
+
+	it('keeps text before and after a directive in an element-wrapped attribute value', () => {
+		// The tokenizer's raw-text loop used to re-anchor at the directive's `@`
+		// (and at `=`), silently dropping the text it had already accumulated —
+		// container-nested elements lost everything before the directive.
+		const element = findElement(
+			`export function FeatureCard() @{
+				<ElementA prop={<h1>before @if (ok) { <div>1</div> } @else { <div>2</div> } after</h1>} />
+			}`,
+			'ElementA',
+		);
+
+		const [attribute] = element.openingElement.attributes;
+		expect(attribute.value.expression.children.map((child) => child.type)).toEqual([
+			'JSXText',
+			'JSXIfExpression',
+			'JSXText',
+		]);
+		const [before, , after] = attribute.value.expression.children;
+		expect(before.value).toBe('before ');
+		expect(after.value).toBe(' after');
+	});
+
+	it('keeps text before and after a directive in an element nested in an expression container', () => {
+		const element = findElement(
+			`export function FeatureCard() @{
+				<div>{<h1>before @if (ok) { <div>1</div> } @else { <div>2</div> } after</h1>}</div>
+			}`,
+			'h1',
+		);
+
+		expect(element.children.map((child) => child.type)).toEqual([
+			'JSXText',
+			'JSXIfExpression',
+			'JSXText',
+		]);
+		const [before, , after] = element.children;
+		expect(before.value).toBe('before ');
+		expect(after.value).toBe(' after');
+	});
+
+	it('keeps a significant inline space between a sibling element and a directive in every position', () => {
+		// Sibling whitespace is rendered by the browser (`<a></a> <li>` shows a
+		// space), so it must not depend on which construct the template sits in.
+		// The tokenizer used to drop it at the directive's `@` in container and
+		// attribute positions, inside `@switch` bodies (JS switch label bail),
+		// and inside value-position directives (template-script depth bail).
+		const host = `<h1><a /> @if (ok) { <li>x</li> }</h1>`;
+		const positions = [
+			['template child', `function App({ ok }) @{ <div>${host}</div> }`],
+			['directive render body', `function App({ ok }) @{ @if (ok) { ${host} } }`],
+			[
+				'directive value',
+				`function App({ ok }) @{ const v = @if (ok) { ${host} }; <div>{v}</div> }`,
+			],
+			['@switch case body', `function App({ ok, c }) @{ @switch (c) { @case 1: { ${host} } } }`],
+			['attribute value', `function App({ ok }) @{ <ElementA prop={${host}} /> }`],
+			['expression container child', `function App({ ok }) @{ <div>{${host}}</div> }`],
+		];
+
+		for (const [position, source] of positions) {
+			const element = findElement(source, 'h1');
+			expect(
+				element.children.map((child) => child.type),
+				position,
+			).toEqual(['JSXElement', 'JSXText', 'JSXIfExpression']);
+			expect(element.children[1].value, position).toBe(' ');
+		}
+	});
+
+	it('still drops layout indentation before a directive', () => {
+		// Whitespace containing a newline is layout, not content — the JSX
+		// significant-whitespace rule removes it in every position.
+		const element = findElement(
+			`function App({ ok, c }) @{
+				const v = @switch (c) { @case 1: { <h1><a />
+					@if (ok) { <li>x</li> }
+				</h1> } };
+				<div>{v}</div>
+			}`,
+			'h1',
+		);
+
+		expect(element.children.map((child) => child.type)).toEqual(['JSXElement', 'JSXIfExpression']);
+	});
+
+	it('keeps text around `=` inside a container-nested element', () => {
+		// `=` is a raw-text bail boundary like `@`; the accumulated run before it
+		// used to be discarded in expression-container positions.
+		for (const [position, source] of [
+			['expression container child', `function App() @{ <div>{<h1>a = b</h1>}</div> }`],
+			['attribute value', `function App() @{ <ElementA prop={<h1>a = b</h1>} /> }`],
+		]) {
+			const element = findElement(source, 'h1');
+			expect(
+				element.children.map((child) => child.type),
+				position,
+			).toEqual(['JSXText']);
+			expect(element.children[0].value, position).toBe('a = b');
+		}
+	});
+
 	it('parses an attribute that follows a directive attribute value', () => {
 		const element = findElement(
 			`export function FeatureCard() @{


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core parser, client/server transforms, and hydration DOM shape across many compiled fixtures; behavior changes are broad but covered by expanded tests rather than security-sensitive areas.
> 
> **Overview**
> Fixes **template lowering and parsing** so inline JSX in `{…}` children and `prop={…}` attributes (including `@if` inside those elements) compile to **`tsrx_element` values** on client and server instead of raw JSX or broken directive nodes.
> 
> Introduces **`is_text_primitive_expression`** to route children: provably text primitives keep inline escape/`set_text` paths and can **merge into one text run** (e.g. `label: {String(f())}`), while opaque values use **`render_expression`** so elements and props render as markup rather than `[object Object]`. **`<title>`** children always use the escaping text path.
> 
> **Authored `<>…</>` in children position** now **flatten** during normalization (no extra comment anchors), aligning client DOM with SSR and fixing fragment hydration; **`<head>`** extraction follows flattened fragments.
> 
> **Parser** changes: attribute `{…}` values parse like child containers (directives recognized); **significant whitespace** before `@` directives and around siblings is retained instead of dropped at bail boundaries; `@` in existing `jsxText` stays text.
> 
> SSR/streaming golden output shifts to **`<!--[-->`…`<!--]-->`** around dynamic expression segments where `render_expression` is used.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00e9a7da4f677834c363e2e9674850a0e968e5bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->