### PR TITLE
fix(vite-plugin-react): scan dependencies in server environments

### DIFF
--- a/.changeset/warm-pandas-scan.md
+++ b/.changeset/warm-pandas-scan.md
@@ -1,0 +1,5 @@
+---
+'@tsrx/vite-plugin-react': patch
+---
+
+Register the TSRX dependency scanner for server environments that enable dependency discovery.

--- a/packages/tsrx/tests/shared/dep-scan.js
+++ b/packages/tsrx/tests/shared/dep-scan.js
@@ -1,7 +1,7 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { optimizeDeps, resolveConfig } from 'vite';
+import { createServer, optimizeDeps, resolveConfig } from 'vite';
 
 const DEFAULT_INDEX_HTML = `<!doctype html>
 <html>
@@ -62,6 +62,57 @@ export async function scanFixture({ root, files, plugins }) {
 
 		return Object.keys(metadata.optimized);
 	} finally {
+		rmSync(cache_dir, { recursive: true, force: true });
+		rmSync(root, { recursive: true, force: true });
+	}
+}
+
+/**
+ * Run the initial dependency scan for a named Vite environment.
+ *
+ * @param {{
+ *   root: string,
+ *   files: Record<string, string>,
+ *   plugins: import('vite').PluginOption[],
+ *   name: string,
+ *   environment: import('vite').EnvironmentOptions,
+ * }} options
+ * @returns {Promise<string[]>} the dependency ids found during the initial scan
+ */
+export async function scanEnvironmentFixture({ root, files, plugins, name, environment }) {
+	const cache_dir = mkdtempSync(join(tmpdir(), 'tsrx-environment-dep-scan-'));
+	/** @type {import('vite').ViteDevServer | undefined} */
+	let server;
+
+	mkdirSync(root, { recursive: true });
+	for (const [file_name, source] of Object.entries(files)) {
+		writeFileSync(join(root, file_name), source);
+	}
+
+	try {
+		server = await createServer({
+			root,
+			appType: 'custom',
+			configFile: false,
+			cacheDir: cache_dir,
+			logLevel: 'silent',
+			plugins,
+			server: { middlewareMode: true },
+			environments: { [name]: environment },
+		});
+
+		const target = server.environments[name];
+		await target.listen(server);
+
+		const optimizer = target.depsOptimizer;
+		if (!optimizer) {
+			throw new Error(`Dependency optimizer is disabled for environment ${name}`);
+		}
+
+		await optimizer.scanProcessing;
+		return Object.keys(optimizer.metadata.discovered);
+	} finally {
+		await server?.close();
 		rmSync(cache_dir, { recursive: true, force: true });
 		rmSync(root, { recursive: true, force: true });
 	}

--- a/packages/vite-plugin-react/src/index.js
+++ b/packages/vite-plugin-react/src/index.js
@@ -15,7 +15,7 @@
  *   (id: `\0${string}?tsrx-css&lang.css`): string,
  *   (id: string): string | null,
  * }} TsrxReactLoad
- * @typedef {() => {
+ * @typedef {{
  *   optimizeDeps: {
  *     extensions: string[],
  *     rolldownOptions: {
@@ -23,9 +23,13 @@
  *       plugins: [DepScanTransformPlugin],
  *     },
  *   },
- * }} TsrxReactConfigHook
- * @typedef {Omit<Plugin, 'config' | 'transform' | 'resolveId' | 'load'> & {
- *   config: TsrxReactConfigHook,
+ * }} TsrxReactEnvironmentConfig
+ * @typedef {(
+ *   name: string,
+ *   config: import('vite').EnvironmentOptions,
+ * ) => TsrxReactEnvironmentConfig | undefined} TsrxReactConfigEnvironmentHook
+ * @typedef {Omit<Plugin, 'configEnvironment' | 'transform' | 'resolveId' | 'load'> & {
+ *   configEnvironment: TsrxReactConfigEnvironmentHook,
  *   transform: TsrxReactTransform,
  *   resolveId: TsrxReactResolveId,
  *   load: TsrxReactLoad,
@@ -72,24 +76,14 @@ export function tsrxReact(options = {}) {
 		name: '@tsrx/vite-plugin-react',
 		enforce: 'pre',
 
-		config() {
-			return {
-				optimizeDeps: {
-					// The scanner externalizes anything that is not a known JS
-					// type unless its extension is listed here, so without this
-					// entry the dep-scan plugin below never runs.
-					extensions: ['.tsrx'],
-					rolldownOptions: {
-						// The scan runs its own jsx transform over the tsx the
-						// dep-scan plugin hands back, and that transform defaults to
-						// react's runtime. Point it at the configured source, or the
-						// scan fails outright on an unresolvable
-						// `react/jsx-dev-runtime` in a project that has no react.
-						transform: { jsx: { importSource: jsxImportSource } },
-						plugins: [create_dep_scan_plugin(jsxImportSource)],
-					},
-				},
-			};
+		configEnvironment(name, config) {
+			const discovers_dependencies =
+				name === 'client' || config.optimizeDeps?.noDiscovery === false;
+			if (!discovers_dependencies) {
+				return;
+			}
+
+			return create_dep_scan_config(jsxImportSource);
 		},
 
 		resolveId(/** @type {string} */ source) {
@@ -151,6 +145,29 @@ export function tsrxReact(options = {}) {
 			return [...ctx.modules, css_mod];
 		},
 	});
+}
+
+/**
+ * @param {string} jsxImportSource
+ * @returns {TsrxReactEnvironmentConfig}
+ */
+function create_dep_scan_config(jsxImportSource) {
+	return {
+		optimizeDeps: {
+			// The scanner externalizes anything that is not a known JS type
+			// unless its extension is listed here, so without this entry the
+			// dep-scan plugin below never runs.
+			extensions: ['.tsrx'],
+			rolldownOptions: {
+				// The scan runs its own jsx transform over the tsx the dep-scan
+				// plugin hands back, and that transform defaults to react's runtime.
+				// Point it at the configured source, or the scan fails outright on
+				// an unresolvable `react/jsx-dev-runtime` in a project without react.
+				transform: { jsx: { importSource: jsxImportSource } },
+				plugins: [create_dep_scan_plugin(jsxImportSource)],
+			},
+		},
+	};
 }
 
 /**

--- a/packages/vite-plugin-react/tests/scan.test.js
+++ b/packages/vite-plugin-react/tests/scan.test.js
@@ -1,6 +1,6 @@
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { scanFixture } from '@tsrx/core/test-harness/dep-scan';
+import { scanEnvironmentFixture, scanFixture } from '@tsrx/core/test-harness/dep-scan';
 import { tsrxReact } from '../src/index.js';
 
 const fixtures_dir = join(dirname(fileURLToPath(import.meta.url)), 'fixtures');
@@ -29,15 +29,29 @@ const MALFORMED = `export function Broken() @{
 
 /**
  * @param {ReturnType<typeof tsrxReact>} plugin
+ * @param {string} [name]
+ * @param {import('vite').EnvironmentOptions} [options]
+ */
+function get_environment_config(plugin, name = 'client', options = {}) {
+	const config = plugin.configEnvironment(name, options);
+	if (!config) {
+		throw new Error(`Missing dependency scan config for environment ${name}`);
+	}
+
+	return config;
+}
+
+/**
+ * @param {ReturnType<typeof tsrxReact>} plugin
  */
 function get_scan_plugin(plugin) {
-	return plugin.config().optimizeDeps.rolldownOptions.plugins[0];
+	return get_environment_config(plugin).optimizeDeps.rolldownOptions.plugins[0];
 }
 
 describe('@tsrx/vite-plugin-react dep scan', () => {
-	it('registers the .tsrx extension and the dep-scan plugin via the config hook', () => {
+	it('registers the .tsrx extension and dep-scan plugin for the client environment', () => {
 		const plugin = tsrxReact();
-		const config = plugin.config();
+		const config = get_environment_config(plugin);
 
 		expect(config.optimizeDeps.extensions).toEqual(['.tsrx']);
 
@@ -48,8 +62,27 @@ describe('@tsrx/vite-plugin-react dep scan', () => {
 		expect(scan_plugins[0].transform.filter.id.test('/app/src/App.tsx')).toBe(false);
 	});
 
+	it('registers the dep-scan config for server environments with discovery enabled', () => {
+		const plugin = tsrxReact();
+		const config = get_environment_config(plugin, 'ssr', {
+			optimizeDeps: { noDiscovery: false },
+		});
+
+		expect(config.optimizeDeps.extensions).toEqual(['.tsrx']);
+		expect(config.optimizeDeps.rolldownOptions.plugins).toHaveLength(1);
+	});
+
+	it('does not register the dep-scan config for server environments without discovery', () => {
+		const plugin = tsrxReact();
+
+		expect(plugin.configEnvironment('ssr', {})).toBeUndefined();
+		expect(
+			plugin.configEnvironment('ssr', { optimizeDeps: { noDiscovery: true } }),
+		).toBeUndefined();
+	});
+
 	it('points the scan jsx transform at the configured import source', () => {
-		expect(tsrxReact().config().optimizeDeps.rolldownOptions.transform).toEqual({
+		expect(get_environment_config(tsrxReact()).optimizeDeps.rolldownOptions.transform).toEqual({
 			jsx: { importSource: 'react' },
 		});
 
@@ -57,7 +90,8 @@ describe('@tsrx/vite-plugin-react dep scan', () => {
 		// `react/jsx-dev-runtime` import into a project that has no react and
 		// fail outright.
 		expect(
-			tsrxReact({ jsxImportSource: 'preact' }).config().optimizeDeps.rolldownOptions.transform,
+			get_environment_config(tsrxReact({ jsxImportSource: 'preact' })).optimizeDeps.rolldownOptions
+				.transform,
 		).toEqual({ jsx: { importSource: 'preact' } });
 	});
 
@@ -119,6 +153,23 @@ describe('@tsrx/vite-plugin-react dep scan', () => {
 		});
 
 		expect(optimized).toContain('@tanstack/react-query');
+	}, 60_000);
+
+	it('discovers .tsrx dependencies in the initial scan for a named SSR environment', async () => {
+		const discovered = await scanEnvironmentFixture({
+			root: join(fixtures_dir, 'scan-ssr'),
+			files: { 'main.tsx': MAIN, 'App.tsrx': APP },
+			plugins: [tsrxReact()],
+			name: 'ssr',
+			environment: {
+				optimizeDeps: {
+					entries: ['main.tsx'],
+					noDiscovery: false,
+				},
+			},
+		});
+
+		expect(discovered).toContain('@tanstack/react-query');
 	}, 60_000);
 
 	it('still pre-bundles the rest of the graph when a .tsrx file fails to compile', async () => {

--- a/packages/vite-plugin-react/types/index.d.ts
+++ b/packages/vite-plugin-react/types/index.d.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from 'vite';
+import type { EnvironmentOptions, Plugin } from 'vite';
 import type { DepScanTransformPlugin } from '@tsrx/core/types/vite/dep-scan';
 
 export interface TsrxReactPluginOptions {
@@ -12,17 +12,22 @@ export interface TsrxReactTransformResult {
 
 export interface TsrxReactPlugin extends Omit<
 	Plugin,
-	'config' | 'transform' | 'resolveId' | 'load'
+	'configEnvironment' | 'transform' | 'resolveId' | 'load'
 > {
-	config: () => {
-		optimizeDeps: {
-			extensions: string[];
-			rolldownOptions: {
-				transform: { jsx: { importSource: string } };
-				plugins: [DepScanTransformPlugin];
-			};
-		};
-	};
+	configEnvironment: (
+		name: string,
+		config: EnvironmentOptions,
+	) =>
+		| {
+				optimizeDeps: {
+					extensions: string[];
+					rolldownOptions: {
+						transform: { jsx: { importSource: string } };
+						plugins: [DepScanTransformPlugin];
+					};
+				};
+		  }
+		| undefined;
 	transform: {
 		(code: string, id: `${string}.tsrx`): Promise<TsrxReactTransformResult>;
 		(code: string, id: string): Promise<TsrxReactTransformResult | null>;


### PR DESCRIPTION
I made a mistake in [#1392](https://github.com/Ripple-TS/ripple/pull/1392): the dependency scanner was registered through `config()`, so it only reached the client environment.

This moves the scanner setup to `configEnvironment()` and applies it to the client plus server environments that enable dependency discovery. It also adds a named SSR environment regression test covering dependencies imported only from `.tsrx` files.

Stet is still carrying [a local workaround](https://github.com/jamiedavenport/stet/blob/main/apps/web/vite.config.ts) for its TanStack Start SSR environment.

Tested with the `vite-plugin-react` and `tsrx-react-runtime` Vitest projects, plus the affected type checks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Vite dev dependency discovery for client and SSR; behavior change for multi-environment apps but scoped to environments that opt into discovery, with regression tests.
> 
> **Overview**
> Fixes a regression where the `.tsrx` dependency scanner only applied to the **client** environment because it was wired through Vite's global `config()` hook.
> 
> The plugin now uses **`configEnvironment()`** and returns the same `optimizeDeps` / dep-scan rolldown setup for the client and for any environment with **`optimizeDeps.noDiscovery === false`** (typical SSR setups with discovery on). Server environments with discovery off get no scanner config. The scan options are factored into **`create_dep_scan_config`**; public types switch from `config` to **`configEnvironment`**.
> 
> The shared test harness adds **`scanEnvironmentFixture`** (dev server + per-environment initial scan), and **`scan.test.js`** covers SSR registration rules and an end-to-end check that dependencies reachable only from `.tsrx` files are discovered in a named SSR environment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84fad06be0e72283d5f23972716f7b0a5a75f13d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->