### PR TITLE
fix: declare global handling

### DIFF
--- a/.changeset/calm-otters-augment.md
+++ b/.changeset/calm-otters-augment.md
@@ -1,0 +1,6 @@
+---
+'@tsrx/core': patch
+'@tsrx/ripple': patch
+---
+
+Normalize TypeScript module declarations to the `kind` discriminator, preserve `declare global` in type-only output, and erase ambient modules from Ripple client and server output.

--- a/packages/prettier-plugin/src/index.js
+++ b/packages/prettier-plugin/src/index.js
@@ -2300,16 +2300,17 @@ function printRippleNode(node, path, options, print, args) {
 		case 'TSModuleDeclaration': {
 			// `declare global` augments the global scope; printing it as
 			// `declare module global` declares an unrelated module named `global`.
-			nodeContent = node.global
-				? [node.declare ? 'declare ' : '', path.call(print, 'id'), ' ', path.call(print, 'body')]
-				: [
-						node.declare ? 'declare ' : '',
-						node.metadata?.module_keyword ?? 'module',
-						' ',
-						path.call(print, 'id'),
-						' ',
-						path.call(print, 'body'),
-					];
+			nodeContent =
+				node.kind === 'global'
+					? [node.declare ? 'declare ' : '', path.call(print, 'id'), ' ', path.call(print, 'body')]
+					: [
+							node.declare ? 'declare ' : '',
+							node.kind,
+							' ',
+							path.call(print, 'id'),
+							' ',
+							path.call(print, 'body'),
+						];
 			break;
 		}
 

--- a/packages/tsrx-ripple/src/analyze/index.js
+++ b/packages/tsrx-ripple/src/analyze/index.js
@@ -153,7 +153,7 @@ function get_module_declaration_name(node) {
  * @returns {boolean}
  */
 function is_submodule_declaration(node) {
-	return node.type === 'TSModuleDeclaration' && node.metadata?.module_keyword === 'module';
+	return node.type === 'TSModuleDeclaration' && node.declare !== true && node.kind === 'module';
 }
 
 /**

--- a/packages/tsrx-ripple/src/transform/client/index.js
+++ b/packages/tsrx-ripple/src/transform/client/index.js
@@ -343,7 +343,8 @@ function get_submodule_import_source_name(node) {
 function is_server_module_declaration(node) {
 	return (
 		node.type === 'TSModuleDeclaration' &&
-		/** @type {AST.TSModuleDeclaration} */ (node).metadata?.module_keyword === 'module' &&
+		/** @type {AST.TSModuleDeclaration} */ (node).declare !== true &&
+		/** @type {AST.TSModuleDeclaration} */ (node).kind === 'module' &&
 		/** @type {AST.TSModuleDeclaration} */ (node).id?.type === 'Identifier' &&
 		/** @type {AST.Identifier} */ (/** @type {AST.TSModuleDeclaration} */ (node).id).name ===
 			'server'
@@ -3464,6 +3465,9 @@ const visitors = {
 	},
 
 	TSModuleDeclaration(node, context) {
+		if (!context.state.to_ts && node.declare) {
+			return b.empty;
+		}
 		if (!is_server_module_declaration(node)) {
 			return context.next();
 		}
@@ -5998,6 +6002,15 @@ function create_tsx_with_typescript_support(comments) {
 			if (node.typeParameters) {
 				context.visit(node.typeParameters);
 			}
+		},
+		TSModuleDeclaration(node, context) {
+			if (node.kind !== 'global') {
+				base_tsx.TSModuleDeclaration?.(node, context);
+				return;
+			}
+			if (node.declare) context.write('declare ');
+			context.visit(node.id);
+			context.visit(node.body);
 		},
 		AssignmentPattern(node, context) {
 			// We need to make sure that the whole AssignmentPattern has a start and end mapping

--- a/packages/tsrx-ripple/src/transform/server/index.js
+++ b/packages/tsrx-ripple/src/transform/server/index.js
@@ -511,7 +511,8 @@ function get_submodule_import_source_name(node) {
 function is_server_module_declaration(node) {
 	return (
 		node.type === 'TSModuleDeclaration' &&
-		/** @type {AST.TSModuleDeclaration} */ (node).metadata?.module_keyword === 'module' &&
+		/** @type {AST.TSModuleDeclaration} */ (node).declare !== true &&
+		/** @type {AST.TSModuleDeclaration} */ (node).kind === 'module' &&
 		/** @type {AST.TSModuleDeclaration} */ (node).id?.type === 'Identifier' &&
 		/** @type {AST.Identifier} */ (/** @type {AST.TSModuleDeclaration} */ (node).id).name ===
 			'server'
@@ -3004,6 +3005,9 @@ const visitors = {
 	},
 
 	TSModuleDeclaration(node, context) {
+		if (node.declare) {
+			return b.empty;
+		}
 		if (!is_server_module_declaration(node)) {
 			return context.next();
 		}

--- a/packages/tsrx-ripple/tests/basic.test.js
+++ b/packages/tsrx-ripple/tests/basic.test.js
@@ -5,6 +5,7 @@ import {
 import { compile, compile_to_volar_mappings } from '../src/index.js';
 import { describe, expect, it } from 'vitest';
 import { find_exact_mapping } from '../../tsrx/src/source-map-utils.js';
+import { check_types } from '../../tsrx/tests/shared/type-diagnostics.js';
 
 runSharedClassFunctionComponentTests({
 	compile,
@@ -16,6 +17,37 @@ runSharedComponentParamsTests({
 	compile,
 	compile_to_volar_mappings,
 	name: 'ripple',
+});
+
+describe('@tsrx/ripple TypeScript declarations in to_ts', () => {
+	it('preserves global augmentations without submodule diagnostics', () => {
+		const source =
+			'export {};\n' +
+			'declare global {\n' +
+			'\tvar __tsrxGlobalValue: string | undefined;\n' +
+			'}\n' +
+			'const globalValue = globalThis.__tsrxGlobalValue;\n';
+		const typeOutput = compile_to_volar_mappings(source, 'App.tsrx', { loose: true });
+		const runtimeOutputs = [
+			compile(source, 'App.tsrx', { loose: true }),
+			compile(source, 'App.tsrx', { loose: true, mode: 'server' }),
+		];
+
+		expect(typeOutput.errors).toEqual([]);
+		expect(typeOutput.code).toContain('declare global');
+		expect(typeOutput.code).not.toContain('declare module global');
+		expect(check_types(typeOutput.code)).toEqual({
+			errors: [],
+			types: { globalValue: 'string | undefined' },
+		});
+		for (const result of runtimeOutputs) {
+			expect(result.errors).toEqual([]);
+			expect(result.code).not.toContain('declare global');
+			expect(result.code).not.toContain('declare module global');
+			expect(result.code).not.toContain('var __tsrxGlobalValue');
+			expect(result.code).toContain('globalThis.__tsrxGlobalValue');
+		}
+	});
 });
 
 describe('@tsrx/ripple deferred imports', () => {

--- a/packages/tsrx/src/plugin.js
+++ b/packages/tsrx/src/plugin.js
@@ -299,12 +299,32 @@ export function TSRXPlugin(config) {
 			finishNode(node, type) {
 				const finished = super.finishNode(node, type);
 				if (type === 'TSModuleDeclaration') {
-					const start = /** @type {number} */ (finished.start);
-					const source = this.input.slice(start, start + 'namespace'.length);
-					finished.metadata ??= { path: [] };
-					finished.metadata.module_keyword = source.startsWith('namespace')
-						? 'namespace'
-						: 'module';
+					const declaration = /** @type {AST.TSModuleDeclaration} */ (finished);
+					const start = /** @type {number} */ (declaration.start);
+					// acorn-typescript still exposes the legacy `global` flag without
+					// TSESTree's replacement `kind`; replace it at the parser boundary
+					// so downstream consumers only receive the current discriminator.
+					const legacy = /** @type {{ global?: boolean }} */ (declaration);
+					const prefix = this.input
+						.slice(start, declaration.id.start)
+						.replace(/\/\*[\s\S]*?\*\/|\/\/[^\r\n]*/g, ' ')
+						.trim();
+					const kind =
+						declaration.kind ??
+						(legacy.global ? 'global' : prefix.endsWith('namespace') ? 'namespace' : 'module');
+					/** @type {AST.TSModuleDeclaration | null} */
+					let current = declaration;
+					while (current !== null) {
+						const current_legacy = /** @type {{ global?: boolean }} */ (current);
+						current.kind = kind;
+						delete current_legacy.global;
+						current.metadata ??= { path: [] };
+						current.metadata.module_keyword = kind;
+						const body = /** @type {AST.TSModuleBlock | AST.TSModuleDeclaration} */ (
+							/** @type {unknown} */ (current.body)
+						);
+						current = body?.type === 'TSModuleDeclaration' ? body : null;
+					}
 				}
 				return finished;
 			}

--- a/packages/tsrx/src/scope.js
+++ b/packages/tsrx/src/scope.js
@@ -130,7 +130,7 @@ export function create_scopes(ast, root, parent, error_options) {
 		},
 
 		TSModuleDeclaration(node, { state, next }) {
-			const is_submodule = node.metadata?.module_keyword === 'module';
+			const is_submodule = node.declare !== true && node.kind === 'module';
 			if (is_submodule && node.id?.type === 'Identifier') {
 				state.scope.declare(node.id, 'normal', 'module', node);
 			}

--- a/packages/tsrx/src/transform/jsx/helpers.js
+++ b/packages/tsrx/src/transform/jsx/helpers.js
@@ -180,12 +180,18 @@ export function tsx_with_ts_locations(boundary_tokens = false, comments = undefi
 			}
 		},
 		TSModuleDeclaration: (node, context) => {
-			// Ambient `declare module '…' { … }` must keep its `declare` — the
-			// typeOnly/volar output is real TS and `module '…' { … }` alone is a
-			// syntax error (TS1035). Non-ambient `module name { }` blocks have no
-			// `declare` and print unchanged.
+			// `declare global` is represented as a TSModuleDeclaration whose id is
+			// `global`; adding `module` changes it into an unrelated named module.
+			// Ambient `declare module '…' { … }` must still keep its `declare` —
+			// the typeOnly/volar output is real TS and `module '…' { … }` alone is
+			// a syntax error (TS1035).
 			if (node.declare) context.write('declare ');
-			context.write(node.metadata?.module_keyword ?? 'module');
+			if (node.kind === 'global') {
+				context.visit(node.id);
+				context.visit(node.body);
+				return;
+			}
+			context.write(node.kind);
 			context.write(' ');
 			context.visit(node.id);
 			context.visit(node.body);

--- a/packages/tsrx/src/transform/jsx/server-module.js
+++ b/packages/tsrx/src/transform/jsx/server-module.js
@@ -110,7 +110,7 @@ function is_server_module_declaration(node, block_name) {
 	return (
 		node.type === 'TSModuleDeclaration' &&
 		node.declare !== true &&
-		node.metadata?.module_keyword === 'module' &&
+		node.kind === 'module' &&
 		identifier_name(node.id) === block_name
 	);
 }
@@ -465,6 +465,7 @@ function lower_declaration(declaration, outside_names, block_name) {
 	const namespace = /** @type {AST.TSStatement<AST.TSModuleDeclaration>} */ ({
 		...declaration,
 		id,
+		kind: 'namespace',
 		metadata: { ...declaration.metadata, module_keyword: 'namespace' },
 		body: { ...declaration.body, body: [...aliases, ...rest] },
 	});

--- a/packages/tsrx/tests/utils/server-module-lowering.test.js
+++ b/packages/tsrx/tests/utils/server-module-lowering.test.js
@@ -3,6 +3,7 @@
 
 import { describe, expect, it } from 'vitest';
 import { createJsxTransform, createVolarMappingsResult, parseModule } from '../../src/index.js';
+import { check_types } from '../shared/type-diagnostics.js';
 
 /**
  * Type-only lowering of the opt-in server-module dialect
@@ -113,6 +114,52 @@ const DIALECT_SOURCE =
 	"\tconst pending = placeOrder('r1');\n" +
 	'\t<button>{String(pending)}</button>\n' +
 	'}\n';
+
+describe('ordinary TypeScript module declarations in type-only output', () => {
+	it('preserves global augmentations and their globalThis types', () => {
+		const source =
+			'export {};\n' +
+			'declare global {\n' +
+			'\tvar __tsrxGlobalValue: string | undefined;\n' +
+			'}\n' +
+			'const globalValue = globalThis.__tsrxGlobalValue;\n';
+		const globalDeclaration = parseModule(source, 'App.tsrx', PARSE_OPTIONS).body[1];
+		const namedModule = parseModule('declare module global {}', 'App.tsrx', PARSE_OPTIONS).body[0];
+		const declaredNamespace = parseModule(
+			'declare namespace Outer.Inner {}',
+			'App.tsrx',
+			PARSE_OPTIONS,
+		).body[0];
+		const result = compile_to_volar_mappings(source, {
+			platform: PLAIN_PLATFORM,
+		});
+
+		expect(globalDeclaration).toMatchObject({
+			type: 'TSModuleDeclaration',
+			kind: 'global',
+		});
+		expect(globalDeclaration).not.toHaveProperty('global');
+		expect(namedModule).toMatchObject({
+			type: 'TSModuleDeclaration',
+			kind: 'module',
+		});
+		expect(declaredNamespace).toMatchObject({
+			type: 'TSModuleDeclaration',
+			kind: 'namespace',
+			body: {
+				type: 'TSModuleDeclaration',
+				kind: 'namespace',
+			},
+		});
+		expect(result.errors).toEqual([]);
+		expect(result.code).toContain('declare global');
+		expect(result.code).not.toContain('declare module global');
+		expect(check_types(result.code)).toEqual({
+			errors: [],
+			types: { globalValue: 'string | undefined' },
+		});
+	});
+});
 
 describe('server-module type-only lowering', () => {
 	it('hoists block imports and lowers the block to a namespace keeping the authored name and id location', () => {

--- a/packages/tsrx/types/index.d.ts
+++ b/packages/tsrx/types/index.d.ts
@@ -106,7 +106,7 @@ export interface BaseNodeMetaData {
 	has_template?: boolean;
 	source_name?: string;
 	source_length?: number;
-	module_keyword?: 'module' | 'namespace';
+	module_keyword?: 'global' | 'module' | 'namespace';
 	/**
 	 * Generated identifier whose SOURCE span sits inside an authored string
 	 * literal (e.g. a server-module lowering's namespace reference carrying
@@ -1302,7 +1302,7 @@ declare module 'estree' {
 	}
 	interface TSModuleDeclaration extends Omit<
 		AcornTSNode<TSESTree.TSModuleDeclaration>,
-		'body' | 'id'
+		'body' | 'global' | 'id'
 	> {
 		body: TSModuleBlock;
 		/** A string literal for `declare module '<specifier>'`. */


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches parser normalization, scope analysis, and multiple compile/print paths for module declarations; incorrect `kind` handling could mis-classify server blocks or break global augmentation typing.
> 
> **Overview**
> **TypeScript module declarations** now use TSESTree’s `kind` (`global` | `module` | `namespace`) end-to-end instead of inferring behavior from `metadata.module_keyword` or acorn’s legacy `global` flag. The parser sets `kind` on nested declarations and keeps `metadata.module_keyword` in sync for compatibility.
> 
> **Printing and transforms** treat `kind === 'global'` specially so Volar/type-only output keeps `declare global { … }` instead of incorrectly emitting `declare module global`. Ambient `declare module` / `declare namespace` nodes are dropped from Ripple **client and server** runtime bundles while still flowing through type-only paths where needed.
> 
> Ripple analyze/server-module detection and shared scope logic now identify real `module { }` blocks via `declare !== true && kind === 'module'`. The Prettier plugin mirrors the same `kind`-based formatting. New tests assert global augmentation types and that runtime output strips declaration noise but keeps `globalThis` usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 501a03e645ef65bd04d69ddb6865625aacc39d16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->