### PR TITLE
fix: auto detect dist octane

### DIFF
--- a/.changeset/olive-panthers-shake.md
+++ b/.changeset/olive-panthers-shake.md
@@ -1,0 +1,22 @@
+---
+'@tsrx/typescript-plugin': patch
+'@ripple-ts/vscode-plugin': patch
+---
+
+fix: detect the published Octane compiler under `dist/`, and rename `RIPPLE_DEBUG` to `TSRX_DEBUG`
+
+Automatic compiler detection only probed `octane/src/compiler/volar.js`, a path
+that published `octane` releases do not ship — they contain `dist/` and expose
+the compiler as `octane/compiler/volar`. Every `.tsrx` file in an Octane project
+therefore reported `Ripple compiler not found` and was parsed as plain
+TypeScript unless the project declared `"tsrx": { "compiler": "octane/compiler/volar" }`
+by hand.
+
+Candidates can now list several entry paths, and Octane probes
+`dist/compiler/volar.js` first, falling back to `src/compiler/volar.js` for
+source checkouts.
+
+The debug logging environment variable is now `TSRX_DEBUG` instead of
+`RIPPLE_DEBUG`. The old name is no longer read, so anything that sets it —
+scripts, launch configs, CI — needs updating to keep verbose language-tooling
+logs.

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,7 +15,7 @@
       "outFiles": ["${workspaceFolder}/packages/vscode-plugin/dist/**/*.js"],
       "sourceMaps": true,
       "env": {
-        "RIPPLE_DEBUG": "true"
+        "TSRX_DEBUG": "true"
       }
     },
     {

--- a/packages/typescript-plugin/src/language.js
+++ b/packages/typescript-plugin/src/language.js
@@ -35,7 +35,13 @@ const { log, logWarning, logError } = createLogging('[Ripple Language]');
 /** @type {Set<string>} */
 const loggedCompilationFailures = new Set();
 export const RIPPLE_EXTENSIONS = ['.tsrx'];
-/** @typedef {[string, string[], string[], string[], string[]?]} CompilerCandidate */
+/**
+ * `[package name, package directory parts, supported extensions, package hints, entry candidates?]`.
+ * Entry candidates are relative to the package directory and are probed in order,
+ * so a package that ships both a build output and its sources lists the published
+ * layout first.
+ * @typedef {[string, string[], string[], string[], string[][]?]} CompilerCandidate
+ */
 /** @type {CompilerCandidate[]} */
 export const COMPILER_CANDIDATES = [
 	[
@@ -73,11 +79,17 @@ export const COMPILER_CANDIDATES = [
 		['node_modules', 'octane'],
 		['.tsrx'],
 		['octane', '@octanejs/vite-plugin'],
-		['src', 'compiler', 'volar.js'],
+		// Published `octane` releases only ship `dist/` and expose the compiler as
+		// `octane/compiler/volar`; the `src/` layout is kept for source checkouts.
+		[
+			['dist', 'compiler', 'volar.js'],
+			['src', 'compiler', 'volar.js'],
+		],
 	],
 ];
 
-const DEFAULT_COMPILER_ENTRY_PARTS = ['src', 'index.js'];
+/** @type {string[][]} */
+const DEFAULT_COMPILER_ENTRY_CANDIDATES = [['src', 'index.js']];
 
 /**
  * @param {string} file_name
@@ -1059,14 +1071,17 @@ export function find_workspace_compiler_entry_for_file(
 				compiler_dir_parts,
 				supported_extensions,
 				package_hints,
-				entry_parts = DEFAULT_COMPILER_ENTRY_PARTS,
+				entry_candidates = DEFAULT_COMPILER_ENTRY_CANDIDATES,
 			] of COMPILER_CANDIDATES) {
 				if (!supported_extensions.includes(ext)) {
 					continue;
 				}
-				const full_path = [dir, ...compiler_dir_parts, ...entry_parts].join('/');
-				if (exists_sync(full_path)) {
-					available_candidates.push([compiler_name, full_path, package_hints]);
+				for (const entry_parts of entry_candidates) {
+					const full_path = [dir, ...compiler_dir_parts, ...entry_parts].join('/');
+					if (exists_sync(full_path)) {
+						available_candidates.push([compiler_name, full_path, package_hints]);
+						break;
+					}
 				}
 			}
 
@@ -1121,15 +1136,18 @@ export function get_compiler_entry_for_file(normalized_file_name, options) {
 			compiler_dir_parts,
 			supported_extensions,
 			package_hints,
-			entry_parts = DEFAULT_COMPILER_ENTRY_PARTS,
+			entry_candidates = DEFAULT_COMPILER_ENTRY_CANDIDATES,
 		] of COMPILER_CANDIDATES) {
 			if (!supported_extensions.includes(ext)) {
 				continue;
 			}
 			const full_path = path.join(current_dir, ...compiler_dir_parts);
-			const entry_path = path.join(full_path, ...entry_parts);
-			if (fs.existsSync(entry_path)) {
-				available_candidates.push([compiler_name, entry_path, package_hints]);
+			for (const entry_parts of entry_candidates) {
+				const entry_path = path.join(full_path, ...entry_parts);
+				if (fs.existsSync(entry_path)) {
+					available_candidates.push([compiler_name, entry_path, package_hints]);
+					break;
+				}
 			}
 		}
 
@@ -1180,11 +1198,13 @@ export function get_tsrx_compiler_name_for_file(file_name, options) {
 		compiler_dir_parts,
 		,
 		,
-		entry_parts = DEFAULT_COMPILER_ENTRY_PARTS,
+		entry_candidates = DEFAULT_COMPILER_ENTRY_CANDIDATES,
 	] of COMPILER_CANDIDATES) {
-		const suffix = '/' + [...compiler_dir_parts, ...entry_parts].join('/');
-		if (normalized_entry.endsWith(suffix)) {
-			return compiler_name;
+		for (const entry_parts of entry_candidates) {
+			const suffix = '/' + [...compiler_dir_parts, ...entry_parts].join('/');
+			if (normalized_entry.endsWith(suffix)) {
+				return compiler_name;
+			}
 		}
 	}
 

--- a/packages/typescript-plugin/src/utils.js
+++ b/packages/typescript-plugin/src/utils.js
@@ -1,4 +1,4 @@
-export const DEBUG = process.env.RIPPLE_DEBUG === 'true';
+export const DEBUG = process.env.TSRX_DEBUG === 'true';
 // Matches valid JS/CSS identifier characters: word chars, dashes (CSS), $, and # (Ripple shorthands)
 export const charAllowedWordRegex = /[\w\-$#]/;
 

--- a/packages/typescript-plugin/tests/compiler-resolution.test.js
+++ b/packages/typescript-plugin/tests/compiler-resolution.test.js
@@ -137,8 +137,27 @@ describe('typescript-plugin compiler resolution', () => {
 			);
 		});
 
-		it('selects the octane compiler (package-internal entry path) in an octane-only project', () => {
+		it('selects the octane compiler (published dist entry path) in an octane-only project', () => {
 			const workspace = create_fixture_workspace('octane-only');
+			const file_name = path.join(workspace, 'src', 'App.tsrx');
+			const expected = path.join(
+				workspace,
+				'node_modules',
+				'octane',
+				'dist',
+				'compiler',
+				'volar.js',
+			);
+
+			expect(find_workspace_compiler_entry_for_file(file_name, fs.existsSync, new Map())).toBe(
+				expected,
+			);
+		});
+
+		// Octane source checkouts expose the same entry under `src/`, which stays
+		// supported now that published releases ship only `dist/`.
+		it('falls back to the octane source entry path when no dist build is installed', () => {
+			const workspace = create_fixture_workspace('octane-src-only');
 			const file_name = path.join(workspace, 'src', 'App.tsrx');
 			const expected = path.join(
 				workspace,
@@ -161,7 +180,7 @@ describe('typescript-plugin compiler resolution', () => {
 				workspace,
 				'node_modules',
 				'octane',
-				'src',
+				'dist',
 				'compiler',
 				'volar.js',
 			);
@@ -299,12 +318,13 @@ describe('typescript-plugin compiler resolution', () => {
 			{ name: 'solid-only', expected: ['@tsrx', 'solid'] },
 			{ name: 'preact-only', expected: ['@tsrx', 'preact'] },
 			{ name: 'vue-only', expected: ['@tsrx', 'vue'] },
-			{ name: 'octane-only', expected: ['octane', 'src', 'compiler', 'volar.js'] },
+			{ name: 'octane-only', expected: ['octane', 'dist', 'compiler', 'volar.js'] },
+			{ name: 'octane-src-only', expected: ['octane', 'src', 'compiler', 'volar.js'] },
 			{ name: 'both', expected: ['@tsrx', 'ripple'] },
 			{ name: 'both-react', expected: ['@tsrx', 'react'] },
 			{ name: 'both-preact', expected: ['@tsrx', 'preact'] },
 			{ name: 'both-vue', expected: ['@tsrx', 'vue'] },
-			{ name: 'both-octane', expected: ['octane', 'src', 'compiler', 'volar.js'] },
+			{ name: 'both-octane', expected: ['octane', 'dist', 'compiler', 'volar.js'] },
 		];
 
 		for (const test_case of cases) {
@@ -335,6 +355,7 @@ describe('typescript-plugin compiler resolution', () => {
 			{ name: 'both', compiler: '@tsrx/ripple', is_ripple: true },
 			{ name: 'both-react', compiler: '@tsrx/react', is_ripple: false },
 			{ name: 'octane-only', compiler: 'octane', is_ripple: false },
+			{ name: 'octane-src-only', compiler: 'octane', is_ripple: false },
 			{ name: 'both-octane', compiler: 'octane', is_ripple: false },
 		];
 

--- a/packages/typescript-plugin/tests/plugin-integration.test.js
+++ b/packages/typescript-plugin/tests/plugin-integration.test.js
@@ -79,7 +79,7 @@ function prepare_fixture(workspace_name, configure, file_parts = ['src', 'App.ts
 
 /** @param {WorkspaceName} workspace_name @param {FixtureConfigurator} [configure] @param {string[]} [file_parts] */
 async function compile_debug_fixture(workspace_name, configure, file_parts = ['src', 'App.tsrx']) {
-	vi.stubEnv('RIPPLE_DEBUG', 'true');
+	vi.stubEnv('TSRX_DEBUG', 'true');
 	vi.resetModules();
 	const error_spy = vi.spyOn(console, 'error').mockImplementation(() => {});
 	const warning_spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
@@ -284,18 +284,30 @@ describe('typescript-plugin language plugin integration', () => {
 	});
 
 	// Octane exercises BOTH octane-specific paths at once: the package-internal
-	// compiler entry (src/compiler/volar.js instead of the @tsrx/* layout) and
+	// compiler entry (dist/compiler/volar.js instead of the @tsrx/* layout) and
 	// the camelCase `compileToVolarMappings` module-shape normalization.
-	it('creates virtual code with the octane compiler in an octane project', () => {
-		const plugin = create_plugin();
-		const workspace = create_fixture_workspace('octane-only');
-		const file_name = path.join(workspace, 'src', 'App.tsrx');
-		const virtual_code = create_virtual_code(plugin, file_name, 'export default <div>Hello</div>;');
+	/** @type {Array<[string, WorkspaceName]>} */
+	const octane_layout_cases = [
+		['published dist layout', 'octane-only'],
+		['source checkout layout', 'octane-src-only'],
+	];
+	it.each(octane_layout_cases)(
+		'creates virtual code with the octane compiler (%s)',
+		(_, workspace_name) => {
+			const plugin = create_plugin();
+			const workspace = create_fixture_workspace(workspace_name);
+			const file_name = path.join(workspace, 'src', 'App.tsrx');
+			const virtual_code = create_virtual_code(
+				plugin,
+				file_name,
+				'export default <div>Hello</div>;',
+			);
 
-		expect(virtual_code).toBeInstanceOf(TSRXVirtualCode);
-		expect(virtual_code.generatedCode).toContain('compiler:octane');
-		expect(virtual_code.generatedCode).toContain(file_name);
-	});
+			expect(virtual_code).toBeInstanceOf(TSRXVirtualCode);
+			expect(virtual_code.generatedCode).toContain('compiler:octane');
+			expect(virtual_code.generatedCode).toContain(file_name);
+		},
+	);
 
 	it('prefers the octane compiler when other compilers also exist in an octane project', () => {
 		const plugin = create_plugin();

--- a/packages/typescript-plugin/tests/workspace-fixtures.js
+++ b/packages/typescript-plugin/tests/workspace-fixtures.js
@@ -115,9 +115,9 @@ const COMPILER_STUBS = {
 	},
 };
 `,
-	// Octane ships its compiler inside the `octane` package at
-	// `src/compiler/volar.js` and exports the contract under a camelCase name —
-	// this stub mirrors the real published shape so the tests cover the
+	// Octane ships its compiler inside the `octane` package under
+	// `<layout>/compiler/volar.js` and exports the contract under a camelCase name
+	// — this stub mirrors the real published shape so the tests cover the
 	// plugin's entry-path override AND its module-shape normalization.
 	octane: `module.exports = {
 	compileToVolarMappings(source, filename) {
@@ -198,11 +198,23 @@ const DECLARED_COMPILER_STUB = COMPILER_STUBS.octane.replace('compiler:octane', 
  */
 
 /**
+ * Published `octane` releases only ship `dist/` and expose the compiler through
+ * the `./compiler/volar` export; `octane-src` models a source checkout of the
+ * same package, which the plugin still falls back to.
+ */
+const OCTANE_LAYOUT_DIRS = {
+	octane: 'dist',
+	'octane-src': 'src',
+};
+
+/** @typedef {keyof typeof COMPILER_STUBS | keyof typeof OCTANE_LAYOUT_DIRS} FixtureCompilerName */
+
+/**
  * @typedef {object} WorkspaceFixtureConfig
  * @property {Record<string, unknown>} package_json
  * @property {unknown} [tsconfig_json]
  * @property {unknown} [nested_tsconfig_json]
- * @property {(keyof typeof COMPILER_STUBS)[]} compilers
+ * @property {FixtureCompilerName[]} compilers
  * @property {DeclaredCompilerFixture[]} [declared_compilers]
  * @property {boolean} [imports_escape]
  */
@@ -299,6 +311,17 @@ export const WORKSPACE_CONFIGS = {
 			},
 		},
 		compilers: ['octane'],
+	},
+	'octane-src-only': {
+		package_json: {
+			name: '@octanejs/fixture-octane-src-only-project',
+			private: true,
+			devDependencies: {
+				octane: 'workspace:*',
+				'@octanejs/vite-plugin': 'workspace:*',
+			},
+		},
+		compilers: ['octane-src'],
 	},
 	'both-octane': {
 		package_json: {
@@ -451,15 +474,19 @@ export const WORKSPACE_CONFIGS = {
 /** @type {string[]} */
 const created_workspaces = [];
 
-/** @param {string} workspace_dir @param {keyof typeof COMPILER_STUBS} compiler_name */
+/** @param {string} workspace_dir @param {FixtureCompilerName} compiler_name */
 function write_compiler_stub(workspace_dir, compiler_name) {
-	if (compiler_name === 'octane') {
+	if (compiler_name === 'octane' || compiler_name === 'octane-src') {
 		// Octane's layout: the compiler entry lives INSIDE the octane package.
+		const octane_layout_dir = OCTANE_LAYOUT_DIRS[compiler_name];
 		const package_dir = path.join(workspace_dir, 'node_modules', 'octane');
-		const compiler_dir = path.join(package_dir, 'src', 'compiler');
+		const compiler_dir = path.join(package_dir, octane_layout_dir, 'compiler');
 		fs.mkdirSync(compiler_dir, { recursive: true });
-		write_json(path.join(package_dir, 'package.json'), { name: 'octane' });
-		fs.writeFileSync(path.join(compiler_dir, 'volar.js'), COMPILER_STUBS[compiler_name]);
+		write_json(path.join(package_dir, 'package.json'), {
+			name: 'octane',
+			exports: { './compiler/volar': `./${octane_layout_dir}/compiler/volar.js` },
+		});
+		fs.writeFileSync(path.join(compiler_dir, 'volar.js'), COMPILER_STUBS.octane);
 		return;
 	}
 	const package_dir = path.join(workspace_dir, 'node_modules', '@tsrx', compiler_name);

--- a/packages/vscode-plugin/src/extension.js
+++ b/packages/vscode-plugin/src/extension.js
@@ -140,7 +140,7 @@ export async function activate(context) {
 		execArgv: [],
 		env: {
 			...process.env,
-			RIPPLE_DEBUG: process.env.RIPPLE_DEBUG === 'false' ? 'false' : 'true',
+			TSRX_DEBUG: process.env.TSRX_DEBUG === 'false' ? 'false' : 'true',
 		},
 	};
 
@@ -148,7 +148,7 @@ export async function activate(context) {
 		execArgv: ['--nolazy', '--inspect'],
 		env: {
 			...process.env,
-			RIPPLE_DEBUG: process.env.RIPPLE_DEBUG === 'false' ? 'false' : 'true',
+			TSRX_DEBUG: process.env.TSRX_DEBUG === 'false' ? 'false' : 'true',
 		},
 	};
 


### PR DESCRIPTION
closes #1403 

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Behavior change fixes a real Octane DX bug but alters compiler resolution and breaks existing `RIPPLE_DEBUG` setups until they migrate to `TSRX_DEBUG`.
> 
> **Overview**
> Fixes **Octane compiler auto-detection** so published installs work without a manual `tsrx.compiler` override. Resolution used to look only at `octane/src/compiler/volar.js`; published packages ship **`dist/compiler/volar.js`** via `octane/compiler/volar`, which led to “Ripple compiler not found” and plain TypeScript parsing for `.tsrx` files.
> 
> **Compiler candidates** can now specify **ordered entry paths**. For Octane, the plugin tries `dist/compiler/volar.js` first, then `src/compiler/volar.js` for source checkouts. The same probing applies to workspace lookup, packaged fallback, and compiler-name inference from the resolved entry.
> 
> **Debug logging** now uses **`TSRX_DEBUG`** instead of **`RIPPLE_DEBUG`** (typescript-plugin `utils.js`, VS Code launch config, language server env). The old variable is no longer read.
> 
> Tests and fixtures add **`octane-src-only`** and cover both dist and src Octane layouts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2901cd044875ce7bc370efdbb1baa47ff6c2802b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->