### PR TITLE
fix(tsrx): treat < as literal text in markup when it cannot start a tag

### DIFF
--- a/.changeset/tidy-pugs-cheat.md
+++ b/.changeset/tidy-pugs-cheat.md
@@ -1,0 +1,5 @@
+---
+'@tsrx/core': patch
+---
+
+Treat `<` in markup text as a literal character when it cannot start a tag, so `<span><3</span>` parses instead of throwing `Unexpected token`

--- a/.changeset/tidy-pugs-cheat.md
+++ b/.changeset/tidy-pugs-cheat.md
@@ -2,4 +2,4 @@
 '@tsrx/core': patch
 ---
 
-Treat `<` in markup text as a literal character when it cannot start a tag, so `<span><3</span>` parses instead of throwing `Unexpected token`
+Treat `<` in markup text as a literal character when it cannot start a tag, so `<span><3</span>` parses instead of throwing `Unexpected token`. The JSX printer emits such text (and raw-text `<script>` bodies) with `<` escaped as `&lt;`, so the compiled output of JSX targets stays parseable by downstream toolchains

--- a/packages/ripple/tests/client/compiler/compiler.basic.test.tsrx
+++ b/packages/ripple/tests/client/compiler/compiler.basic.test.tsrx
@@ -1293,12 +1293,21 @@ export function App() @{
 		expect(result).toContain('_$_.spread_props(');
 	});
 
-	it('rejects less-than comparisons at line start in element children without whitespace', () => {
+	it('reads a less-than at line start in element children as literal text', () => {
 		const source = `function TodoList({ items }: { items: { text: string }[] }) @{
 	<ul>var a = 3
 	<4;</ul>
 		}`;
-
-		expect(() => parse(source, 'App.tsrx')).toThrow();
+		const ast = parse(source, 'App.tsrx');
+		const returned = get_returned_tsrx(ast.body[0]);
+		const ul =
+			returned.type === 'JSXElement'
+				? returned
+				: returned.children.find((n: AST.Node) => n.type === 'JSXElement') as ESTreeJSX.JSXElement;
+		expect((ul.openingElement.name as ESTreeJSX.JSXIdentifier).name).toBe('ul');
+		expect(ul.children).toHaveLength(1);
+		const text = ul.children[0] as unknown as { type: string; value: string };
+		expect(text.type).toBe('JSXText');
+		expect(text.value).toBe('var a = 3\n\t<4;');
 	});
 });

--- a/packages/tsrx/src/plugin.js
+++ b/packages/tsrx/src/plugin.js
@@ -109,6 +109,28 @@ function get_argument_clash_reported_names(check_clashes) {
 }
 
 /**
+ * A `<` opens a tag only when the character after it can begin one: `/` for a
+ * closing tag, `>` for a fragment, `{` for a dynamic tag, or an element or
+ * component name start. Any other character, or end of input, leaves the `<`
+ * as literal text.
+ * @param {string} input
+ * @param {number} index Index of the `<`.
+ */
+function can_start_tag_after_lt(input, index) {
+	const next = index + 1 < input.length ? input.charCodeAt(index + 1) : -1;
+	return (
+		next === CharCode.slash ||
+		next === CharCode.greaterThan ||
+		next === CharCode.openBrace ||
+		next === CharCode.at ||
+		next === CharCode.dollar ||
+		next === CharCode.underscore ||
+		(next >= CharCode.uppercaseA && next <= CharCode.uppercaseZ) ||
+		(next >= CharCode.lowercaseA && next <= CharCode.lowercaseZ)
+	);
+}
+
+/**
  * @param {string} input
  * @param {number} i
  */
@@ -623,7 +645,7 @@ export function TSRXPlugin(config) {
 					}
 					const ch = this.input.charCodeAt(index);
 					if (
-						ch === CharCode.lessThan ||
+						(ch === CharCode.lessThan && can_start_tag_after_lt(this.input, index)) ||
 						ch === CharCode.openBrace ||
 						ch === CharCode.closeBrace ||
 						this.#isCodeBlockStart(index) ||
@@ -1146,7 +1168,7 @@ export function TSRXPlugin(config) {
 				while (index < this.input.length) {
 					const ch = this.input.charCodeAt(index);
 					if (
-						ch === CharCode.lessThan ||
+						(ch === CharCode.lessThan && can_start_tag_after_lt(this.input, index)) ||
 						ch === CharCode.openBrace ||
 						ch === CharCode.closeBrace ||
 						this.#isJSXControlFlowDirectiveAt(index) ||
@@ -1247,16 +1269,8 @@ export function TSRXPlugin(config) {
 				const index = skip_whitespace_from(this.input, this.start);
 				const ch = this.input.charCodeAt(index);
 				if (ch === CharCode.lessThan) {
-					const next = this.input.charCodeAt(index + 1);
-					if (next === CharCode.slash) return false;
-					const tagLike =
-						next === CharCode.greaterThan ||
-						next === CharCode.openBrace ||
-						next === CharCode.at ||
-						next === CharCode.dollar ||
-						next === CharCode.underscore ||
-						(next >= CharCode.uppercaseA && next <= CharCode.uppercaseZ) ||
-						(next >= CharCode.lowercaseA && next <= CharCode.lowercaseZ);
+					if (this.input.charCodeAt(index + 1) === CharCode.slash) return false;
+					const tagLike = can_start_tag_after_lt(this.input, index);
 					const previous = this.#previousNonSpaceTabIndex(index);
 					const afterSemicolon =
 						previous >= 0 && this.input.charCodeAt(previous) === CharCode.semicolon;
@@ -2895,7 +2909,7 @@ export function TSRXPlugin(config) {
 				this.#suppressTemplateRawTextToken = false;
 				const context = this.curContext();
 				if (
-					code !== CharCode.lessThan &&
+					(code !== CharCode.lessThan || !can_start_tag_after_lt(this.input, this.pos)) &&
 					code !== CharCode.greaterThan &&
 					code !== CharCode.openBrace &&
 					code !== CharCode.closeBrace &&
@@ -2933,17 +2947,7 @@ export function TSRXPlugin(config) {
 					return super.readToken(code);
 				}
 				if (code === CharCode.lessThan) {
-					const next = this.input.charCodeAt(this.pos + 1);
-					const isTagLikeAfterLt =
-						next === CharCode.slash ||
-						next === CharCode.greaterThan ||
-						next === CharCode.openBrace ||
-						next === CharCode.at ||
-						next === CharCode.dollar ||
-						next === CharCode.underscore ||
-						(next >= CharCode.uppercaseA && next <= CharCode.uppercaseZ) ||
-						(next >= CharCode.lowercaseA && next <= CharCode.lowercaseZ);
-					if (this.exprAllowed && isTagLikeAfterLt) {
+					if (this.exprAllowed && can_start_tag_after_lt(this.input, this.pos)) {
 						++this.pos;
 						return this.finishToken(tstt.jsxTagStart);
 					}
@@ -3058,21 +3062,7 @@ export function TSRXPlugin(config) {
 					// <Something>...</Something>\n\n<Child />
 					// <head><style>...</style></head>
 					// We only do this when '<' is in a tag-like position.
-					const isWhitespaceAfterLt =
-						nextChar === CharCode.space ||
-						nextChar === CharCode.tab ||
-						nextChar === CharCode.lineFeed ||
-						nextChar === CharCode.carriageReturn;
-					const isTagLikeAfterLt =
-						!isWhitespaceAfterLt &&
-						(nextChar === CharCode.slash ||
-							nextChar === CharCode.greaterThan ||
-							nextChar === CharCode.openBrace ||
-							nextChar === CharCode.at ||
-							nextChar === CharCode.dollar ||
-							nextChar === CharCode.underscore ||
-							(nextChar >= CharCode.uppercaseA && nextChar <= CharCode.uppercaseZ) ||
-							(nextChar >= CharCode.lowercaseA && nextChar <= CharCode.lowercaseZ));
+					const isTagLikeAfterLt = can_start_tag_after_lt(this.input, this.pos);
 					const prevAllowsTagStart =
 						prevNonWhitespaceChar === null ||
 						prevNonWhitespaceChar === CharCode.lineFeed || // '\n'
@@ -3099,7 +3089,7 @@ export function TSRXPlugin(config) {
 							prevNonWhitespaceChar === CharCode.openBrace ||
 							prevNonWhitespaceChar === CharCode.greaterThan
 						) {
-							if (!isWhitespaceAfterLt) {
+							if (isTagLikeAfterLt) {
 								++this.pos;
 								return this.finishToken(tstt.jsxTagStart);
 							}
@@ -4136,6 +4126,16 @@ export function TSRXPlugin(config) {
 
 						case CharCode.lessThan:
 						case CharCode.openBrace:
+							// This path reads the children of an element nested in a `{ … }`
+							// expression container, where the raw-text intercept in `readToken`
+							// is off, so the literal-`<` rule has to be applied here too. Keep
+							// scanning rather than finishing the token: the `<` belongs to the
+							// text run, and finishing here would emit an empty text token when
+							// it is the run's first character.
+							if (ch === CharCode.lessThan && !can_start_tag_after_lt(this.input, this.pos)) {
+								++this.pos;
+								break;
+							}
 							if (out || this.pos > chunkStart) {
 								return this.finishToken(tstt.jsxText, out + this.input.slice(chunkStart, this.pos));
 							}
@@ -4629,10 +4629,13 @@ export function TSRXPlugin(config) {
 				} else if (this.type === tstt.jsxText) {
 					// A nested element with its own body can leak a JSX expression context,
 					// so the whitespace after its closing tag is mis-tokenized as a stale
-					// text token whose start was advanced onto the following `<`. Real JSX
-					// text never starts at `<`, so drop the leaked context and re-read the
-					// tag instead of emitting an empty node.
-					if (this.input.charCodeAt(this.start) === CharCode.lessThan) {
+					// text token whose start was advanced onto the following `<`. Text never
+					// starts at a `<` that can open a tag, so drop the leaked context and
+					// re-read the tag instead of emitting an empty node.
+					if (
+						this.input.charCodeAt(this.start) === CharCode.lessThan &&
+						can_start_tag_after_lt(this.input, this.start)
+					) {
 						if (this.#jsxExpressionContainerDepth > 0) {
 							// Inside a `{ … }` container the whole-stack counts below are
 							// blind: the enclosing template's `tc_expr` contexts sit on the

--- a/packages/tsrx/src/transform/jsx/helpers.js
+++ b/packages/tsrx/src/transform/jsx/helpers.js
@@ -152,6 +152,15 @@ export function tsx_with_ts_locations(boundary_tokens = false, comments = undefi
 			context.visit(value.body);
 		},
 
+		// TSRX text may contain a literal `<` — one that cannot start a tag
+		// (`<span><3</span>`) or a raw-text `<script>` body — but the printed TSX
+		// is re-parsed by a JSX toolchain (esbuild, Babel, SWC), and JSX forbids
+		// a bare `<` in text. Emit it as `&lt;`, which those parsers decode back
+		// to the same string.
+		JSXText: (node, context) => {
+			context.write(node.value.replace(/</g, '&lt;'), node);
+		},
+
 		// esrap's JSXOpeningElement printer doesn't emit `typeArguments`, so generic
 		// component tags like `<RenderProp<User>>` lose the `<User>` in the output.
 		JSXOpeningElement: (node, context) => {

--- a/packages/tsrx/tests/shared/compile.js
+++ b/packages/tsrx/tests/shared/compile.js
@@ -1968,6 +1968,30 @@ export function runSharedCompileTests({
 		});
 	});
 
+	describe(`[${name}] literal \`<\` in text`, () => {
+		// The TSRX parser reads a `<` that cannot start a tag as literal text
+		// (`<span><3</span>`), but the compiled output is re-parsed by a JSX
+		// toolchain (esbuild, Babel, SWC) that forbids a bare `<` in text, so the
+		// printer must emit it as `&lt;` — which decodes back to the same string.
+		it('escapes a literal `<` in text as `&lt;`', () => {
+			const { code } = compile(
+				`export function App() { return <span><3 and a < b</span>; }`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('<span>&lt;3 and a &lt; b</span>');
+		});
+
+		it('escapes `<` in a raw-text script body', () => {
+			const { code } = compile(
+				`export function App() { return <div><script>if (a < b) x();</script></div>; }`,
+				'App.tsrx',
+			);
+
+			expect(code).toContain('<script>if (a &lt; b) x();</script>');
+		});
+	});
+
 	describe(`[${name}] fragment expression children`, () => {
 		// A bare expression placed directly as a JSX child reads as JSX text
 		// (`<>{a}b</>` renders the letter "b"), so every expression that ends up

--- a/packages/tsrx/tests/utils/parser.test.js
+++ b/packages/tsrx/tests/utils/parser.test.js
@@ -4612,3 +4612,55 @@ describe('expression-container children inside JSX attribute values', () => {
 		expect(as_type(element.openingElement, 'JSXOpeningElement').selfClosing).toBe(true);
 	});
 });
+
+// A `<` in markup child position only opens a tag when the next character can
+// begin one. Anything else — a digit, an operator, an emoji, whitespace — is a
+// literal `<` in the text, the same rule the HTML tokenizer uses. Every case
+// below throws `Unexpected token` before this rule.
+describe('literal `<` in markup text', () => {
+	it('reads a `<` that cannot start a tag as text', () => {
+		for (const [label, source, text] of [
+			['digit', `function App() { return <span><3</span>; }`, '<3'],
+			['operator', `function App() { return <span><= arrow</span>; }`, '<= arrow'],
+			['non-ASCII', `function App() { return <span><\u{1F600}</span>; }`, '<\u{1F600}'],
+			['surrounding spaces', `function App() { return <span>a < b</span>; }`, 'a < b'],
+			['template body', `function App() @{ <span><3</span> }`, '<3'],
+		]) {
+			const span = findElement(source, 'span');
+
+			expect(
+				span.children.map((child) => child.type),
+				label,
+			).toEqual(['JSXText']);
+			expect(child(span, 0, 'JSXText').value, label).toBe(text);
+		}
+	});
+
+	it('keeps a literal `<` as text when a real tag follows it', () => {
+		const div = findElement(`function App() { return <div><3<span>x</span></div>; }`, 'div');
+
+		expect(div.children.map((child) => child.type)).toEqual(['JSXText', 'JSXElement']);
+		expect(child(div, 0, 'JSXText').value).toBe('<3');
+		expect(openingName(child(div, 1, 'JSXElement')).name).toBe('span');
+	});
+
+	// An element nested in a `{ … }` expression container reads its children
+	// through `jsx_readToken` rather than the raw-text token path, so the rule
+	// has to hold there too.
+	it('reads a `<` that cannot start a tag as text inside an expression container', () => {
+		for (const [label, source, text] of [
+			['digit', `function App() @{ <div>{<span><3</span>}</div> }`, '<3'],
+			['operator', `function App() @{ <div>{<span><= x</span>}</div> }`, '<= x'],
+			['surrounding spaces', `function App() @{ <div>{<span>a < b</span>}</div> }`, 'a < b'],
+			['JSX return', `function App() { return <div>{<span><3</span>}</div>; }`, '<3'],
+		]) {
+			const span = findElement(source, 'span');
+
+			expect(
+				span.children.map((child) => child.type),
+				label,
+			).toEqual(['JSXText']);
+			expect(child(span, 0, 'JSXText').value, label).toBe(text);
+		}
+	});
+});


### PR DESCRIPTION
`<span><3</span>` is a parse error today. This makes `<` in markup text open a tag only when the next character can start one (a letter, `/`, `>`, `{`, `@`, `$`, `_`), same as HTML. Anything else means the `<` is literal text.

```tsx
<span><3</span>    // before: Unexpected token    after: renders <3
<span>a < b</span> // before: Unexpected token    after: renders a < b
```

Strict superset: everything that parses today is unchanged, only former errors now parse. JSX and Babel also reject `<3`, so nothing relies on it.

The rule is one predicate, `can_start_tag_after_lt`, used at every `<` decision site. It existed inline in three places before; the diff is mostly deduplication.

One existing test asserted the old throw and now asserts the text content instead. That is the single behavior change to review.

10 new tests, full suite green, changeset included.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core tokenizer/parser paths for `<` across many contexts; behavior change is intentionally a strict superset but lexer edge cases around comparisons vs tags warrant careful review.
> 
> **Overview**
> **Parser behavior:** `<` in markup text only starts a tag when the next character can begin one (letters, `/`, `>`, `{`, `@`, `$`, `_`). Cases like `<span><3</span>` and `a < b` now parse as **JSX text** instead of `Unexpected token`. The rule is centralized in `can_start_tag_after_lt` and wired through raw-text scanning, template tokenization, `readToken` / `jsx_readToken`, and leaked-token recovery.
> 
> **Emit:** The TSX printer escapes literal `<` in `JSXText` (and raw `<script>` bodies) as `&lt;` so esbuild/Babel/SWC can re-parse compiled output.
> 
> Existing valid templates are unchanged; former parse errors become accepted input. One test flipped from expecting a throw to asserting text content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6a9630ee226c26cf8866716c7de9f59bb6fc21d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->