### PR TITLE
fix(prettier-plugin): stop dropping TypeScript modifiers

### DIFF
--- a/.changeset/eighty-donkeys-repeat.md
+++ b/.changeset/eighty-donkeys-repeat.md
@@ -1,0 +1,17 @@
+---
+'@tsrx/prettier-plugin': patch
+'@tsrx/core': patch
+---
+
+fix: stop dropping TypeScript modifiers when formatting
+
+Formatting silently rewrote what the source declared. `readonly` was dropped from
+interface and type-literal members, turning `readonly id: number` into a mutable
+`id: number`; `abstract` was dropped from classes and their members (and abstract
+methods gained an empty body, making them concrete); and `declare`, `override`,
+`accessor`, accessor kinds on method signatures (`get`/`set`), `abstract new`,
+`declare global` (printed as `declare module global`), computed keys, class static
+blocks, and constructor parameter properties were dropped or mangled the same way.
+
+All of these now round-trip, and `@tsrx/core`'s AST types carry the class modifiers
+the printer needs.

--- a/packages/prettier-plugin/src/index.js
+++ b/packages/prettier-plugin/src/index.js
@@ -821,9 +821,9 @@ function buildInlineArrayCommentDoc(comments) {
 }
 
 /**
- * Print an object or method key
- * @param {AST.Property | AST.MethodDefinition} node - The property or method node
- * @param {AstPath<AST.Property | AST.MethodDefinition>} path - The AST path
+ * Print an object, method, or class field key
+ * @param {AST.Property | AST.MethodDefinition | AST.PropertyDefinition} node - The property or method node
+ * @param {AstPath<AST.Property | AST.MethodDefinition | AST.PropertyDefinition>} path - The AST path
  * @param {RippleFormatOptions} options - Prettier options
  * @param {PrintFn} print - Print callback
  * @returns {Doc[]}
@@ -2146,14 +2146,18 @@ function printRippleNode(node, path, options, print, args) {
 		}
 
 		case 'TSModuleDeclaration': {
-			nodeContent = [
-				node.declare ? 'declare ' : '',
-				node.metadata?.module_keyword ?? 'module',
-				' ',
-				path.call(print, 'id'),
-				' ',
-				path.call(print, 'body'),
-			];
+			// `declare global` augments the global scope; printing it as
+			// `declare module global` declares an unrelated module named `global`.
+			nodeContent = node.global
+				? [node.declare ? 'declare ' : '', path.call(print, 'id'), ' ', path.call(print, 'body')]
+				: [
+						node.declare ? 'declare ' : '',
+						node.metadata?.module_keyword ?? 'module',
+						' ',
+						path.call(print, 'id'),
+						' ',
+						path.call(print, 'body'),
+					];
 			break;
 		}
 
@@ -2560,6 +2564,43 @@ function printRippleNode(node, path, options, print, args) {
 			break;
 		}
 
+		case 'TSParameterProperty': {
+			// A constructor parameter property declares a class field. Losing
+			// the modifiers loses the field, so this must not fall through to
+			// the unknown-node path.
+			/** @type {Doc[]} */
+			const parts = [];
+
+			if (node.accessibility) {
+				parts.push(node.accessibility, ' ');
+			}
+
+			if (node.override) {
+				parts.push('override ');
+			}
+
+			if (node.readonly) {
+				parts.push('readonly ');
+			}
+
+			parts.push(path.call(print, 'parameter'));
+			nodeContent = parts;
+			break;
+		}
+
+		case 'StaticBlock': {
+			nodeContent =
+				node.body && node.body.length > 0
+					? group([
+							'static {',
+							indent([hardline, join(hardline, path.map(print, 'body'))]),
+							hardline,
+							'}',
+						])
+					: 'static {}';
+			break;
+		}
+
 		case 'TSExpressionWithTypeArguments': {
 			/** @type {Doc[]} */
 			const parts = [];
@@ -2812,8 +2853,11 @@ function printVariableDeclaration(node, path, options, print) {
 	const declarations = path.map(print, 'declarations');
 	const declarationParts = join(', ', declarations);
 
+	// `declare` makes the binding ambient (no emit) — never a for-loop head
+	const declarePrefix = node.declare ? 'declare ' : '';
+
 	if (!isForLoopInit) {
-		return [kind, ' ', declarationParts, semi(options)];
+		return [declarePrefix, kind, ' ', declarationParts, semi(options)];
 	}
 
 	return [kind, ' ', declarationParts];
@@ -4017,6 +4061,16 @@ function printObjectExpression(node, path, options, print, args) {
 function printClassDeclaration(node, path, options, print) {
 	/** @type {Doc[]} */
 	const parts = [];
+
+	// Ambient/abstract markers change what the class is, so they must survive
+	if (node.declare) {
+		parts.push('declare ');
+	}
+
+	if (node.abstract) {
+		parts.push('abstract ');
+	}
+
 	parts.push('class');
 
 	// Class name (optional for ClassExpression)
@@ -4147,6 +4201,11 @@ function printPropertyDefinition(node, path, options, print) {
 	/** @type {Doc[]} */
 	const parts = [];
 
+	// `declare` must lead the modifier list
+	if (node.declare) {
+		parts.push('declare ');
+	}
+
 	// Access modifiers (public, private, protected)
 	if (node.accessibility) {
 		parts.push(node.accessibility);
@@ -4158,13 +4217,28 @@ function printPropertyDefinition(node, path, options, print) {
 		parts.push('static ');
 	}
 
+	// Abstract / override keywords
+	if (node.abstract) {
+		parts.push('abstract ');
+	}
+
+	if (node.override) {
+		parts.push('override ');
+	}
+
 	// Readonly keyword
 	if (node.readonly) {
 		parts.push('readonly ');
 	}
 
-	// Property name
-	parts.push(path.call(print, 'key'));
+	// `accessor` turns the field into a getter/setter pair — not decoration
+	if (node.accessor) {
+		parts.push('accessor ');
+	}
+
+	// Property name. Must go through printKey so a computed key keeps its
+	// brackets — `[key] = 1` and `key = 1` name different fields.
+	parts.push(...printKey(node, path, options, print));
 
 	// Optional marker
 	if (node.optional) {
@@ -4209,6 +4283,15 @@ function printMethodDefinition(node, path, options, print) {
 	// Static keyword
 	if (node.static) {
 		parts.push('static ');
+	}
+
+	// Abstract / override keywords
+	if (node.abstract) {
+		parts.push('abstract ');
+	}
+
+	if (node.override) {
+		parts.push('override ');
 	}
 
 	// Method kind and name
@@ -4258,12 +4341,14 @@ function printMethodDefinition(node, path, options, print) {
 		parts.push(': ', path.call(print, 'value', 'returnType'));
 	}
 
-	// Method body
-	parts.push(' ');
+	// Method body. Bodiless members (abstract, declared, overload signatures)
+	// terminate with a semicolon — inventing an empty body makes an abstract
+	// method concrete.
 	if (node.value && node.value.body) {
+		parts.push(' ');
 		parts.push(path.call(print, 'value', 'body'));
 	} else {
-		parts.push('{}');
+		parts.push(semi(options));
 	}
 
 	return parts;
@@ -4639,6 +4724,10 @@ function printTSUnionType(node, path, print, args) {
 function printTSEnumDeclaration(node, path, options, print) {
 	/** @type {Doc[]} */
 	const parts = [];
+
+	if (node.declare) {
+		parts.push('declare ');
+	}
 
 	// Handle 'const enum' vs 'enum'
 	if (node.const) {
@@ -5576,7 +5665,19 @@ function printTSTypeLiteral(node, path, options, print) {
 function printTSPropertySignature(node, path, options, print) {
 	/** @type {Doc[]} */
 	const parts = [];
-	parts.push(path.call(print, 'key'));
+
+	// `readonly` is part of the declared type, not decoration — dropping it
+	// silently widens the member to mutable.
+	if (node.readonly) {
+		parts.push('readonly ');
+	}
+
+	// Computed keys keep their brackets — `[Symbol.iterator]` is not `Symbol.iterator`
+	if (node.computed) {
+		parts.push('[', path.call(print, 'key'), ']');
+	} else {
+		parts.push(path.call(print, 'key'));
+	}
 
 	if (node.optional) {
 		parts.push('?');
@@ -5602,8 +5703,20 @@ function printTSMethodSignature(node, path, options, print) {
 	/** @type {Doc[]} */
 	const parts = [];
 
-	// Print the method name/key
-	parts.push(path.call(print, 'key'));
+	// Accessor kind — without it `get x(): number` and `set x(v: number)`
+	// both collapse to `x(...)`, which is a different (and duplicated) member.
+	if (node.kind === 'get') {
+		parts.push('get ');
+	} else if (node.kind === 'set') {
+		parts.push('set ');
+	}
+
+	// Print the method name/key, keeping brackets on computed keys
+	if (node.computed) {
+		parts.push('[', path.call(print, 'key'), ']');
+	} else {
+		parts.push(path.call(print, 'key'));
+	}
 
 	// Add optional marker if present
 	if (node.optional) {
@@ -5825,6 +5938,10 @@ function printTSIndexSignature(node, path, options, print) {
 function printTSConstructorType(node, path, options, print) {
 	/** @type {Doc[]} */
 	const parts = [];
+	// `abstract new () => T` only accepts abstract constructors
+	if (node.abstract) {
+		parts.push('abstract ');
+	}
 	parts.push('new ');
 	parts.push('(');
 	const hasParameters = Array.isArray(node.parameters) && node.parameters.length > 0;

--- a/packages/prettier-plugin/src/index.test.js
+++ b/packages/prettier-plugin/src/index.test.js
@@ -6972,4 +6972,177 @@ function g() {
 			expect(result).toBeWithNewline(expected);
 		});
 	});
+
+	// A formatter may never change what the source declares. Every modifier
+	// below is load-bearing: dropping it silently retypes or redefines the
+	// member, and the result still compiles, so nothing catches it downstream.
+	describe('TypeScript modifiers survive formatting', () => {
+		/**
+		 * Assert the input is already formatted and comes back byte-identical.
+		 * @param {string} source
+		 */
+		const expectUnchanged = async (source) => {
+			const result = await format(source);
+			expect(result).toBeWithNewline(source);
+		};
+
+		it('keeps readonly on interface members', async () => {
+			await expectUnchanged(`export interface BenchRow {
+  readonly id: number;
+  readonly label: string;
+  mutable: string;
+}`);
+		});
+
+		it('keeps readonly on type literal members', async () => {
+			await expectUnchanged(`type Row = {
+  readonly id: number;
+  readonly label?: string;
+  mutable: string;
+};`);
+		});
+
+		it('keeps readonly on nested type literal members', async () => {
+			await expectUnchanged(`interface Outer {
+  readonly inner: {
+    readonly deep: number;
+  };
+}`);
+		});
+
+		it('keeps readonly on index signatures', async () => {
+			await expectUnchanged(`interface Bag {
+  readonly [key: string]: number;
+}`);
+		});
+
+		it('keeps readonly array and tuple type operators', async () => {
+			await expectUnchanged(`interface Lists {
+  xs: readonly string[];
+  ys: ReadonlyArray<number>;
+  pair: readonly [number, string];
+}`);
+		});
+
+		it('keeps get and set accessor kinds on method signatures', async () => {
+			await expectUnchanged(`interface Box {
+  get value(): number;
+  set value(next: number);
+}`);
+		});
+
+		it('keeps class field modifiers', async () => {
+			await expectUnchanged(`class Fields {
+  readonly a = 1;
+  static readonly b = 2;
+  private readonly c = 3;
+  protected d = 4;
+  public e = 5;
+  declare f: number;
+  accessor g = 6;
+}`);
+		});
+
+		it('keeps abstract on classes and their members', async () => {
+			await expectUnchanged(`abstract class Shape {
+  abstract area(): number;
+  abstract readonly sides: number;
+  protected abstract render(): void;
+}`);
+		});
+
+		it('keeps override on class members', async () => {
+			await expectUnchanged(`class Derived extends Base {
+  override toString(): string {
+    return "";
+  }
+  override readonly tag: string = "derived";
+}`);
+		});
+
+		it('keeps modifiers on constructor parameter properties', async () => {
+			await expectUnchanged(`class Point {
+  readonly origin = 0;
+  constructor(private readonly x: number, public y: string) {}
+}`);
+		});
+
+		it('keeps declare on ambient declarations', async () => {
+			await expectUnchanged(`declare const version: number;
+declare function init(): void;
+declare class Ambient {}
+declare enum Level {
+  A = 1,
+}`);
+		});
+
+		it('keeps declare global rather than declaring a module named global', async () => {
+			await expectUnchanged(`declare global {
+  interface Window {
+    readonly octane: number;
+  }
+}`);
+		});
+
+		it('keeps declare module', async () => {
+			await expectUnchanged(`declare module "octane" {
+  const x: number;
+}`);
+		});
+
+		it('keeps const enum', async () => {
+			await expectUnchanged(`const enum Flags {
+  None = 0,
+}`);
+		});
+
+		it('keeps abstract on constructor types', async () => {
+			await expectUnchanged(`type Ctor = abstract new () => object;`);
+		});
+
+		it('keeps class static blocks', async () => {
+			await expectUnchanged(`class WithStatic {
+  static {
+    console.log(1);
+  }
+}`);
+		});
+
+		it('keeps readonly through the mapped type modifier forms', async () => {
+			await expectUnchanged(`type Frozen = { readonly [K in keyof T]: T[K] };`);
+			await expectUnchanged(`type Thawed = { -readonly [K in keyof T]: T[K] };`);
+		});
+
+		it('terminates bodiless class members with a semicolon, not an empty body', async () => {
+			const input = `abstract class Shape {
+	abstract area(): number;
+}`;
+
+			const result = await format(input);
+			expect(result).not.toContain('{}');
+		});
+
+		it('keeps brackets on computed signature keys', async () => {
+			await expectUnchanged(`interface Iterable {
+  readonly [Symbol.iterator]: () => void;
+  [Symbol.asyncIterator](): void;
+}`);
+		});
+
+		it('keeps brackets on computed class field keys', async () => {
+			await expectUnchanged(`class Keyed { [key] = 1; readonly [other] = 2; }`);
+		});
+
+		it('normalises readonly onto reformatted interface members', async () => {
+			const input = `interface Row {readonly   id:number
+      readonly label : string}`;
+			const expected = `interface Row {
+  readonly id: number;
+  readonly label: string;
+}`;
+
+			const result = await format(input);
+			expect(result).toBeWithNewline(expected);
+		});
+	});
 });

--- a/packages/tsrx/types/index.d.ts
+++ b/packages/tsrx/types/index.d.ts
@@ -303,6 +303,8 @@ declare module 'estree' {
 		typeParameters?: TSTypeParameterDeclaration;
 		accessibility?: Accessibility;
 		optional?: boolean;
+		abstract?: boolean;
+		override?: boolean;
 	}
 
 	interface PropertyDefinition {
@@ -310,18 +312,26 @@ declare module 'estree' {
 		readonly?: boolean;
 		optional?: boolean;
 		definite?: boolean;
+		abstract?: boolean;
+		override?: boolean;
+		declare?: boolean;
+		accessor?: boolean;
 	}
 
 	interface ClassDeclaration {
 		typeParameters?: AST.TSTypeParameterDeclaration;
 		superTypeParameters?: AST.TSTypeParameterInstantiation;
 		implements?: AST.TSClassImplements[];
+		abstract?: boolean;
+		declare?: boolean;
 	}
 
 	interface ClassExpression {
 		typeParameters?: AST.TSTypeParameterDeclaration;
 		superTypeParameters?: AST.TSTypeParameterInstantiation;
 		implements?: AST.TSClassImplements[];
+		abstract?: boolean;
+		declare?: boolean;
 	}
 
 	interface Identifier extends AST.TrackedNode {


### PR DESCRIPTION
## The bug

Reported as `readonly` vanishing from interface members. Put this in a `.tsrx` file and format it:

```ts
export interface BenchRow {
	readonly id: number;
	readonly label: string;
}
```

It comes back as `id: number` / `label: string` — a different, mutable type. Hit while adding a benchmark component in the octane repo, which was reworded to avoid `readonly` as a workaround.

## Root cause

Not specific to `readonly`. The printer re-emits each AST node from scratch, so **any field it forgets to read is silently deleted**. `readonly` was one of twelve:

| Source | Was printed as |
|---|---|
| `readonly id: number` (interface + type literal) | `id: number` |
| `abstract class C` | `class C` |
| `abstract foo(): void;` | `foo(): void {}` — concrete, with an invented body |
| `declare` on const / class / enum / field | dropped |
| `override`, `accessor` | dropped |
| `get x(): T` + `set x(v: T)` | `x(): T` + `x(v: T)` — duplicate member |
| `abstract new () => T` | `new () => T` |
| `declare global {}` | `declare module global {}` — a different declaration |
| `[key] = 1` | `key = 1` |
| `readonly [Symbol.iterator]` | `readonly Symbol.iterator` |
| `constructor(private readonly x: number)` | `Unknown node type: TSParameterProperty` |
| `static {}` | `Unknown node type: StaticBlock` |

`TSParameterProperty` and `StaticBlock` had no printer at all and fell through to the unknown-node path, replacing the member with a comment placeholder.

Index-signature `readonly` and `readonly` array/tuple types were already handled correctly.

Every rewritten form still compiles, so nothing downstream catches it. A formatter must never change what the source declares.

## The fix

Print the modifiers. `@tsrx/core`'s AST types gained the class modifiers the printer needs — acorn-typescript's types omit them, so reading `node.abstract` / `node.override` / `node.declare` / `node.accessor` failed typecheck.

Bodiless class members (abstract, declared, overload signatures) now terminate with a semicolon instead of an invented `{}` body.

## Verification

- 21 new regression tests. The suite's shared `format` helper asserts idempotence on every call, so each also doubles as a fixpoint check.
- `vitest run packages/prettier-plugin`: 405 passed.
- Full repo suite: 4828 passed. (7 `eslint-plugin` test *files* fail to resolve `@tsrx/eslint-parser` in a fresh worktree — its `exports` point at an unbuilt `./dist`. Pre-existing and unrelated.)
- `pnpm format:check` and full `pnpm typecheck` clean.
- Diffed every `.tsrx` file in this repo (197) and in the octane repo (1436) through the old and new printer: **0 differ**. The change is confined to sources that actually use these modifiers — which is also why the bug survived to 0.3.116.

## Not in scope

**Decorators are dropped too**, in all four positions (`@sealed class`, `@log method()`, `@inject accessor x`, `m(@param() a)`). Same severity, but it is an unimplemented feature rather than a dropped field, and it needs line-breaking decisions across four positions. Left for a follow-up.

Two cosmetic behaviours left alone, neither of which changes meaning: constructor parameter lists do not break across lines when over `printWidth`, and `declare namespace X` is rewritten to the equivalent `declare module X`.

## History

Third semantics-changing bug in this plugin, after the paren-drop bug (fixed in 0.3.95, #1335) and the still-open JSX-text rewrap bug. All three share the same shape: the printer reconstructs output and quietly loses whatever it does not explicitly handle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core formatter path for many TypeScript constructs; behavior change is intentional and well-tested, but any missed node type could still drop modifiers.
> 
> **Overview**
> Fixes a **semantics-changing formatting bug**: the `@tsrx/prettier-plugin` printer rebuilt AST nodes without reading many modifier fields, so output often still compiled but meant something different.
> 
> The printer now **preserves** `readonly` on interface/type members; `declare` / `abstract` / `override` / `accessor` on classes and members; `get`/`set` on method signatures; `abstract` on constructor types; `declare` on variables, enums, and ambient declarations; and **computed keys** via `printKey`. **`declare global`** is no longer printed as `declare module global`. **Bodiless** class members end with a semicolon instead of `{}`. New handlers cover **`TSParameterProperty`** and **`StaticBlock`** (previously unknown-node placeholders).
> 
> **`@tsrx/core`** AST types gain the class modifier fields the printer reads. **21 regression tests** assert modifier round-trips and idempotent formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a82e7d4e809ab071b4e840654249d84da3f40a88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->