### PR TITLE
fix: put back default emmet settings in vscode

### DIFF
--- a/.changeset/fuzzy-pandas-smile.md
+++ b/.changeset/fuzzy-pandas-smile.md
@@ -1,0 +1,5 @@
+---
+'@ripple-ts/vscode-plugin': patch
+---
+
+fix: enable Emmet completions in `.tsrx` files by default

--- a/packages/vscode-plugin/package.json
+++ b/packages/vscode-plugin/package.json
@@ -112,6 +112,12 @@
         "configuration": "./language-configuration.json"
       }
     ],
+    "configurationDefaults": {
+      "emmet.includeLanguages": {
+        "ripple": "html"
+      },
+      "emmet.showExpandedAbbreviation": "always"
+    },
     "grammars": [
       {
         "language": "ripple",

--- a/packages/vscode-plugin/tests/package.test.js
+++ b/packages/vscode-plugin/tests/package.test.js
@@ -1,0 +1,24 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const package_json = JSON.parse(readFileSync(resolve(__dirname, '../package.json'), 'utf8'));
+
+describe('@ripple-ts/vscode-plugin package contract', () => {
+	it('enables Emmet completions for TSRX files by default', () => {
+		const languages = /** @type {{ id: string, extensions: string[] }[]} */ (
+			package_json.contributes.languages
+		);
+		const tsrx_language = languages.find((language) => language.extensions.includes('.tsrx'));
+
+		expect(tsrx_language?.id).toBe('ripple');
+		expect(package_json.contributes.configurationDefaults).toMatchObject({
+			'emmet.includeLanguages': {
+				ripple: 'html',
+			},
+			'emmet.showExpandedAbbreviation': 'always',
+		});
+	});
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -489,6 +489,15 @@ export default defineConfig({
 			},
 			{
 				test: {
+					name: 'vscode-plugin',
+					include: ['packages/vscode-plugin/tests/**/*.test.js'],
+					environment: 'node',
+					globals: true,
+				},
+				plugins: [],
+			},
+			{
+				test: {
 					name: 'tsrx-mcp',
 					include: ['packages/tsrx-mcp/tests/**/*.test.js'],
 					environment: 'node',


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Editor-only default settings and manifest tests; no runtime, auth, or data-path changes.
> 
> **Overview**
> Restores **Emmet** support for the `ripple` language in the VS Code extension by contributing **`configurationDefaults`**: maps `ripple` to `html` via `emmet.includeLanguages` and sets `emmet.showExpandedAbbreviation` to `always`, so abbreviations work in `.tsrx` without manual user settings.
> 
> Adds a **package contract** test that asserts the `.tsrx` language id and those defaults, and registers a dedicated **`vscode-plugin`** Vitest project so those tests run in CI. Includes a patch **changeset** for `@ripple-ts/vscode-plugin`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e996ddbf0699fab55ab44d57cf690ab3e65fb20f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->