### PR TITLE
fix: parsing for JSX-valued attributes

### DIFF
--- a/.changeset/jsx-attribute-child-container-siblings.md
+++ b/.changeset/jsx-attribute-child-container-siblings.md
@@ -1,0 +1,5 @@
+---
+'@tsrx/core': patch
+---
+
+Fix parsing for JSX-valued attributes whose element has an expression-container child with JSX inside (e.g. `slot={<button>{ok ? <X /> : <Y />}</button>}`) followed by another attribute.

--- a/packages/tsrx/src/plugin.js
+++ b/packages/tsrx/src/plugin.js
@@ -2440,9 +2440,15 @@ export function TSRXPlugin(config) {
 				}
 				// Statement-bodied native template attributes can leave the attribute's
 				// expression contexts above the still-open JSX tag context. Strip
-				// those so a following `/>` stays in JSX opening-tag mode.
+				// those so a following `/>` stays in JSX opening-tag mode. Once the
+				// stack has unwound below the enclosing expression's depth the same
+				// tail shape means something else: the `}` closed an inner child
+				// container (its own brace context already popped) and the tc_expr
+				// belongs to a still-open element between the attribute brace and
+				// this one — stripping would drop the attribute container's brace.
 				if (
 					this.type === tt.braceR &&
+					ctx.length >= enclosing_context_depth &&
 					top === tstc.tc_expr &&
 					second === b_expr &&
 					ctx[ci - 2] === tstc.tc_oTag

--- a/packages/tsrx/tests/utils/parser.test.js
+++ b/packages/tsrx/tests/utils/parser.test.js
@@ -4518,3 +4518,97 @@ describe('casts around JSX in attribute values', () => {
 		assert_type(container.expression, 'MemberExpression');
 	});
 });
+
+describe('expression-container children inside JSX attribute values', () => {
+	// After an element parsed inside a child `{ … }` container of a JSX-valued
+	// attribute, the container's closing `}` has already popped its own brace
+	// context, leaving the tail [tc_oTag, b_expr, tc_expr] — the same shape a
+	// statement-bodied attribute leaks when the attribute's own container
+	// closes. The after-element fixup treated it as that leak and stripped the
+	// attribute container's brace plus the outer element's children context, so
+	// the `=` of the following attribute tokenized as template text and failed.
+	// In the child-container case the stack sits below the enclosing
+	// expression's depth, which now gates the strip.
+
+	/**
+	 * Name of a `JSXElement`'s opening tag.
+	 *
+	 * @param {AST.Node} node
+	 * @returns {string}
+	 */
+	function elementName(node) {
+		return as_type(as_type(node, 'JSXElement').openingElement.name, 'JSXIdentifier').name;
+	}
+
+	it('parses a ternary of elements in the value before another attribute', () => {
+		const element = findElement(
+			`export function App({ ok }: any) {
+	return (
+		<Host
+			slot={
+				<button>
+					{ok ? <X /> : <Y />}
+				</button>
+			}
+			onChange={(d: any) => go(d)}
+		/>
+	);
+}`,
+			'Host',
+		);
+		const value = as_type(attributeExpression(element.openingElement.attributes[0]), 'JSXElement');
+		expect(openingName(value).name).toBe('button');
+		const container = as_type(
+			found(node_children(value).find((c) => c.type === 'JSXExpressionContainer')),
+			'JSXExpressionContainer',
+		);
+		const conditional = as_type(container.expression, 'ConditionalExpression');
+		expect(elementName(conditional.consequent)).toBe('X');
+		expect(elementName(conditional.alternate)).toBe('Y');
+		const handler = as_type(
+			attributeExpression(element.openingElement.attributes[1]),
+			'ArrowFunctionExpression',
+		);
+		expect(handler.params).toHaveLength(1);
+	});
+
+	it('parses a lone element in a child container before another attribute', () => {
+		const element = findElement(
+			`export function App() {
+	return <Host slot={<button>{<X />}</button>} onChange={(d: any) => go(d)} />;
+}`,
+			'Host',
+		);
+		const value = as_type(attributeExpression(element.openingElement.attributes[0]), 'JSXElement');
+		expect(openingName(value).name).toBe('button');
+		const container = as_type(
+			found(node_children(value).find((c) => c.type === 'JSXExpressionContainer')),
+			'JSXExpressionContainer',
+		);
+		expect(elementName(container.expression)).toBe('X');
+		assert_type(
+			attributeExpression(element.openingElement.attributes[1]),
+			'ArrowFunctionExpression',
+		);
+	});
+
+	it('still strips the leak for a directive-bodied attribute value', () => {
+		const element = findElement(
+			`export function App() {
+	return <Card
+		content={
+			<div>
+				@if (foo) {
+					<span />
+				}
+			</div>
+		}
+	/>;
+}`,
+			'Card',
+		);
+		const value = as_type(attributeExpression(element.openingElement.attributes[0]), 'JSXElement');
+		expect(openingName(value).name).toBe('div');
+		expect(as_type(element.openingElement, 'JSXOpeningElement').selfClosing).toBe(true);
+	});
+});


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Targeted one-condition change in parser context fixup with focused tests; no API or runtime behavior outside JSX attribute parsing edge cases.
> 
> **Overview**
> Fixes **TSRX parser failures** when a JSX-valued attribute wraps an element whose children use an expression container (e.g. `slot={<button>{ok ? <X /> : <Y />}</button>}`) and the host tag has **more attributes after** that value.
> 
> After the inner `}` closes, the tokenizer context stack can look like the **statement-bodied attribute leak** case (`tc_oTag`, `b_expr`, `tc_expr`). The post-element fixup in `#popTokenContextsAfterTemplateExpressionElement` used to strip contexts whenever it saw that shape on `}`, which wrongly removed the **attribute value's** brace context when the stack had already unwound below the enclosing expression depth—so the next `=` was read as template text and parsing broke.
> 
> The change adds **`ctx.length >= enclosing_context_depth`** to that strip branch (with expanded comments) so the fixup only runs while still inside the enclosing attribute/expression, not for inner child containers. **Regression tests** cover ternaries and nested elements before a sibling attribute, plus directive-bodied attribute values still getting the leak strip.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4660839778c2506a802ef148a6c5bf00ae19c5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->