### PR TITLE
fix(prettier-plugin): keep parens around parenthesized default exports

### DIFF
--- a/.changeset/tender-pugs-shave.md
+++ b/.changeset/tender-pugs-shave.md
@@ -1,0 +1,16 @@
+---
+'@tsrx/prettier-plugin': patch
+---
+
+fix: keep parentheses around a parenthesized default-exported class or function expression
+
+`export default (class Named {})` was formatted to `export default class Named {}`,
+which is a different program. The parenthesized form is a class *expression*, so
+`Named` is bound only inside the class body; the paren-less form is a class
+*declaration*, so `Named` becomes a module-scoped binding that later code can
+reference. The same applied to `export default (function foo() {})`.
+
+The printer now consults the original source for the parens rather than the node
+type alone — a decorated `export default @dec class Named {}` also parses as a
+`ClassExpression` but is genuinely a declaration — and terminates the
+parenthesized expression export with a semicolon.

--- a/packages/prettier-plugin/src/index.js
+++ b/packages/prettier-plugin/src/index.js
@@ -3019,6 +3019,78 @@ function isTemplateExpression(node) {
 }
 
 /**
+ * Remove line and block comments from a span of source text.
+ * @param {string} text - Source text
+ * @returns {string} - The text with every comment replaced by nothing
+ */
+function stripComments(text) {
+	let result = '';
+
+	for (let i = 0; i < text.length; i++) {
+		if (text.charAt(i) === '/' && text.charAt(i + 1) === '*') {
+			const close = text.indexOf('*/', i + 2);
+			i = close === -1 ? text.length : close + 1;
+			continue;
+		}
+		if (text.charAt(i) === '/' && text.charAt(i + 1) === '/') {
+			while (i < text.length && !isCharNewLine(text.charAt(i))) {
+				i++;
+			}
+			continue;
+		}
+		result += text.charAt(i);
+	}
+
+	return result;
+}
+
+/**
+ * Check whether `export default` wraps its declaration in parentheses.
+ *
+ * The parens are load-bearing for a named class or function expression:
+ * `export default (class Named {})` binds `Named` only inside the class body,
+ * while `export default class Named {}` binds it module-wide. Dropping them
+ * silently turns the expression into a declaration.
+ *
+ * The node type alone cannot tell the two apart. Node spans exclude the
+ * parens, and a decorated `export default @dec class Named {}` also parses as
+ * a ClassExpression even though it is a declaration, so the source text
+ * between the keyword and the declaration has to be consulted.
+ *
+ * @param {AST.ExportDefaultDeclaration} node - The export default node
+ * @param {RippleFormatOptions} options - Prettier options
+ * @returns {boolean}
+ */
+function isParenthesizedDefaultExport(node, options) {
+	const declaration = node.declaration;
+
+	if (
+		!declaration ||
+		(declaration.type !== 'ClassExpression' && declaration.type !== 'FunctionExpression')
+	) {
+		return false;
+	}
+
+	const text = options.originalText;
+
+	if (typeof text !== 'string') {
+		return false;
+	}
+
+	const start = options.locStart(/** @type {AST.NodeWithLocation} */ (node));
+	const end = options.locStart(/** @type {AST.NodeWithLocation} */ (declaration));
+
+	if (!(start < end)) {
+		return false;
+	}
+
+	// Only the keyword, whitespace, comments and opening parens can appear
+	// here, so a trailing `(` after stripping comments means the declaration
+	// was parenthesized.
+	return stripComments(text.slice(start, end)).trimEnd().endsWith('(');
+}
+
+/**
  * Print an export default declaration
  * @param {AST.ExportDefaultDeclaration} node - The export default node
  * @param {AstPath<AST.ExportDefaultDeclaration>} path - The AST path
@@ -3030,6 +3102,14 @@ function printExportDefaultDeclaration(node, path, options, print) {
 	/** @type {Doc[]} */
 	const parts = [];
 	parts.push('export default ');
+
+	if (isParenthesizedDefaultExport(node, options)) {
+		// An expression export, not a declaration: it keeps its parens and
+		// takes a statement terminator.
+		parts.push('(', path.call(print, 'declaration'), ')', semi(options));
+		return parts;
+	}
+
 	parts.push(path.call(print, 'declaration'));
 	return parts;
 }

--- a/packages/prettier-plugin/src/index.test.js
+++ b/packages/prettier-plugin/src/index.test.js
@@ -7145,4 +7145,88 @@ declare enum Level {
 			expect(result).toBeWithNewline(expected);
 		});
 	});
+
+	// `export default (class Named {})` is an expression: `Named` is bound only
+	// inside the class body. `export default class Named {}` is a declaration:
+	// `Named` becomes a module-scoped binding. Dropping the parens swaps one for
+	// the other, and the file still compiles, so nothing catches it downstream.
+	describe('export default parentheses survive formatting', () => {
+		/**
+		 * Assert the input is already formatted and comes back byte-identical.
+		 * @param {string} source
+		 */
+		const expectUnchanged = async (source) => {
+			const result = await format(source);
+			expect(result).toBeWithNewline(source);
+		};
+
+		it('keeps parens around a named class expression', async () => {
+			await expectUnchanged(`export default (class Named {});`);
+		});
+
+		it('keeps parens around an anonymous class expression', async () => {
+			await expectUnchanged(`export default (class {});`);
+		});
+
+		it('keeps parens around a class expression with a superclass', async () => {
+			await expectUnchanged(`export default (class Named extends Base {});`);
+		});
+
+		it('keeps parens around a named function expression', async () => {
+			await expectUnchanged(`export default (function foo() {});`);
+		});
+
+		it('keeps parens around an anonymous function expression', async () => {
+			await expectUnchanged(`export default (function () {});`);
+		});
+
+		it('does not leak the class expression name into module scope', async () => {
+			const input = `export default (class Named {});
+export const alias = Named;`;
+
+			await expectUnchanged(input);
+		});
+
+		it('collapses redundant parens down to one pair', async () => {
+			const input = `export default ((class Named {}));`;
+			const expected = `export default (class Named {});`;
+
+			const result = await format(input);
+			expect(result).toBeWithNewline(expected);
+		});
+
+		it('collapses a multiline parenthesized class expression', async () => {
+			const input = `export default (
+  class Named {}
+);`;
+			const expected = `export default (class Named {});`;
+
+			const result = await format(input);
+			expect(result).toBeWithNewline(expected);
+		});
+
+		it('omits the terminator when semi is disabled', async () => {
+			const input = `export default (class Named {});`;
+			const expected = `export default (class Named {})`;
+
+			const result = await format(input, { semi: false });
+			expect(result).toBeWithNewline(expected);
+		});
+
+		it('leaves an unparenthesized class declaration alone', async () => {
+			await expectUnchanged(`export default class Named {}`);
+		});
+
+		it('leaves an unparenthesized function declaration alone', async () => {
+			await expectUnchanged(`export default function foo() {}`);
+		});
+
+		it('does not invent parens around other default exports', async () => {
+			const input = `export default (0);`;
+			const expected = `export default 0`;
+
+			const result = await format(input);
+			expect(result).toBeWithNewline(expected);
+		});
+	});
 });


### PR DESCRIPTION
## Problem

Formatting with the `tsrx` parser drops the parentheses around a parenthesized default-exported class expression:

```ts
// in
export default (class Named {});

// out
export default class Named {}
```

These are not equivalent. `export default (class Named {})` is a class **expression**: `Named` is bound only inside the class body. `export default class Named {}` is a class **declaration**: `Named` becomes a module-scoped binding that later code can reference. A formatter must not change semantics.

The same applied to `export default (function foo() {})`.

Vanilla prettier's `typescript` parser preserves the parens.

This is pre-existing and unrelated to decorators — it reproduces with no decorator involved. It was found while reviewing #1406 (decorator printing), where Cursor Bugbot flagged an adjacent concern; the decorator hoisting there is not the cause.

## Fix

`printExportDefaultDeclaration` printed `export default ` followed by the printed declaration with no parenthesization logic.

The node type alone cannot drive the fix: node spans exclude the parens, and the paren-less `export default @dec class Named {}` also parses as a `ClassExpression` even though it is genuinely a declaration. So the new `isParenthesizedDefaultExport` slices `options.originalText` between the start of the export and the start of the declaration, strips comments from that span (only the keyword, whitespace, comments and opening parens can appear there), and tests for a trailing `(`.

It is gated to `ClassExpression` and `FunctionExpression` — the two forms where the parens are load-bearing. Redundant parens elsewhere (`export default (0)`) are still dropped, matching vanilla.

The paren branch also emits `semi(options)`. The parenthesized form is an *expression* export, so it takes a statement terminator; without one, `export default (class Named {})` followed by a line starting with `(` would be swallowed by ASI.

## Tests

New `describe('export default parentheses survive formatting')` block, 11 cases using the same `expectUnchanged` pattern as the modifiers block: named/anonymous/extending class expressions, named/anonymous function expressions, a case where a later reference to `Named` proves scope is not leaked, redundant-paren collapse, multiline collapse, `semi: false`, and negatives (unparenthesized declarations untouched, no invented parens). The shared `format` helper asserts idempotence on every one.

## Verification

- `npx vitest run packages/prettier-plugin` — 417 passed
- `pnpm format:check` — clean
- `npx tsgo --noEmit -p packages/prettier-plugin/tsconfig.typecheck.json` — clean

## Left alone

Two adjacent bugs surfaced while diffing against vanilla, both out of scope here:

- `export default @dec class Named {}` currently formats to `export default class Named {}` — the decorator is dropped entirely. That is #1406's territory; this change does not touch the unparenthesized path.
- Every *other* expression default export prints without a terminator: `export default foo;` → `export default foo`, `export default { a: 1 };` → `export default { a: 1 }`. `semi(options)` was added only on the paren branch, where its absence would be an ASI hazard introduced by this change. Fixing it across all expression exports would churn the existing corpus and belongs in a separate pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Formatter output now affects module binding semantics; the fix is localized to export-default printing with tests, but incorrect detection could still mis-print edge cases.
> 
> **Overview**
> The TSRX Prettier printer was **silently changing program semantics** by stripping parentheses from `export default (class …)` and `export default (function …)`, turning expression exports into declaration exports (different binding for the inner name).
> 
> **`printExportDefaultDeclaration`** now detects load-bearing parens via **`isParenthesizedDefaultExport`**, which inspects **`originalText`** between `export default` and the declaration (with **`stripComments`**) because AST node types/spans cannot distinguish parenthesized expressions from declarations (e.g. decorated defaults). When parens are preserved, output is wrapped as `( … )` and **`semi(options)`** is applied on that branch only.
> 
> Adds an **11-case** test block covering class/function expressions, scope leakage, paren collapse, `semi: false`, and negatives. Patch changeset included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21a6fd4e1cbbfc04d60586abee0f088f9f56e931. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->