### PR TITLE
fix conditional rendering syntax in LiveCodes.vue

### DIFF
--- a/website/.vitepress/components/LiveCodes.vue
+++ b/website/.vitepress/components/LiveCodes.vue
@@ -254,7 +254,7 @@ export default function Counter() {
 
       <button onClick={() => count--}>"-"</button>
       <button onClick={() => count++}>"+"</button>
-      if (count !== 0) {
+      @if (count !== 0) {
         <div>
           <button onClick={() => count = 0}>"Reset"</button>
         </div>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation/playground sample string only; no runtime or build logic changes.
> 
> **Overview**
> Updates the embedded **Counter** default snippet in `LiveCodes.vue` so the Reset block uses Ripple’s **`@if (count !== 0)`** directive instead of a plain JavaScript `if` inside JSX.
> 
> This matches how conditionals are written elsewhere in docs and examples, so the playground demo compiles and behaves correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 892e8f15a920298016e924c0a5af96f1783e71de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->