### PR TITLE
Add Octane to the TSRX website and playground

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1744,6 +1744,9 @@ importers:
       '@tsrx/vue':
         specifier: workspace:*
         version: link:../packages/tsrx-vue
+      octane:
+        specifier: ^0.1.6
+        version: 0.1.6(@typescript-eslint/types@8.56.1)
       prettier:
         specifier: 'catalog:'
         version: 3.9.6

--- a/website-tsrx/package.json
+++ b/website-tsrx/package.json
@@ -27,6 +27,7 @@
     "@tsrx/ripple": "workspace:*",
     "@tsrx/solid": "workspace:*",
     "@tsrx/vue": "workspace:*",
+    "octane": "^0.1.6",
     "prettier": "catalog:",
     "shiki": "catalog:"
   },

--- a/website-tsrx/public/llms.txt
+++ b/website-tsrx/public/llms.txt
@@ -3,8 +3,8 @@
 ## Overview
 
 TSRX (TypeScript Render Extensions) is a **TypeScript language extension** for
-building declarative UIs. It compiles one `.tsrx` source file to **React**,
-**Preact**, **Solid**, **Vue**, or **Ripple**. TSRX is the
+building declarative UIs. It compiles one `.tsrx` source file to **Octane**,
+**React**, **Preact**, **Solid**, **Vue**, or **Ripple**. TSRX is the
 source language; the target picks the runtime semantics.
 
 Think of TSRX as a spiritual successor to JSX: the same mental model of
@@ -15,7 +15,7 @@ them all the way through to the compiled output.
 
 **Key characteristics:**
 
-- **One source, many targets**: `@tsrx/react`, `@tsrx/preact`, `@tsrx/solid`, `@tsrx/vue`, `@tsrx/ripple`
+- **One source, many targets**: `octane`, `@tsrx/react`, `@tsrx/preact`, `@tsrx/solid`, `@tsrx/vue`, `@tsrx/ripple`
 - **JSX-shaped templates**: JSX elements, fragments, text, and expression containers use standard JSX node shapes
 - **JSX statement containers**: `@{ ... }` keeps TypeScript setup local to the JSX that uses it
 - **Declarative control flow**: `@if`, `@for`, `@switch`, and `@try` are JSX expressions whose bodies use `{...}` template blocks
@@ -27,7 +27,7 @@ them all the way through to the compiled output.
 **Canonical compiler packages**: `@tsrx/core` (framework-agnostic
 parser/analyzer), `@tsrx/react` (React codegen), `@tsrx/preact` (Preact codegen),
 `@tsrx/solid` (Solid codegen), `@tsrx/vue` (Vue/Vapor codegen), `@tsrx/ripple`
-(Ripple codegen).
+(Ripple codegen), and `octane/compiler` (Octane codegen).
 
 ## Installation & Targets
 
@@ -61,10 +61,61 @@ npm install -D @tsrx/bun-plugin-vue        # Bun
 
 # Ripple target
 npm install ripple @ripple-ts/vite-plugin
+
+# Octane target (Node.js 22+)
+npm install octane @octanejs/vite-plugin
 ```
 
 Vue's Vite setup should use `tsrxVue()` from `@tsrx/vite-plugin-vue`,
 and editor/typecheck configs should set `jsxImportSource: 'vue-jsx-vapor'`.
+
+### Octane setup
+
+Octane is a compiler-first, React-compatible UI framework built on TSRX. It is
+currently alpha software. A `.tsrx` file is always owned by the Octane compiler
+when using Octane's bundler integration.
+
+```ts
+// vite.config.ts
+import { defineConfig } from 'vite';
+import { octane } from '@octanejs/vite-plugin';
+
+export default defineConfig({
+	plugins: [octane()],
+});
+```
+
+Mount TSRX components with Octane's root API and import hooks from `octane`:
+
+```ts
+import { createRoot } from 'octane';
+import { App } from './App.tsrx';
+
+const root = createRoot(document.getElementById('root')!);
+root.render(App, { title: 'Hello TSRX' });
+```
+
+Octane derives omitted dependency lists for effects, memos, callbacks, and
+imperative handles from lexical captures. Explicit arrays retain React
+semantics; pass `null` for every render. Hooks are tracked by compiler-assigned
+call sites, so they may be conditional, but a slot-based hook cannot be called
+inside a plain JavaScript loop; use keyed `@for` instead.
+
+Octane uses native DOM events. Use `onInput` for per-keystroke text input;
+`onChange` keeps the browser's commit behavior. The TSRX editor tooling detects
+Octane-only projects automatically. In a repository with multiple TSRX
+compilers, set the applicable `tsconfig.json` explicitly:
+
+```json
+{
+	"tsrx": {
+		"compiler": "octane"
+	}
+}
+```
+
+See https://octanejs.dev/docs/build-tools for Vite, Rspack, Rsbuild, SSR, and
+mixed-toolchain setup.
 
 ### Rspack setup (React target)
 
@@ -729,6 +780,14 @@ directive-prefixed template control flow, scoped styles, host `innerHTML`, and
 `@try/pending` lowering through Vue suspense APIs. Component-level `await` is
 not supported for Vue TSRX.
 
+### Octane
+
+Octane compiles TSRX directly to DOM operations without a virtual DOM while
+keeping React-style function components and hooks. It supports TSRX control
+flow, scoped styles, client rendering, SSR, hydration, and Suspense. Octane
+dependency arrays are compiler-inferred when omitted, hooks use stable call-site
+slots, and text inputs use native `onInput` for per-edit updates.
+
 ### Ripple
 
 Ripple is both a compiler target and a runtime. See the Ripple llms.txt
@@ -826,6 +885,7 @@ const List = <T,>({ items, render }: Props<T>) =>
 - **Playground**: https://tsrx.dev/playground
 - **Source**: https://github.com/Ripple-TS/ripple/tree/main/packages/tsrx
 - **Ripple target (runtime APIs)**: https://www.ripple-ts.com/llms.txt
+- **Octane target (runtime and build tools)**: https://octanejs.dev/llms.txt
 
 This document is optimized for AI/LLM understanding of the TSRX language.
 For the most up-to-date information, visit https://tsrx.dev or the GitHub

--- a/website-tsrx/src/components/compiler-demo.tsrx
+++ b/website-tsrx/src/components/compiler-demo.tsrx
@@ -10,6 +10,7 @@ const HASH_DEBOUNCE_MS = 400;
 const CUSTOM_SNIPPET_VALUE = '__custom';
 const EMPTY_DEMO_SOURCE = '';
 const TARGET_OPTIONS = [
+	{ value: 'octane', label: 'Octane' },
 	{ value: 'react', label: 'React' },
 	{ value: 'preact', label: 'Preact' },
 	{ value: 'ripple', label: 'Ripple' },
@@ -17,6 +18,7 @@ const TARGET_OPTIONS = [
 	{ value: 'vue', label: 'Vue' },
 ];
 const TARGET_LABELS: Record<string, string> = {
+	octane: 'Octane output',
 	react: 'React output',
 	preact: 'Preact output',
 	vue: 'Vue output',

--- a/website-tsrx/src/lib/demo-snippets.ts
+++ b/website-tsrx/src/lib/demo-snippets.ts
@@ -9,7 +9,7 @@ export const DEMO_SNIPPETS: DemoSnippet[] = [
 	{
 		value: 'feature-card',
 		label: 'Feature card',
-		targets: ['react', 'preact', 'ripple', 'solid', 'vue'],
+		targets: ['octane', 'react', 'preact', 'ripple', 'solid', 'vue'],
 		source: `export function FeatureCard({
   title,
   items,
@@ -79,7 +79,7 @@ export const DEMO_SNIPPETS: DemoSnippet[] = [
 	{
 		value: 'conditional-rendering',
 		label: 'Conditional rendering',
-		targets: ['react', 'preact', 'ripple', 'solid', 'vue'],
+		targets: ['octane', 'react', 'preact', 'ripple', 'solid', 'vue'],
 		source: `function StatusBadge({ status }: { status: 'active' | 'idle' | 'offline' }) @{
   @if (status === 'active') {
     <span class="badge active">Online</span>
@@ -93,7 +93,7 @@ export const DEMO_SNIPPETS: DemoSnippet[] = [
 	{
 		value: 'list-rendering',
 		label: 'List rendering',
-		targets: ['react', 'preact', 'ripple', 'solid', 'vue'],
+		targets: ['octane', 'react', 'preact', 'ripple', 'solid', 'vue'],
 		source: `function TodoList({ items }: { items: { text: string }[] }) @{
   <ul>
     @for (const item of items; index i) {
@@ -105,7 +105,7 @@ export const DEMO_SNIPPETS: DemoSnippet[] = [
 	{
 		value: 'switch-statements',
 		label: 'Switch statements',
-		targets: ['react', 'preact', 'ripple', 'solid', 'vue'],
+		targets: ['octane', 'react', 'preact', 'ripple', 'solid', 'vue'],
 		source: `function StatusMessage({ status }: { status: string }) @{
   @switch (status) {
     @case 'loading': {
@@ -123,7 +123,7 @@ export const DEMO_SNIPPETS: DemoSnippet[] = [
 	{
 		value: 'error-boundary',
 		label: 'Error boundary',
-		targets: ['react', 'preact', 'ripple', 'solid', 'vue'],
+		targets: ['octane', 'react', 'preact', 'ripple', 'solid', 'vue'],
 		source: `function SafeProfile({ userId }: { userId: string }) @{
   @try {
     <UserProfile id={userId} />
@@ -137,7 +137,7 @@ export const DEMO_SNIPPETS: DemoSnippet[] = [
 	{
 		value: 'async-boundary',
 		label: 'Async boundary',
-		targets: ['react', 'preact', 'ripple', 'solid', 'vue'],
+		targets: ['octane', 'react', 'preact', 'ripple', 'solid', 'vue'],
 		source: `import { AsyncProfile } from './profile.tsrx';
 
 export function App() @{
@@ -151,7 +151,7 @@ export function App() @{
 	{
 		value: 'async-boundary-error',
 		label: 'Async + Error boundary',
-		targets: ['react', 'preact', 'ripple', 'solid', 'vue'],
+		targets: ['octane', 'react', 'preact', 'ripple', 'solid', 'vue'],
 		source: `import { AsyncProfile } from './profile.tsrx';
 
 export function App() @{
@@ -186,6 +186,27 @@ export function App() @{
     </style>
   </>
 }`,
+	},
+	{
+		value: 'octane-starter',
+		label: 'Octane starter',
+		targets: ['octane'],
+		source: `import { useEffect, useState } from 'octane';
+
+function App() @{
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    document.title = \`Count: \${count}\`;
+  });
+
+  <main>
+    <h1>Hello from TSRX + Octane</h1>
+    <button onClick={() => setCount(count + 1)}>Count: {count}</button>
+  </main>
+}
+
+export default App;`,
 	},
 	{
 		value: 'vue-starter',

--- a/website-tsrx/src/octane-compiler.d.ts
+++ b/website-tsrx/src/octane-compiler.d.ts
@@ -1,0 +1,16 @@
+declare module 'octane/compiler' {
+	export type CompileResult = {
+		code: string;
+		map: unknown;
+	};
+
+	export function compile(
+		source: string,
+		filename: string,
+		options?: {
+			hmr?: boolean | 'vite' | 'webpack';
+			mode?: 'client' | 'server';
+			dev?: boolean;
+		},
+	): CompileResult;
+}

--- a/website-tsrx/src/pages/features.tsrx
+++ b/website-tsrx/src/pages/features.tsrx
@@ -706,6 +706,8 @@ export const FeaturesPage = () => @{
 								from
 								<code class="inline-code">react</code>
 								,
+								<code class="inline-code">octane</code>
+								,
 								<code class="inline-code">preact/compat</code>
 								, or
 								<code class="inline-code">solid-js</code>

--- a/website-tsrx/src/pages/getting-started.tsrx
+++ b/website-tsrx/src/pages/getting-started.tsrx
@@ -53,6 +53,28 @@ const VUE_VITE_CONFIG_HTML = [
 	'<span class="ln">6</span> <span class="br">}</span><span class="br">)</span>;',
 ].join('\n');
 
+const OCTANE_INSTALL_HTML = [
+	'<span class="ln">1</span> <span class="fn">pnpm</span> <span class="prop">add</span> <span class="str">octane</span> <span class="str">@octanejs/vite-plugin</span>',
+	'<span class="ln">2</span> <span class="fn">pnpm</span> <span class="prop">add</span> <span class="str">-D</span> <span class="str">vite</span>',
+].join('\n');
+
+const OCTANE_VITE_CONFIG_HTML = [
+	'<span class="ln">1</span> <span class="kw-export">import</span> <span class="br">{</span> <span class="prop">defineConfig</span> <span class="br">}</span> <span class="kw-export">from</span> <span class="str">\'vite\'</span>;',
+	'<span class="ln">2</span> <span class="kw-export">import</span> <span class="br">{</span> <span class="prop">octane</span> <span class="br">}</span> <span class="kw-export">from</span> <span class="str">\'@octanejs/vite-plugin\'</span>;',
+	'<span class="ln">3</span>',
+	'<span class="ln">4</span> <span class="kw-export">export default</span> <span class="fn">defineConfig</span><span class="br">(</span><span class="br">{</span>',
+	'<span class="ln">5</span>   <span class="prop">plugins</span>: <span class="br">[</span><span class="fn">octane</span><span class="br">(</span><span class="br">)</span><span class="br">]</span>,',
+	'<span class="ln">6</span> <span class="br">}</span><span class="br">)</span>;',
+].join('\n');
+
+const OCTANE_MOUNT_HTML = [
+	'<span class="ln">1</span> <span class="kw-export">import</span> <span class="br">{</span> <span class="prop">createRoot</span> <span class="br">}</span> <span class="kw-export">from</span> <span class="str">\'octane\'</span>;',
+	'<span class="ln">2</span> <span class="kw-export">import</span> <span class="br">{</span> <span class="prop">App</span> <span class="br">}</span> <span class="kw-export">from</span> <span class="str">\'./App.tsrx\'</span>;',
+	'<span class="ln">3</span>',
+	'<span class="ln">4</span> <span class="kw">const</span> <span class="prop">root</span> = <span class="fn">createRoot</span><span class="br">(</span><span class="prop">document</span>.<span class="fn">getElementById</span><span class="br">(</span><span class="str">\'root\'</span><span class="br">)</span>!<span class="br">)</span>;',
+	'<span class="ln">5</span> <span class="prop">root</span>.<span class="fn">render</span><span class="br">(</span><span class="prop">App</span>, <span class="br">{</span> <span class="prop">title</span>: <span class="str">\'Hello TSRX\'</span> <span class="br">}</span><span class="br">)</span>;',
+].join('\n');
+
 const REACT_RSPACK_INSTALL_HTML = [
 	'<span class="ln">1</span> <span class="fn">pnpm</span> <span class="prop">install</span> <span class="str">@tsrx/react</span> <span class="str">@tsrx/rspack-plugin-react</span>',
 ].join('\n');
@@ -256,6 +278,7 @@ const NAV_GROUPS = [
 			{ id: 'vue-rspack', label: 'Vue + Rspack' },
 			{ id: 'vue-bun', label: 'Vue + Bun' },
 			{ id: 'ripple', label: 'Ripple' },
+			{ id: 'octane', label: 'Octane' },
 		],
 	},
 	{
@@ -283,7 +306,7 @@ export function GettingStartedPage() @{
 			<title>TSRX | Getting Started</title>
 			<meta
 				name="description"
-				content="Get started with TSRX: install with React, Preact, Solid, Vue, or Ripple for Vite, Rspack, Turbopack, or Bun, learn the function-return syntax, and explore inline template control flow."
+				content="Get started with TSRX: install with Octane, React, Preact, Solid, Vue, or Ripple for Vite, Rspack, Turbopack, or Bun, learn the function-return syntax, and explore inline template control flow."
 			/>
 		</head>
 		<div class="app-shell">
@@ -313,8 +336,8 @@ export function GettingStartedPage() @{
 				<section class="hero">
 					<h1>Getting Started</h1>
 					<p class="lede">
-						Set up TSRX with React, Preact, Solid, Vue, or Ripple and then wire in the editor
-						tooling that makes
+						Set up TSRX with Octane, React, Preact, Solid, Vue, or Ripple and then wire in the
+						editor tooling that makes
 						<code class="inline-code">.tsrx</code>
 						files feel native in the rest of your repo.
 					</p>
@@ -666,6 +689,69 @@ export function GettingStartedPage() @{
 								,
 								<code class="inline-code">.tsrx</code>
 								files work out of the box — no additional packages needed.
+							</p>
+						</section>
+
+						<section class="doc-section" id="octane">
+							<h2 class="section-heading">Octane</h2>
+							<p class="section-body">
+								Octane is a compiler-first UI framework built on TSRX. Its published packages
+								require Node.js 22 or newer, and Octane is currently alpha software. Install the
+								runtime and Vite integration:
+							</p>
+							<pre class="code-block">
+								<code innerHTML={OCTANE_INSTALL_HTML} />
+							</pre>
+							<p class="section-body">
+								Add the Octane plugin to a normal Vite app. A
+								<code class="inline-code">.tsrx</code>
+								file is always compiled by Octane; the same integration can also compile
+								Octane-owned
+								<code class="inline-code">.tsx</code>
+								,
+								<code class="inline-code">.ts</code>
+								, and
+								<code class="inline-code">.js</code>
+								modules.
+							</p>
+							<pre class="code-block">
+								<code innerHTML={OCTANE_VITE_CONFIG_HTML} />
+							</pre>
+							<p class="section-body">
+								Mount a TSRX component with Octane's root API:
+							</p>
+							<pre class="code-block">
+								<code innerHTML={OCTANE_MOUNT_HTML} />
+							</pre>
+							<p class="section-body">
+								Import hooks such as
+								<code class="inline-code">useState</code>
+								and
+								<code class="inline-code">useEffect</code>
+								from
+								<code class="inline-code">octane</code>
+								. Octane derives omitted effect and memo dependency lists from their closures and
+								tracks hooks by call site, so conditional hooks are supported. DOM events are
+								native: use
+								<code class="inline-code">onInput</code>
+								for per-keystroke text updates, while
+								<code class="inline-code">onChange</code>
+								keeps the browser's commit behavior.
+							</p>
+							<p class="section-body">
+								The TSRX editor tooling detects an Octane-only project automatically. If a repo has
+								multiple TSRX target compilers, set
+								<code class="inline-code">{'"tsrx": { "compiler": "octane" }'}</code>
+								in the applicable
+								<code class="inline-code">tsconfig.json</code>
+								. See the
+								<a
+									class="inline-link"
+									href="https://octanejs.dev/docs/build-tools"
+									target="_blank"
+									rel="noopener noreferrer"
+								>Octane build tools guide</a>
+								for Rspack, Rsbuild, SSR, and mixed-toolchain setups.
 							</p>
 						</section>
 

--- a/website-tsrx/src/pages/index.tsrx
+++ b/website-tsrx/src/pages/index.tsrx
@@ -122,8 +122,8 @@ export const IndexPage = () => @{
 						the compiled output.
 					</p>
 					<p class="section-body what-is-copy">
-						TSRX is framework-agnostic and interoperable. Today it compiles to React, Preact,
-						Ripple, Solid, and Vue, with room for more targets over time. You can import
+						TSRX is framework-agnostic and interoperable. Today it compiles to Octane, React,
+						Preact, Ripple, Solid, and Vue, with room for more targets over time. You can import
 						<code class="inline-code">.tsrx</code>
 						modules from JS, TS, and TSX files and it just works.
 					</p>
@@ -246,8 +246,10 @@ export const IndexPage = () => @{
 						<code class="inline-code">@tsrx/ripple</code>
 						,
 						<code class="inline-code">@tsrx/solid</code>
-						, and
+						,
 						<code class="inline-code">@tsrx/vue</code>
+						, and
+						<code class="inline-code">octane/compiler</code>
 						transform the same AST into idiomatic output for their target runtimes, including scoped
 						CSS. New targets can be added as standalone compiler plugins without changing the
 						language itself.

--- a/website-tsrx/src/routes.ts
+++ b/website-tsrx/src/routes.ts
@@ -5,10 +5,11 @@ import { compile as compile_react } from '@tsrx/react';
 import { compile as compile_ripple } from '@tsrx/ripple';
 import { compile as compile_solid } from '@tsrx/solid';
 import { compile as compile_vue } from '@tsrx/vue';
+import { compile as compile_octane } from 'octane/compiler';
 import { format } from 'prettier';
 
 const MAX_SOURCE_LENGTH = 12000;
-const VALID_TARGETS = ['react', 'preact', 'ripple', 'solid', 'vue'] as const;
+const VALID_TARGETS = ['octane', 'react', 'preact', 'ripple', 'solid', 'vue'] as const;
 
 type CompileTarget = (typeof VALID_TARGETS)[number];
 
@@ -64,6 +65,18 @@ async function format_css(css: string) {
  * @param {string} source
  */
 async function compile_target(target: CompileTarget, source: string) {
+	if (target === 'octane') {
+		const octane_result = compile_octane(source, 'LiveDemo.tsrx');
+
+		return {
+			target,
+			output: {
+				code: await format_js(octane_result.code),
+				css: '',
+			},
+		};
+	}
+
 	if (target === 'react') {
 		const react_result = compile_react(source, 'LiveDemo.tsrx');
 
@@ -208,7 +221,7 @@ export const routes = [
 
 			if (!is_valid_target(target)) {
 				return Response.json(
-					{ error: 'Target must be one of: react, preact, ripple, solid, vue.' },
+					{ error: 'Target must be one of: octane, react, preact, ripple, solid, vue.' },
 					{ status: 400 },
 				);
 			}


### PR DESCRIPTION
## Summary

- document Octane setup, Vite integration, mounting, hook behavior, native text events, and TSRX compiler selection
- list Octane across the TSRX homepage, feature guidance, and `llms.txt`
- add Octane as a live playground compilation target with a dedicated starter snippet
- add the Octane compiler dependency and a local declaration for the playground server

## Impact

TSRX users can now discover how to use the language with Octane and inspect Octane's generated output directly in the existing playground.

## Validation

- `corepack pnpm@11.15.1 --filter tsrx-website build`
- `corepack pnpm@11.15.1 format:check`
- focused `octane/compiler` compilation of the new starter pattern

`node packages/typescript-plugin/dist/tsc.js --noEmit -p website-tsrx/tsconfig.json` still reports the two existing parser errors in the untouched `website-tsrx/src/pages/specification.tsrx` at lines 513 and 517.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and demo-site changes only; adds an external compiler dependency for the compile API with no auth or production app behavior changes.
> 
> **Overview**
> **Adds Octane as a first-class TSRX target** on the marketing site and in the live playground, alongside existing React/Preact/Solid/Vue/Ripple flows.
> 
> Documentation and discovery updates include **`llms.txt`**, homepage copy, a **Getting Started → Octane** section (Vite plugin, `createRoot`, hooks/events, `tsconfig` compiler selection), and a mention of **`lazy()` from `octane`** on the features page. The playground gains an **Octane** target in the selector, **`octane` in shared demo snippets**, and an **Octane-only starter** sample.
> 
> The **`/api/compile`** path compiles via **`octane/compiler`** (formatted JS, no separate CSS payload). **`octane@^0.1.6`** is added as a dependency with a local **`octane/compiler`** module declaration for the server build.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ace940eedf870af4e9faea81249e199723a19ae1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->