### PR TITLE
fix(zed-plugin): launch the language server directly

### DIFF
--- a/packages/zed-plugin/src/lib.rs
+++ b/packages/zed-plugin/src/lib.rs
@@ -252,53 +252,11 @@ impl zed::Extension for TsrxExtension {
     ) -> Result<zed::Command, String> {
         let binary_path = self.language_server_binary_path(language_server_id, worktree)?;
 
-        // Wrap the spawn in a shell snippet that prints an actionable error if
-        // the bin disappears between detection and exec. Needed because we
-        // cannot probe paths under node_modules from inside the wasm sandbox,
-        // so the project-local path returned by system_binary_path is a guess
-        // (we trust package.json + that the user ran their package manager).
-        // If the guess is wrong, this gives the user a clear message and
-        // recovery steps instead of a bare OS-level "no such file" error.
-        let (os, _) = zed::current_platform();
-        let mut env = worktree.shell_env();
-        env.push(("RIPPLE_LSP_BIN".into(), binary_path.clone()));
-        env.push(("RIPPLE_LSP_PKG".into(), PACKAGE_NAME.into()));
-
-        let cmd = match os {
-            zed::Os::Windows => zed::Command {
-                command: "cmd".into(),
-                args: vec![
-                    "/c".into(),
-                    "if exist \"%RIPPLE_LSP_BIN%\" ( \
-                       \"%RIPPLE_LSP_BIN%\" --stdio \
-                     ) else ( \
-                       echo [ripple-language-server] not found at \"%RIPPLE_LSP_BIN%\". \
-Run `pnpm install` ^(or `npm install`^) in your project, \
-or remove \"%RIPPLE_LSP_PKG%\" from your dependencies to use the auto-installed version. 1>&2 \
-                       & exit /b 127 \
-                     )".into(),
-                ],
-                env,
-            },
-            _ => zed::Command {
-                command: "/bin/sh".into(),
-                args: vec![
-                    "-c".into(),
-                    "if [ -x \"$RIPPLE_LSP_BIN\" ]; then \
-                       exec \"$RIPPLE_LSP_BIN\" --stdio; \
-                     else \
-                       printf '%s\\n' \
-                         \"[ripple-language-server] not found at $RIPPLE_LSP_BIN. \
-Run \\`pnpm install\\` (or \\`npm install\\`) in your project, \
-or remove \\\"$RIPPLE_LSP_PKG\\\" from your dependencies to use the auto-installed version.\" >&2; \
-                       exit 127; \
-                     fi".into(),
-                ],
-                env,
-            },
-        };
-
-        Ok(cmd)
+        Ok(zed::Command {
+            command: binary_path,
+            args: vec!["--stdio".into()],
+            env: worktree.shell_env(),
+        })
     }
 }
 


### PR DESCRIPTION
## Summary

- launch the resolved Ripple language server executable directly
- remove the shell and cmd wrappers plus their temporary environment variables
- keep binary resolution, installation, and the pinned server version unchanged

## Why

The Zed extensions review on zed-industries/extensions#7173 asked the extension to use native process launch and Zed error handling instead of checking the executable through a shell script.

## Validation

- cargo check --manifest-path packages/zed-plugin/Cargo.toml --target wasm32-wasip2
- cargo build --manifest-path packages/zed-plugin/Cargo.toml --target wasm32-wasip2 --release
- cargo clippy --manifest-path packages/zed-plugin/Cargo.toml --target wasm32-wasip2

Clippy completes with three pre-existing unnecessary_map_or warnings in untouched code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the LSP is spawned and removes friendly errors when a guessed project-local bin is missing; users may see generic launch failures instead of the old install hints.
> 
> **Overview**
> **Zed extension review feedback:** the Ripple language server is now started as a native process instead of via `cmd`/`sh` wrappers.
> 
> `language_server_command` returns a `zed::Command` that runs the resolved `binary_path` with `--stdio` and `worktree.shell_env()`. The previous pre-exec existence check, custom `RIPPLE_LSP_BIN` / `RIPPLE_LSP_PKG` env vars, and hand-written install/recovery error messages are removed—missing or bad binaries are expected to surface through Zed’s normal launch/error handling.
> 
> Binary resolution (`language_server_binary_path`, project-local vs npm install, pinned version) is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32a18073d90d1d31a40080f468f8358b265dfe84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->