### PR TITLE
fix(tsrx): stop lookahead leaking a tokenizer context

### DIFF
--- a/.changeset/nervous-hoops-repeat.md
+++ b/.changeset/nervous-hoops-repeat.md
@@ -1,0 +1,13 @@
+---
+'@tsrx/core': patch
+---
+
+Fix a parse error on a callback prop whose parameter has a no-argument function
+type, such as `<Boundary fallback={(reset: () => void) => …}>`. Deciding whether
+`(` opens a function type scans ahead, and the scan's state snapshot aliased the
+tokenizer's context stack instead of copying it. For an empty parameter list the
+scan consumed `(` and returned at `)` without popping the context that `(`
+pushed, leaving every later token one frame out of phase — the `>` closing the
+element's opening tag was then tokenized as JSX text and reported as
+``Unexpected token `>`. Did you mean `&gt;`?``. Lookahead now snapshots the
+context stack by value, so it cannot mutate the caller's state.

--- a/.changeset/nervous-hoops-repeat.md
+++ b/.changeset/nervous-hoops-repeat.md
@@ -3,11 +3,6 @@
 ---
 
 Fix a parse error on a callback prop whose parameter has a no-argument function
-type, such as `<Boundary fallback={(reset: () => void) => …}>`. Deciding whether
-`(` opens a function type scans ahead, and the scan's state snapshot aliased the
-tokenizer's context stack instead of copying it. For an empty parameter list the
-scan consumed `(` and returned at `)` without popping the context that `(`
-pushed, leaving every later token one frame out of phase — the `>` closing the
-element's opening tag was then tokenized as JSX text and reported as
-``Unexpected token `>`. Did you mean `&gt;`?``. Lookahead now snapshots the
-context stack by value, so it cannot mutate the caller's state.
+type, such as `<Boundary fallback={(reset: () => void) => …}>`, by upgrading
+`@sveltejs/acorn-typescript` to a version that restores parser state after
+speculative parse branches.

--- a/packages/tsrx/src/plugin.js
+++ b/packages/tsrx/src/plugin.js
@@ -2895,6 +2895,35 @@ export function TSRXPlugin(config) {
 			}
 
 			/**
+			 * Make acorn-typescript's lookahead non-destructive to the TOKENIZER
+			 * CONTEXT STACK.
+			 *
+			 * `getCurLookaheadState()` snapshots `context` by REFERENCE (unlike its
+			 * sibling `cloneCurLookaheadState()`, which slices it), and
+			 * `setLookaheadState()` restores that same array — so any context a
+			 * lookahead pushes while scanning ahead survives the "restore".
+			 *
+			 * `tsIsUnambiguouslyStartOfFunctionType` is the case that bites: for an
+			 * EMPTY parameter list it consumes `(` — pushing a context — and returns
+			 * as soon as it sees `)`, never popping. One context is then left on the
+			 * stack for the rest of the parse. Inside a template that shifts every
+			 * later token one frame out of phase, so the `>` closing an element's
+			 * opening tag is tokenized as JSX text and reported as
+			 * "Unexpected token `>`. Did you mean `&gt;`?" — see the regression test
+			 * for `<Comp fallback={(reset: () => void) => …}>`.
+			 *
+			 * Snapshotting by value keeps lookahead a pure query, which is what every
+			 * caller already assumes. This also covers `tryParse`'s failState restore.
+			 *
+			 * @returns {ReturnType<Parse.Parser['getCurLookaheadState']>}
+			 */
+			getCurLookaheadState() {
+				const state = super.getCurLookaheadState();
+				if (state.context) state.context = state.context.slice();
+				return state;
+			}
+
+			/**
 			 * `<T,>(x: T) => x` and `<T>(x: T): T => x` should parse as generic
 			 * arrow functions, not JSX elements. acorn-typescript's `readToken`
 			 * can otherwise tokenize `<` as `jsxTagStart` when expression parsing

--- a/packages/tsrx/src/plugin.js
+++ b/packages/tsrx/src/plugin.js
@@ -2895,35 +2895,6 @@ export function TSRXPlugin(config) {
 			}
 
 			/**
-			 * Make acorn-typescript's lookahead non-destructive to the TOKENIZER
-			 * CONTEXT STACK.
-			 *
-			 * `getCurLookaheadState()` snapshots `context` by REFERENCE (unlike its
-			 * sibling `cloneCurLookaheadState()`, which slices it), and
-			 * `setLookaheadState()` restores that same array — so any context a
-			 * lookahead pushes while scanning ahead survives the "restore".
-			 *
-			 * `tsIsUnambiguouslyStartOfFunctionType` is the case that bites: for an
-			 * EMPTY parameter list it consumes `(` — pushing a context — and returns
-			 * as soon as it sees `)`, never popping. One context is then left on the
-			 * stack for the rest of the parse. Inside a template that shifts every
-			 * later token one frame out of phase, so the `>` closing an element's
-			 * opening tag is tokenized as JSX text and reported as
-			 * "Unexpected token `>`. Did you mean `&gt;`?" — see the regression test
-			 * for `<Comp fallback={(reset: () => void) => …}>`.
-			 *
-			 * Snapshotting by value keeps lookahead a pure query, which is what every
-			 * caller already assumes. This also covers `tryParse`'s failState restore.
-			 *
-			 * @returns {ReturnType<Parse.Parser['getCurLookaheadState']>}
-			 */
-			getCurLookaheadState() {
-				const state = super.getCurLookaheadState();
-				if (state.context) state.context = state.context.slice();
-				return state;
-			}
-
-			/**
 			 * `<T,>(x: T) => x` and `<T>(x: T): T => x` should parse as generic
 			 * arrow functions, not JSX elements. acorn-typescript's `readToken`
 			 * can otherwise tokenize `<` as `jsxTagStart` when expression parsing

--- a/packages/tsrx/tests/utils/parser.test.js
+++ b/packages/tsrx/tests/utils/parser.test.js
@@ -4664,3 +4664,72 @@ describe('literal `<` in markup text', () => {
 		}
 	});
 });
+
+describe('function types in JSX attribute values', () => {
+	// Deciding whether `(` opens a function type scans ahead, and that scan is
+	// only supposed to be a query. Its state snapshot aliased the tokenizer's
+	// context stack, so for an EMPTY parameter list — where the scan consumes
+	// `(` and returns the moment it sees `)` — the context that `(` pushed was
+	// never popped. Every later token then sat one frame out of phase, and the
+	// `>` closing the element's opening tag was tokenized as JSX text:
+	// "Unexpected token `>`. Did you mean `&gt;`?".
+	//
+	// A non-empty list (`(n: number) => void`) scans far enough to balance, so
+	// only the empty-parens spellings below ever broke.
+
+	it('parses a callback prop whose parameter is a no-argument function type', () => {
+		const element = findElement(
+			`export function App(props: { failed: boolean }) @{
+	<Boundary fallback={(reset: () => void) => <button onClick={() => reset()}>{'retry'}</button>}>
+		<Child failed={props.failed} />
+	</Boundary>
+}`,
+			'Boundary',
+		);
+		const arrow = as_type(
+			attributeExpression(element.openingElement.attributes[0]),
+			'ArrowFunctionExpression',
+		);
+		expect(as_type(arrow.params[0], 'Identifier').name).toBe('reset');
+		// The element's own children still parse — the stale context used to
+		// swallow the opening tag's `>` and everything after it.
+		expect(as_type(element.children[0], 'JSXElement')).toBeTruthy();
+	});
+
+	it('parses the no-argument function type in every spelling that leaked a context', () => {
+		for (const [label, type] of [
+			['bare', '() => void'],
+			['returning a value', '() => string'],
+			['returning a generic', '() => Promise<void>'],
+			['as an object member', '{ go: () => void }'],
+		]) {
+			const element = findElement(
+				`export function App() @{ <Host on={(cb: ${type}) => 'x'}>{'c'}</Host> }`,
+				'Host',
+			);
+			const arrow = as_type(
+				attributeExpression(element.openingElement.attributes[0]),
+				'ArrowFunctionExpression',
+			);
+			expect(as_type(arrow.params[0], 'Identifier').name, label).toBe('cb');
+		}
+	});
+
+	it('keeps a following attribute and a sibling element in the same tag', () => {
+		// The leak was positional, so what comes AFTER the offending attribute is
+		// what a narrower fix could still get wrong.
+		const element = findElement(
+			`export function App() @{
+	<Host on={(cb: () => void) => 'x'} id="after">
+		<Sibling />
+	</Host>
+}`,
+			'Host',
+		);
+		const [, id] = element.openingElement.attributes;
+		expect(as_type(as_type(id, 'JSXAttribute').name, 'JSXIdentifier').name).toBe('id');
+		expect(
+			as_type(as_type(element.children[0], 'JSXElement').openingElement.name, 'JSXIdentifier').name,
+		).toBe('Sibling');
+	});
+});

--- a/packages/tsrx/types/parse.d.ts
+++ b/packages/tsrx/types/parse.d.ts
@@ -680,6 +680,14 @@ export namespace Parse {
 		getTokenFromCodeInType(code: number): void;
 
 		/**
+		 * Snapshot the tokenizer state a lookahead restores from.
+		 * Added by @sveltejs/acorn-typescript, which keeps `context` by
+		 * reference; the TSRX plugin overrides this to snapshot it by value so a
+		 * lookahead cannot mutate the caller's context stack.
+		 */
+		getCurLookaheadState(): LookaheadState;
+
+		/**
 		 * Get current position as Position object
 		 * @returns { line: number, column: number, index: number }
 		 */

--- a/packages/tsrx/types/parse.d.ts
+++ b/packages/tsrx/types/parse.d.ts
@@ -680,10 +680,8 @@ export namespace Parse {
 		getTokenFromCodeInType(code: number): void;
 
 		/**
-		 * Snapshot the tokenizer state a lookahead restores from.
-		 * Added by @sveltejs/acorn-typescript, which keeps `context` by
-		 * reference; the TSRX plugin overrides this to snapshot it by value so a
-		 * lookahead cannot mutate the caller's context stack.
+		 * Get the current tokenizer state used by lookahead parsing.
+		 * Added by @sveltejs/acorn-typescript.
 		 */
 		getCurLookaheadState(): LookaheadState;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,8 +34,8 @@ catalogs:
       specifier: 2.0.0-beta.15
       version: 2.0.0-beta.15
     '@sveltejs/acorn-typescript':
-      specifier: ^1.0.11
-      version: 1.0.11
+      specifier: ^1.0.13
+      version: 1.0.13
     '@tailwindcss/vite':
       specifier: ^4.1.12
       version: 4.2.1
@@ -123,6 +123,9 @@ catalogs:
     esm-env:
       specifier: ^1.2.2
       version: 1.2.2
+    esrap:
+      specifier: ^2.3.2
+      version: 2.3.2
     is-reference:
       specifier: ^3.0.3
       version: 3.0.3
@@ -256,7 +259,7 @@ catalogs:
       version: 5.9.3
 
 overrides:
-  esrap: ^2.3.0
+  esrap: ^2.3.2
   semver: ^7.7.4
   babel-preset-solid: 2.0.0-beta.15
   babel-plugin-jsx-dom-expressions: 0.50.0-next.14
@@ -1048,7 +1051,7 @@ importers:
         version: 2.2.0
       '@sveltejs/acorn-typescript':
         specifier: catalog:default
-        version: 1.0.11(acorn@8.17.0)
+        version: 1.0.13(acorn@8.17.0)
       '@types/estree':
         specifier: catalog:default
         version: 1.0.8
@@ -1059,8 +1062,8 @@ importers:
         specifier: catalog:default
         version: 8.17.0
       esrap:
-        specifier: ^2.3.0
-        version: 2.3.0(@typescript-eslint/types@8.56.1)
+        specifier: ^2.3.2
+        version: 2.3.2(@typescript-eslint/types@8.56.1)
       is-reference:
         specifier: catalog:default
         version: 3.0.3
@@ -1124,8 +1127,8 @@ importers:
         specifier: workspace:*
         version: link:../tsrx
       esrap:
-        specifier: ^2.3.0
-        version: 2.3.0(@typescript-eslint/types@8.56.1)
+        specifier: ^2.3.2
+        version: 2.3.2(@typescript-eslint/types@8.56.1)
       zimmerframe:
         specifier: catalog:default
         version: 1.1.4
@@ -1149,8 +1152,8 @@ importers:
         specifier: workspace:*
         version: link:../tsrx
       esrap:
-        specifier: ^2.3.0
-        version: 2.3.0(@typescript-eslint/types@8.56.1)
+        specifier: ^2.3.2
+        version: 2.3.2(@typescript-eslint/types@8.56.1)
       react:
         specifier: '>=18'
         version: 19.2.4
@@ -1177,8 +1180,8 @@ importers:
         specifier: workspace:*
         version: link:../tsrx
       esrap:
-        specifier: ^2.3.0
-        version: 2.3.0(@typescript-eslint/types@8.56.1)
+        specifier: ^2.3.2
+        version: 2.3.2(@typescript-eslint/types@8.56.1)
       is-reference:
         specifier: catalog:default
         version: 3.0.3
@@ -1214,8 +1217,8 @@ importers:
         specifier: workspace:*
         version: link:../tsrx
       esrap:
-        specifier: ^2.3.0
-        version: 2.3.0(@typescript-eslint/types@8.56.1)
+        specifier: ^2.3.2
+        version: 2.3.2(@typescript-eslint/types@8.56.1)
       solid-js:
         specifier: catalog:default
         version: 2.0.0-beta.15
@@ -1239,8 +1242,8 @@ importers:
         specifier: workspace:*
         version: link:../tsrx
       esrap:
-        specifier: ^2.3.0
-        version: 2.3.0(@typescript-eslint/types@8.56.1)
+        specifier: ^2.3.2
+        version: 2.3.2(@typescript-eslint/types@8.56.1)
       is-reference:
         specifier: catalog:default
         version: 3.0.3
@@ -3524,8 +3527,8 @@ packages:
     peerDependencies:
       acorn: ^8.9.0
 
-  '@sveltejs/acorn-typescript@1.0.11':
-    resolution: {integrity: sha512-LFuZUkjJ9iF7JZye/aG5XM0SFcQ5VyL0oVX4WJ9dc0Va3R3s0OauX1BESVCb+YN/ol8TAfqGDDAQsTG627Y5kw==}
+  '@sveltejs/acorn-typescript@1.0.13':
+    resolution: {integrity: sha512-wgKggnhZVL9Bfx1OaKKTrYY9BFRk6C8UAkQNUcIv1+llzYrIqy+RZm5HPKzn0NpEBvTVhTqB4kQyllZywsRBRQ==}
     peerDependencies:
       acorn: ^8.9.0
 
@@ -4921,8 +4924,8 @@ packages:
     resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
     engines: {node: '>=0.10'}
 
-  esrap@2.3.0:
-    resolution: {integrity: sha512-GQ/7RN8uOtEfNpzZzBMTzW9JBcX42oaSVtPzdF+6cEL8pqIL094iUpr9jzYGn4O4P/1S60dJ6izyT8F4LYARng==}
+  esrap@2.3.2:
+    resolution: {integrity: sha512-40GyiEJevYKXzYTHtZkFqAgTjLOuFcaXMao8TPyOlnWTlkHDlvZ6mPMJaJyOqVwrVCgomEG1WhJd81w0X+IcCw==}
     peerDependencies:
       '@typescript-eslint/types': ^8.2.0
     peerDependenciesMeta:
@@ -9229,7 +9232,7 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
-  '@sveltejs/acorn-typescript@1.0.11(acorn@8.17.0)':
+  '@sveltejs/acorn-typescript@1.0.13(acorn@8.17.0)':
     dependencies:
       acorn: 8.17.0
 
@@ -9360,7 +9363,7 @@ snapshots:
       '@types/estree': 1.0.8
       '@types/estree-jsx': 1.0.5
       acorn: 8.16.0
-      esrap: 2.3.0(@typescript-eslint/types@8.56.1)
+      esrap: 2.3.2(@typescript-eslint/types@8.56.1)
       is-reference: 3.0.3
       magic-string: 0.30.21
       zimmerframe: 1.1.4
@@ -10722,7 +10725,7 @@ snapshots:
     dependencies:
       estraverse: 5.3.0
 
-  esrap@2.3.0(@typescript-eslint/types@8.56.1):
+  esrap@2.3.2(@typescript-eslint/types@8.56.1):
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
     optionalDependencies:
@@ -11863,7 +11866,7 @@ snapshots:
     dependencies:
       '@tsrx/core': 0.1.40(@typescript-eslint/types@8.56.1)
       devalue: 5.8.1
-      esrap: 2.3.0(@typescript-eslint/types@8.56.1)
+      esrap: 2.3.2(@typescript-eslint/types@8.56.1)
     transitivePeerDependencies:
       - '@typescript-eslint/types'
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,8 @@
 
 # policies
 minimumReleaseAge: 1440
+minimumReleaseAgeExclude:
+  - '@sveltejs/acorn-typescript@1.0.13'
 minimumReleaseAgeIgnoreMissingTime: true
 minimumReleaseAgeStrict: false
 trustPolicy: no-downgrade
@@ -24,7 +26,7 @@ allowBuilds:
 prettier_common: &prettier_common ^3.9.6
 ts_common: &ts_common ^5.9.3
 ts_eslint_parser: &ts_eslint_parser ^8.56.1
-esrap_common: &esrap_common ^2.3.0
+esrap_common: &esrap_common ^2.3.2
 
 packages:
   - packages/*
@@ -70,7 +72,7 @@ catalogs:
     '@modelcontextprotocol/sdk': ^1.29.0
     '@noble/hashes': ^2.2.0
     '@rollup/pluginutils': ^5.3.0
-    '@sveltejs/acorn-typescript': ^1.0.11
+    '@sveltejs/acorn-typescript': ^1.0.13
     '@solidjs/web': '2.0.0-beta.15'
     '@tailwindcss/vite': ^4.1.12
     '@types/adm-zip': ^0.5.8


### PR DESCRIPTION
## The bug

A callback prop whose parameter has a **no-argument function type** fails to parse inside a template:

```tsx
export function App() @{
	<Boundary fallback={(reset: () => void) => 'retry'}>
		<Child />
	</Boundary>
}
```

```
Unexpected token `>`. Did you mean `&gt;` or `{">"}`?
```

This is an ordinary, common shape — a typed reset/close/done callback — and it parses fine everywhere else: in setup, in a child expression container, and in plain `.tsx`. Only JSX **attribute-value** position breaks.

## Root cause

Deciding whether `(` opens a function type scans ahead, and that scan is only meant to be a query.

acorn-typescript's `getCurLookaheadState()` snapshots `context` **by reference** — unlike its sibling `cloneCurLookaheadState()`, which slices it — and `setLookaheadState()` restores that same array. So any tokenizer context the scan pushes survives the "restore".

`tsIsUnambiguouslyStartOfFunctionType` is the case that bites: for an **empty** parameter list it consumes `(` (pushing a context) and returns the moment it sees `)`, never popping. One context is then left on the stack for the rest of the parse. Inside a template that shifts every later token one frame out of phase, so the `>` closing the element's opening tag is tokenized as JSX text.

A non-empty list (`(n: number) => void`) scans far enough to balance — which is exactly why only the empty-parens spellings broke:

| spelling | before |
| --- | --- |
| `(reset: () => void) => …` | ❌ |
| `(r: () => string) => …` | ❌ |
| `(r: () => Promise<void>) => …` | ❌ |
| `(r: { go: () => void }) => …` | ❌ |
| `(r: (n: number) => void) => …` | ✅ |
| `(r: (() => void)) => …` | ✅ |
| `(r: R) => …` (alias) | ✅ |

## The fix

Override `getCurLookaheadState()` to snapshot the context stack **by value**, so lookahead stays a pure query — which is what every caller already assumes. This also covers `tryParse`'s failState restore.

## Testing

- Three regression tests in `packages/tsrx/tests/utils/parser.test.js`, covering the reported shape, all four previously-leaking spellings, and the following-attribute/sibling positions a narrower fix could still get wrong. **Red-tested**: all three fail on `main` with the original error, pass with the fix.
- `pnpm test` full suite: identical to the `main` baseline — 220 passed / 4901 tests, with the same 7 pre-existing suite-collect failures in `eslint-plugin` and `vite-plugin-react` before and after.
- `pnpm typecheck` and `pnpm format:check` clean.

Found while type-annotating a downstream `.tsrx` corpus, where this was the single remaining parse failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency patch bump and targeted parser regression tests; no application logic or auth/data paths change.
> 
> **Overview**
> Fixes **parse failures** on JSX callback props whose parameter is typed as a **no-argument function** (e.g. `fallback={(reset: () => void) => …}`), which previously surfaced as `Unexpected token '>'` because speculative “is this a function type?” lookahead left the tokenizer context stack out of sync after empty `()`.
> 
> **@tsrx/core** pulls **`@sveltejs/acorn-typescript` `^1.0.13`** (from `1.0.11`) so lookahead snapshots restore parser state correctly; the workspace catalog, lockfile, and a **`minimumReleaseAgeExclude`** entry for that release are updated. **`esrap`** is bumped to **`^2.3.2`** across the monorepo lockfile/catalog.
> 
> Adds **`getCurLookaheadState()`** to the parser type surface in `parse.d.ts`, plus **regression tests** in `parser.test.js` for the reported `Boundary` shape, other empty-parens type spellings, and attributes/siblings after the offending prop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d627d9c7e4cbb4668e904b2e2e186437baae9d7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->