### PR TITLE
for `as` casts around parenthesized JSX in attribute values

### DIFF
--- a/.changeset/jsx-attribute-cast-parens.md
+++ b/.changeset/jsx-attribute-cast-parens.md
@@ -1,0 +1,5 @@
+---
+'@tsrx/core': patch
+---
+
+Fix a parse error for `as` casts around parenthesized JSX in attribute values (`prop={((c) => (<Col />)) as any}`). The after-element context fixup popped a still-open outer `(` as if it were leaked, so the outer `)` popped the attribute container's brace and the `as` tokenized as a JSX name instead of starting the cast.

--- a/packages/tsrx/src/plugin.js
+++ b/packages/tsrx/src/plugin.js
@@ -2348,8 +2348,9 @@ export function TSRXPlugin(config) {
 
 			/**
 			 * @param {ESTreeJSX.JSXElement | ESTreeJSX.JSXFragment} node
+			 * @param {number} enclosing_context_depth
 			 */
-			#popTokenContextsAfterTemplateExpressionElement(node) {
+			#popTokenContextsAfterTemplateExpressionElement(node, enclosing_context_depth) {
 				// A fragment in expression position (`() => <>…</>`) leaves the tokenizer
 				// at `exprAllowed === false`, unlike a self-closing element. When the next
 				// token is a `;` or ASI can insert one, the following statement may
@@ -2452,13 +2453,20 @@ export function TSRXPlugin(config) {
 				// Closing token after the template at expression position. For `}`
 				// only pop if it actually closes this `b_expr` — otherwise the
 				// brace targets an inner callback/object body that should pop it
-				// naturally on the next token step.
+				// naturally on the next token step. Only compensate while the stack
+				// has not unwound below the enclosing expression's depth: a balanced
+				// element leaves the stack at that depth and the closing token's own
+				// `updateContext` then pops its real opener (going one below), so a
+				// remaining `(`/`[`/b_expr on top belongs to a still-open outer
+				// group — popping it would make the group's own closer pop the
+				// context underneath it (e.g. an attribute container's brace).
 				if (
-					(this.type === tt.braceR &&
+					ctx.length >= enclosing_context_depth &&
+					((this.type === tt.braceR &&
 						top === b_expr &&
 						(this.#countFollowingRightBraces() === 0 || second === b_expr)) ||
-					(this.type === tt.parenR && top?.token === '(') ||
-					(this.type === tt.bracketR && top?.token === '[')
+						(this.type === tt.parenR && top?.token === '(') ||
+						(this.type === tt.bracketR && top?.token === '['))
 				) {
 					ctx.pop();
 					this.exprAllowed = false;
@@ -4314,11 +4322,15 @@ export function TSRXPlugin(config) {
 					}
 				}
 
+				// This element's `jsxTagStart` has already pushed its own `tc_expr` and
+				// `tc_oTag`, so everything below them is the enclosing expression's
+				// stack — the depth a balanced element parse must return to.
+				const enclosing_context_depth = this.context.length - 2;
 				this.next();
 				const parsed = /** @type {import('estree-jsx').JSXElement} */ (
 					/** @type {unknown} */ (this.parseElement())
 				);
-				this.#popTokenContextsAfterTemplateExpressionElement(parsed);
+				this.#popTokenContextsAfterTemplateExpressionElement(parsed, enclosing_context_depth);
 				return parsed;
 			}
 

--- a/packages/tsrx/tests/utils/parser.test.js
+++ b/packages/tsrx/tests/utils/parser.test.js
@@ -4411,3 +4411,110 @@ describe('multi-line JSX elements as attribute values', () => {
 		expect(other.value).toBe(1);
 	});
 });
+
+describe('casts around JSX in attribute values', () => {
+	// A balanced element inside nested parens leaves the token-context stack
+	// already unwound below the enclosing expression's depth, so the
+	// after-element fixup must not pop the still-open outer `(` — doing so made
+	// the outer `)` pop the attribute container's brace instead, and the `as`
+	// that followed tokenized as a JSX name, never reaching the cast parse.
+
+	/**
+	 * The attribute value's `… as any` cast, asserted and unwrapped.
+	 *
+	 * @param {AST.TSRXJSXElement} element
+	 * @param {number} index
+	 * @returns {AST.Expression}
+	 */
+	function attributeCastExpression(element, index) {
+		const cast = as_type(
+			attributeExpression(element.openingElement.attributes[index]),
+			'TSAsExpression',
+		);
+		return cast.expression;
+	}
+
+	it('parses a cast parenthesized arrow returning parenthesized JSX', () => {
+		const element = findElement(
+			`export function App() {
+	return <Host prop={((c: any) => (<Col id={c.id} />)) as any} />;
+}`,
+			'Host',
+		);
+		const arrow = as_type(attributeCastExpression(element, 0), 'ArrowFunctionExpression');
+		const body = as_type(arrow.body, 'JSXElement');
+		expect(as_type(body.openingElement.name, 'JSXIdentifier').name).toBe('Col');
+	});
+
+	it('parses a cast arrow returning a paired element with an expression child', () => {
+		const element = findElement(
+			`export function App() {
+	return <Host prop={((c: any) => (<Col a={c.a}>{c.name}</Col>)) as any} />;
+}`,
+			'Host',
+		);
+		const arrow = as_type(attributeCastExpression(element, 0), 'ArrowFunctionExpression');
+		const body = as_type(arrow.body, 'JSXElement');
+		const container = as_type(
+			found(node_children(body).find((c) => c.type === 'JSXExpressionContainer')),
+			'JSXExpressionContainer',
+		);
+		assert_type(container.expression, 'MemberExpression');
+	});
+
+	it('parses a cast call whose argument is an arrow returning JSX', () => {
+		const element = findElement(
+			`export function App() {
+	return <Host prop={fn((c: any) => (<Col id={c.id} />)) as any} />;
+}`,
+			'Host',
+		);
+		const call = as_type(attributeCastExpression(element, 0), 'CallExpression');
+		const arrow = as_type(call.arguments[0], 'ArrowFunctionExpression');
+		assert_type(arrow.body, 'JSXElement');
+	});
+
+	it('parses a cast around doubly parenthesized JSX', () => {
+		const element = findElement(
+			`export function App() {
+	return <Host prop={((<Col id={c.id} />)) as any} />;
+}`,
+			'Host',
+		);
+		const value = as_type(attributeCastExpression(element, 0), 'JSXElement');
+		expect(as_type(value.openingElement.name, 'JSXIdentifier').name).toBe('Col');
+	});
+
+	it('parses a multi-line cast arrow inside a cast element array', () => {
+		const element = findElement(
+			`export function Table() {
+	const state = useTableState({
+		children: [
+			<TableHeader
+				key="head"
+				columns={columns}
+				children={
+					((c: any) => (
+						<Column key={c.id} isRowHeader={c.isRowHeader}>
+							{c.name}
+						</Column>
+					)) as any
+				}
+			/>,
+		] as any,
+		selectionMode: 'multiple',
+	});
+	return <div>{state.collection.size}</div>;
+}`,
+			'TableHeader',
+		);
+		const arrow = as_type(attributeCastExpression(element, 2), 'ArrowFunctionExpression');
+		const body = as_type(arrow.body, 'JSXElement');
+		expect(as_type(body.openingElement.name, 'JSXIdentifier').name).toBe('Column');
+		const container = as_type(
+			found(node_children(body).find((c) => c.type === 'JSXExpressionContainer')),
+			'JSXExpressionContainer',
+		);
+		assert_type(container.expression, 'MemberExpression');
+	});
+});


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches JSX tokenizer context fixup in the core parser, which is easy to regress elsewhere, but the change is narrowly scoped with dedicated regression tests.
> 
> **Overview**
> Fixes a **parse failure** for TypeScript `as` casts around parenthesized JSX inside attribute values (e.g. `prop={((c) => (<Col />)) as any}`).
> 
> After a balanced JSX element finishes, `#popTokenContextsAfterTemplateExpressionElement` could still **pop a leaked `(`** even when that paren belonged to an **outer** group that was still open. The following `)` then closed the attribute `{` instead, and **`as` was read as a JSX name** rather than starting `TSAsExpression`.
> 
> The fix passes an **`enclosing_context_depth`** from `jsx_parseElement` (stack depth below the element’s own tag contexts) and only runs the closing-token context pop when **`ctx.length >= enclosing_context_depth`**, so still-open outer `(`/groups are left alone.
> 
> Adds parser tests for cast + arrow/JSX, nested calls, double parens, and multi-line table-style attribute patterns. Ships as a **patch** on `@tsrx/core`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2a1f1d455bfeaa24e6c24ab5d3c0224f2839459. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->