### PR TITLE
fix(vite-plugin-react): make .tsrx imports visible to Vite's dep scanner

### DIFF
--- a/.changeset/vite-plugin-react-dep-scan.md
+++ b/.changeset/vite-plugin-react-dep-scan.md
@@ -10,4 +10,6 @@ and got discovered at request time instead, forcing a re-optimize and a full
 page reload. The plugin now registers a dep-scan plugin under
 `optimizeDeps.rolldownOptions.plugins` (plus the `.tsrx` entry in
 `optimizeDeps.extensions`) that compiles `.tsrx` modules for the scan pass, so
-their imports are crawled up front.
+their imports are crawled up front. A `.tsrx` file that fails to compile is
+skipped by the scan rather than failing it, so one malformed file no longer
+costs the project its dependency pre-bundling.

--- a/.changeset/vite-plugin-react-dep-scan.md
+++ b/.changeset/vite-plugin-react-dep-scan.md
@@ -1,0 +1,13 @@
+---
+'@tsrx/vite-plugin-react': patch
+---
+
+fix: make `.tsrx` imports visible to Vite's dependency scanner
+
+Vite's dep scanner runs through Rolldown without the main plugin pipeline, so
+any npm dependency imported only from `.tsrx` files was invisible at startup
+and got discovered at request time instead, forcing a re-optimize and a full
+page reload. The plugin now registers a dep-scan plugin under
+`optimizeDeps.rolldownOptions.plugins` (plus the `.tsrx` entry in
+`optimizeDeps.extensions`) that compiles `.tsrx` modules for the scan pass, so
+their imports are crawled up front.

--- a/packages/vite-plugin-react/src/index.js
+++ b/packages/vite-plugin-react/src/index.js
@@ -167,7 +167,20 @@ function create_dep_scan_plugin(jsxImportSource) {
 		transform: {
 			filter: { id: TSRX_EXTENSION_PATTERN },
 			handler(code, id) {
-				const { code: tsx_code } = compile(code, id);
+				/** @type {string} */
+				let tsx_code;
+
+				try {
+					({ code: tsx_code } = compile(code, id));
+				} catch {
+					// A single malformed `.tsrx` file must not fail the scan:
+					// vite reacts to a scan failure by skipping pre-bundling for
+					// the whole project. Hand back an empty module instead so the
+					// rest of the graph is still crawled, and let the main
+					// transform report the error at request time where it can be
+					// surfaced properly.
+					return { code: '', moduleType: 'tsx' };
+				}
 
 				// The main transform always emits automatic-runtime JSX, so the
 				// jsx runtime module is a dependency of every compiled `.tsrx`

--- a/packages/vite-plugin-react/src/index.js
+++ b/packages/vite-plugin-react/src/index.js
@@ -14,7 +14,21 @@
  *   (id: `\0${string}?tsrx-css&lang.css`): string,
  *   (id: string): string | null,
  * }} TsrxReactLoad
- * @typedef {Omit<Plugin, 'transform' | 'resolveId' | 'load'> & {
+ * @typedef {{
+ *   name: string,
+ *   transform: {
+ *     filter: { id: RegExp },
+ *     handler: (code: string, id: string) => { code: string, moduleType: 'tsx' },
+ *   },
+ * }} TsrxDepScanPlugin
+ * @typedef {() => {
+ *   optimizeDeps: {
+ *     extensions: string[],
+ *     rolldownOptions: { plugins: [TsrxDepScanPlugin] },
+ *   },
+ * }} TsrxReactConfigHook
+ * @typedef {Omit<Plugin, 'config' | 'transform' | 'resolveId' | 'load'> & {
+ *   config: TsrxReactConfigHook,
  *   transform: TsrxReactTransform,
  *   resolveId: TsrxReactResolveId,
  *   load: TsrxReactLoad,
@@ -59,6 +73,20 @@ export function tsrxReact(options = {}) {
 	return /** @type {TsrxReactPlugin} */ ({
 		name: '@tsrx/vite-plugin-react',
 		enforce: 'pre',
+
+		config() {
+			return {
+				optimizeDeps: {
+					// The scanner externalizes anything that is not a known JS
+					// type unless its extension is listed here, so without this
+					// entry the dep-scan plugin below never runs.
+					extensions: ['.tsrx'],
+					rolldownOptions: {
+						plugins: [create_dep_scan_plugin(jsxImportSource)],
+					},
+				},
+			};
+		},
 
 		resolveId(/** @type {string} */ source) {
 			if (!source.includes(CSS_QUERY)) return null;
@@ -119,6 +147,38 @@ export function tsrxReact(options = {}) {
 			return [...ctx.modules, css_mod];
 		},
 	});
+}
+
+/**
+ * Vite's dependency scanner runs through Rolldown without the main plugin
+ * pipeline, so on its own it cannot read `.tsrx` modules. Any npm dependency
+ * imported only from `.tsrx` files would then be discovered at request time
+ * instead of at startup, forcing a re-optimize and a full page reload.
+ * Registered under `optimizeDeps.rolldownOptions.plugins`, this plugin
+ * teaches the scan pass to compile `.tsrx` modules so their imports are
+ * crawled up front.
+ *
+ * @param {string} jsxImportSource
+ * @returns {TsrxDepScanPlugin}
+ */
+function create_dep_scan_plugin(jsxImportSource) {
+	return {
+		name: '@tsrx/vite-plugin-react:dep-scan',
+		transform: {
+			filter: { id: TSRX_EXTENSION_PATTERN },
+			handler(code, id) {
+				const { code: tsx_code } = compile(code, id);
+
+				// The main transform always emits automatic-runtime JSX, so the
+				// jsx runtime module is a dependency of every compiled `.tsrx`
+				// file. Import it explicitly so the scanner records it no matter
+				// how the scan's own jsx transform is configured.
+				const jsx_runtime_import = `import ${JSON.stringify(jsxImportSource + '/jsx-runtime')};\n`;
+
+				return { code: jsx_runtime_import + tsx_code, moduleType: 'tsx' };
+			},
+		},
+	};
 }
 
 export default tsrxReact;

--- a/packages/vite-plugin-react/tests/fixtures/scan/App.tsrx
+++ b/packages/vite-plugin-react/tests/fixtures/scan/App.tsrx
@@ -1,0 +1,9 @@
+import { QueryClient } from '@tanstack/react-query';
+
+const client = new QueryClient();
+
+export function App() @{
+	const label = `fetching: ${String(client.isFetching())}`;
+
+	<div>{label}</div>
+}

--- a/packages/vite-plugin-react/tests/fixtures/scan/index.html
+++ b/packages/vite-plugin-react/tests/fixtures/scan/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+	<head>
+		<meta charset="utf-8" />
+	</head>
+	<body>
+		<div id="root"></div>
+		<script type="module" src="/main.tsx"></script>
+	</body>
+</html>

--- a/packages/vite-plugin-react/tests/fixtures/scan/main.tsx
+++ b/packages/vite-plugin-react/tests/fixtures/scan/main.tsx
@@ -1,0 +1,3 @@
+import { App } from './App.tsrx';
+
+console.log(App);

--- a/packages/vite-plugin-react/tests/scan.test.js
+++ b/packages/vite-plugin-react/tests/scan.test.js
@@ -1,17 +1,108 @@
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { optimizeDeps, resolveConfig } from 'vite';
 import { tsrxReact } from '../src/index.js';
 
-const fixture_root = join(dirname(fileURLToPath(import.meta.url)), 'fixtures', 'scan');
+const fixtures_dir = join(dirname(fileURLToPath(import.meta.url)), 'fixtures');
+const fixture_root = join(fixtures_dir, 'scan');
+const scan_error_root = join(fixtures_dir, 'scan-error');
+
+/** Source that fails to parse, so `compile` throws. */
+const MALFORMED_SOURCE = `export function Broken() @{
+	<div>{ <<< }</div>
+}`;
+
+/**
+ * The scan-error fixture is written at test time rather than committed. It
+ * hinges on a `.tsrx` file that cannot compile, and such a file in the tree is
+ * reported as a fatal error by the language server and refused by prettier —
+ * neither of which a TS directive can suppress, since the file never reaches
+ * TypeScript. Its valid siblings are generated alongside it so the fixture
+ * stays in one piece rather than half on disk and half here.
+ */
+const SCAN_ERROR_FILES = {
+	'index.html': `<!doctype html>
+<html>
+	<head>
+		<meta charset="utf-8" />
+	</head>
+	<body>
+		<div id="root"></div>
+		<script type="module" src="/main.tsx"></script>
+	</body>
+</html>
+`,
+	'main.tsx': `import { Broken } from './Broken.tsrx';
+import { Good } from './Good.tsrx';
+
+console.log(Broken, Good);
+`,
+	'Broken.tsrx': MALFORMED_SOURCE,
+	// The import here is what the scan has to keep finding despite its
+	// malformed sibling.
+	'Good.tsrx': `import { QueryClient } from '@tanstack/react-query';
+
+const client = new QueryClient();
+
+export function Good() @{
+	const label = String(client.isFetching());
+
+	<div>{label}</div>
+}
+`,
+};
 
 /**
  * @param {ReturnType<typeof tsrxReact>} plugin
  */
 function get_scan_plugin(plugin) {
 	return plugin.config().optimizeDeps.rolldownOptions.plugins[0];
+}
+
+/**
+ * Materialize {@link SCAN_ERROR_FILES} under `tests/fixtures/scan-error`, which
+ * has to sit inside the package so imports resolve against its `node_modules`.
+ *
+ * @returns {void}
+ */
+function write_scan_error_fixture() {
+	mkdirSync(scan_error_root, { recursive: true });
+
+	for (const [name, source] of Object.entries(SCAN_ERROR_FILES)) {
+		writeFileSync(join(scan_error_root, name), source);
+	}
+}
+
+/**
+ * Run vite's dep optimizer over a fixture the way `vite dev` does at startup,
+ * into a throwaway cache dir so runs stay independent.
+ *
+ * @param {string} root
+ * @returns {Promise<string[]>} the pre-bundled dependency ids
+ */
+async function scan_fixture(root) {
+	const cache_dir = mkdtempSync(join(tmpdir(), 'tsrx-react-scan-'));
+
+	try {
+		const config = await resolveConfig(
+			{
+				root,
+				configFile: false,
+				cacheDir: cache_dir,
+				logLevel: 'silent',
+				plugins: [tsrxReact()],
+			},
+			'serve',
+		);
+
+		const metadata = await optimizeDeps(config, true);
+
+		return Object.keys(metadata.optimized);
+	} finally {
+		rmSync(cache_dir, { recursive: true, force: true });
+	}
 }
 
 describe('@tsrx/vite-plugin-react dep scan', () => {
@@ -75,26 +166,32 @@ export function App() @{
 		expect(result.code).not.toContain('tsrx-css');
 	});
 
+	it('returns an empty module instead of throwing on a malformed .tsrx file', () => {
+		const scan_plugin = get_scan_plugin(tsrxReact());
+		const source = `export function App() @{
+	<div>{ <<< }</div>
+}`;
+
+		const result = scan_plugin.transform.handler(source, '/virtual/App.tsrx');
+
+		expect(result).toEqual({ code: '', moduleType: 'tsx' });
+	});
+
 	it('discovers dependencies imported only from .tsrx files at scan time', async () => {
-		const cache_dir = mkdtempSync(join(tmpdir(), 'tsrx-react-scan-'));
+		const optimized = await scan_fixture(fixture_root);
+
+		expect(optimized).toContain('@tanstack/react-query');
+	}, 60_000);
+
+	it('still pre-bundles the rest of the graph when a .tsrx file fails to compile', async () => {
+		write_scan_error_fixture();
 
 		try {
-			const config = await resolveConfig(
-				{
-					root: fixture_root,
-					configFile: false,
-					cacheDir: cache_dir,
-					logLevel: 'silent',
-					plugins: [tsrxReact()],
-				},
-				'serve',
-			);
+			const optimized = await scan_fixture(scan_error_root);
 
-			const metadata = await optimizeDeps(config, true);
-
-			expect(Object.keys(metadata.optimized)).toContain('@tanstack/react-query');
+			expect(optimized).toContain('@tanstack/react-query');
 		} finally {
-			rmSync(cache_dir, { recursive: true, force: true });
+			rmSync(scan_error_root, { recursive: true, force: true });
 		}
 	}, 60_000);
 });

--- a/packages/vite-plugin-react/tests/scan.test.js
+++ b/packages/vite-plugin-react/tests/scan.test.js
@@ -1,0 +1,100 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { optimizeDeps, resolveConfig } from 'vite';
+import { tsrxReact } from '../src/index.js';
+
+const fixture_root = join(dirname(fileURLToPath(import.meta.url)), 'fixtures', 'scan');
+
+/**
+ * @param {ReturnType<typeof tsrxReact>} plugin
+ */
+function get_scan_plugin(plugin) {
+	return plugin.config().optimizeDeps.rolldownOptions.plugins[0];
+}
+
+describe('@tsrx/vite-plugin-react dep scan', () => {
+	it('registers the .tsrx extension and the dep-scan plugin via the config hook', () => {
+		const plugin = tsrxReact();
+		const config = plugin.config();
+
+		expect(config.optimizeDeps.extensions).toEqual(['.tsrx']);
+
+		const scan_plugins = config.optimizeDeps.rolldownOptions.plugins;
+		expect(scan_plugins).toHaveLength(1);
+		expect(scan_plugins[0].name).toBe('@tsrx/vite-plugin-react:dep-scan');
+		expect(scan_plugins[0].transform.filter.id.test('/app/src/App.tsrx')).toBe(true);
+		expect(scan_plugins[0].transform.filter.id.test('/app/src/App.tsx')).toBe(false);
+	});
+
+	it('compiles .tsrx sources for the scanner with the tsx module type', () => {
+		const scan_plugin = get_scan_plugin(tsrxReact());
+		const source = `import { QueryClient } from '@tanstack/react-query';
+const client = new QueryClient();
+export function App() @{
+	<div>{String(client.isFetching())}</div>
+}`;
+
+		const result = scan_plugin.transform.handler(source, '/virtual/App.tsrx');
+
+		expect(result.moduleType).toBe('tsx');
+		expect(result.code).toContain(`from '@tanstack/react-query'`);
+		expect(result.code).toContain('import "react/jsx-runtime"');
+	});
+
+	it('honors jsxImportSource for the scanner jsx runtime import', () => {
+		const scan_plugin = get_scan_plugin(tsrxReact({ jsxImportSource: 'preact' }));
+
+		const result = scan_plugin.transform.handler(
+			`export function App() @{
+	<div>{'hi'}</div>
+}`,
+			'/virtual/App.tsrx',
+		);
+
+		expect(result.code).toContain('import "preact/jsx-runtime"');
+	});
+
+	it('does not inject the css virtual module import into scan output', () => {
+		const scan_plugin = get_scan_plugin(tsrxReact());
+		const source = `export function App() @{
+	<>
+	<div className="div">{'Hello world'}</div>
+
+	<style>
+		.div {
+			color: red;
+		}
+	</style>
+	</>
+}`;
+
+		const result = scan_plugin.transform.handler(source, '/virtual/App.tsrx');
+
+		expect(result.code).not.toContain('tsrx-css');
+	});
+
+	it('discovers dependencies imported only from .tsrx files at scan time', async () => {
+		const cache_dir = mkdtempSync(join(tmpdir(), 'tsrx-react-scan-'));
+
+		try {
+			const config = await resolveConfig(
+				{
+					root: fixture_root,
+					configFile: false,
+					cacheDir: cache_dir,
+					logLevel: 'silent',
+					plugins: [tsrxReact()],
+				},
+				'serve',
+			);
+
+			const metadata = await optimizeDeps(config, true);
+
+			expect(Object.keys(metadata.optimized)).toContain('@tanstack/react-query');
+		} finally {
+			rmSync(cache_dir, { recursive: true, force: true });
+		}
+	}, 60_000);
+});

--- a/packages/vite-plugin-react/types/index.d.ts
+++ b/packages/vite-plugin-react/types/index.d.ts
@@ -9,7 +9,24 @@ export interface TsrxReactTransformResult {
 	map: unknown;
 }
 
-export interface TsrxReactPlugin extends Omit<Plugin, 'transform' | 'resolveId' | 'load'> {
+export interface TsrxDepScanPlugin {
+	name: string;
+	transform: {
+		filter: { id: RegExp };
+		handler: (code: string, id: string) => { code: string; moduleType: 'tsx' };
+	};
+}
+
+export interface TsrxReactPlugin extends Omit<
+	Plugin,
+	'config' | 'transform' | 'resolveId' | 'load'
+> {
+	config: () => {
+		optimizeDeps: {
+			extensions: string[];
+			rolldownOptions: { plugins: [TsrxDepScanPlugin] };
+		};
+	};
 	transform: {
 		(code: string, id: `${string}.tsrx`): Promise<TsrxReactTransformResult>;
 		(code: string, id: string): Promise<TsrxReactTransformResult | null>;


### PR DESCRIPTION
Vite's dependency scanner doesn't run the main plugin pipeline, so it can't read `.tsrx` files. Any npm dependency imported only from `.tsrx` modules is invisible at dev-server startup and gets discovered at request time instead, triggering a re-optimize and a full page reload. I hit this in an app where Playwright runs specs in parallel against one dev server: a request in flight during the reload loads mixed pre/post-optimize chunks and fails with `Invalid hook call` (jamiedavenport/onyx#63). Dev-only; `vite build` runs the full pipeline and is unaffected.

## Fix

Same approach `@tsrx/vite-plugin-vue` already ships: a `config` hook registers a dep-scan plugin under `optimizeDeps.rolldownOptions.plugins` that compiles `.tsrx` to tsx for the scan pass. Two details:

- `optimizeDeps.extensions` needs `'.tsrx'`, since the scanner's catch-all resolver externalizes unknown extensions before any plugin can load them.
- The scan output explicitly imports `<jsxImportSource>/jsx-runtime`, which the main transform always emits, so the scanner records it regardless of how the scan's own jsx transform is configured.

## Tests

Unit tests for the config hook and scan transform, plus an integration test that runs a real `optimizeDeps` pass over a fixture and asserts a dep imported only from a `.tsrx` file lands in the optimized metadata. The integration test fails without the fix (the scanner finds zero deps).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only `optimizeDeps` behavior in the Vite plugin; production builds still use the full transform pipeline, with broad test coverage for the new scan path.
> 
> **Overview**
> Fixes **dev-server startup** missing npm deps that are imported only from `.tsrx` files, which previously surfaced as a late **re-optimize + full reload** (and could break parallel tests with mixed chunk versions).
> 
> The React Vite plugin now exposes a **`config` hook** that adds `optimizeDeps.extensions: ['.tsrx']` and a Rolldown **dep-scan plugin** (`create_dep_scan_plugin`) under `optimizeDeps.rolldownOptions.plugins`. That pass **compiles `.tsrx` to TSX** for crawling, **prepends** `<jsxImportSource>/jsx-runtime`, **omits** CSS virtual imports, and on compile failure returns an **empty module** so one bad file does not abort pre-bundling for the whole app.
> 
> Adds **unit + `optimizeDeps` integration tests** (including a malformed `.tsrx` sibling) and updates **TypeScript plugin types** for the new `config` surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 975ebbc67aee549eda209946a935d69b13c8ea80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->