### PR TITLE
fix: ref-count handle_root_events per target for shared-target Portals

### DIFF
--- a/.changeset/chubby-lemons-clean.md
+++ b/.changeset/chubby-lemons-clean.md
@@ -2,8 +2,8 @@
 'ripple': patch
 ---
 
-Fix event delegation breaking for a Portal when a sibling Portal sharing the same target unmounts.
+Fix event delegation breaking when multiple roots (Portals, mounts) share or mix targets.
 
-`handle_root_events(target)` had no notion of multiple callers sharing the same `target` element. Each Portal (or the app root) calls it once on mount and returns a cleanup function; that cleanup unconditionally removed the delegated event listeners from `target` and reset the shared `root_target` state. When two Portals both mount to `document.body` (a very common case — e.g. a Modal and a SideSheet both portaling there), closing/unmounting the first one would tear down the delegated `click` (and other) listeners for `document.body` entirely, silently breaking every click inside the second Portal even though it was still open. The DOM nodes and their `__click` handler references were untouched — only the root delegation listener was gone — so the failure had no error, no warning, and no obvious cause from either component's own code.
-
-`handle_root_events` now ref-counts callers per `target` (`root_target_refs: Map<Element, { count, registered_events }>`). The delegated listeners for a given target are only actually torn down once every caller for that target has released it.
+- `handle_root_events(target)` had no notion of multiple callers sharing the same `target` element. Each Portal (or the app root) calls it once on mount; its cleanup unconditionally removed the delegated event listeners from `target`. When two Portals both mount to `document.body` (e.g. a Modal and a SideSheet), closing the first tore down the delegated listeners for `document.body` entirely, silently breaking every click inside the second — no error, no warning. `handle_root_events` now ref-counts callers per target, and the delegated listeners are only torn down once every caller for that target has released it.
+- The single `root_target` global is gone. `on()` now checks the element against every active root target, so attaching a listener directly to one root's target while another root (e.g. a Portal to a sibling layer) was acquired later no longer silently takes the broken delegated path.
+- `Portal` acquires root event delegation in its own render block keyed on `target`, so a children-only update no longer releases and re-adds every delegated listener on the target.

--- a/.changeset/chubby-lemons-clean.md
+++ b/.changeset/chubby-lemons-clean.md
@@ -1,0 +1,9 @@
+---
+'ripple': patch
+---
+
+Fix event delegation breaking for a Portal when a sibling Portal sharing the same target unmounts.
+
+`handle_root_events(target)` had no notion of multiple callers sharing the same `target` element. Each Portal (or the app root) calls it once on mount and returns a cleanup function; that cleanup unconditionally removed the delegated event listeners from `target` and reset the shared `root_target` state. When two Portals both mount to `document.body` (a very common case — e.g. a Modal and a SideSheet both portaling there), closing/unmounting the first one would tear down the delegated `click` (and other) listeners for `document.body` entirely, silently breaking every click inside the second Portal even though it was still open. The DOM nodes and their `__click` handler references were untouched — only the root delegation listener was gone — so the failure had no error, no warning, and no obvious cause from either component's own code.
+
+`handle_root_events` now ref-counts callers per `target` (`root_target_refs: Map<Element, { count, registered_events }>`). The delegated listeners for a given target are only actually torn down once every caller for that target has released it.

--- a/packages/ripple/src/runtime/internal/client/events.js
+++ b/packages/ripple/src/runtime/internal/client/events.js
@@ -29,6 +29,20 @@ var root_event_handles = new Set();
 var root_target = null;
 
 /**
+ * Multiple Portals (or a Portal plus the app root) can share the same target
+ * element (most commonly `document.body`). `handle_root_events` used to be
+ * called once per Portal with no notion of sharing: the first call's cleanup
+ * would tear down the delegated listeners for *all* callers the moment that
+ * one Portal's content changed or unmounted, even while siblings targeting
+ * the same element were still relying on them (e.g. a Modal closing would
+ * silently break click delegation for a still-open SideSheet, since both
+ * portal to `document.body`). Ref-count per target so cleanup only runs once
+ * every caller for that target has released it.
+ * @type {Map<Element, { count: number, registered_events: Set<string> }>}
+ */
+var root_target_refs = new Map();
+
+/**
  * @param {AddEventOptions} options
  * @returns {AddEventListenerOptions}
  */
@@ -381,9 +395,14 @@ export function delegate(events) {
 
 /** @param {Element} target */
 export function handle_root_events(target) {
-	/** @type {Set<string>} */
-	var registered_events = new Set();
+	var ref = root_target_refs.get(target);
+	if (ref === undefined) {
+		ref = { count: 0, registered_events: new Set() };
+		root_target_refs.set(target, ref);
+	}
+	ref.count += 1;
 	root_target = target;
+	var registered_events = ref.registered_events;
 
 	/**
 	 * @typedef {Object} EventHandleOptions
@@ -417,14 +436,30 @@ export function handle_root_events(target) {
 	event_handle(array_from(all_registered_events));
 	root_event_handles.add(event_handle);
 
+	var released = false;
+
 	return () => {
-		for (var event_name of registered_events) {
+		if (released) return;
+		released = true;
+
+		root_event_handles.delete(event_handle);
+
+		var current_ref = root_target_refs.get(target);
+		if (current_ref === undefined) return;
+
+		current_ref.count -= 1;
+		if (current_ref.count > 0) return;
+
+		// Last caller for this target: actually tear down the shared listeners.
+		root_target_refs.delete(target);
+		for (var event_name of current_ref.registered_events) {
 			target.removeEventListener(
 				event_name,
 				/** @type {EventListener} */ (handle_event_propagation),
 			);
 		}
-		root_event_handles.delete(event_handle);
-		root_target = null;
+		if (root_target === target) {
+			root_target = null;
+		}
 	};
 }

--- a/packages/ripple/src/runtime/internal/client/events.js
+++ b/packages/ripple/src/runtime/internal/client/events.js
@@ -25,22 +25,31 @@ var all_registered_events = new Set();
 /** @type {Set<(events: Array<string>) => void>} */
 var root_event_handles = new Set();
 
-/** @type {Element | null} */
-var root_target = null;
-
 /**
- * Multiple Portals (or a Portal plus the app root) can share the same target
- * element (most commonly `document.body`). `handle_root_events` used to be
- * called once per Portal with no notion of sharing: the first call's cleanup
- * would tear down the delegated listeners for *all* callers the moment that
- * one Portal's content changed or unmounted, even while siblings targeting
- * the same element were still relying on them (e.g. a Modal closing would
- * silently break click delegation for a still-open SideSheet, since both
- * portal to `document.body`). Ref-count per target so cleanup only runs once
- * every caller for that target has released it.
+ * Active root delegation targets, ref-counted per target. Multiple callers of
+ * `handle_root_events` can share one target element — sibling Portals both
+ * targeting `document.body`, a Portal targeting the app's mount target, or
+ * nested mounts. The shared delegated listeners for a target may only be torn
+ * down once every caller for that target has released it, otherwise
+ * unmounting one Portal silently kills event delegation for its siblings.
  * @type {Map<Element, { count: number, registered_events: Set<string> }>}
  */
 var root_target_refs = new Map();
+
+/**
+ * Delegated handling only works for elements strictly below a root delegation
+ * target: the root listener's propagation walk never visits the target itself
+ * or anything above it, so a delegated handler stored there would never fire.
+ * @param {EventTarget} element
+ */
+function is_root_target_or_above(element) {
+	for (var target of root_target_refs.keys()) {
+		if (element === target || /** @type {Element} */ (element).contains?.(target)) {
+			return true;
+		}
+	}
+	return false;
+}
 
 /**
  * @param {AddEventOptions} options
@@ -77,9 +86,8 @@ export function on(element, type, handler, options = {}) {
 		element === window ||
 		element === document ||
 		element === document.body ||
-		element === root_target ||
 		element instanceof MediaQueryList ||
-		/** @type {Element} */ (element).contains(root_target)
+		is_root_target_or_above(element)
 	) {
 		opts.delegated = false;
 	}
@@ -395,13 +403,12 @@ export function delegate(events) {
 
 /** @param {Element} target */
 export function handle_root_events(target) {
-	var ref = root_target_refs.get(target);
-	if (ref === undefined) {
-		ref = { count: 0, registered_events: new Set() };
-		root_target_refs.set(target, ref);
-	}
+	var ref = root_target_refs.get(target) ?? {
+		count: 0,
+		registered_events: /** @type {Set<string>} */ (new Set()),
+	};
 	ref.count += 1;
-	root_target = target;
+	root_target_refs.set(target, ref);
 	var registered_events = ref.registered_events;
 
 	/**
@@ -444,22 +451,18 @@ export function handle_root_events(target) {
 
 		root_event_handles.delete(event_handle);
 
-		var current_ref = root_target_refs.get(target);
-		if (current_ref === undefined) return;
-
-		current_ref.count -= 1;
-		if (current_ref.count > 0) return;
+		// The map entry for `target` is always this `ref`: it is only deleted
+		// when the count hits 0, which requires this cleanup to have run.
+		ref.count -= 1;
+		if (ref.count > 0) return;
 
 		// Last caller for this target: actually tear down the shared listeners.
 		root_target_refs.delete(target);
-		for (var event_name of current_ref.registered_events) {
+		for (var event_name of registered_events) {
 			target.removeEventListener(
 				event_name,
 				/** @type {EventListener} */ (handle_event_propagation),
 			);
-		}
-		if (root_target === target) {
-			root_target = null;
 		}
 	};
 }

--- a/packages/ripple/src/runtime/internal/client/portal.js
+++ b/packages/ripple/src/runtime/internal/client/portal.js
@@ -38,6 +38,14 @@ export function Portal(props) {
 		}
 
 		try {
+			// Root event delegation lives in its own render block so it only
+			// re-runs when `props.target` changes — a children-only update must
+			// not release and re-acquire the target's delegated listeners.
+			render(() => {
+				const cleanup_events = handle_root_events(/** @type {Element} */ (props.target));
+				return cleanup_events;
+			});
+
 			render(() => {
 				const next_target = props.target;
 				const next_children = props.children;
@@ -60,8 +68,6 @@ export function Portal(props) {
 				anchor = create_text();
 				/** @type {Element} */ (target).append(anchor);
 
-				const cleanup_events = handle_root_events(/** @type {Element} */ (target));
-
 				var block = /** @type {Block} */ (active_block);
 
 				b = branch(() => {
@@ -74,7 +80,6 @@ export function Portal(props) {
 				dom_end = b?.s?.end;
 
 				return () => {
-					cleanup_events();
 					/** @type {Text} */ (anchor).remove();
 					if (dom_start && dom_end) {
 						remove_block_dom(dom_start, dom_end);

--- a/packages/ripple/tests/client/events.test.tsrx
+++ b/packages/ripple/tests/client/events.test.tsrx
@@ -1,5 +1,5 @@
 import type { OnEventListenerRemover } from 'ripple';
-import { effect, flushSync, on, track } from 'ripple';
+import { effect, flushSync, on, Portal, track } from 'ripple';
 
 describe('on() event handler', () => {
 	it('should attach multiple handlers via onClick attribute (delegated)', () => {
@@ -31,6 +31,38 @@ describe('on() event handler', () => {
 		flushSync();
 		expect(count1Div.textContent).toBe('1');
 		expect(count2Div.textContent).toBe('1');
+	});
+
+	it('attaches directly on a root delegation target even when a portal roots elsewhere', () => {
+		// Regression test: `on()` must not delegate handlers attached to any
+		// active root delegation target. With a single `root_target` global,
+		// a Portal targeting a sibling layer overwrote it, so `on(container)`
+		// took the delegated path and its handler never fired.
+		const layer = document.createElement('div');
+		document.body.appendChild(layer);
+
+		function App() @{
+			<>
+				<button class="inner">{'Inner'}</button>
+				<Portal target={layer}>
+					<div class="layer-content">{'Layer content'}</div>
+				</Portal>
+			</>
+		}
+
+		render(App);
+
+		let calls = 0;
+		const off = on(container, 'click', () => {
+			calls++;
+		});
+
+		container.querySelector('.inner').click();
+		flushSync();
+		expect(calls).toBe(1);
+
+		off();
+		layer.remove();
 	});
 
 	it('should attach and remove a single event handler', () => {

--- a/packages/ripple/tests/client/portal.test.tsrx
+++ b/packages/ripple/tests/client/portal.test.tsrx
@@ -137,66 +137,70 @@ describe('Portal', () => {
 		document.body.removeChild(target2);
 	});
 
-	it('two portals sharing the same target: closing one does not break click delegation for the other', () => {
-		// Regression test: handle_root_events used to have no ref-counting per
-		// target. When two Portals both targeted document.body (e.g. a Modal
-		// and a SideSheet), closing/unmounting the first Portal would tear
-		// down the shared delegated event listeners for *all* portals on that
-		// target, silently breaking clicks inside any portal still open.
-		function TestSharedTargetPortals() @{
-			let &[modalOpen] = track(true);
-			let &[sheetOpen] = track(true);
-			let &[sheetClicks] = track(0);
-			<>
-				@if (modalOpen) {
-					<Portal target={document.body}>
-						<div class="test-portal test-modal">
-							<button class="close-modal" onClick={() => (modalOpen = false)}>{'Close modal'}</button>
-						</div>
-					</Portal>
-				}
-				@if (sheetOpen) {
-					<Portal target={document.body}>
-						<div class="test-portal test-sheet">
-							<span class="sheet-clicks">{String(sheetClicks)}</span>
-							<button
-								class="sheet-btn"
-								onClick={() => {
-									sheetClicks++;
-								}}
-							>
-								{'Sheet button'}
-							</button>
-						</div>
-					</Portal>
-				}
-			</>
-		}
+	it(
+		'two portals sharing the same target: closing one does not break click delegation for the other',
+		() => {
+			// Regression test: handle_root_events used to have no ref-counting per
+			// target. When two Portals both targeted document.body (e.g. a Modal
+			// and a SideSheet), closing/unmounting the first Portal would tear
+			// down the shared delegated event listeners for *all* portals on that
+			// target, silently breaking clicks inside any portal still open.
+			function TestSharedTargetPortals() @{
+				let &[modalOpen] = track(true);
+				let &[sheetOpen] = track(true);
+				let &[sheetClicks] = track(0);
+				<>
+					@if (modalOpen) {
+						<Portal target={document.body}>
+							<div class="test-portal test-modal">
+								<button
+									class="close-modal"
+									onClick={() => (modalOpen = false)}
+								>{'Close modal'}</button>
+							</div>
+						</Portal>
+					}
+					@if (sheetOpen) {
+						<Portal target={document.body}>
+							<div class="test-portal test-sheet">
+								<span class="sheet-clicks">{String(sheetClicks)}</span>
+								<button
+									class="sheet-btn"
+									onClick={() => {
+										sheetClicks++;
+									}}
+								>{'Sheet button'}</button>
+							</div>
+						</Portal>
+					}
+				</>
+			}
 
-		render(TestSharedTargetPortals);
+			render(TestSharedTargetPortals);
 
-		expect(document.body.querySelector('.close-modal')).toBeTruthy();
-		expect(document.body.querySelector('.sheet-btn')).toBeTruthy();
+			expect(document.body.querySelector('.close-modal')).toBeTruthy();
+			expect(document.body.querySelector('.sheet-btn')).toBeTruthy();
 
-		// Close the modal portal - its cleanup must not tear down the shared
-		// document.body event delegation that the still-open sheet portal relies on.
-		document.body.querySelector('.close-modal').click();
-		flushSync();
+			// Close the modal portal - its cleanup must not tear down the shared
+			// document.body event delegation that the still-open sheet portal relies on.
+			document.body.querySelector('.close-modal').click();
+			flushSync();
 
-		expect(document.body.querySelector('.close-modal')).toBeNull();
-		const sheetBtn = document.body.querySelector('.sheet-btn');
-		expect(sheetBtn).toBeTruthy();
-		expect(document.body.querySelector('.sheet-clicks').textContent).toBe('0');
+			expect(document.body.querySelector('.close-modal')).toBeNull();
+			const sheetBtn = document.body.querySelector('.sheet-btn');
+			expect(sheetBtn).toBeTruthy();
+			expect(document.body.querySelector('.sheet-clicks').textContent).toBe('0');
 
-		sheetBtn.click();
-		flushSync();
+			sheetBtn.click();
+			flushSync();
 
-		// This is the actual regression check: before the fix, the shared
-		// document.body listener was removed when the modal portal's cleanup
-		// ran, so this click would never reach the handler and the count
-		// would stay at 0.
-		expect(document.body.querySelector('.sheet-clicks').textContent).toBe('1');
-	});
+			// This is the actual regression check: before the fix, the shared
+			// document.body listener was removed when the modal portal's cleanup
+			// ran, so this click would never reach the handler and the count
+			// would stay at 0.
+			expect(document.body.querySelector('.sheet-clicks').textContent).toBe('1');
+		},
+	);
 
 	it('handles portal with reactive content', () => {
 		function TestReactivePortal() @{

--- a/packages/ripple/tests/client/portal.test.tsrx
+++ b/packages/ripple/tests/client/portal.test.tsrx
@@ -137,6 +137,67 @@ describe('Portal', () => {
 		document.body.removeChild(target2);
 	});
 
+	it('two portals sharing the same target: closing one does not break click delegation for the other', () => {
+		// Regression test: handle_root_events used to have no ref-counting per
+		// target. When two Portals both targeted document.body (e.g. a Modal
+		// and a SideSheet), closing/unmounting the first Portal would tear
+		// down the shared delegated event listeners for *all* portals on that
+		// target, silently breaking clicks inside any portal still open.
+		function TestSharedTargetPortals() @{
+			let &[modalOpen] = track(true);
+			let &[sheetOpen] = track(true);
+			let &[sheetClicks] = track(0);
+			<>
+				@if (modalOpen) {
+					<Portal target={document.body}>
+						<div class="test-portal test-modal">
+							<button class="close-modal" onClick={() => (modalOpen = false)}>{'Close modal'}</button>
+						</div>
+					</Portal>
+				}
+				@if (sheetOpen) {
+					<Portal target={document.body}>
+						<div class="test-portal test-sheet">
+							<span class="sheet-clicks">{String(sheetClicks)}</span>
+							<button
+								class="sheet-btn"
+								onClick={() => {
+									sheetClicks++;
+								}}
+							>
+								{'Sheet button'}
+							</button>
+						</div>
+					</Portal>
+				}
+			</>
+		}
+
+		render(TestSharedTargetPortals);
+
+		expect(document.body.querySelector('.close-modal')).toBeTruthy();
+		expect(document.body.querySelector('.sheet-btn')).toBeTruthy();
+
+		// Close the modal portal - its cleanup must not tear down the shared
+		// document.body event delegation that the still-open sheet portal relies on.
+		document.body.querySelector('.close-modal').click();
+		flushSync();
+
+		expect(document.body.querySelector('.close-modal')).toBeNull();
+		const sheetBtn = document.body.querySelector('.sheet-btn');
+		expect(sheetBtn).toBeTruthy();
+		expect(document.body.querySelector('.sheet-clicks').textContent).toBe('0');
+
+		sheetBtn.click();
+		flushSync();
+
+		// This is the actual regression check: before the fix, the shared
+		// document.body listener was removed when the modal portal's cleanup
+		// ran, so this click would never reach the handler and the count
+		// would stay at 0.
+		expect(document.body.querySelector('.sheet-clicks').textContent).toBe('1');
+	});
+
 	it('handles portal with reactive content', () => {
 		function TestReactivePortal() @{
 			let &[count] = track(0);

--- a/packages/ripple/tests/client/portal.test.tsrx
+++ b/packages/ripple/tests/client/portal.test.tsrx
@@ -202,6 +202,48 @@ describe('Portal', () => {
 		},
 	);
 
+	it('retargets portal when target changes and keeps click delegation working', () => {
+		const target1 = document.createElement('div');
+		const target2 = document.createElement('div');
+		document.body.appendChild(target1);
+		document.body.appendChild(target2);
+
+		function TestRetargetPortal() @{
+			let &[useSecond] = track(false);
+			let &[clicks] = track(0);
+			<>
+				<button class="swap" onClick={() => (useSecond = true)}>{'Swap'}</button>
+				<Portal target={useSecond ? target2 : target1}>
+					<div class="test-portal">
+						<span class="clicks">{String(clicks)}</span>
+						<button class="portal-btn" onClick={() => clicks++}>{'Click'}</button>
+					</div>
+				</Portal>
+			</>
+		}
+
+		render(TestRetargetPortal);
+
+		expect(target1.querySelector('.portal-btn')).toBeTruthy();
+		target1.querySelector('.portal-btn').click();
+		flushSync();
+		expect(target1.querySelector('.clicks').textContent).toBe('1');
+
+		container.querySelector('.swap').click();
+		flushSync();
+
+		// Content moved to the new target, and delegation must follow it there.
+		expect(target1.querySelector('.portal-btn')).toBeNull();
+		expect(target2.querySelector('.portal-btn')).toBeTruthy();
+
+		target2.querySelector('.portal-btn').click();
+		flushSync();
+		expect(target2.querySelector('.clicks').textContent).toBe('2');
+
+		document.body.removeChild(target1);
+		document.body.removeChild(target2);
+	});
+
 	it('handles portal with reactive content', () => {
 		function TestReactivePortal() @{
 			let &[count] = track(0);


### PR DESCRIPTION
## Bug

`handle_root_events(target)` is called once per `Portal` on mount and returns a cleanup function. Each caller was treated independently with no notion of sharing the same `target` — the cleanup unconditionally removed the delegated event listeners from `target` and reset the shared `root_target`.

When two Portals both mount to the same target — very common, since `document.body` is the typical Portal target for things like modals, drawers/side sheets, tooltips, etc. — closing/unmounting the first Portal runs its cleanup, which tears down the delegated listeners for `document.body` entirely. Any sibling Portal still open on that same target silently loses all event handling: clicks (and other delegated events) inside it stop working with no error, no warning. The DOM nodes and their delegated handler references (`__click` etc., set in `create_event`) are completely untouched — only the shared root delegation listener on `target` is gone — which makes this very hard to track down from either component's own code.

### Repro

```jsx
function App() @{
  let &[modalOpen] = track(true);
  let &[sheetOpen] = track(true);
  <>
    @if (modalOpen) {
      <Portal target={document.body}>
        <button onClick={() => (modalOpen = false)}>{'Close modal'}</button>
      </Portal>
    }
    @if (sheetOpen) {
      <Portal target={document.body}>
        <button onClick={() => console.log('clicked')}>{'Sheet button'}</button>
      </Portal>
    }
  </>
}
```

Click "Close modal", then click "Sheet button" — nothing happens. The sheet's button still exists in the DOM with its click handler attached via the delegated-events mechanism, but `document.body` no longer has a `click` listener routing to it, because the modal Portal's cleanup removed it when it unmounted.

I ran into this building a Modal + SideSheet pair for a component library, both portaling to `document.body` — closing the Modal silently broke click handling in an already-open SideSheet.

## Fix

`handle_root_events` now ref-counts callers per `target`:

```js
/** @type {Map<Element, { count: number, registered_events: Set<string> }>} */
var root_target_refs = new Map();

export function handle_root_events(target) {
  var ref = root_target_refs.get(target);
  if (ref === undefined) {
    ref = { count: 0, registered_events: new Set() };
    root_target_refs.set(target, ref);
  }
  ref.count += 1;
  // ... registered_events now comes from the shared ref, not a fresh Set per call

  return () => {
    // ...
    var current_ref = root_target_refs.get(target);
    current_ref.count -= 1;
    if (current_ref.count > 0) return; // other callers still need this target's listeners
    // last caller: actually tear down
  };
}
```

The delegated listeners for a given target are only actually torn down once every caller for that target has released it. `registered_events` is now shared per-target too (previously each call had its own `Set`, so a second Portal on the same target that introduced a new event type wouldn't correctly track it for removal purposes either).

## Testing

- Added a regression test to `packages/ripple/tests/client/portal.test.tsrx` ("two portals sharing the same target: closing one does not break click delegation for the other") — fails before this fix (`expected '0' to be '1'`, i.e. the click never reaches the handler) and passes after.
- Ran `packages/ripple` test suite locally: all passing (pre-existing failures elsewhere in the monorepo are `adapter-vercel` Node-version-support checks and `eslint-plugin` config loading, both unrelated and reproducible on `main` without this change).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core client event delegation and Portal mount/cleanup paths; behavior change is intentional but affects all delegated events at root targets.
> 
> **Overview**
> Fixes **silent loss of delegated clicks** when multiple `Portal`s (or mounts) share the same delegation target—especially `document.body`—because one unmount used to remove the shared root listeners for everyone.
> 
> **`handle_root_events`** now keeps a per-target ref count and shared `registered_events` set; cleanup only removes listeners when the last caller for that element releases. The global **`root_target`** is replaced by **`root_target_refs`**, and **`on()`** uses **`is_root_target_or_above`** so listeners on any active root target stay non-delegated even when another Portal roots elsewhere.
> 
> **`Portal`** acquires root delegation in a **separate `render` block** tied to `props.target`, so children-only updates no longer tear down and re-register delegation on every re-render.
> 
> Regression coverage: shared-target portals, portal retargeting, and `on(container)` with a sibling Portal layer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b5bb7dcc99f74ecaa4630707358d4d9a32e341d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->