### PR TITLE
fix(prettier): semi for default exports missing

### DIFF
--- a/.changeset/olive-donkeys-shake.md
+++ b/.changeset/olive-donkeys-shake.md
@@ -1,0 +1,37 @@
+---
+'@tsrx/prettier-plugin': patch
+'@tsrx/core': patch
+---
+
+fix: terminate expression default exports, and print anonymous default-exported functions
+
+`export default <expression>` is a statement and needs a `;`, but the printer
+only emitted one for the parenthesized class and function expressions handled in
+the previous fix. Every other expression form lost its terminator:
+`export default foo;` was formatted to `export default foo`.
+
+That is an ASI hazard, not a cosmetic difference. The following line is pulled
+into the exported expression whenever it starts with `(`, `[`, a template
+literal, `+`, `-`, or `/`, so
+
+```ts
+export default foo;
+(function () {})();
+```
+
+was reformatted into the single call `export default foo(function () {})()`.
+
+The terminator is now decided by whether the export is a declaration or an
+expression. The declaration forms — `class`, `function`, `interface`, an
+overload signature, and the decorated `export default @dec class Named {}` that
+parses as a `ClassExpression` — still end at their closing brace.
+
+Separately, `export default function () {}` crashed the printer. It is the one
+position where a `FunctionDeclaration` may be anonymous, and the printer read
+the name unconditionally. Anonymous default-exported functions, async functions,
+and generators now print.
+
+`@tsrx/core` gains `TSRXExportDefaultDeclaration`, which models the two
+TypeScript-only declaration forms the parser puts in that slot —
+`export default interface Foo {}` and `export default function foo();` — that
+estree's `ExportDefaultDeclaration` does not.

--- a/packages/prettier-plugin/src/index.js
+++ b/packages/prettier-plugin/src/index.js
@@ -3236,7 +3236,7 @@ function stripComments(text) {
  * a ClassExpression even though it is a declaration, so the source text
  * between the keyword and the declaration has to be consulted.
  *
- * @param {AST.ExportDefaultDeclaration} node - The export default node
+ * @param {AST.TSRXExportDefaultDeclaration} node - The export default node
  * @param {RippleFormatOptions} options - Prettier options
  * @returns {boolean}
  */
@@ -3270,6 +3270,50 @@ function isParenthesizedDefaultExport(node, options) {
 }
 
 /**
+ * Whether an `export default` takes a statement terminator.
+ *
+ * The grammar admits two shapes after the keyword. A HoistableDeclaration,
+ * ClassDeclaration or TypeScript declaration form is a *declaration* and ends
+ * at its closing brace. Everything else is an AssignmentExpression, which is a
+ * *statement* and needs a `;`.
+ *
+ * Omitting it is an ASI hazard rather than a cosmetic slip: the next line is
+ * swallowed into the exported expression whenever it starts with `(`, `[`,
+ * a template literal, `+`, `-`, or `/`. `export default foo;` followed by
+ * `(function () {})();` silently becomes the single call
+ * `export default foo(function () {})();`.
+ *
+ * The node type alone cannot decide this. A decorated
+ * `export default @dec class Named {}` parses as a ClassExpression but is
+ * still a declaration, so the two expression node types defer to
+ * {@link isParenthesizedDefaultExport}, which reads the source.
+ *
+ * @param {AST.TSRXExportDefaultDeclaration} node - The export default node
+ * @param {RippleFormatOptions} options - Prettier options
+ * @returns {boolean}
+ */
+function defaultExportNeedsSemicolon(node, options) {
+	const declaration = node.declaration;
+
+	if (!declaration) {
+		return false;
+	}
+
+	switch (declaration.type) {
+		case 'FunctionDeclaration':
+		case 'ClassDeclaration':
+		case 'TSDeclareFunction':
+		case 'TSInterfaceDeclaration':
+			return false;
+		case 'ClassExpression':
+		case 'FunctionExpression':
+			return isParenthesizedDefaultExport(node, options);
+		default:
+			return true;
+	}
+}
+
+/**
  * Print an export default declaration
  * @param {AST.ExportDefaultDeclaration} node - The export default node
  * @param {AstPath<AST.ExportDefaultDeclaration>} path - The AST path
@@ -3283,23 +3327,26 @@ function printExportDefaultDeclaration(node, path, options, print) {
 	parts.push(...printDeclarationDecorators(node, path, options, print));
 	parts.push('export default ');
 
+	// Declaration forms end at their closing brace; expression forms are
+	// statements and terminate.
+	const terminator = defaultExportNeedsSemicolon(node, options) ? semi(options) : '';
+
 	if (isParenthesizedDefaultExport(node, options)) {
-		// An expression export, not a declaration: it keeps its parens and
-		// takes a statement terminator.
+		// An expression export, not a declaration: it keeps its parens.
 		const declaration = path.call(print, 'declaration');
 
 		if (getDecorators(/** @type {AST.Node} */ (node.declaration)).length > 0) {
 			// The decorators stay inside the parens, each on its own line, so
 			// the whole expression is indented to keep them off column zero.
-			parts.push('(', indent([hardline, declaration]), hardline, ')', semi(options));
+			parts.push('(', indent([hardline, declaration]), hardline, ')', terminator);
 			return parts;
 		}
 
-		parts.push('(', declaration, ')', semi(options));
+		parts.push('(', declaration, ')', terminator);
 		return parts;
 	}
 
-	parts.push(path.call(print, 'declaration'));
+	parts.push(path.call(print, 'declaration'), terminator);
 	return parts;
 }
 
@@ -3852,7 +3899,13 @@ function printFunctionDeclaration(node, path, options, print) {
 	}
 
 	parts.push(' ');
-	parts.push(node.id.name);
+
+	// `export default function () {}` is an anonymous FunctionDeclaration, the
+	// one position where the name is optional. The space stays either way, so
+	// the parameter list is not glued to the keyword.
+	if (node.id) {
+		parts.push(node.id.name);
+	}
 
 	// Add TypeScript generics if present
 	if (node.typeParameters) {

--- a/packages/prettier-plugin/src/index.test.js
+++ b/packages/prettier-plugin/src/index.test.js
@@ -7223,10 +7223,134 @@ export const alias = Named;`;
 
 		it('does not invent parens around other default exports', async () => {
 			const input = `export default (0);`;
-			const expected = `export default 0`;
+			const expected = `export default 0;`;
 
 			const result = await format(input);
 			expect(result).toBeWithNewline(expected);
+		});
+	});
+
+	// `export default <expression>` is a statement and terminates; only the
+	// declaration forms end at their closing brace. Dropping the `;` lets ASI
+	// pull the next line into the exported expression.
+	describe('export default terminators', () => {
+		/**
+		 * Assert the input is already formatted and comes back byte-identical.
+		 * @param {string} source
+		 */
+		const expectUnchanged = async (source) => {
+			const result = await format(source);
+			expect(result).toBeWithNewline(source);
+		};
+
+		it('terminates an identifier export', async () => {
+			await expectUnchanged(`export default foo;`);
+		});
+
+		it('terminates an object export', async () => {
+			await expectUnchanged(`export default { a: 1 };`);
+		});
+
+		it('terminates an array export', async () => {
+			await expectUnchanged(`export default [1, 2];`);
+		});
+
+		it('terminates a numeric literal export', async () => {
+			await expectUnchanged(`export default 42;`);
+		});
+
+		it('terminates an arrow function export', async () => {
+			await expectUnchanged(`export default (a, b) => a + b;`);
+		});
+
+		it('terminates a call expression export', async () => {
+			await expectUnchanged(`export default createStore();`);
+		});
+
+		it('terminates an `as` expression export', async () => {
+			await expectUnchanged(`export default foo as Bar;`);
+		});
+
+		// Without the terminator these two lines reparse as the single call
+		// `export default foo(function () {})();`.
+		it('does not let a following paren line join the exported expression', async () => {
+			await expectUnchanged(`export default foo;
+(function () {})();`);
+		});
+
+		it('does not let a following bracket line join the exported expression', async () => {
+			await expectUnchanged(`export default foo;
+[1, 2].forEach(log);`);
+		});
+
+		it('does not let a following template line join the exported expression', async () => {
+			await expectUnchanged('export default foo;\n`side effect`;');
+		});
+
+		it('omits the terminator when semi is disabled', async () => {
+			const input = `export default foo;`;
+			const expected = `export default foo`;
+
+			const result = await format(input, { semi: false });
+			expect(result).toBeWithNewline(expected);
+		});
+
+		it('leaves a class declaration unterminated', async () => {
+			await expectUnchanged(`export default class Named {}`);
+		});
+
+		it('leaves an abstract class declaration unterminated', async () => {
+			await expectUnchanged(`export default abstract class A {}`);
+		});
+
+		it('leaves a function declaration unterminated', async () => {
+			await expectUnchanged(`export default function foo() {}`);
+		});
+
+		it('leaves an interface declaration unterminated', async () => {
+			await expectUnchanged(`export default interface Foo {}`);
+		});
+
+		// A decorated default export parses as a ClassExpression but is still a
+		// declaration, so it must not pick up a terminator.
+		it('leaves a decorated class declaration unterminated', async () => {
+			const input = `export default @dec class Named {}`;
+			const expected = `@dec
+export default class Named {}`;
+
+			const result = await format(input);
+			expect(result).toBeWithNewline(expected);
+		});
+	});
+
+	// `export default function () {}` is the one position where a
+	// FunctionDeclaration may be anonymous.
+	describe('anonymous default-exported function declarations', () => {
+		/**
+		 * Assert the input is already formatted and comes back byte-identical.
+		 * @param {string} source
+		 */
+		const expectUnchanged = async (source) => {
+			const result = await format(source);
+			expect(result).toBeWithNewline(source);
+		};
+
+		it('prints an anonymous function declaration', async () => {
+			await expectUnchanged(`export default function () {}`);
+		});
+
+		it('prints an anonymous async function declaration', async () => {
+			await expectUnchanged(`export default async function () {}`);
+		});
+
+		it('prints an anonymous generator declaration', async () => {
+			await expectUnchanged(`export default function* () {}`);
+		});
+
+		it('prints an anonymous function declaration with parameters', async () => {
+			await expectUnchanged(`export default function (a, b) {
+  return a + b;
+}`);
 		});
 	});
 

--- a/packages/tsrx/types/index.d.ts
+++ b/packages/tsrx/types/index.d.ts
@@ -715,6 +715,19 @@ declare module 'estree' {
 		declaration?: TSRXDeclaration | null | undefined;
 	}
 
+	/**
+	 * estree's `ExportDefaultDeclaration` predates the two TypeScript-only
+	 * declaration forms the parser puts in this slot: `export default interface
+	 * Foo {}` yields a `TSInterfaceDeclaration`, and the overload signature
+	 * `export default function foo();` yields a `TSDeclareFunction`.
+	 */
+	interface TSRXExportDefaultDeclaration extends Omit<AST.ExportDefaultDeclaration, 'declaration'> {
+		declaration:
+			| AST.ExportDefaultDeclaration['declaration']
+			| AST.TSDeclareFunction
+			| AST.TSInterfaceDeclaration;
+	}
+
 	interface TSRXProgram extends Omit<Program, 'body'> {
 		body: (Program['body'][number] | FunctionExpression)[];
 	}


### PR DESCRIPTION
there was a finding by an agent on this pr while fixing parens for prettier: https://github.com/Ripple-TS/ripple/pull/1407

this part:

> Every other expression default export prints without a terminator: export default foo; → export default foo, export default { a: 1 }; → export default { a: 1 }. semi(options) was added only on the paren branch, where its absence would be an ASI hazard introduced by this change. Fixing it across all expression exports would churn the existing corpus and belongs in a separate pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes formatter output for many `export default` expression forms (intentional correctness fix) and touches export/function printing paths where ASI mistakes could alter program meaning if wrong.
> 
> **Overview**
> The Prettier plugin now **emits statement terminators** for `export default` when the right-hand side is an expression (identifiers, literals, objects, calls, etc.), not only for parenthesized class/function expressions. A new `defaultExportNeedsSemicolon` helper distinguishes **declaration** forms (`class`, `function`, `interface`, overload signatures, and decorated defaults that parse as expressions) from **expression** exports, deferring ambiguous `ClassExpression` / `FunctionExpression` cases to the existing source-based `isParenthesizedDefaultExport` check. This avoids **ASI bugs** where a following line starting with `(`, `[`, templates, or certain operators could be swallowed into the export.
> 
> **Anonymous default-exported functions** (`export default function () {}`, including async and generators) no longer crash the printer because `printFunctionDeclaration` only prints `node.id.name` when a name exists.
> 
> `@tsrx/core` adds **`TSRXExportDefaultDeclaration`** so default-export nodes can carry TypeScript-only declaration children (`TSInterfaceDeclaration`, `TSDeclareFunction`) that estree’s type omits. Tests cover terminator preservation, ASI edge cases, `semi: false`, and anonymous default function printing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3e263c108f1686a32a8b4878483aa2271b614e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->