### PR TITLE
fix(nvim-plugin): register the ripple parser correctly with nvim-treesitter

### DIFF
--- a/packages/nvim-plugin/lua/ripple/treesitter.lua
+++ b/packages/nvim-plugin/lua/ripple/treesitter.lua
@@ -1,23 +1,33 @@
 local M = {}
 
 local function resolve_parser_install_info(plugin)
-	if plugin and type(plugin.dir) == 'string' and plugin.dir ~= '' then
-		return {
-			url = plugin.dir,
-			location = 'grammars/tree-sitter',
-			files = { 'src/parser.c', 'src/scanner.c' },
-		}
-	end
-
-	return {
+	local install_info = {
 		url = 'https://github.com/Ripple-TS/ripple',
 		location = 'grammars/tree-sitter',
+		-- `files` is only read by nvim-treesitter's master branch; main compiles
+		-- everything under `location` and ignores it.
 		files = { 'src/parser.c', 'src/scanner.c' },
 	}
+
+	if plugin and type(plugin.dir) == 'string' and plugin.dir ~= '' then
+		-- Local checkout: master detects a directory passed as `url`, while main
+		-- only treats `path` as local (it overrides `url` there).
+		install_info.url = plugin.dir
+		install_info.path = plugin.dir
+	end
+
+	return install_info
 end
 
 local function add_ripple(plugin)
-	require('nvim-treesitter.parsers').list.ripple = {
+	local parsers = require('nvim-treesitter.parsers')
+	-- nvim-treesitter's master branch keeps parser configs in a `list` subtable
+	-- (exposed via get_parser_configs()); the main rewrite returns the config
+	-- table directly from the module.
+	local configs = type(parsers.get_parser_configs) == 'function' and parsers.get_parser_configs()
+		or parsers
+
+	configs.ripple = {
 		install_info = resolve_parser_install_info(plugin),
 		filetype = 'ripple',
 	}

--- a/packages/nvim-plugin/lua/ripple/treesitter.lua
+++ b/packages/nvim-plugin/lua/ripple/treesitter.lua
@@ -3,21 +3,21 @@ local M = {}
 local function resolve_parser_install_info(plugin)
 	if plugin and type(plugin.dir) == 'string' and plugin.dir ~= '' then
 		return {
-			path = plugin.dir,
+			url = plugin.dir,
 			location = 'grammars/tree-sitter',
-			files = { 'src/parser.c' },
+			files = { 'src/parser.c', 'src/scanner.c' },
 		}
 	end
 
 	return {
 		url = 'https://github.com/Ripple-TS/ripple',
 		location = 'grammars/tree-sitter',
-		files = { 'src/parser.c' },
+		files = { 'src/parser.c', 'src/scanner.c' },
 	}
 end
 
-function add_ripple(plugin)
-	require('nvim-treesitter.parsers').ripple = {
+local function add_ripple(plugin)
+	require('nvim-treesitter.parsers').list.ripple = {
 		install_info = resolve_parser_install_info(plugin),
 		filetype = 'ripple',
 	}


### PR DESCRIPTION
## Summary

The nvim plugin's treesitter setup never actually installs the `ripple` parser, so syntax highlighting silently never turns on (LSP features like go-to-definition work fine since they go through a separate pipeline). Three bugs in `add_ripple()` (`packages/nvim-plugin/lua/ripple/treesitter.lua`):

- The parser config was assigned to `require('nvim-treesitter.parsers').ripple`, but that module keeps its parser table under `.list` (`M = { list = list }`). Setting `.ripple` directly just sets a stray field nvim-treesitter never reads, so `ripple` never shows up as an installable/available parser.
- `install_info.path` isn't a field nvim-treesitter's installer reads. A local checkout is passed via `install_info.url`, which the installer detects as local via `isdirectory()`.
- `files` only listed `src/parser.c`, but the grammar ships an external scanner (`src/scanner.c`) that the parser needs to link against — without it, compilation fails with undefined symbol errors (`_tree_sitter_ripple_external_scanner_*`).

Also added a missing `local` to `add_ripple`, which was leaking into the global namespace.

## Test plan

- [x] Confirmed before the fix: `require('nvim-treesitter.parsers').get_parser_configs().ripple` is `nil`, `:TSInstall ripple` fails as "not available"
- [x] After fixing table + key: `:TSInstall ripple` finds it but fails to compile (`ld: symbol(s) not found ... external_scanner`)
- [x] After adding `src/scanner.c`: `:TSInstall ripple` compiles and installs successfully
- [x] Opened a real `.tsrx` file — `vim.treesitter.highlighter.active[bufnr]` is `true`, syntax highlighting renders correctly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to Neovim plugin Tree-sitter registration and install metadata; no runtime server or security-sensitive paths.
> 
> **Overview**
> Fixes **silent missing Tree-sitter highlighting** for Ripple by registering the `ripple` parser where **nvim-treesitter** actually reads configs, and by supplying install metadata that compiles the full grammar.
> 
> **Parser registration** now writes to `get_parser_configs()` when present (master’s `.list` table) or the module table directly (main), instead of a stray `.ripple` field on `require('nvim-treesitter.parsers')`. **`add_ripple`** is **`local`** so it no longer leaks into the global namespace.
> 
> **Install info** is built as one table: default remote **`url`**, **`files`** includes **`src/scanner.c`** alongside **`src/parser.c`** so linking succeeds on master; local plugin dirs set both **`url`** and **`path`** so master and main both treat the checkout as a local grammar source.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84ce616071a27d3d897c5bf95ac11ad6b144b0ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->