### PR TITLE
fix: parse for multi-line JSX elements in attribute

### DIFF
--- a/.changeset/jsx-attribute-value-elements.md
+++ b/.changeset/jsx-attribute-value-elements.md
@@ -2,4 +2,4 @@
 '@tsrx/core': patch
 ---
 
-Fix a parse error for multi-line JSX elements with element children used as attribute values (`prop={<div><span>x</span></div>}`). The tokenizer's stale-text fixup popped the value element's own children context before its closing tag, unbalancing the context stack so the token after the container's `}` failed to parse.
+Fix parse errors for multi-line JSX elements with element children used as attribute values (`prop={<div><span>x</span></div>}`), including nested paired elements and sibling elements after a nested close. The tokenizer's stale-text fixups counted contexts against the whole stack, which is blind inside a `{ … }` container; they now scope the count to the container so each still-open element keeps the children context its own closing tag pops.

--- a/.changeset/jsx-attribute-value-elements.md
+++ b/.changeset/jsx-attribute-value-elements.md
@@ -1,0 +1,5 @@
+---
+'@tsrx/core': patch
+---
+
+Fix a parse error for multi-line JSX elements with element children used as attribute values (`prop={<div><span>x</span></div>}`). The tokenizer's stale-text fixup popped the value element's own children context before its closing tag, unbalancing the context stack so the token after the container's `}` failed to parse.

--- a/packages/tsrx/src/plugin.js
+++ b/packages/tsrx/src/plugin.js
@@ -4595,17 +4595,35 @@ export function TSRXPlugin(config) {
 					// text never starts at `<`, so drop the leaked context and re-read the
 					// tag instead of emitting an empty node.
 					if (this.input.charCodeAt(this.start) === CharCode.lessThan) {
-						if (this.input.charCodeAt(this.start + 1) === CharCode.slash) {
-							// The re-read closing tag's `jsxTagEnd` pops the element's own
-							// children `tc_expr` itself, so keep exactly one and pop only the
-							// leaked extras above it. Popping all of them (e.g. for an element
-							// directly inside an attribute-value `{ … }` container, where the
-							// context below is the container's brace) would make the closing
-							// tag pop the enclosing container/tag context instead.
-							while (
-								this.curContext() === tstc.tc_expr &&
-								this.context[this.context.length - 2] === tstc.tc_expr
+						if (this.#jsxExpressionContainerDepth > 0) {
+							// Inside a `{ … }` container the whole-stack counts below are
+							// blind: the enclosing template's `tc_expr` contexts sit on the
+							// stack but their elements are not on the container-scoped
+							// `#path`. Scope both counts to the container instead — each
+							// element opened inside it (all on `#path` above the container's
+							// baseline) still owns one `tc_expr` that its closing tag's
+							// `jsxTagEnd` pops itself, so only the run's excess above that
+							// quota is leaked. Popping deeper would make a re-read closing
+							// tag pop the container's brace or the enclosing tag context.
+							const path_baseline = this.#expressionContainerPathBaselines.at(-1) ?? 0;
+							let open_elements = 0;
+							for (let i = path_baseline; i < this.#path.length; i++) {
+								if (this.#isNativeTemplateNode(this.#path[i])) open_elements++;
+							}
+							let run = 0;
+							for (
+								let i = this.context.length - 1;
+								i >= 0 && this.context[i] === tstc.tc_expr;
+								i--
 							) {
+								run++;
+							}
+							while (run > open_elements && this.curContext() === tstc.tc_expr) {
+								this.context.pop();
+								run--;
+							}
+						} else if (this.input.charCodeAt(this.start + 1) === CharCode.slash) {
+							while (this.curContext() === tstc.tc_expr) {
 								this.context.pop();
 							}
 						} else {

--- a/packages/tsrx/src/plugin.js
+++ b/packages/tsrx/src/plugin.js
@@ -4596,7 +4596,16 @@ export function TSRXPlugin(config) {
 					// tag instead of emitting an empty node.
 					if (this.input.charCodeAt(this.start) === CharCode.lessThan) {
 						if (this.input.charCodeAt(this.start + 1) === CharCode.slash) {
-							while (this.curContext() === tstc.tc_expr) {
+							// The re-read closing tag's `jsxTagEnd` pops the element's own
+							// children `tc_expr` itself, so keep exactly one and pop only the
+							// leaked extras above it. Popping all of them (e.g. for an element
+							// directly inside an attribute-value `{ … }` container, where the
+							// context below is the container's brace) would make the closing
+							// tag pop the enclosing container/tag context instead.
+							while (
+								this.curContext() === tstc.tc_expr &&
+								this.context[this.context.length - 2] === tstc.tc_expr
+							) {
 								this.context.pop();
 							}
 						} else {

--- a/packages/tsrx/tests/utils/parser.test.js
+++ b/packages/tsrx/tests/utils/parser.test.js
@@ -4271,3 +4271,75 @@ describe('keywordTokens parse option', () => {
 		expect(ast.tsrx_keyword_tokens).toBeUndefined();
 	});
 });
+
+describe('multi-line JSX elements as attribute values', () => {
+	// A paired element with element children spread over multiple lines inside an
+	// attribute's `{ … }` container used to unbalance the tokenizer context stack:
+	// the stale-text fixup before its closing tag popped the element's own
+	// children context, so the token after the container's `}` (the tag's `>`,
+	// `/>`, or a following attribute) tokenized as template text and failed.
+
+	/**
+	 * The `prop` attribute's value, asserted to be a `<div>` wrapping a `<span>`.
+	 *
+	 * @param {AST.TSRXJSXElement} element
+	 */
+	function expectDivSpanValue(element) {
+		const value = as_type(attributeExpression(element.openingElement.attributes[0]), 'JSXElement');
+		expect(openingName(value).name).toBe('div');
+		expect(node_children(value).some((c) => c.type === 'JSXElement')).toBe(true);
+	}
+
+	it('parses one before other attributes of a self-closing tag', () => {
+		const element = findElement(
+			`export function App() @{
+	<Child
+		prop={<div>
+			<span>x</span>
+		</div>}
+		other={1}
+	/>
+}`,
+			'Child',
+		);
+		expectDivSpanValue(element);
+		const other = as_type(attributeExpression(element.openingElement.attributes[1]), 'Literal');
+		expect(other.value).toBe(1);
+	});
+
+	it('parses one as the sole attribute of a self-closing tag', () => {
+		const element = findElement(
+			`export function App() @{
+	<Child
+		prop={<div>
+			<span>x</span>
+		</div>}
+	/>
+}`,
+			'Child',
+		);
+		expectDivSpanValue(element);
+		expect(as_type(element.openingElement, 'JSXOpeningElement').selfClosing).toBe(true);
+	});
+
+	it('parses one on a paired tag with children', () => {
+		const element = findElement(
+			`export function App() @{
+	<Child
+		prop={<div id="a">
+			<span>x</span>
+		</div>}
+	>
+		<i>child</i>
+	</Child>
+}`,
+			'Child',
+		);
+		expectDivSpanValue(element);
+		const child_element = as_type(
+			found(node_children(element).find((c) => c.type === 'JSXElement')),
+			'JSXElement',
+		);
+		expect(as_type(child_element.openingElement.name, 'JSXIdentifier').name).toBe('i');
+	});
+});

--- a/packages/tsrx/tests/utils/parser.test.js
+++ b/packages/tsrx/tests/utils/parser.test.js
@@ -4342,4 +4342,72 @@ describe('multi-line JSX elements as attribute values', () => {
 		);
 		expect(as_type(child_element.openingElement.name, 'JSXIdentifier').name).toBe('i');
 	});
+
+	// The stale-text fixup must keep one `tc_expr` context per element still open
+	// inside the container — not a fixed count. Two levels of paired nesting and
+	// a sibling element after a nested close each caught a wrong quota.
+
+	it('parses two levels of paired nesting before another attribute', () => {
+		const element = findElement(
+			`export function App() @{
+	<Child
+		prop={<div>
+			<section>
+				<span>x</span>
+			</section>
+		</div>}
+		other={1}
+	/>
+}`,
+			'Child',
+		);
+		expectDivSpanValue(element);
+		const other = as_type(attributeExpression(element.openingElement.attributes[1]), 'Literal');
+		expect(other.value).toBe(1);
+	});
+
+	it('parses two levels of paired nesting on a paired tag with children', () => {
+		const element = findElement(
+			`export function App() @{
+	<Child
+		prop={<div>
+			<section>
+				<span>x</span>
+			</section>
+		</div>}
+	>
+		<i>child</i>
+	</Child>
+}`,
+			'Child',
+		);
+		expectDivSpanValue(element);
+		const child_element = as_type(
+			found(node_children(element).find((c) => c.type === 'JSXElement')),
+			'JSXElement',
+		);
+		expect(as_type(child_element.openingElement.name, 'JSXIdentifier').name).toBe('i');
+	});
+
+	it('parses a sibling element after a nested close inside the value', () => {
+		const element = findElement(
+			`export function App() @{
+	<Child
+		prop={<div>
+			<span>x</span>
+			<b>y</b>
+		</div>}
+		other={1}
+	/>
+}`,
+			'Child',
+		);
+		const value = as_type(attributeExpression(element.openingElement.attributes[0]), 'JSXElement');
+		const tags = node_children(value)
+			.filter((c) => c.type === 'JSXElement')
+			.map((c) => as_type(as_type(c, 'JSXElement').openingElement.name, 'JSXIdentifier').name);
+		expect(tags).toEqual(['span', 'b']);
+		const other = as_type(attributeExpression(element.openingElement.attributes[1]), 'Literal');
+		expect(other.value).toBe(1);
+	});
 });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes tokenizer context-stack fixups in a subtle JSX edge case; risk is localized to the parser plugin but incorrect popping could affect other nested JSX-in-expression patterns.
> 
> **Overview**
> Fixes **parse failures** when an attribute value is a multi-line JSX element with nested children (e.g. `prop={<div>\n  <span>x</span>\n</div>}`).
> 
> The tokenizer’s stale-`jsxText` recovery was popping **`tc_expr` contexts using the full context stack**, which breaks inside a `{ … }` attribute container because outer template contexts are still on the stack but aren’t represented on the container-scoped `#path`. The fix **scopes the open-element count to the expression container** (via `#expressionContainerPathBaselines`) and only pops the excess `tc_expr` run above that quota, so tokens after `}`—`/>`, `>`, or the next attribute—tokenize correctly again.
> 
> Adds parser tests for self-closing and paired tags, two levels of nesting, and sibling elements after a nested close; ships as a **patch** on `@tsrx/core`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a971fd7abde7476bac6ee8dca7a1624727bf9664. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->