### PR TITLE
fix(prettier-plugin): stop dropping decorators

### DIFF
--- a/.changeset/lucky-pugs-refuse.md
+++ b/.changeset/lucky-pugs-refuse.md
@@ -1,0 +1,19 @@
+---
+'@tsrx/prettier-plugin': patch
+'@tsrx/core': patch
+---
+
+fix: stop dropping decorators when formatting
+
+The printer had no decorator handling at all, so formatting silently deleted every
+`@decorator` in a `.tsrx` file — on class declarations, methods, fields, accessors,
+and parameters alike. Decorators have runtime effects, so this changed what the
+code did.
+
+All four positions now round-trip, following prettier's line breaking: class
+decorators each take their own line, class member decorators keep the lines they
+were written with (and an inline decorator too long to share the member's line
+moves to its own), and parameter decorators stay inline. Decorators on an exported
+class print above the `export` keyword, and a parameter property's decorators print
+before its modifiers. `@tsrx/core`'s AST types now carry the `Decorator` node the
+printer needs.

--- a/packages/prettier-plugin/src/index.js
+++ b/packages/prettier-plugin/src/index.js
@@ -16,6 +16,12 @@
 
 /** @typedef {Partial<Pick<ParserOptions, 'singleQuote' | 'jsxSingleQuote' | 'semi' | 'trailingComma' | 'useTabs' | 'tabWidth' | 'singleAttributePerLine' | 'bracketSameLine' | 'bracketSpacing' | 'arrowParens' | 'originalText' | 'printWidth'>> & { locStart: (node: AST.NodeWithLocation) => number, locEnd: (node: AST.NodeWithLocation) => number }} RippleFormatOptions */
 
+/**
+ * Any node the parser may hang decorators off. The individual node types do not
+ * declare the property, so reading it needs a cast.
+ * @typedef {AST.Node & { decorators?: AST.Decorator[] }} MaybeDecoratedNode
+ */
+
 /** @typedef {{ isInAttribute?: boolean, isInArray?: boolean, allowInlineObject?: boolean, isConditionalTest?: boolean, isNestedConditional?: boolean, suppressLeadingComments?: boolean, suppressExpressionLeadingComments?: boolean, suppressOwnParens?: boolean, isInlineContext?: boolean, isStatement?: boolean, isLogicalAndOr?: boolean, allowShorthandProperty?: boolean, isFirstChild?: boolean, noBreakInside?: boolean, expandLastArg?: boolean, preferInlineSimpleUnionType?: boolean }} PrintArgs */
 
 import { parseModule } from '@tsrx/core';
@@ -854,6 +860,152 @@ function printKey(node, path, options, print) {
 	}
 
 	return parts;
+}
+
+/**
+ * Read a node's decorator list, if it has one.
+ * @param {AST.Node | null | undefined} node - The AST node
+ * @returns {AST.Decorator[]} The decorators, or an empty array
+ */
+function getDecorators(node) {
+	const decorators = /** @type {MaybeDecoratedNode | null | undefined} */ (node)?.decorators;
+	return Array.isArray(decorators) ? decorators : [];
+}
+
+/**
+ * Whether an ancestor prints this node's decorators, so the node must not print
+ * them again. Two positions hoist decorators out of the node that owns them:
+ *
+ * - `@dec export class A {}` and `export @dec class A {}` produce identical
+ *   ASTs, so the export printer emits them above the `export` keyword.
+ * - A parameter property's decorators live on the inner parameter, but belong
+ *   before the modifiers: `@inject private readonly x: Foo`.
+ *
+ * A parenthesized default export is not hoisted: its decorators apply to the
+ * expression inside the parens, and lifting them above `export default` would
+ * both change what they decorate and strand the parens.
+ * @param {AST.Node} node - The AST node
+ * @param {AstPath} path - The AST path
+ * @param {RippleFormatOptions} options - Prettier options
+ * @returns {boolean}
+ */
+function decoratorsPrintedByParent(node, path, options) {
+	const parent = /** @type {AST.Node | null} */ (path.getParentNode());
+
+	if (!parent) {
+		return false;
+	}
+
+	if (parent.type === 'ExportDefaultDeclaration') {
+		return parent.declaration === node && !isParenthesizedDefaultExport(parent, options);
+	}
+
+	if (parent.type === 'ExportNamedDeclaration') {
+		return parent.declaration === node;
+	}
+
+	if (parent.type === 'TSParameterProperty') {
+		return /** @type {AST.Node} */ (/** @type {unknown} */ (parent.parameter)) === node;
+	}
+
+	return false;
+}
+
+/**
+ * Whether a node is a class member, whose decorators may sit either on their
+ * own line or inline with the member.
+ * @param {AST.Node} node - The AST node
+ * @returns {boolean}
+ */
+function isClassMember(node) {
+	return node.type === 'PropertyDefinition' || node.type === 'MethodDefinition';
+}
+
+/**
+ * Whether a class member's decorators must each go on their own line, which is
+ * how they were written when any of them is followed by a newline.
+ * @param {AST.Node} node - The decorated node
+ * @param {RippleFormatOptions} options - Prettier options
+ * @returns {boolean}
+ */
+function shouldBreakDecorators(node, options) {
+	const text = options.originalText;
+
+	if (typeof text !== 'string') {
+		return false;
+	}
+
+	return getDecorators(node).some(
+		(decorator) => typeof decorator.end === 'number' && hasNewline(text, decorator.end),
+	);
+}
+
+/**
+ * Print a decorator list as a prefix for the node it decorates, including the
+ * separator that follows the last decorator.
+ *
+ * Classes always put each decorator on its own line. A class member keeps the
+ * lines it was written with, and when it was written inline the decorators get
+ * their own group, so a decorator too long to share the member's line moves to
+ * its own line rather than breaking apart. Everywhere else — parameters, most
+ * notably — decorators stay inline.
+ * @param {AST.Node} node - The decorated node
+ * @param {AstPath} path - The AST path, positioned at the decorated node
+ * @param {RippleFormatOptions} options - Prettier options
+ * @param {PrintFn} print - Print callback
+ * @returns {Doc[]} The prefix parts, or an empty array when there are none
+ */
+function printDecorators(node, path, options, print) {
+	if (getDecorators(node).length === 0) {
+		return [];
+	}
+
+	const printed = /** @type {Doc[]} */ (path.map(print, 'decorators'));
+	const isClass = node.type === 'ClassDeclaration' || node.type === 'ClassExpression';
+
+	if (isClass || (isClassMember(node) && shouldBreakDecorators(node, options))) {
+		return [join(hardline, printed), hardline];
+	}
+
+	if (isClassMember(node)) {
+		return [group([join(line, printed), line])];
+	}
+
+	return [join(' ', printed), ' '];
+}
+
+/**
+ * Print the decorators of an exported declaration, which belong above the
+ * `export` keyword rather than on the declaration itself. A parenthesized
+ * default export keeps its decorators inside the parens, so it prints none
+ * here — see {@link decoratorsPrintedByParent}.
+ * @param {AST.ExportNamedDeclaration | AST.ExportDefaultDeclaration} node - The export node
+ * @param {AstPath} path - The AST path
+ * @param {RippleFormatOptions} options - Prettier options
+ * @param {PrintFn} print - Print callback
+ * @returns {Doc[]} The prefix parts, or an empty array when there are none
+ */
+function printDeclarationDecorators(node, path, options, print) {
+	const declaration = /** @type {AST.Node | null | undefined} */ (node.declaration);
+
+	if (getDecorators(declaration).length === 0) {
+		return [];
+	}
+
+	if (
+		node.type === 'ExportDefaultDeclaration' &&
+		isParenthesizedDefaultExport(/** @type {AST.ExportDefaultDeclaration} */ (node), options)
+	) {
+		return [];
+	}
+
+	return /** @type {Doc[]} */ (
+		path.call(
+			(declarationPath) =>
+				printDecorators(/** @type {AST.Node} */ (declaration), declarationPath, options, print),
+			'declaration',
+		)
+	);
 }
 
 /**
@@ -2571,6 +2723,21 @@ function printRippleNode(node, path, options, print, args) {
 			/** @type {Doc[]} */
 			const parts = [];
 
+			// The parser hangs the decorators off the inner parameter, but they
+			// are written before the modifiers: `@inject private readonly x: T`.
+			const parameter = /** @type {AST.Node} */ (/** @type {unknown} */ (node.parameter));
+
+			if (getDecorators(parameter).length > 0) {
+				parts.push(
+					.../** @type {Doc[]} */ (
+						path.call(
+							(parameterPath) => printDecorators(parameter, parameterPath, options, print),
+							'parameter',
+						)
+					),
+				);
+			}
+
 			if (node.accessibility) {
 				parts.push(node.accessibility, ' ');
 			}
@@ -2658,11 +2825,22 @@ function printRippleNode(node, path, options, print, args) {
 			break;
 		}
 
+		case 'Decorator':
+			nodeContent = ['@', path.call(print, 'expression')];
+			break;
+
 		default:
 			// Fallback for unknown node types
 			console.warn('Unknown node type:', node.type);
 			nodeContent = '/* Unknown: ' + node.type + ' */';
 			break;
+	}
+
+	// Decorators have runtime effects, so every decorated node prints them —
+	// unless an ancestor hoisted them out (see `decoratorsPrintedByParent`).
+	const decorated = /** @type {AST.Node} */ (node);
+	if (getDecorators(decorated).length > 0 && !decoratorsPrintedByParent(decorated, path, options)) {
+		nodeContent = [...printDecorators(decorated, path, options, print), nodeContent];
 	}
 
 	return finishRippleNode(/** @type {AST.Node} */ (node), parts, nodeContent);
@@ -2784,6 +2962,7 @@ function printExportNamedDeclaration(node, path, options, print) {
 	if (node.declaration) {
 		/** @type {Doc[]} */
 		const parts = [];
+		parts.push(...printDeclarationDecorators(node, path, options, print));
 		parts.push('export ');
 		parts.push(path.call(print, 'declaration'));
 		return parts;
@@ -3101,12 +3280,22 @@ function isParenthesizedDefaultExport(node, options) {
 function printExportDefaultDeclaration(node, path, options, print) {
 	/** @type {Doc[]} */
 	const parts = [];
+	parts.push(...printDeclarationDecorators(node, path, options, print));
 	parts.push('export default ');
 
 	if (isParenthesizedDefaultExport(node, options)) {
 		// An expression export, not a declaration: it keeps its parens and
 		// takes a statement terminator.
-		parts.push('(', path.call(print, 'declaration'), ')', semi(options));
+		const declaration = path.call(print, 'declaration');
+
+		if (getDecorators(/** @type {AST.Node} */ (node.declaration)).length > 0) {
+			// The decorators stay inside the parens, each on its own line, so
+			// the whole expression is indented to keep them off column zero.
+			parts.push('(', indent([hardline, declaration]), hardline, ')', semi(options));
+			return parts;
+		}
+
+		parts.push('(', declaration, ')', semi(options));
 		return parts;
 	}
 
@@ -5566,6 +5755,12 @@ function printVariableDeclarator(node, path, options, print) {
 	if (node.init) {
 		const id = path.call(print, 'id');
 		const init = path.call(print, 'init');
+
+		// A decorated class expression leads with its decorators on their own
+		// lines, so the whole thing moves below the `=` to stay indented.
+		if (node.init.type === 'ClassExpression' && getDecorators(node.init).length > 0) {
+			return [id, ' =', indent([hardline, init])];
+		}
 
 		// For conditional expressions that will break, put them on a new line
 		if (node.init.type === 'ConditionalExpression') {

--- a/packages/prettier-plugin/src/index.test.js
+++ b/packages/prettier-plugin/src/index.test.js
@@ -7229,4 +7229,213 @@ export const alias = Named;`;
 			expect(result).toBeWithNewline(expected);
 		});
 	});
+
+	describe('decorators survive formatting', () => {
+		/**
+		 * Assert the input is already formatted and comes back byte-identical.
+		 * @param {string} source
+		 */
+		const expectUnchanged = async (source) => {
+			const result = await format(source);
+			expect(result).toBeWithNewline(source);
+		};
+
+		it('keeps decorators in every position', async () => {
+			await expectUnchanged(`@sealed
+class A {
+  @log
+  method() {}
+  @inject accessor x = 1;
+  m(@param() a: number) {}
+}`);
+		});
+
+		it('keeps a decorator on a class declaration', async () => {
+			await expectUnchanged(`@sealed
+class Widget {
+  render() {
+    return 1;
+  }
+}`);
+		});
+
+		it('gives each class decorator its own line', async () => {
+			const input = `@first @second class Widget {}`;
+			const expected = `@first
+@second
+class Widget {}`;
+
+			const result = await format(input);
+			expect(result).toBeWithNewline(expected);
+		});
+
+		it('keeps a class member decorator on its own line', async () => {
+			await expectUnchanged(`class Store {
+  @observable
+  count = 0;
+
+  @action
+  increment() {
+    this.count++;
+  }
+}`);
+		});
+
+		it('keeps a class member decorator inline when it was written inline', async () => {
+			await expectUnchanged(`class Store {
+  @observable count = 0;
+  @inject accessor service = null;
+
+  @action increment() {
+    this.count++;
+  }
+}`);
+		});
+
+		it('keeps several inline decorators on one member', async () => {
+			await expectUnchanged(`class Store {
+  @first @second count = 0;
+
+  ping() {
+    return 1;
+  }
+}`);
+		});
+
+		it('moves an inline decorator too long for the line onto its own line', async () => {
+			const input = `class Store {
+  @veryLongDecoratorNameHere({ option: 1, another: 2, third: 3, fourth: 4 }) method() {
+    return 1;
+  }
+}`;
+			const expected = `class Store {
+  @veryLongDecoratorNameHere({ option: 1, another: 2, third: 3, fourth: 4 })
+  method() {
+    return 1;
+  }
+}`;
+
+			const result = await format(input);
+			expect(result).toBeWithNewline(expected);
+		});
+
+		it('keeps decorators alongside other member modifiers', async () => {
+			await expectUnchanged(`class Store {
+  @dec static base = 1;
+  @dec declare readonly id: number;
+
+  @dec
+  @other
+  private static async *walk() {
+    yield 1;
+  }
+}`);
+		});
+
+		it('keeps decorators on accessors and computed keys', async () => {
+			await expectUnchanged(`class Store {
+  @dec ["computed"] = 1;
+
+  @dec
+  @other()
+  get value() {
+    return 1;
+  }
+
+  @dec set value(next) {
+    this.inner = next;
+  }
+}`);
+		});
+
+		it('keeps decorators built from member and call expressions', async () => {
+			await expectUnchanged(`@dec.nested.deep({ a: 1 })
+class Widget {}`);
+		});
+
+		it('keeps parameter decorators inline', async () => {
+			await expectUnchanged(`class Store {
+  handle(@inject() service: Service, @body() payload: Payload) {
+    return service;
+  }
+}`);
+		});
+
+		it('keeps parameter decorators before parameter property modifiers', async () => {
+			await expectUnchanged(`class Store {
+  constructor(@inject private readonly service: Service) {
+    this.ready = true;
+  }
+}`);
+		});
+
+		it('keeps decorators above the export keyword', async () => {
+			await expectUnchanged(`@sealed
+export class Widget {}`);
+		});
+
+		it('hoists decorators written after the export keyword', async () => {
+			const input = `export @sealed class Widget {}`;
+			const expected = `@sealed
+export class Widget {}`;
+
+			const result = await format(input);
+			expect(result).toBeWithNewline(expected);
+		});
+
+		it('keeps decorators on a default-exported class', async () => {
+			await expectUnchanged(`@sealed
+export default class Widget {}`);
+		});
+
+		// Hoisting these above `export default` would change what they decorate
+		// and strand the parens, which a second pass then drops — turning the
+		// class expression into a declaration and leaking its name into module
+		// scope.
+		it('keeps decorators inside a parenthesized default export', async () => {
+			await expectUnchanged(`export default (
+  @sealed
+  class Named {}
+);`);
+		});
+
+		it('does not hoist decorators out of a parenthesized default export', async () => {
+			const input = `export default (@sealed class Named {});`;
+			const expected = `export default (
+  @sealed
+  class Named {}
+);`;
+
+			const result = await format(input);
+			expect(result).toBeWithNewline(expected);
+		});
+
+		it('keeps decorators on a class expression', async () => {
+			await expectUnchanged(`const Widget =
+  @sealed
+  class {};`);
+		});
+
+		it('keeps decorators alongside leading comments', async () => {
+			await expectUnchanged(`// widget entry point
+@sealed
+class Widget {
+  // the counter
+  @observable
+  count = 0;
+
+  ping() {
+    return 1;
+  }
+}`);
+		});
+
+		it('keeps blank lines between decorated classes', async () => {
+			await expectUnchanged(`@first
+class A {}
+
+@second
+class B {}`);
+		});
+	});
 });

--- a/packages/tsrx/types/index.d.ts
+++ b/packages/tsrx/types/index.d.ts
@@ -361,8 +361,16 @@ declare module 'estree' {
 		tracked?: boolean;
 	}
 
+	// A `@decorator` on a class, class member, or parameter. The parser emits
+	// these, but estree has no node type for them.
+	interface Decorator extends AST.BaseNode {
+		type: 'Decorator';
+		expression: AST.Expression;
+	}
+
 	// Include TypeScript node types and TSRX-specific nodes in NodeMap
 	interface NodeMap {
+		Decorator: Decorator;
 		JSXSpreadChild: ESTreeJSX.JSXSpreadChild;
 		TSRXImportDeclaration: TSRXImportDeclaration;
 		TSRXJSXElement: TSRXJSXElement;


### PR DESCRIPTION
## Problem

The printer had no decorator handling at all, so formatting a `.tsrx` file silently **deleted every `@decorator`** — on class declarations, methods, fields, accessors, and parameters alike. Decorators have runtime effects, so this changed what the code did.

```ts
@sealed
class A {
  @log
  method() {}
  @inject accessor x = 1;
  m(@param() a: number) {}
}
```

formatted to `class A { method() {} accessor x = 1; m(a: number) {} }` — every decorator gone, in all four positions.

`printClassDeclaration`, `printPropertyDefinition`, `printMethodDefinition`, and the parameter printers never read `node.decorators`, even though the parser populates it.

## Fix

- A `Decorator` case in the print switch, plus a single hook at the printer's one exit point that prefixes decorators onto any node carrying them — so every position is covered by construction rather than per-printer.
- Line breaking follows prettier: class decorators each take their own line; class member decorators keep the lines they were written with; an inline member decorator gets its own group, so one too long to share the member's line moves down rather than breaking apart; parameter decorators stay inline.
- Two hoists, where a decorator's owner isn't where it's printed: exported classes emit decorators above `export`, and a parameter property's decorators (which the parser hangs off the inner parameter) print before `private readonly`.
- A decorated class expression in a declarator moves below the `=` so its hardlines stay indented.
- `@tsrx/core`'s AST types gain the `Decorator` node, so the printer's handling is typed rather than cast around.

Follow-up to #1404, which fixed the same family of bugs for `readonly`/`abstract`/`declare`/`override`/`accessor` and left decorators as a separate concern.

## Divergences from vanilla prettier

I diffed 26 decorator cases against prettier's own `typescript` parser: 24 match byte-for-byte and all are idempotent. Two deliberate exceptions:

- `export @dec class A {}` normalizes to `@dec` above `export`. Both forms parse to identical ASTs here, so the position isn't recoverable; the two are equivalent TypeScript.
- `constructor(@inject private readonly x: Foo, @other b: Bar)` stays on one line where vanilla breaks it. Pre-existing and unrelated — `printMethodDefinition` joins params with a literal `', '` and never breaks them, decorators or not.

## Testing

- 18 new tests in a `describe('decorators survive formatting')` block. All 18 fail without the printer change and pass with it. The shared `format` helper asserts single-pass idempotence on every call.
- 423 prettier-plugin tests pass; `pnpm format:check` clean; `pnpm typecheck` clean repo-wide (worth running given the shared-types change).
- Full `pnpm test`: 4846 pass. The 7 failing test *files* are the pre-existing `@tsrx/eslint-parser` resolution failures in a fresh worktree (its exports point at `./dist`, which isn't built) — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The change fixes behavior that altered emitted code (decorators), but scope is limited to the formatter with broad tests; export/parenthesis edge cases are the main review focus.
> 
> **Overview**
> **Fixes a bug where `@tsrx/prettier-plugin` stripped every decorator on format**, which could change runtime behavior because decorators are not cosmetic.
> 
> The printer now emits `Decorator` nodes and prefixes decorator lists on decorated nodes via a single exit hook, with Prettier-like breaks: one decorator per line on classes, member decorators that respect original line breaks (or wrap when too long), and inline parameter decorators. **Export** printers hoist class decorators above `export` (except parenthesized `export default`), **TS parameter properties** print inner-parameter decorators before modifiers, and **decorated class expressions** in variable declarators indent below `=`.
> 
> `@tsrx/core` gains a typed **`Decorator`** AST node for the printer. A large **`decorators survive formatting`** test suite covers round-trip and edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d7d35270d7de7ad98e532b4a04102bc5b5434f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->