### PR TITLE
fix(compiler): preserve virtual declaration metadata

### DIFF
--- a/.changeset/calm-rivers-document.md
+++ b/.changeset/calm-rivers-document.md
@@ -1,0 +1,5 @@
+---
+'@tsrx/core': patch
+---
+
+Preserve declaration documentation and annotations in virtual TSX, and map complete export and property-signature ranges for declaration tooling.

--- a/packages/tsrx/package.json
+++ b/packages/tsrx/package.json
@@ -85,6 +85,7 @@
     "@types/node": "catalog:default",
     "@typescript-eslint/types": "catalog:default",
     "@volar/language-core": "catalog:default",
+    "@volar/source-map": "catalog:default",
     "typescript": "catalog:default",
     "vite": "catalog:default",
     "vscode-languageserver-types": "catalog:default"

--- a/packages/tsrx/src/comment-utils.js
+++ b/packages/tsrx/src/comment-utils.js
@@ -30,16 +30,21 @@ export function is_triple_slash_directive(comment) {
 }
 
 /**
+ * @param {AST.CommentWithLocation} comment
+ * @returns {boolean}
+ */
+export function is_jsdoc_comment(comment) {
+	return comment.type === 'Block' && comment.value.startsWith('*');
+}
+
+/**
  * Check if a comment is a JSDoc comment with TypeScript annotations
  * Examples: block comments containing `@type`, `@typedef`, `@param`, `@returns`, etc.
  * @param {AST.CommentWithLocation} comment
  * @returns {boolean}
  */
 export function is_jsdoc_ts_annotation(comment) {
-	if (comment.type !== 'Block') return false;
-
-	// JSDoc comments start with /** which means the value starts with * after /* is stripped
-	if (!comment.value.startsWith('*')) return false;
+	if (!is_jsdoc_comment(comment)) return false;
 
 	// Check if it contains TypeScript-relevant tags
 	const tsAnnotations = [
@@ -81,6 +86,36 @@ export function should_preserve_comment(comment) {
 		is_triple_slash_directive(comment) ||
 		is_jsdoc_ts_annotation(comment) ||
 		is_jsx_pragma(comment)
+	);
+}
+
+/**
+ * Declaration generators also consume documentation and custom `// @...`
+ * annotations from JSX-backed virtual TypeScript. Keep this broader policy
+ * separate from the legacy to_ts printer's semantic-comment policy.
+ * @param {AST.CommentWithLocation} comment
+ * @returns {boolean}
+ */
+export function should_preserve_jsx_tooling_comment(comment) {
+	return (
+		should_preserve_comment(comment) ||
+		is_jsdoc_comment(comment) ||
+		(comment.type === 'Line' && comment.value.trimStart().startsWith('@'))
+	);
+}
+
+/**
+ * Only file-wide directives may move ahead of generated imports or hoists.
+ * In particular, @ts-ignore/@ts-expect-error and declaration JSDoc must stay
+ * with the statement they describe.
+ * @param {AST.CommentWithLocation} comment
+ * @returns {boolean}
+ */
+export function is_file_level_pragma(comment) {
+	return (
+		is_jsx_pragma(comment) ||
+		is_triple_slash_directive(comment) ||
+		(comment.type === 'Line' && /^\s*@ts-(?:no)?check\b/.test(comment.value))
 	);
 }
 

--- a/packages/tsrx/src/transform/jsx/helpers.js
+++ b/packages/tsrx/src/transform/jsx/helpers.js
@@ -2,7 +2,13 @@
 /** @import * as ESRap from 'esrap' */
 
 import tsx from 'esrap/languages/tsx';
-import { should_preserve_comment, format_comment } from '../../comment-utils.js';
+import {
+	should_preserve_comment,
+	should_preserve_jsx_tooling_comment,
+	is_file_level_pragma,
+	format_comment,
+} from '../../comment-utils.js';
+import { has_location } from '../../utils/ast.js';
 import { with_deferred_imports } from '../imports.js';
 
 /**
@@ -69,25 +75,64 @@ export function set_node_path_metadata(node, path) {
  * (structural tokens carry one-character source locations). typeOnly/volar
  * prints opt in — their maps are consumed positionally by the language
  * tooling and never shipped; build prints stay sparse.
- * @param {AST.CommentWithLocation[]} [comments] Source comments; the ones
- * `should_preserve_comment` classifies as semantic-to-TS (`@ts-nocheck`,
- * `@jsxImportSource`, triple-slash references, …) and that LEAD the program
- * are re-emitted at the top of the printed output. The generated TSX is real
- * TS input — dropping a leading pragma changes how the whole file checks.
+ * @param {AST.CommentWithLocation[]} [comments] Source comments. In type-only
+ * output, file-wide pragmas lead the program while documentation and scoped
+ * annotations stay with their declarations, members, or statements. A sparse
+ * print with explicitly supplied comments retains its existing leading-pragma
+ * behavior. Ordinary build callers supply no comments.
  */
 export function tsx_with_ts_locations(boundary_tokens = false, comments = undefined) {
 	const base = with_deferred_imports(tsx({ boundaryTokens: boundary_tokens }));
 	const { _: base_visitor, ...base_visitors } = base;
+	const preserve_comments = comments !== undefined;
+	const preserve_owner_comments = boundary_tokens && preserve_comments;
+	/** @type {Set<string> | null} */
+	const emitted_comments = preserve_comments ? new Set() : null;
+
+	/**
+	 * @param {AST.CommentWithLocation} comment
+	 * @param {ESRap.Context} context
+	 */
+	const write_preserved_comment = (comment, context) => {
+		if (
+			!emitted_comments ||
+			!(preserve_owner_comments
+				? should_preserve_jsx_tooling_comment(comment)
+				: should_preserve_comment(comment))
+		) {
+			return;
+		}
+		const key = `${comment.start}:${comment.end}:${comment.type}:${comment.value}`;
+		if (emitted_comments.has(key)) return;
+		emitted_comments.add(key);
+		if (comment.loc) context.location(comment.loc.start.line, comment.loc.start.column);
+		context.write(format_comment(comment));
+		if (comment.loc) context.location(comment.loc.end.line, comment.loc.end.column);
+		context.newline();
+	};
+
+	/**
+	 * @param {AST.Node} node
+	 * @param {ESRap.Context} context
+	 */
+	const write_leading_comments = (node, context) => {
+		if (!node.leadingComments || !is_comment_owner(node)) return;
+		for (const comment of node.leadingComments) {
+			if (has_location(comment)) write_preserved_comment(comment, context);
+		}
+	};
 
 	const leading_preserved = (/** @type {AST.Program} */ program) => {
-		if (!comments?.length) return [];
+		if (!preserve_comments || !comments?.length) return [];
 		// Injected statements (dynamic-import/try-import prepends) carry no
 		// loc; anchor "leading" on the first statement that maps to source,
 		// else every preserved comment in the file would hoist to the top.
 		const first = program.body.find((node) => node.loc);
 		return comments.filter(
 			(comment) =>
-				should_preserve_comment(comment) &&
+				(preserve_owner_comments
+					? is_file_level_pragma(comment)
+					: should_preserve_comment(comment)) &&
 				(first?.loc == null ||
 					(comment.loc &&
 						(comment.loc.end.line < first.loc.start.line ||
@@ -100,10 +145,7 @@ export function tsx_with_ts_locations(boundary_tokens = false, comments = undefi
 	const wrappers = {
 		Program: (node, context) => {
 			for (const comment of leading_preserved(node)) {
-				if (comment.loc) context.location(comment.loc.start.line, comment.loc.start.column);
-				context.write(format_comment(comment));
-				if (comment.loc) context.location(comment.loc.end.line, comment.loc.end.column);
-				context.newline();
+				write_preserved_comment(comment, context);
 			}
 			/** @type {NonNullable<typeof base.Program>} */ (base.Program)(node, context);
 		},
@@ -206,8 +248,13 @@ export function tsx_with_ts_locations(boundary_tokens = false, comments = undefi
 			context.visit(node.body);
 		},
 		_(node, context, visit) {
+			if (preserve_owner_comments) write_leading_comments(node, context);
 			const visit_with_locations = () => {
-				if (!LOCATION_WRAPPED_NODE_TYPES.has(node.type) || !node.loc) {
+				if (
+					!node.loc ||
+					(!LOCATION_WRAPPED_NODE_TYPES.has(node.type) &&
+						!(boundary_tokens && TOOLING_LOCATION_WRAPPED_NODE_TYPES.has(node.type)))
+				) {
 					visit(node);
 					return;
 				}
@@ -225,6 +272,44 @@ export function tsx_with_ts_locations(boundary_tokens = false, comments = undefi
 
 	return { ...base_visitors, ...wrappers };
 }
+
+/**
+ * A newline is safe before a statement/declaration or a member, but not before
+ * an arbitrary expression: `return /** @type {number} *\/ 1` must not become a
+ * bare return, and `throw` forbids a line terminator before its argument.
+ * @param {AST.Node} node
+ * @returns {boolean}
+ */
+function is_comment_owner(node) {
+	return (
+		node.type.endsWith('Declaration') ||
+		node.type.endsWith('Statement') ||
+		COMMENT_OWNER_NODE_TYPES.has(node.type)
+	);
+}
+
+const COMMENT_OWNER_NODE_TYPES = new Set([
+	'VariableDeclarator',
+	'Property',
+	'PropertyDefinition',
+	'AccessorProperty',
+	'MethodDefinition',
+	'TSAbstractPropertyDefinition',
+	'TSAbstractAccessorProperty',
+	'TSAbstractMethodDefinition',
+	'TSPropertySignature',
+	'TSMethodSignature',
+	'TSIndexSignature',
+	'TSEnumMember',
+	'TSExportAssignment',
+]);
+
+const TOOLING_LOCATION_WRAPPED_NODE_TYPES = new Set([
+	'ExportNamedDeclaration',
+	'ExportDefaultDeclaration',
+	'ExportAllDeclaration',
+	'TSPropertySignature',
+]);
 
 // Be careful when adding visitors that are already defined in `wrappers`.
 // JSXOpeningElement is intentionally in both places: its custom printer still

--- a/packages/tsrx/src/transform/segments.js
+++ b/packages/tsrx/src/transform/segments.js
@@ -34,11 +34,19 @@ import {
 	build_line_offsets,
 	get_mapping_from_node,
 } from '../source-map-utils.js';
-import { should_preserve_comment } from '../comment-utils.js';
+import { should_preserve_jsx_tooling_comment, format_comment } from '../comment-utils.js';
 import { has_location } from '../utils/ast.js';
 
 const LAZY_PARAM_IDENTIFIER_REGEX = /^__lazy\d+$/;
 const RETURN_KEYWORD = 'return';
+const EXPORT_KEYWORD = 'export';
+const BLOCK_DECLARATION_TYPES = new Set([
+	'FunctionDeclaration',
+	'ClassDeclaration',
+	'TSInterfaceDeclaration',
+	'TSEnumDeclaration',
+	'TSModuleDeclaration',
+]);
 
 /**
  * @param {string} value
@@ -419,6 +427,88 @@ export function convert_source_map_to_mappings(
 	}
 
 	/**
+	 * A comment's end can share a source coordinate with the next declaration,
+	 * and synthetic file pragmas can share offset zero with the first export.
+	 * Select the position that actually prints this node's opening text instead
+	 * of treating the first source-map entry as an unambiguous boundary.
+	 * @param {AST.Position} position
+	 * @param {string} text
+	 * @returns {number | undefined}
+	 */
+	function generated_offset_for_text(position, text) {
+		const positions = src_to_gen_map.get(`${position.line}:${position.column}`);
+		for (const generated of positions ?? []) {
+			const offset = loc_to_offset(generated.line, generated.column, gen_line_offsets);
+			if (generated_code.startsWith(text, offset)) return offset;
+		}
+	}
+
+	/**
+	 * @param {AST.NodeWithLocation} node
+	 * @param {string} start_text
+	 * @returns {CodeMapping | undefined}
+	 */
+	function declaration_mapping(node, start_text) {
+		const start = generated_offset_for_text(node.loc.start, start_text);
+		if (start === undefined) return;
+		const positions = src_to_gen_map.get(`${node.loc.end.line}:${node.loc.end.column}`);
+		for (const generated of positions ?? []) {
+			const end = loc_to_offset(generated.line, generated.column, gen_line_offsets);
+			if (end < start) continue;
+			return {
+				sourceOffsets: [node.start],
+				lengths: [node.end - node.start],
+				generatedOffsets: [start],
+				generatedLengths: [end - start],
+				data: { ...mapping_data_verify_only, customData: {} },
+			};
+		}
+	}
+
+	/** @param {AST.ExportNamedDeclaration | AST.ExportDefaultDeclaration | AST.ExportAllDeclaration} node */
+	function add_export_mapping(node) {
+		if (!has_location(node)) return;
+		const mapping = declaration_mapping(node, EXPORT_KEYWORD);
+		if (mapping) {
+			const declaration = node.type === 'ExportAllDeclaration' ? null : node.declaration;
+			const end = mapping.generatedOffsets[0] + mapping.generatedLengths[0];
+			// A semicolon-free source declaration shares its end with its last
+			// expression. The first map entry then precedes the statement's emitted
+			// semicolon. Block declarations are different: a following `;` is an
+			// empty statement, not part of TypeScript's declaration range.
+			if (
+				generated_code[end] === ';' &&
+				(!declaration || !BLOCK_DECLARATION_TYPES.has(declaration.type))
+			) {
+				mapping.generatedLengths[0]++;
+			}
+			// Full declaration queries need both endpoints in the same Volar
+			// mapping, not a linear claim over the generated body. A transformed
+			// component can contain synthetic imports, tags, and helper calls that
+			// must not acquire source locations merely because it is exported.
+			const generated_start = mapping.generatedOffsets[0];
+			const generated_end = generated_start + mapping.generatedLengths[0];
+			mapping.sourceOffsets = [node.start, node.end];
+			mapping.generatedOffsets = [generated_start, generated_end];
+			mapping.lengths = [0, 0];
+			mapping.generatedLengths = [0, 0];
+			mappings.push(mapping);
+		}
+		tokens.push({
+			source: EXPORT_KEYWORD,
+			generated: EXPORT_KEYWORD,
+			loc: {
+				start: node.loc.start,
+				end: {
+					line: node.loc.start.line,
+					column: node.loc.start.column + EXPORT_KEYWORD.length,
+				},
+			},
+			metadata: {},
+		});
+	}
+
+	/**
 	 * Needed for a mapping that includes the computed brackets for diagnostics
 	 * @param {AST.MethodDefinition | AST.Property} node
 	 * @param {CodeMapping[]} mappings
@@ -464,25 +554,24 @@ export function convert_source_map_to_mappings(
 			if (!Array.isArray(comments)) continue;
 
 			for (const comment of comments) {
-				if (!has_location(comment) || !should_preserve_comment(comment)) continue;
+				if (!has_location(comment) || !should_preserve_jsx_tooling_comment(comment)) continue;
 
 				const comment_key = `${comment.start}:${comment.end}`;
 				if (mapped_comments.has(comment_key)) continue;
 				mapped_comments.add(comment_key);
 
-				try {
-					mappings.push(
-						get_mapping_from_node(
-							comment,
-							src_to_gen_map,
-							gen_line_offsets,
-							mapping_data_verify_only,
-						),
-					);
-				} catch {
-					// Comments that were not emitted in generated TSX have no source-map
-					// segment. They should not produce Volar mappings.
-				}
+				const text = format_comment(comment);
+				const start = generated_offset_for_text(comment.loc.start, text);
+				// A stripped or moved comment must not claim another node's shared
+				// source coordinate. The printer writes this exact formatted text.
+				if (start === undefined) continue;
+				mappings.push({
+					sourceOffsets: [comment.start],
+					lengths: [comment.end - comment.start],
+					generatedOffsets: [start],
+					generatedLengths: [text.length],
+					data: { ...mapping_data_verify_only, customData: {} },
+				});
 			}
 		}
 	}
@@ -704,6 +793,7 @@ export function convert_source_map_to_mappings(
 				}
 				return;
 			} else if (node.type === 'ExportNamedDeclaration') {
+				add_export_mapping(node);
 				if (node.specifiers && node.specifiers.length > 0) {
 					for (const specifier of node.specifiers) {
 						visit(specifier);
@@ -715,12 +805,14 @@ export function convert_source_map_to_mappings(
 				}
 				return;
 			} else if (node.type === 'ExportDefaultDeclaration') {
+				add_export_mapping(node);
 				// Visit the declaration
 				if (node.declaration) {
 					visit(/** @type {AST.Node} */ (node.declaration));
 				}
 				return;
 			} else if (node.type === 'ExportAllDeclaration') {
+				add_export_mapping(node);
 				// Nothing to visit (just source string)
 				return;
 			} else if (node.type === 'JSXOpeningElement') {
@@ -1908,6 +2000,24 @@ export function convert_source_map_to_mappings(
 				}
 				return;
 			} else if (node.type === 'TSPropertySignature') {
+				if (has_location(node)) {
+					const start_text = node.readonly
+						? 'readonly'
+						: node.computed
+							? '['
+							: node.key.type === 'Identifier'
+								? node.key.name
+								: source.slice(node.start, node.key.end);
+					const mapping = declaration_mapping(node, start_text);
+					if (mapping) {
+						const end = mapping.generatedOffsets[0] + mapping.generatedLengths[0];
+						// esrap's containing type/interface prints member separators
+						// after the property's own end marker. TS includes that `;`
+						// in its PropertySignature range, even when it was not authored.
+						if (generated_code[end] === ';') mapping.generatedLengths[0]++;
+						mappings.push(mapping);
+					}
+				}
 				// Property signature in type
 				if (node.key) {
 					visit(node.key);
@@ -2354,7 +2464,11 @@ export function convert_source_map_to_mappings(
 
 	// Add a mapping for the very beginning of the file to handle import additions
 	// This ensures that code actions adding imports at the top work correctly
-	if (!isImportDeclarationPresent && mappings.length > 0 && mappings[0].sourceOffsets[0] > 0) {
+	if (
+		!isImportDeclarationPresent &&
+		mappings.length > 0 &&
+		(mappings[0].sourceOffsets[0] > 0 || mappings[0].generatedOffsets[0] > 0)
+	) {
 		mappings.unshift({
 			sourceOffsets: [0],
 			generatedOffsets: [0],

--- a/packages/tsrx/tests/utils/declaration-metadata-mapping.test.js
+++ b/packages/tsrx/tests/utils/declaration-metadata-mapping.test.js
@@ -1,0 +1,259 @@
+/** @import * as AST from 'estree' */
+/** @import { CompileError, JsxPlatform } from '../../types/index' */
+
+import { SourceMap } from '@volar/source-map';
+import ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+import { createJsxTransform, createVolarMappingsResult, parseModule } from '../../src/index.js';
+
+/** @type {JsxPlatform} */
+const PLATFORM = {
+	name: 'declaration-metadata-test',
+	imports: {
+		fragment: 'test-platform',
+		suspense: 'test-platform',
+		dynamic: 'test-platform/dynamic',
+		errorBoundary: 'test-platform/error-boundary',
+	},
+	jsx: { rewriteClassAttr: false, classAttrName: 'class' },
+	validation: { requireUseServerForAwait: false },
+};
+
+/** @param {string} source */
+function compile_to_volar_mappings(source) {
+	/** @type {CompileError[]} */
+	const errors = [];
+	/** @type {AST.CommentWithLocation[]} */
+	const comments = [];
+	const ast = parseModule(source, 'App.tsrx', {
+		collect: true,
+		loose: true,
+		preserveParens: true,
+		keywordTokens: true,
+		errors,
+		comments,
+	});
+	const transformed = createJsxTransform(PLATFORM)(ast, source, 'App.tsrx', {
+		collect: true,
+		loose: true,
+		typeOnly: true,
+		errors,
+		comments,
+	});
+	const result = createVolarMappingsResult({
+		ast: transformed.ast,
+		ast_from_source: ast,
+		source,
+		generated_code: transformed.code,
+		source_map: transformed.map,
+		errors,
+	});
+	return { ...result, errors };
+}
+
+/** @param {string} code */
+function parse_virtual_tsx(code) {
+	return ts.createSourceFile('virtual.tsx', code, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+}
+
+/**
+ * Comments as TypeScript and declaration generators see them on a declaration.
+ * @param {ts.SourceFile} file
+ * @param {ts.Node} node
+ */
+function declaration_comments(file, node) {
+	const docs = ts
+		.getJSDocCommentsAndTags(node)
+		.filter(ts.isJSDoc)
+		.filter((doc) => !doc.tags?.some((tag) => tag.tagName.text === 'jsxImportSource'))
+		.map((doc) => ({
+			text: ts.getTextOfJSDocComment(doc.comment) ?? '',
+			tags: (doc.tags ?? []).map((tag) => ({
+				name: tag.tagName.text,
+				text: ts.getTextOfJSDocComment(tag.comment) ?? '',
+			})),
+		}));
+	const annotations = (ts.getLeadingCommentRanges(file.text, node.getFullStart()) ?? [])
+		.filter((comment) => comment.kind === ts.SyntaxKind.SingleLineCommentTrivia)
+		.map((comment) => file.text.slice(comment.pos + 2, comment.end).trim())
+		.filter((comment) => comment.startsWith('@'));
+	return { docs, annotations };
+}
+
+/**
+ * Full exported statements and their property signatures, in authored order.
+ * @param {ts.SourceFile} file
+ */
+function declaration_ranges(file) {
+	/** @type {ts.Node[]} */
+	const declarations = [];
+	/** @param {ts.Node} node */
+	const visit_members = (node) => {
+		if (ts.isPropertySignature(node)) declarations.push(node);
+		ts.forEachChild(node, visit_members);
+	};
+	for (const statement of file.statements) {
+		if (
+			ts.isExportAssignment(statement) ||
+			ts.isExportDeclaration(statement) ||
+			(ts.canHaveModifiers(statement) &&
+				ts
+					.getModifiers(statement)
+					?.some((modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword))
+		) {
+			declarations.push(statement);
+			ts.forEachChild(statement, visit_members);
+		}
+	}
+	return declarations;
+}
+
+describe('virtual declaration metadata', () => {
+	it('keeps declaration and member documentation attached to its TypeScript owner', () => {
+		const source =
+			'/** @ExportModel @Version(1) */\n' +
+			'export interface NativeModel {\n' +
+			'\t/** A stable identifier. */\n' +
+			'\t// @Version(1)\n' +
+			'\treadonly value?: string;\n' +
+			'\t/** @Version(2) */\n' +
+			'\tcount: number;\n' +
+			'}\n' +
+			'/** A separate model. */\n' +
+			'// @ExportModel\n' +
+			'export interface OtherModel {\n' +
+			'\t/** The visible label. */\n' +
+			'\tlabel: string;\n' +
+			'}\n';
+		const result = compile_to_volar_mappings(source);
+		expect(result.errors).toEqual([]);
+		const authored = parse_virtual_tsx(source);
+		const generated = parse_virtual_tsx(result.code);
+		/** @param {ts.SourceFile} file */
+		const describe_declarations = (file) =>
+			declaration_ranges(file).map((node) => ({
+				kind: node.kind,
+				name:
+					ts.isInterfaceDeclaration(node) || ts.isPropertySignature(node)
+						? node.name.getText(file)
+						: undefined,
+				...declaration_comments(file, node),
+			}));
+
+		expect(describe_declarations(generated)).toEqual(describe_declarations(authored));
+	});
+
+	it.each(['export', 'export default'])(
+		'keeps %s component documentation on the function when JSX is hoisted',
+		(export_kind) => {
+			const source =
+				'/** Component documentation. */\n' +
+				'// @ExportModel\n' +
+				`${export_kind} function Scene() @{ <div /> }\n`;
+			const result = compile_to_volar_mappings(source);
+			expect(result.errors).toEqual([]);
+			const generated = parse_virtual_tsx(result.code);
+			const component = generated.statements.find(
+				(statement) => ts.isFunctionDeclaration(statement) && statement.name?.text === 'Scene',
+			);
+			expect(component).toBeDefined();
+			if (!component) throw new Error('Expected the generated Scene function');
+			expect(declaration_comments(generated, component)).toEqual({
+				docs: [{ text: 'Component documentation.', tags: [] }],
+				annotations: ['@ExportModel'],
+			});
+			const documented_statements = generated.statements.filter((statement) => {
+				const comments = declaration_comments(generated, statement);
+				return comments.docs.length > 0 || comments.annotations.length > 0;
+			});
+			expect(documented_statements).toHaveLength(1);
+			expect(documented_statements[0]).toBe(component);
+		},
+	);
+
+	it.each([
+		['interface at offset zero', 'export interface Model { value: string\ncount: number }'],
+		[
+			'type alias with readonly and optional members',
+			'export type Model = { readonly value?: string; count: number };',
+		],
+		['named function', 'export function read(value: string): string { return value; }'],
+		['named variable', 'export const version = 1;'],
+		['named variable without a terminator', 'export const version = 1'],
+		['named re-export', "export { NativeModel as Model } from './native';"],
+		['export-all without a terminator', "export * from './native'"],
+		['default expression', 'export default 42;'],
+		['default expression without a terminator', 'export default 42'],
+		['anonymous default function', 'export default function () { return 42; }'],
+		['block declaration followed by an empty statement', 'export default function read() {};'],
+		['named default class', 'export default class Model {}'],
+		[
+			'adjacent declaration documentation',
+			'/** Model docs. */export interface Model { value: string; }',
+		],
+		[
+			'adjacent member documentation',
+			'export interface Model { /** Field docs. */readonly value?: string; }',
+		],
+		[
+			'mixed property separators',
+			'export interface Model {\n\treadonly value?: string;\n\tcount: number\n\tenabled?: boolean,\n}',
+		],
+	])('maps complete authored declaration ranges for %s', (_name, source) => {
+		const result = compile_to_volar_mappings(source);
+		expect(result.errors).toEqual([]);
+		const authored = parse_virtual_tsx(source);
+		const generated = parse_virtual_tsx(result.code);
+		const source_declarations = declaration_ranges(authored);
+		const generated_declarations = declaration_ranges(generated);
+		expect(generated_declarations.map((node) => node.kind)).toEqual(
+			source_declarations.map((node) => node.kind),
+		);
+		const map = new SourceMap(result.mappings);
+		for (let index = 0; index < source_declarations.length; index++) {
+			const source_node = source_declarations[index];
+			const generated_node = generated_declarations[index];
+			const mapped = map
+				.toSourceRange(generated_node.getStart(generated), generated_node.getEnd(), true)
+				.next().value;
+			expect(mapped?.slice(0, 2), source_node.getText(authored)).toEqual([
+				source_node.getStart(authored),
+				source_node.getEnd(),
+			]);
+		}
+	});
+
+	it('does not change return or throw semantics when preserving inline JSDoc', () => {
+		const source =
+			'export function read() { return /** @type {number} */ 42; }\n' +
+			"export function fail() { throw /** @type {Error} */ new Error('failure'); }\n";
+		const result = compile_to_volar_mappings(source);
+		expect(result.errors).toEqual([]);
+		const generated = parse_virtual_tsx(result.code);
+		const functions = generated.statements.filter(ts.isFunctionDeclaration);
+		const read = functions.find((node) => node.name?.text === 'read');
+		const fail = functions.find((node) => node.name?.text === 'fail');
+		expect(read?.body?.statements).toHaveLength(1);
+		expect(fail?.body?.statements).toHaveLength(1);
+		const return_statement = read?.body?.statements[0];
+		const throw_statement = fail?.body?.statements[0];
+		if (!return_statement || !throw_statement) {
+			throw new Error('Expected both generated function bodies to contain a statement');
+		}
+		expect(ts.isReturnStatement(return_statement)).toBe(true);
+		expect(ts.isThrowStatement(throw_statement)).toBe(true);
+		const returned = ts.isReturnStatement(return_statement)
+			? return_statement.expression
+			: undefined;
+		const thrown = ts.isThrowStatement(throw_statement) ? throw_statement.expression : undefined;
+		expect(returned && ts.isNumericLiteral(returned) ? returned.text : undefined).toBe('42');
+		expect(
+			thrown && ts.isNewExpression(thrown) ? thrown.expression.getText(generated) : undefined,
+		).toBe('Error');
+		expect(
+			thrown && ts.isNewExpression(thrown) && thrown.arguments?.[0]
+				? ts.isStringLiteral(thrown.arguments[0]) && thrown.arguments[0].text
+				: undefined,
+		).toBe('failure');
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ catalogs:
     '@volar/language-service':
       specifier: ~2.4.28
       version: 2.4.28
+    '@volar/source-map':
+      specifier: ~2.4.28
+      version: 2.4.28
     '@volar/typescript':
       specifier: ~2.4.28
       version: 2.4.28
@@ -1084,6 +1087,9 @@ importers:
         specifier: catalog:default
         version: 8.56.1
       '@volar/language-core':
+        specifier: catalog:default
+        version: 2.4.28
+      '@volar/source-map':
         specifier: catalog:default
         version: 2.4.28
       typescript:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -92,6 +92,7 @@ catalogs:
     '@volar/language-core': ~2.4.28
     '@volar/language-service': ~2.4.28
     '@volar/language-server': ~2.4.28
+    '@volar/source-map': ~2.4.28
     '@volar/typescript': ~2.4.28
     '@volar/vscode': ~2.4.28
     '@vscode/vsce': ^3.9.1


### PR DESCRIPTION
## Summary

- preserve declaration JSDoc and custom `// @...` annotations on their TypeScript owners in type-only virtual TSX
- add complete verification-only Volar mappings for exports and property signatures, including omitted terminators and source-offset-zero declarations
- add 19 core regression cases adapted from octanejs/octane#772 and a patch changeset for `@tsrx/core`

## Why

Native declaration generators consume virtual TSX as a real TypeScript document. Previously, documentation and annotations could be dropped or moved onto generated JSX hoists, while incomplete ranges prevented generators from translating full declarations back to their authored `.tsrx` ranges.

The original fix was mistakenly opened as [octanejs/octane#772](https://github.com/octanejs/octane/pull/772). This PR moves the owning compiler changes and regression coverage into TSRX.

## Implementation

Owner-scoped comments are emitted only for tooling prints, while file-wide pragmas retain their leading behavior and normal build output remains sparse. Complete export mappings use verification-only endpoint pairs so transformed helper code does not acquire false authored locations. Comment and declaration boundaries are selected by matching their actual generated text, avoiding shared source-coordinate ambiguity.

## Validation

- `pnpm test --project tsrx-utils` — 464 passed
- `pnpm test --project tsrx-react --project tsrx-preact --project tsrx-solid --project tsrx-vue --project tsrx-ripple --project typescript-plugin --project language-server` — 1,911 passed, 33 skipped
- `pnpm typecheck`
- `pnpm changeset:check`
- focused Prettier check for all changed files
- `pnpm install --frozen-lockfile --lockfile-only --ignore-scripts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches type-only printing and Volar mapping logic used by the language server; build output stays sparse, but incorrect comment placement could affect TS semantics in virtual files.
> 
> **Overview**
> Type-only **virtual TSX** now keeps **JSDoc** and custom **`// @...`** annotations on their declarations and members instead of hoisting them to the file top or dropping them when JSX is transformed. Only **file-wide** pragmas (`@jsxImportSource`, triple-slash references, `@ts-check`) still lead the program; scoped comments stay with statements so inline JSDoc on `return`/`throw` does not break parsing.
> 
> **Volar mappings** gain verification-only **endpoint pairs** for full **export** statements and **`TSPropertySignature`** ranges (including omitted semicolons and offset-zero exports), resolved by matching generated text when source-map positions collide. Preserved comment mappings use the same text-matching approach. Regression tests cover declaration metadata parity and round-trip range mapping via `@volar/source-map`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12d13e587eb89fb4577a52c8aa53ae097bfef146. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->