### PR TITLE
fix(compiler): keep type-only JSX output analyzable

### DIFF
--- a/.changeset/bright-frogs-analyze.md
+++ b/.changeset/bright-frogs-analyze.md
@@ -1,0 +1,5 @@
+---
+'@tsrx/core': patch
+---
+
+Keep multi-style components and host ref/spread elements analyzable in type-only virtual TSX output.

--- a/packages/tsrx/src/analyze/prune.js
+++ b/packages/tsrx/src/analyze/prune.js
@@ -15,6 +15,8 @@ const BACKWARD = 1;
 // since the code is synchronous, this is safe
 /** @type {string} */
 let css_hash;
+/** @type {string} */
+let css_region_hash;
 /** @type {StyleClasses} */
 let style_identifier_classes;
 /** @type {TopScopedClasses} */
@@ -300,6 +302,7 @@ function apply_selector(relative_selectors, rule, element, direction) {
 								start: selector.start,
 								end: selector.end,
 								selector: selector,
+								regionHash: css_region_hash,
 							});
 						}
 					}
@@ -1107,10 +1110,12 @@ function rule_has_animation(rule) {
  * @param {AST.TSRXElementNode} element
  * @param {StyleClasses} styleClasses
  * @param {TopScopedClasses} topScopedClasses
+ * @param {string} [regionHash]
  * @return {void}
  */
-export function prune_css(css, element, styleClasses, topScopedClasses) {
+export function prune_css(css, element, styleClasses, topScopedClasses, regionHash = css.hash) {
 	css_hash = css.hash;
+	css_region_hash = regionHash;
 	style_identifier_classes = styleClasses;
 	top_scoped_classes = topScopedClasses;
 
@@ -1152,6 +1157,7 @@ export function prune_css(css, element, styleClasses, topScopedClasses) {
 							start: class_selector.start,
 							end: class_selector.end,
 							selector: class_selector,
+							regionHash: css_region_hash,
 						});
 					}
 				}

--- a/packages/tsrx/src/transform/jsx/index.js
+++ b/packages/tsrx/src/transform/jsx/index.js
@@ -1091,6 +1091,7 @@ function inject_dynamic_import(program, transform_context) {
  * @param {AST.CSS.StyleSheet} css
  * @param {TransformContext} transform_context
  * @param {boolean} [export_top_scoped_classes]
+ * @param {string} [region_hash]
  * @returns {void}
  */
 function apply_css_definition_metadata(
@@ -1098,6 +1099,7 @@ function apply_css_definition_metadata(
 	css,
 	transform_context,
 	export_top_scoped_classes = false,
+	region_hash = css.hash,
 ) {
 	analyze_css(css);
 
@@ -1108,7 +1110,7 @@ function apply_css_definition_metadata(
 
 	const prune = () => {
 		for (const element of elements) {
-			prune_css(css, element, style_classes, top_scoped_classes);
+			prune_css(css, element, style_classes, top_scoped_classes, region_hash);
 		}
 	};
 
@@ -2357,10 +2359,17 @@ function prepare_tsrx_fragment_styles(node, transform_context) {
 	// `styleClasses`/`topScopedClasses` metadata, so per-sheet calls compose
 	// into one class map for style refs.
 	for (const sheet of sheets) {
+		const region_hash = sheet.hash;
 		sheet.hash = css.hash;
 		// `prune_css` inside marks the matching selectors as used/scoped; selectors
 		// that match no element render commented out, like the Ripple target.
-		apply_css_definition_metadata(node, sheet, transform_context, style_refs.length > 0);
+		apply_css_definition_metadata(
+			node,
+			sheet,
+			transform_context,
+			style_refs.length > 0,
+			region_hash,
+		);
 		transform_context.stylesheets.push(sheet);
 	}
 	const fragment = annotate_tsrx_with_hash(

--- a/packages/tsrx/src/transform/jsx/index.js
+++ b/packages/tsrx/src/transform/jsx/index.js
@@ -728,9 +728,24 @@ export function createJsxTransform(platform) {
 				// hooks can inspect the original JSX child shape.
 				const raw_children = node_children(node).map((child) => ({ ...child }));
 				const inner = /** @type {AST.TSRXJSXElement} */ (next() ?? node);
+				const in_jsx_child = in_jsx_child_context(path);
 				const hook = platform.hooks?.transformElement;
-				if (hook) return hook(inner, state, raw_children);
-				return to_jsx_element(inner, state, raw_children, in_jsx_child_context(path));
+				const produced = hook
+					? hook(inner, state, raw_children)
+					: to_jsx_element(inner, state, raw_children, in_jsx_child);
+				// A host element carrying `ref` plus a spread lowers to a generated
+				// `let X = __normalize_spread_props_for_ref_attr(…)` that rides on the
+				// element's metadata for a later pass to hoist. Only the render-block
+				// statement builder and the native-directive path hoist it, so an
+				// element in plain-JS expression position — a ternary arm, a concise
+				// arrow body, a declarator init, a callback body, an attribute value, an
+				// array element — reaches neither: the declaration is dropped while the
+				// rewritten attributes still reference the name, and the type-only print
+				// carries an undefined identifier (TS2304). Wrap it in the same IIFE the
+				// native-directive path already uses.
+				return state.typeOnly && produced.type !== 'JSXSpreadChild' && produced.type !== 'JSXText'
+					? wrap_jsx_setup_declarations(produced, in_jsx_child)
+					: produced;
 			},
 
 			JSXExpressionContainer(node, { next, state }) {
@@ -791,7 +806,7 @@ export function createJsxTransform(platform) {
 					return visited;
 				}
 				const is_component = is_component_like_jsx_name(visited.name);
-				return b.jsx_opening_element(
+				const lowered = b.jsx_opening_element(
 					visited.name,
 					merge_duplicate_refs(
 						normalize_host_ref_spreads(visited.attributes || [], !is_component, transform_context),
@@ -801,6 +816,17 @@ export function createJsxTransform(platform) {
 					visited.typeArguments,
 					has_location(visited) ? visited : undefined,
 				);
+				// `normalize_host_ref_spreads` is NOT idempotent: run twice it reads the
+				// `ref={[authored, __spread_props1.ref]}` array it just produced as an
+				// AUTHORED ref and lowers again, emitting a second helper binding and a
+				// nested ref array. The attribute list cannot answer "already lowered"
+				// on its own — `merge_duplicate_refs` rebuilds the merged `ref` without
+				// the `synthetic_ref` marker — so record it on the element instead.
+				lowered.metadata = {
+					...(lowered.metadata || {}),
+					host_ref_spread_lowered: true,
+				};
+				return lowered;
 			},
 		});
 
@@ -2291,19 +2317,20 @@ function node_contains_native_tsrx_template(node) {
 
 /**
  * @param {AST.NativeTSRXNode} node
- * @returns {AST.CSS.StyleSheet | null}
+ * @param {boolean} allow_multiple
+ * @returns {AST.CSS.StyleSheet[] | null}
  */
-function collect_tsrx_stylesheet(node) {
+function collect_tsrx_stylesheets(node, allow_multiple) {
 	/** @type {AST.CSS.StyleSheet[]} */
 	const styles = [];
 	collect_style_elements(node_children(node), styles);
 
 	if (styles.length === 0) return null;
-	if (styles.length > 1) {
+	if (styles.length > 1 && !allow_multiple) {
 		throw new Error('TSRX fragments can only have one style tag');
 	}
 
-	return styles[0];
+	return styles;
 }
 
 /**
@@ -2312,14 +2339,30 @@ function collect_tsrx_stylesheet(node) {
  * @returns {JsxStyleContext | null}
  */
 function prepare_tsrx_fragment_styles(node, transform_context) {
-	const css = collect_tsrx_stylesheet(node);
-	if (!css) return null;
+	// Type-only output must stay analyzable: a throw here makes language hosts
+	// (tsrx-tsc, editors) fall back to presenting the RAW source as the virtual
+	// TSX, so every CSS brace in the file becomes a TSX parse error. Platforms
+	// whose runtime dialect allows one scope to split its CSS across several
+	// `<style>` tags are valid input here, and platforms that forbid it still
+	// report the rule through their own runtime compiler.
+	const sheets = collect_tsrx_stylesheets(node, transform_context.typeOnly);
+	if (!sheets) return null;
 
+	const css = sheets[0];
 	const style_refs = collect_style_ref_attributes(node);
-	// `prune_css` inside marks the matching selectors as used/scoped; selectors
-	// that match no element render commented out, like the Ripple target.
-	apply_css_definition_metadata(node, css, transform_context, style_refs.length > 0);
-	transform_context.stylesheets.push(css);
+	// A component scope keeps ONE hash even when its CSS is split across
+	// several `<style>` tags: rebase every sheet onto the first sheet's hash
+	// before scoping, so selector rewriting and the DOM hash annotation below
+	// agree. `apply_css_definition_metadata` accumulates into the component's
+	// `styleClasses`/`topScopedClasses` metadata, so per-sheet calls compose
+	// into one class map for style refs.
+	for (const sheet of sheets) {
+		sheet.hash = css.hash;
+		// `prune_css` inside marks the matching selectors as used/scoped; selectors
+		// that match no element render commented out, like the Ripple target.
+		apply_css_definition_metadata(node, sheet, transform_context, style_refs.length > 0);
+		transform_context.stylesheets.push(sheet);
+	}
 	const fragment = annotate_tsrx_with_hash(
 		node,
 		css.hash,
@@ -6120,8 +6163,16 @@ function transform_element_attributes_dispatch(attrs, transform_context, element
 	}
 	const hook = transform_context.platform.hooks?.transformElementAttributes;
 	const result = hook ? hook(attrs, transform_context, element) : attrs;
+	// An element in plain-JS expression position reaches BOTH lowering sites —
+	// the JSXOpeningElement visitor above and this dispatch — so without the
+	// marker its host ref/spread is lowered twice. Scoped to the type-only
+	// print: runtime emit for the other platforms sharing this transform keeps
+	// its existing output.
+	const already_lowered =
+		transform_context.typeOnly &&
+		element?.openingElement?.metadata?.host_ref_spread_lowered === true;
 	return merge_duplicate_refs(
-		normalize_host_ref_spreads(result, !is_component, transform_context),
+		already_lowered ? result : normalize_host_ref_spreads(result, !is_component, transform_context),
 		transform_context,
 	);
 }

--- a/packages/tsrx/src/transform/segments.js
+++ b/packages/tsrx/src/transform/segments.js
@@ -885,7 +885,7 @@ export function convert_source_map_to_mappings(
 										definition: {
 											description: `CSS class selector for '.${name}'`,
 											location: {
-												embeddedId: get_style_region_id(css.hash),
+												embeddedId: get_style_region_id(cssLocation.regionHash ?? css.hash),
 												start: cssLocation.start,
 												end: cssLocation.end,
 											},

--- a/packages/tsrx/tests/utils/type-only-jsx-analysis.test.js
+++ b/packages/tsrx/tests/utils/type-only-jsx-analysis.test.js
@@ -90,6 +90,16 @@ const SPLIT_STYLE_SOURCE =
 	'\t</>;\n' +
 	'}\n';
 
+const SPLIT_STYLE_DEFINITION_SOURCE =
+	'export function Split() {\n' +
+	'\treturn <>\n' +
+	'\t\t<section class="mailbox">one</section>\n' +
+	'\t\t<aside class="active">two</aside>\n' +
+	'\t\t<style>.mailbox { color: red; }</style>\n' +
+	'\t\t<style>.active { color: blue; }</style>\n' +
+	'\t</>;\n' +
+	'}\n';
+
 const REF_SPREAD_PROPS_TYPE =
 	'type Props = {\n' +
 	'\tnodeRef: (node: SVGTextElement | null) => void;\n' +
@@ -183,6 +193,25 @@ describe('type-only JSX analysis', () => {
 		expect(() => compile_source(SPLIT_STYLE_SOURCE, false)).toThrow(
 			'TSRX fragments can only have one style tag',
 		);
+	});
+
+	it('maps classes to the split style block that defines them', () => {
+		const result = compile_source(SPLIT_STYLE_DEFINITION_SOURCE);
+		const css_mapping_ids = result.cssMappings.map(
+			(mapping) => mapping.data.customData?.embeddedId,
+		);
+		const active_offset =
+			SPLIT_STYLE_DEFINITION_SOURCE.indexOf('class="active"') + 'class="'.length;
+		const active_mapping = result.mappings.find(
+			(mapping) =>
+				mapping.sourceOffsets[0] === active_offset && mapping.data.customData?.definition,
+		);
+		const active_definition = active_mapping?.data.customData?.definition;
+
+		expect(css_mapping_ids).toHaveLength(2);
+		expect(
+			typeof active_definition === 'object' ? active_definition.location?.embeddedId : undefined,
+		).toBe(css_mapping_ids[1]);
 	});
 
 	it('declares generated host ref/spread bindings in every element position', () => {

--- a/packages/tsrx/tests/utils/type-only-jsx-analysis.test.js
+++ b/packages/tsrx/tests/utils/type-only-jsx-analysis.test.js
@@ -1,0 +1,274 @@
+/** @import * as AST from 'estree' */
+/** @import { CompileError, JsxPlatform } from '../../types/index' */
+
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+import {
+	analyzeTsrx,
+	createJsxTransform,
+	createVolarMappingsResult,
+	parseModule,
+} from '../../src/index.js';
+
+/** @type {JsxPlatform} */
+const PLATFORM = {
+	name: 'type-only-jsx-analysis-test',
+	imports: {
+		fragment: 'test-platform',
+		suspense: 'test-platform',
+		dynamic: 'test-platform/dynamic',
+		errorBoundary: 'test-platform/error-boundary',
+		refProp: 'test-platform/ref',
+	},
+	jsx: {
+		rewriteClassAttr: false,
+		classAttrName: 'class',
+		multiRefStrategy: 'array',
+	},
+	validation: { requireUseServerForAwait: false },
+};
+
+/**
+ * Mirrors a target package's public compiler pipeline.
+ * @param {string} source
+ * @param {boolean} [type_only]
+ */
+function compile_source(source, type_only = true) {
+	/** @type {CompileError[]} */
+	const errors = [];
+	/** @type {AST.CommentWithLocation[]} */
+	const comments = [];
+	const filename = 'App.tsrx';
+	const ast = parseModule(source, filename, {
+		collect: true,
+		loose: true,
+		preserveParens: true,
+		keywordTokens: true,
+		errors,
+		comments,
+	});
+	analyzeTsrx(ast, filename, {
+		collect: true,
+		loose: true,
+		typeOnly: type_only,
+		errors,
+		comments,
+	});
+	const transformed = createJsxTransform(PLATFORM)(ast, source, filename, {
+		collect: true,
+		loose: true,
+		typeOnly: type_only,
+		errors,
+		comments,
+	});
+	const result = createVolarMappingsResult({
+		ast: transformed.ast,
+		ast_from_source: ast,
+		source,
+		generated_code: transformed.code,
+		source_map: transformed.map,
+		errors,
+	});
+	return { ...transformed, ...result, errors };
+}
+
+const SPLIT_STYLE_SOURCE =
+	'export function Split(props: { active: boolean }) {\n' +
+	'\treturn <>\n' +
+	"\t\t<section class={['mailbox', { active: props.active }]}>{'hi'}</section>\n" +
+	'\t\t<style>\n' +
+	'\t\t\t.mailbox { color: rgb(10, 20, 30); }\n' +
+	'\t\t</style>\n' +
+	'\t\t<>\n' +
+	'\t\t\t<style>\n' +
+	'\t\t\t\t.active { background-color: rgb(40, 50, 60); }\n' +
+	'\t\t\t</style>\n' +
+	'\t\t</>\n' +
+	'\t</>;\n' +
+	'}\n';
+
+const REF_SPREAD_PROPS_TYPE =
+	'type Props = {\n' +
+	'\tnodeRef: (node: SVGTextElement | null) => void;\n' +
+	'\trest: { x?: number };\n' +
+	'\tmore: { y?: number };\n' +
+	'\trows: number[];\n' +
+	'\tshow: boolean;\n' +
+	'};\n\n';
+
+/** @type {Array<[string, string]>} */
+const REF_SPREAD_POSITIONS = [
+	['return statement', 'return <text ref={props.nodeRef} {...props.rest} />;'],
+	[
+		'nested in a returned element',
+		'return <svg><text ref={props.nodeRef} {...props.rest} /></svg>;',
+	],
+	[
+		'declarator init',
+		'const label = <text ref={props.nodeRef} {...props.rest} />;\n\treturn <svg>{label}</svg>;',
+	],
+	[
+		'ternary arm of a return',
+		'return props.show ? <text ref={props.nodeRef} {...props.rest} /> : null;',
+	],
+	[
+		'ternary arm inside a JSX hole',
+		'return <svg>{props.show ? <text ref={props.nodeRef} {...props.rest} /> : null}</svg>;',
+	],
+	[
+		'logical operand inside a JSX hole',
+		'return <svg>{props.show && <text ref={props.nodeRef} {...props.rest} />}</svg>;',
+	],
+	[
+		'callback body',
+		'return <svg>{props.rows.map((row: number) => <text key={row} ref={props.nodeRef} {...props.rest} />)}</svg>;',
+	],
+	['JSX expression value', 'return <svg>{<text ref={props.nodeRef} {...props.rest} />}</svg>;'],
+	['array literal element', 'return <svg>{[<text ref={props.nodeRef} {...props.rest} />]}</svg>;'],
+	[
+		'element with two spreads',
+		'return <svg>{props.show ? <text ref={props.nodeRef} {...props.rest} {...props.more} /> : null}</svg>;',
+	],
+];
+
+/** @type {Array<[string, string]>} */
+const NATIVE_TEMPLATE_POSITIONS = [
+	[
+		'native @if directive',
+		'<svg>@if (props.show) { <text ref={props.nodeRef} {...props.rest} /> }</svg>',
+	],
+	[
+		'plain-JS callback inside a native template',
+		'<svg>{props.rows.map((row: number) => <text key={row} ref={props.nodeRef} {...props.rest} />)}</svg>',
+	],
+];
+
+/** @returns {Array<[string, string]>} */
+function ref_spread_modules() {
+	return [
+		...REF_SPREAD_POSITIONS.map(
+			([name, body]) =>
+				/** @type {[string, string]} */ ([
+					name,
+					`${REF_SPREAD_PROPS_TYPE}export function Chart(props: Props) {\n\t${body}\n}\n`,
+				]),
+		),
+		[
+			'concise arrow body',
+			REF_SPREAD_PROPS_TYPE +
+				'export const Chart = (props: Props) => <text ref={props.nodeRef} {...props.rest} />;\n',
+		],
+		...NATIVE_TEMPLATE_POSITIONS.map(
+			([name, body]) =>
+				/** @type {[string, string]} */ ([
+					name,
+					`${REF_SPREAD_PROPS_TYPE}export function Chart(props: Props) @{\n\t${body}\n}\n`,
+				]),
+		),
+	];
+}
+
+describe('type-only JSX analysis', () => {
+	it('keeps multiple scoped style blocks analyzable without changing runtime validation', () => {
+		const result = compile_source(SPLIT_STYLE_SOURCE);
+		expect(result.errors).toEqual([]);
+		expect(result.cssMappings).toHaveLength(2);
+		expect(result.code).toContain('Split');
+		expect(result.code).not.toContain('rgb(10, 20, 30)');
+		expect(result.code).not.toContain('rgb(40, 50, 60)');
+
+		expect(() => compile_source(SPLIT_STYLE_SOURCE, false)).toThrow(
+			'TSRX fragments can only have one style tag',
+		);
+	});
+
+	it('declares generated host ref/spread bindings in every element position', () => {
+		const root = mkdtempSync(join(tmpdir(), 'tsrx-ref-spread-'));
+		try {
+			const files = ref_spread_modules().map(([name, source], index) => {
+				const compiled = compile_source(source);
+				expect(compiled.errors).toEqual([]);
+				const file = join(root, `Chart${index}.tsx`);
+				writeFileSync(file, compiled.code);
+				return { name, file };
+			});
+
+			const program = ts.createProgram({
+				rootNames: files.map(({ file }) => file),
+				options: {
+					jsx: ts.JsxEmit.Preserve,
+					module: ts.ModuleKind.ESNext,
+					moduleResolution: ts.ModuleResolutionKind.Bundler,
+					noEmit: true,
+					skipLibCheck: true,
+					strict: true,
+					target: ts.ScriptTarget.ESNext,
+				},
+			});
+			const undefined_names = ts
+				.getPreEmitDiagnostics(program)
+				.filter((diagnostic) => diagnostic.code === 2304)
+				.map((diagnostic) => {
+					const position = files.find(({ file }) => file === diagnostic.file?.fileName);
+					return `${position?.name ?? diagnostic.file?.fileName}: ${ts.flattenDiagnosticMessageText(
+						diagnostic.messageText,
+						' ',
+					)}`;
+				});
+			expect(undefined_names).toEqual([]);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it('lowers each host ref/spread exactly once', () => {
+		for (const [name, source] of ref_spread_modules()) {
+			const compiled = compile_source(source);
+			const generated = ts.createSourceFile(
+				'Chart.tsx',
+				compiled.code,
+				ts.ScriptTarget.ESNext,
+				true,
+				ts.ScriptKind.TSX,
+			);
+			/** @type {ts.ArrayLiteralExpression[]} */
+			const ref_arrays = [];
+			/** @type {ts.CallExpression[]} */
+			const normalize_calls = [];
+			/** @param {ts.Node} node */
+			const visit = (node) => {
+				if (
+					ts.isJsxAttribute(node) &&
+					ts.isIdentifier(node.name) &&
+					node.name.text === 'ref' &&
+					node.initializer &&
+					ts.isJsxExpression(node.initializer) &&
+					node.initializer.expression &&
+					ts.isArrayLiteralExpression(node.initializer.expression)
+				) {
+					ref_arrays.push(node.initializer.expression);
+				}
+				if (
+					ts.isCallExpression(node) &&
+					ts.isIdentifier(node.expression) &&
+					node.expression.text === '__normalize_spread_props_for_ref_attr'
+				) {
+					normalize_calls.push(node);
+				}
+				ts.forEachChild(node, visit);
+			};
+			visit(generated);
+
+			expect(ref_arrays, name).toHaveLength(1);
+			expect(
+				ref_arrays[0].elements.filter((element) => ts.isArrayLiteralExpression(element)),
+				name,
+			).toEqual([]);
+			const authored_spreads = source.match(/{\.\.\./g)?.length ?? 0;
+			expect(normalize_calls, name).toHaveLength(authored_spreads);
+		}
+	});
+});

--- a/packages/tsrx/types/index.d.ts
+++ b/packages/tsrx/types/index.d.ts
@@ -2092,6 +2092,8 @@ export type TopScopedClasses = Map<
 		start: number;
 		end: number;
 		selector: AST.CSS.ClassSelector;
+		/** Source `<style>` region for editor definition navigation. */
+		regionHash?: string;
 	}
 >;
 

--- a/packages/tsrx/types/index.d.ts
+++ b/packages/tsrx/types/index.d.ts
@@ -989,6 +989,8 @@ declare module 'estree-jsx' {
 	interface JSXOpeningElement {
 		metadata: BaseNodeMetaData & {
 			native_tsrx_pretransformed?: boolean;
+			/** Type-only host ref/spread normalization has already run for this element. */
+			host_ref_spread_lowered?: boolean;
 		};
 	}
 


### PR DESCRIPTION
## Summary

- allow multiple scoped `<style>` blocks in type-only/Volar output while retaining the runtime transform's existing single-style validation
- preserve and locally declare generated host ref/spread bindings in plain JavaScript expression positions
- prevent the type-only host ref/spread path from lowering the same element twice and producing nested ref arrays
- add upstream regression coverage for all affected expression positions and a patch changeset for `@tsrx/core`

## Why

Octane currently carries these fixes as a pnpm patch against `@tsrx/core@0.1.56` and `0.1.58`.

The shared JSX transform previously threw when type-only output encountered multiple style blocks. Language hosts then fell back to raw TSRX as virtual TSX, so CSS braces surfaced as TypeScript parse errors even though the target runtime accepts split scoped styles.

A host element combining an authored `ref` with a spread also attached a generated normalizer declaration to element metadata. Render-statement and native-directive paths hoisted that declaration, but ordinary JavaScript expression positions did not, leaving the generated TSX with undefined identifiers. Those elements also passed through both normalization sites, which created a second binding and nested the composed ref array.

## Implementation

The multi-style relaxation is restricted to `typeOnly`; runtime/build transforms keep their existing validation. Type-only style sheets are rebased to one component hash and analyzed independently so both embedded CSS regions remain available.

Residual JSX setup declarations are wrapped in the existing expression IIFE, and an opening-element metadata marker prevents the second host ref/spread normalization. Runtime output does not consult this marker.

## Validation

- focused regression suite reproduced all three failures before the fix and passes after it
- `pnpm test --project tsrx-utils` — 467 passed
- `pnpm test --project tsrx-react --project tsrx-preact --project tsrx-solid --project tsrx-vue --project tsrx-ripple --project typescript-plugin --project language-server` — 1,911 passed, 33 skipped
- `pnpm typecheck`
- `pnpm changeset:check`
- Prettier check for all changed files

## Release and downstream removal

The changeset schedules `@tsrx/core@0.1.60`. Once that release is published, Octane can raise its core catalog minimum to `^0.1.60`, delete `patches/@tsrx__core@0.1.56-0.1.58.patch`, remove the two `patchedDependencies` entries, and remove the temporary patch rationale.

Changesets also schedules compatible patch releases for dependents in the same batch, including `@tsrx/react@0.2.60`, `@tsrx/solid@0.1.60`, `@tsrx/ripple@0.1.61`, `@tsrx/typescript-plugin@0.3.122`, `@tsrx/prettier-plugin@0.3.122`, `@tsrx/vite-plugin-react@0.0.93`, and `@tsrx/vite-plugin-solid@0.0.90`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core JSX transform and CSS metadata used by editors and type-only emit; runtime behavior is intentionally unchanged but the compiler path is shared and regression-tested.
> 
> **Overview**
> Improves **type-only / Volar virtual TSX** so language hosts keep analyzing components instead of falling back to raw TSRX.
> 
> **Multiple `<style>` blocks** are allowed only when `typeOnly` is true; runtime transforms still throw on more than one style tag. Each sheet is scoped with a shared component hash while **`regionHash`** on pruned class metadata and segment mappings points editor go-to-definition at the correct embedded CSS region.
> 
> **Host `ref` + spread** in non-render JSX positions (ternaries, map callbacks, declarator inits, etc.) now get generated `__normalize_spread_props_for_ref_attr` bindings via the existing **`wrap_jsx_setup_declarations`** IIFE, fixing TS2304 in printed TSX. A **`host_ref_spread_lowered`** marker on the opening element stops **`normalize_host_ref_spreads`** from running twice on the type-only path (which had produced nested ref arrays).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a938359a1e533cb6886fc770e4d371bed1aa4e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->