### PR TITLE
fix: prettier bigint

### DIFF
--- a/.changeset/prettier-numeric-literals.md
+++ b/.changeset/prettier-numeric-literals.md
@@ -1,0 +1,12 @@
+---
+'@tsrx/prettier-plugin': patch
+---
+
+fix: print bigint and numeric literals from their source form
+
+Formatting a file containing a bigint literal threw `TypeError: Do not know how
+to serialize a BigInt`, because every non-string literal was reprinted with
+`JSON.stringify(node.value)`. Literals now print from `raw`: bigints keep their
+radix (`0xffn`), and numeric literals keep their radix, digit separators, and
+exponent (`0xff`, `1_000_000`, `1e21`) instead of being rewritten to their
+decimal value.

--- a/packages/prettier-plugin/src/index.js
+++ b/packages/prettier-plugin/src/index.js
@@ -214,6 +214,12 @@ function isRawScriptElement(node) {
  * @returns {string} - The formatted string literal with quotes
  */
 function formatStringLiteral(value, options) {
+	if (typeof value === 'bigint') {
+		// `JSON.stringify` throws on BigInt; a BigInt literal is its decimal
+		// digits plus the `n` suffix.
+		return `${value}n`;
+	}
+
 	if (typeof value !== 'string') {
 		return JSON.stringify(value);
 	}
@@ -227,6 +233,31 @@ function formatStringLiteral(value, options) {
 		.replace(/\t/g, '\\t');
 
 	return quote + escapedValue + quote;
+}
+
+/**
+ * Normalize a numeric literal the way Prettier's core printer does: keep the
+ * author's radix, separators, and exponent, but lowercase the notation and drop
+ * redundant zeroes. Reprinting `value` instead would rewrite the source
+ * (`0xff` -> `255`, `1_000` -> `1000`).
+ * @param {string} raw - The literal exactly as written in the source
+ * @returns {string} - The normalized literal
+ */
+function formatNumericLiteral(raw) {
+	return (
+		raw
+			.toLowerCase()
+			// Remove unnecessary plus and zeroes from scientific notation.
+			.replace(/^([+-]?[\d.]+e)(?:\+|(-))?0*(\d)/, '$1$2$3')
+			// Remove unnecessary scientific notation (1x).
+			.replace(/^([+-]?[\d.]+)e[+-]?0+$/, '$1')
+			// Make sure numbers always start with a digit.
+			.replace(/^([+-])?\./, '$10.')
+			// Remove extraneous trailing decimal zeroes.
+			.replace(/(\.\d+?)0+(?=e|$)/, '$1')
+			// Remove trailing dot.
+			.replace(/\.(?=e|$)/, '')
+	);
 }
 
 /**
@@ -1968,17 +1999,26 @@ function printRippleNode(node, path, options, print, args) {
 			}
 			break;
 		}
-		case 'Literal':
+		case 'Literal': {
 			// Handle regex literals specially
 			const node_typed = /** @type {AST.RegExpLiteral} */ (node);
+			const bigint_typed = /** @type {AST.BigIntLiteral} */ (node);
 			if (node_typed.regex) {
 				// Regex literal: use the raw representation
 				nodeContent = node_typed.raw || `/${node_typed.regex.pattern}/${node_typed.regex.flags}`;
+			} else if (typeof bigint_typed.bigint === 'string') {
+				// BigInt literal: `bigint` is always decimal, so only `raw` keeps
+				// the author's radix (`0xffn`).
+				nodeContent = (bigint_typed.raw || `${bigint_typed.bigint}n`).toLowerCase();
+			} else if (typeof node.value === 'number' && typeof node_typed.raw === 'string') {
+				// Numeric literal: normalize, but never reprint from `value`.
+				nodeContent = formatNumericLiteral(node_typed.raw);
 			} else {
-				// String, number, boolean, or null literal
+				// String, boolean, or null literal
 				nodeContent = formatStringLiteral(node.value, options);
 			}
 			break;
+		}
 
 		case 'ArrowFunctionExpression':
 			nodeContent = printArrowFunction(node, path, options, print, args);

--- a/packages/prettier-plugin/src/index.test.js
+++ b/packages/prettier-plugin/src/index.test.js
@@ -6687,6 +6687,46 @@ function RowList({ rows, Row }) {
 		});
 	});
 
+	describe('numeric literals', () => {
+		it('prints bigint literals instead of crashing on JSON.stringify', async () => {
+			const input = `const total = 1n;
+const mask = 0xffn;`;
+
+			const result = await format(input);
+			expect(result).toBeWithNewline(input);
+		});
+
+		it('prints bigint literals inside templates', async () => {
+			const input = `function App() @{
+  const label = "big:";
+  <div>
+    {label}
+    {1n}
+  </div>
+}`;
+
+			const result = await format(input);
+			expect(result).toBeWithNewline(input);
+		});
+
+		it('keeps the authored radix, separators, and exponent of numeric literals', async () => {
+			const input = `const a = 0xFF;
+const b = 1_000_000;
+const c = .5;
+const d = 1e21;
+const e = 1E3;
+const f = 1.50;`;
+
+			const result = await format(input);
+			expect(result).toBeWithNewline(`const a = 0xff;
+const b = 1_000_000;
+const c = 0.5;
+const d = 1e21;
+const e = 1e3;
+const f = 1.5;`);
+		});
+	});
+
 	describe('idempotence', () => {
 		/**
 		 * @param {string} code

--- a/packages/ripple/tests/client/basic/basic.rendering.test.tsrx
+++ b/packages/ripple/tests/client/basic/basic.rendering.test.tsrx
@@ -671,6 +671,7 @@ second
 		// merged after a provably-string operand renders its decimal text.
 		function App() @{
 			const label = 'big:';
+			// prettier-ignore
 			<div>{label}{1n}</div>
 		}
 

--- a/packages/ripple/tests/server/basic.test.tsrx
+++ b/packages/ripple/tests/server/basic.test.tsrx
@@ -621,6 +621,7 @@ second
 	it('renders a bigint merged into a text run after a string', async () => {
 		function App() @{
 			const label = 'big:';
+			// prettier-ignore
 			<div>{label}{1n}</div>
 		}
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Scoped to the TSRX Prettier printer’s literal handling and tests; no runtime auth, data, or compiler behavior changes beyond formatting output.
> 
> **Overview**
> Fixes **Prettier crashes** on files with bigint literals (`TypeError: Do not know how to serialize a BigInt`) by stopping use of `JSON.stringify` for those cases.
> 
> **Literal printing** in `@tsrx/prettier-plugin` now prefers AST **`raw`**: bigints keep authored form (e.g. `0xffn`), and numbers keep radix, digit separators, and exponents while applying Prettier-style normalization (lowercase hex/exponent, trim redundant zeros) instead of rewriting to decimal (`0xff` → `255`, `1_000_000` → `1000000`).
> 
> Adds **plugin tests** for bigint (including in templates) and numeric normalization; Ripple rendering tests add `prettier-ignore` where formatting would otherwise rewrite `{1n}` in JSX.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02574565aab0b6601d0b6e4e8e56d0b9cd866efa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->