### PR TITLE
fix(ci): bootstrap new npm packages

### DIFF
--- a/.github/workflows/bootstrap-npm-packages.yml
+++ b/.github/workflows/bootstrap-npm-packages.yml
@@ -1,0 +1,72 @@
+name: Bootstrap npm packages
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: Publish every package version that is missing from npm
+        required: true
+        type: boolean
+        default: false
+
+concurrency:
+  group: npm-publish
+
+permissions: {}
+
+jobs:
+  publish:
+    if: >-
+      github.repository == 'Ripple-TS/ripple' &&
+      github.ref == 'refs/heads/main' &&
+      inputs.confirm == true
+    permissions:
+      contents: write
+    name: Bootstrap npm packages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require npm bootstrap token
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_BOOTSTRAP_TOKEN }}
+        run: |
+          if [ -z "$NPM_TOKEN" ]; then
+            echo "NPM_BOOTSTRAP_TOKEN must contain a short-lived npm token that can create public packages." >&2
+            exit 1
+          fi
+
+      - name: Checkout Repo
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24.x
+          # Do not enable dependency caching in this token-authenticated job.
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Disallow major and minor bumps in changesets
+        run: pnpm changeset:check
+
+      # This job intentionally has no id-token permission. npm prefers OIDC when
+      # it is available, but a package cannot use OIDC until it exists on npm and
+      # has a trusted publisher configured.
+      - name: Publish missing packages to npm
+        uses: changesets/action@v1
+        with:
+          publish: pnpm changeset:publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_BOOTSTRAP_TOKEN }}
+
+      - name: Record trusted publishing follow-up
+        if: success()
+        run: |
+          echo "Configure publish.yml as the trusted publisher for every newly created npm package." >> "$GITHUB_STEP_SUMMARY"
+          echo "Delete NPM_BOOTSTRAP_TOKEN after the trusted publishers are configured." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ on:
       - main
 
 concurrency:
-  group: ${{ github.workflow }}
+  group: npm-publish
 
 permissions: {}
 


### PR DESCRIPTION
## Summary

- add a manually dispatched, main-branch-only workflow for publishing package versions that do not exist on npm yet
- require a short-lived `NPM_BOOTSTRAP_TOKEN` and deliberately omit `id-token: write` so npm uses token authentication instead of retrying OIDC
- serialize bootstrap and normal releases through the same `npm-publish` concurrency group
- keep the normal publish workflow OIDC-only

## Root cause

The failed [Version Packages run](https://github.com/Ripple-TS/ripple/actions/runs/32078456857/job/95536473480) successfully published existing packages but received `E404` for the five new `@tsrx/*-runtime` packages. npm trusted publishers are configured per package, and a package must already exist before that trust relationship can be created.

## Impact

Maintainers now have an explicit one-time path to create new npm packages without weakening routine trusted publishing. Changesets continues to identify and publish only versions missing from the registry, so the packages already published by the partial release are skipped.

## Validation

- `pnpm changeset:check`
- `pnpm exec prettier --check .github/workflows/bootstrap-npm-packages.yml .github/workflows/publish.yml`
- `actionlint v1.7.12 .github/workflows/bootstrap-npm-packages.yml .github/workflows/publish.yml`
- `git diff --check`

No changeset is included because this is CI-only.

## Post-merge bootstrap

1. Create a short-lived npm granular token with package/scope read-write access, permission to create public packages under `@tsrx`, and bypass 2FA.
2. Store it as the Actions secret `NPM_BOOTSTRAP_TOKEN`.
3. Run **Bootstrap npm packages** on `main` with **confirm** enabled.
4. Configure `Ripple-TS/ripple` / `publish.yml` as the trusted publisher for each newly created package.
5. Delete `NPM_BOOTSTRAP_TOKEN`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a token-based publish path for creating packages; it is tightly gated (manual, main-only, confirm) and separate from routine OIDC publishing, but mishandling `NPM_BOOTSTRAP_TOKEN` could allow unauthorized publishes until the secret is removed.
> 
> **Overview**
> Adds a **manual** `workflow_dispatch` workflow (`bootstrap-npm-packages.yml`) so maintainers can publish npm versions that are not on the registry yet—addressing `E404` when new packages have no trusted publisher until they exist.
> 
> The bootstrap job runs only on `main` with a **confirm** flag, requires `NPM_BOOTSTRAP_TOKEN`, runs `changeset:check` and `changeset:publish`, and **does not** grant `id-token: write` so npm uses the token instead of OIDC. On success it reminds operators to set trusted publishers on `publish.yml` and remove the bootstrap secret.
> 
> **`publish.yml`** now shares the **`npm-publish`** concurrency group with bootstrap (replacing per-workflow grouping) so bootstrap and normal releases cannot overlap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9770979ae155e9ff383d425abb139d8623e4b36e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->