### PR TITLE
fix(language-server): fix HTML and component tag auto-closing in .tsrx files

### DIFF
--- a/packages/language-server/src/autoInsertPlugin.js
+++ b/packages/language-server/src/autoInsertPlugin.js
@@ -71,90 +71,111 @@ export function createAutoInsertPlugin() {
 						return null;
 					}
 
-					// Map position back to source
+					// The position is right after the typed '>' in the source document
+					const sourceCode = document.getText();
 					const offset = document.offsetAt(position);
-					const mapping = virtualCode.findMappingByGeneratedRange(lastChange.rangeOffset, offset);
 
-					if (!mapping) {
+					// Ensure character right before cursor is '>'
+					if (offset === 0 || sourceCode[offset - 1] !== '>') {
 						return null;
 					}
 
-					const sourceOffset = mapping.sourceOffsets[0];
-
-					// search backwards from sourceOffset to find the line tag
-					const sourceCode = virtualCode.originalCode;
-					if (sourceCode[sourceOffset - 1] === '/') {
-						// self-closing tag '/>'
+					// Check for self-closing tag '/>'
+					if (offset >= 2 && sourceCode[offset - 2] === '/') {
 						return null;
 					}
 
-					let attempts = 0;
-					let found = false;
-					let i = sourceOffset - 1;
-					for (; i >= 0; i--) {
+					// Find the opening '<' for this tag by searching backwards from '>'
+					let openingAngleIndex = -1;
+					let depth = 0;
+					let inString = false;
+					let stringQuote = '';
+
+					for (let i = offset - 2; i >= 0; i--) {
 						const char = sourceCode[i];
-						if (char === '<') {
-							attempts++;
-							// Confirm that it's definitely the start of the tag
-							// We have `<` and `>` in source maps
-							if (virtualCode.findMappingBySourceRange(i, i + 1)) {
-								found = true;
+
+						// Handle string literals in attribute values (e.g. <div attr=">">)
+						if (inString) {
+							if (char === stringQuote && sourceCode[i - 1] !== '\\') {
+								inString = false;
+							}
+							continue;
+						}
+
+						if (char === '"' || char === "'" || char === '`') {
+							inString = true;
+							stringQuote = char;
+							continue;
+						}
+
+						// Handle nested JSX expressions or generics inside attributes
+						if (char === '}') depth++;
+						else if (char === '{') depth--;
+
+						if (depth === 0) {
+							if (char === '>') {
+								// Hit another tag's closing bracket before finding our opening '<'
+								break;
+							}
+							if (char === '<') {
+								openingAngleIndex = i;
 								break;
 							}
 						}
-
-						if (attempts === 3) {
-							break;
-						}
 					}
 
-					if (!found) {
-						// This shouldn't happen in reality
-						log(`No opening tag position found from source position ${sourceOffset}`);
+					if (openingAngleIndex === -1) {
+						log(`No opening tag found for '>' at offset ${offset}`);
 						return null;
 					}
 
-					const line = sourceCode.slice(i, sourceOffset + 1);
+					const tagText = sourceCode.slice(openingAngleIndex, offset);
 
-					log('Auto-insert triggered at:', {
-						selection: `${position.line}:${position.character}`,
-						line,
-						change: lastChange,
-						sourceOffset,
-					});
+					// Check for JSX Fragment: <>
+					if (tagText === '<>') {
+						log('Fragment matched, inserting </>');
+						const restOfLine = sourceCode.slice(offset, offset + 100);
+						if (restOfLine.startsWith('</>')) {
+							return null;
+						}
+						return '$0</>';
+					}
 
-					// Check if we just typed '>' after a tag name
-					// Match patterns like: <div> or <Component> but not <div /> or <Component/>
-					const tagMatch = line.match(/<([@$\w][\w.-]*)[^>]*?(?<!\/)>$/);
+					// Match patterns like: <div> or <Component attr="val"> or <tag-name>
+					// Exclude self-closing tags (ending with />) and closing tags (starting with </)
+					if (tagText.startsWith('</')) {
+						return null;
+					}
+
+					const tagMatch = tagText.match(/^<([@$\w][\w.-]*)(?:[\s/][^>]*)?>$/);
 					if (!tagMatch) {
-						log('No tag match found');
+						log('No valid tag pattern matched for:', tagText);
 						return null;
 					}
 
 					const tagName = tagMatch[1];
-					log('Tag matched:', tagName);
 
-					// Don't auto-close void elements (self-closing HTML tags)
+					// Ignore TSRX control-flow directives (@if, @for, @switch, @try, @else, @case, @default, @catch)
+					if (/^@(if|for|switch|try|else|case|default|catch)$/.test(tagName)) {
+						return null;
+					}
+
+					// Don't auto-close void elements (self-closing HTML tags like <img>, <input>, etc.)
 					if (VOID_ELEMENTS.has(tagName.toLowerCase())) {
 						log('Void element, skipping auto-close:', tagName);
 						return null;
 					}
 
-					// Check if there's already a closing tag ahead
-					const restOfLine = document.getText({
-						start: position,
-						end: { line: position.line, character: position.character + 100 },
-					});
+					// Check if there's already a matching closing tag ahead
+					const restOfLine = sourceCode.slice(offset, offset + 100);
 					if (restOfLine.startsWith(`</${tagName}>`)) {
 						log('Closing tag already exists, skipping');
 						return null;
 					}
 
-					// Insert the closing tag
+					// Insert the closing tag with $0 cursor position between tags
 					const closingTag = `</${tagName}>`;
 					log('Inserting closing tag:', closingTag);
-
-					// Return a snippet with $0 to place cursor between the tags
 					return `$0${closingTag}`;
 				},
 			};

--- a/packages/language-server/src/autoInsertPlugin.js
+++ b/packages/language-server/src/autoInsertPlugin.js
@@ -166,6 +166,45 @@ export function createAutoInsertPlugin() {
 						return null;
 					}
 
+					// DISAMBIGUATION: Prevent auto-closing TypeScript generic type arguments & parameters
+					// 1. Multiple type arguments separated by commas (e.g. <T, U>, <string, number>)
+					if (tagText.includes(',')) {
+						log('TS generic comma list, skipping auto-close:', tagText);
+						return null;
+					}
+
+					// 2. Generic constraints or default types (e.g. <T extends object>, <T = string>)
+					// Exclude JSX attribute assignments like class="btn" or onClick={fn}
+					const tagContent = tagText.slice(1, -1).trim();
+					if (/\bextends\b/.test(tagContent) || (tagContent.includes('=') && !/=\s*["'{]/.test(tagContent))) {
+						log('TS generic constraint/default, skipping auto-close:', tagText);
+						return null;
+					}
+
+					// 3. Single uppercase letter generic type parameter names (e.g. <T>, <U>, <V>, <K>, <T1>)
+					if (/^[A-Z][0-9]?$/.test(tagName)) {
+						log('Single letter TS generic type parameter, skipping auto-close:', tagName);
+						return null;
+					}
+
+					// 4. Preceding TypeScript declaration / type annotation keywords before '<'
+					const codeBeforeAngle = sourceCode.slice(0, openingAngleIndex);
+					const lastLineBeforeAngle = codeBeforeAngle.slice(Math.max(0, codeBeforeAngle.lastIndexOf('\n') + 1));
+					if (
+						/\b(function|type|interface|class|implements|extends|as|new)\s*[\w$]*$/.test(lastLineBeforeAngle) ||
+						/:\s*[\w$.]*$/.test(lastLineBeforeAngle)
+					) {
+						log('TS declaration / type annotation context, skipping auto-close:', lastLineBeforeAngle);
+						return null;
+					}
+
+					// 5. Generic function invocations followed by call parenthesis '(' (e.g. fn<number>(...), useState<string>())
+					const codeAfterAngle = sourceCode.slice(offset);
+					if (/^\s*\(/.test(codeAfterAngle)) {
+						log('TS generic call expression followed by (, skipping auto-close');
+						return null;
+					}
+
 					// Check if there's already a matching closing tag ahead
 					const restOfLine = sourceCode.slice(offset, offset + 100);
 					if (restOfLine.startsWith(`</${tagName}>`)) {

--- a/packages/language-server/src/utils.js
+++ b/packages/language-server/src/utils.js
@@ -84,13 +84,16 @@ export function concatMarkdownContents(...contents) {
  */
 export function getVirtualCode(document, context) {
 	const uri = URI.parse(document.uri);
-	const decoded = /** @type {[documentUri: URI, embeddedCodeId: string]} */ (
+	const decoded = /** @type {[documentUri: URI, embeddedCodeId: string] | undefined} */ (
 		context.decodeEmbeddedDocumentUri(uri)
 	);
-	const [sourceUri, virtualCodeId] = decoded;
+	const sourceUri = decoded ? decoded[0] : uri;
+	const virtualCodeId = decoded ? decoded[1] : undefined;
 	const sourceScript = context.language.scripts.get(sourceUri);
 	const virtualCode = /** @type {TSRXVirtualCodeInstance} */ (
-		sourceScript?.generated?.embeddedCodes.get(virtualCodeId)
+		virtualCodeId
+			? sourceScript?.generated?.embeddedCodes.get(virtualCodeId)
+			: sourceScript?.generated?.root
 	);
 
 	const sourceMap =

--- a/packages/language-server/tests/autoInsertPlugin.test.js
+++ b/packages/language-server/tests/autoInsertPlugin.test.js
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest';
+import { create_auto_insert_harness } from './setup.js';
+
+describe('autoInsert plugin — tag auto-closing', () => {
+	it('auto-closes standard HTML tags like <div>', async () => {
+		const source = 'export function App() {\n\treturn <div>;\n}';
+		const { service, uri } = create_auto_insert_harness(source);
+
+		// Position is right after the '>' in <div> (line 1, character 13)
+		const snippet = await service.getAutoInsertSnippet(
+			uri,
+			{ line: 1, character: 13 },
+			{ rangeOffset: 12, rangeLength: 0, text: '>' },
+		);
+
+		expect(snippet).toBe('$0</div>');
+	});
+
+	it('auto-closes HTML tags with attributes', async () => {
+		const source = 'export function App() {\n\treturn <button class="btn" id="save">\n}';
+		const { service, uri } = create_auto_insert_harness(source);
+
+		// Line 1: \treturn <button class="btn" id="save">
+		// position right after '>'
+		const lineText = '\treturn <button class="btn" id="save">';
+		const character = lineText.length;
+
+		const snippet = await service.getAutoInsertSnippet(
+			uri,
+			{ line: 1, character },
+			{ rangeOffset: character - 1, rangeLength: 0, text: '>' },
+		);
+
+		expect(snippet).toBe('$0</button>');
+	});
+
+	it('auto-closes custom TSRX components', async () => {
+		const source = 'export function App() {\n\treturn <MyCustomComponent>\n}';
+		const { service, uri } = create_auto_insert_harness(source);
+
+		const lineText = '\treturn <MyCustomComponent>';
+		const character = lineText.length;
+
+		const snippet = await service.getAutoInsertSnippet(
+			uri,
+			{ line: 1, character },
+			{ rangeOffset: character - 1, rangeLength: 0, text: '>' },
+		);
+
+		expect(snippet).toBe('$0</MyCustomComponent>');
+	});
+
+	it('auto-closes fragments <>', async () => {
+		const source = 'export function App() {\n\treturn <>;\n}';
+		const { service, uri } = create_auto_insert_harness(source);
+
+		const snippet = await service.getAutoInsertSnippet(
+			uri,
+			{ line: 1, character: 9 },
+			{ rangeOffset: 32, rangeLength: 0, text: '>' },
+		);
+
+		expect(snippet).toBe('$0</>');
+	});
+
+	it('does not auto-close void elements like <img> or <input>', async () => {
+		const imgSource = 'export function App() {\n\treturn <img src="test.png">\n}';
+		const { service: imgService, uri: imgUri } = create_auto_insert_harness(imgSource);
+
+		const imgLine = '\treturn <img src="test.png">';
+		const snippetImg = await imgService.getAutoInsertSnippet(
+			imgUri,
+			{ line: 1, character: imgLine.length },
+			{ rangeOffset: imgLine.length - 1, rangeLength: 0, text: '>' },
+		);
+
+		expect(snippetImg).toBeFalsy();
+	});
+
+	it('does not auto-close self-closing tags <div />', async () => {
+		const source = 'export function App() {\n\treturn <div />\n}';
+		const { service, uri } = create_auto_insert_harness(source);
+
+		const lineText = '\treturn <div />';
+		const snippet = await service.getAutoInsertSnippet(
+			uri,
+			{ line: 1, character: lineText.length },
+			{ rangeOffset: lineText.length - 1, rangeLength: 0, text: '>' },
+		);
+
+		expect(snippet).toBeFalsy();
+	});
+
+	it('does not auto-close control flow directives like @if', async () => {
+		const source = 'export function App() @{\n\t@if (count > 0) {\n\t}\n}';
+		const { service, uri } = create_auto_insert_harness(source);
+
+		// After '>' in count > 0
+		const snippet = await service.getAutoInsertSnippet(
+			uri,
+			{ line: 1, character: 12 },
+			{ rangeOffset: 11, rangeLength: 0, text: '>' },
+		);
+
+		expect(snippet).toBeFalsy();
+	});
+
+	it('skips auto-closing if a closing tag already exists ahead', async () => {
+		const source = 'export function App() {\n\treturn <div></div>\n}';
+		const { service, uri } = create_auto_insert_harness(source);
+
+		const snippet = await service.getAutoInsertSnippet(
+			uri,
+			{ line: 1, character: 13 },
+			{ rangeOffset: 12, rangeLength: 0, text: '>' },
+		);
+
+		expect(snippet).toBeFalsy();
+	});
+});

--- a/packages/language-server/tests/autoInsertPlugin.test.js
+++ b/packages/language-server/tests/autoInsertPlugin.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { create_auto_insert_harness } from './setup.js';
+import { createAutoInsertPlugin } from '../src/autoInsertPlugin.js';
 
 describe('autoInsert plugin — tag auto-closing', () => {
 	it('auto-closes standard HTML tags like <div>', async () => {
@@ -51,13 +52,15 @@ describe('autoInsert plugin — tag auto-closing', () => {
 	});
 
 	it('auto-closes fragments <>', async () => {
-		const source = 'export function App() {\n\treturn <>;\n}';
-		const { service, uri } = create_auto_insert_harness(source);
+		const source = 'export function App() {\n\treturn <>\n}';
+		const { document, service } = create_auto_insert_harness(source);
+		const plugin = createAutoInsertPlugin().create(service.context);
 
-		const snippet = await service.getAutoInsertSnippet(
-			uri,
-			{ line: 1, character: 9 },
-			{ rangeOffset: 32, rangeLength: 0, text: '>' },
+		const lineText = '\treturn <>';
+		const snippet = await plugin.provideAutoInsertSnippet(
+			document,
+			{ line: 1, character: lineText.length },
+			{ rangeOffset: 33, rangeLength: 0, text: '>' },
 		);
 
 		expect(snippet).toBe('$0</>');
@@ -109,10 +112,53 @@ describe('autoInsert plugin — tag auto-closing', () => {
 		const source = 'export function App() {\n\treturn <div></div>\n}';
 		const { service, uri } = create_auto_insert_harness(source);
 
+		// Position right after opening '>' in <div>
 		const snippet = await service.getAutoInsertSnippet(
 			uri,
 			{ line: 1, character: 13 },
 			{ rangeOffset: 12, rangeLength: 0, text: '>' },
+		);
+
+		expect(snippet).toBeFalsy();
+	});
+
+	it('does not auto-close TypeScript generic function declarations function foo<T>', async () => {
+		const source = 'export function foo<T>() {}';
+		const { service, uri } = create_auto_insert_harness(source);
+
+		const lineText = 'export function foo<T>';
+		const snippet = await service.getAutoInsertSnippet(
+			uri,
+			{ line: 0, character: lineText.length },
+			{ rangeOffset: lineText.length - 1, rangeLength: 0, text: '>' },
+		);
+
+		expect(snippet).toBeFalsy();
+	});
+
+	it('does not auto-close TypeScript generic type definitions type Map<K, V>', async () => {
+		const source = 'export type Dict<K, V> = Map<K, V>;';
+		const { service, uri } = create_auto_insert_harness(source);
+
+		const lineText = 'export type Dict<K, V>';
+		const snippet = await service.getAutoInsertSnippet(
+			uri,
+			{ line: 0, character: lineText.length },
+			{ rangeOffset: lineText.length - 1, rangeLength: 0, text: '>' },
+		);
+
+		expect(snippet).toBeFalsy();
+	});
+
+	it('does not auto-close TypeScript generic function calls useState<number>(0)', async () => {
+		const source = 'const [val, setVal] = useState<number>(0);';
+		const { service, uri } = create_auto_insert_harness(source);
+
+		const lineText = 'const [val, setVal] = useState<number>';
+		const snippet = await service.getAutoInsertSnippet(
+			uri,
+			{ line: 0, character: lineText.length },
+			{ rangeOffset: lineText.length - 1, rangeLength: 0, text: '>' },
 		);
 
 		expect(snippet).toBeFalsy();

--- a/packages/language-server/tests/setup.js
+++ b/packages/language-server/tests/setup.js
@@ -9,6 +9,7 @@ import { beforeEach } from 'vitest';
 import { getRippleLanguagePlugin, _reset_for_test } from '@tsrx/typescript-plugin/src/language.js';
 import { createDocumentSymbolPlugin } from '../src/documentSymbolPlugin.js';
 import { createCompletionPlugin } from '../src/completionPlugin.js';
+import { createAutoInsertPlugin } from '../src/autoInsertPlugin.js';
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 const root_dir = path.resolve(dirname, '../../..');
@@ -105,6 +106,32 @@ export function create_stateful_completion_harness(initial_source, fixture_name 
 	);
 
 	return { service, uri, set_document };
+}
+
+/**
+ * Build a Volar language service wired with the auto insert plugin.
+ * @param {string} source
+ * @param {string} [fixture_name]
+ */
+export function create_auto_insert_harness(source, fixture_name = 'App.tsrx') {
+	const uri = URI.file(path.join(fixture_dir, fixture_name));
+	const scripts = createUriMap();
+	const language = createLanguage([getRippleLanguagePlugin()], scripts, () => {});
+	const source_snapshot = create_snapshot(source);
+	language.scripts.set(uri, source_snapshot, 'ripple');
+
+	const service = createLanguageService(
+		language,
+		[createAutoInsertPlugin()],
+		{
+			workspaceFolders: [URI.file(root_dir)],
+			console,
+		},
+		{},
+	);
+	const document = TextDocument.create(uri.toString(), 'ripple', 0, source);
+
+	return { document, service, uri };
 }
 
 /**


### PR DESCRIPTION
This PR introduces a fix in Ripple's language server for enabling HTML tag auto-completion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editor-only auto-insert behavior in the language server with targeted heuristics; no runtime or auth/data paths, backed by new tests.
> 
> **Overview**
> Fixes **tag auto-closing** when typing `>` in `.tsrx` files by parsing the **source document** instead of relying on virtual-code source maps, so opening tags with attributes, fragments, and components resolve reliably.
> 
> The auto-insert logic now walks backward from `>` with awareness of **strings**, **`{}` in attributes**, **`/>`**, **void elements**, **TSRX `@` control-flow tags**, and several **TypeScript generic** heuristics (commas, `extends`/defaults, single-letter type params, declaration context, and `(` after `>`). **`getVirtualCode`** also resolves the **root** generated script when the URI is not an embedded document.
> 
> Adds a **Vitest harness** and coverage for happy paths and the main skip cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea9606e3a932eeab4cc12d84efcb768c8ad01bb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->