### PR TITLE
feat: sibling-scoped style blocks, $class, and apply (TSRX RFC #1)

### DIFF
--- a/.changeset/scoped-styles-apply.md
+++ b/.changeset/scoped-styles-apply.md
@@ -1,0 +1,14 @@
+---
+'@tsrx/ripple': patch
+'ripple': patch
+---
+
+Implement sibling-scoped `<style>` blocks, `$class`, and `apply` ([TSRX RFC #1](https://github.com/tsrx-org/RFCs/discussions/1)) for the Ripple target.
+
+- A `<style>` block is scoped to its siblings: it styles the items beside it and everything below them, never the element that contains it. Blocks among the same children share one hash and one stylesheet; nested children lists that hold blocks are nested scopes, and every element carries the hash of each enclosing scope, outer first. Control-flow branches and templates assigned to variables host scopes too.
+- Assigning a block to a variable exposes `$class`. Exported, applied, or `$class`-read blocks are themes that keep every selector; other assigned blocks stay class maps. `<style apply={theme} />` attaches a theme to a whole scope, `<style apply={theme}>…</style>` applies and declares in one tag, arrays apply several themes, and a theme may apply other themes. Same-module themes inline as literals; imported themes are read through `theme.$class` at runtime.
+- CSS is emitted in lexical order (an applied theme before the block that applies it, a scope's blocks together, nested scopes after their parent). On the server a render registers the sheets it needs in that order, class-map reads register their own sheet, and reading `theme.$class` outside a render no longer throws.
+- The style diagnostics of the RFC (`tsrx-style-*` codes) are reported, and type-only output verifies `apply` targets through a `$class` read.
+- Fixed: a `@{ … }` block rendered as the child of a DOM element on the client was dropped; it now renders in place. The `#class` spread attribute accepts several class tokens.
+
+Raw CSS in a `<style>` inside a plain function that returns JSX is now an error (`tsrx-style-standalone-outside-template`): use a `@{ … }` body, or `<style>{css}</style>`. Elements are stamped with the scope class after their authored classes, and every element of a scope carries it, not only those a selector matches.

--- a/.cursor/rules/project.mdc
+++ b/.cursor/rules/project.mdc
@@ -92,6 +92,13 @@ pnpm rules:generate
   setup.
 - Use `@if`, `@for`, `@switch`, and `@try` for template control flow. Plain
   JavaScript control flow remains ordinary setup code.
+- A `<style>` block is scoped to its siblings: it styles the elements beside it
+  and everything below them, never the element that contains it. Put the block and
+  its markup side by side in a fragment or element, inside a `@{ ... }` body or a
+  control-flow branch. Blocks among the same children share one hash; nested
+  children lists with blocks are nested scopes. Assign a block to a variable for a
+  theme (`theme.$class`, `<style apply={theme} />`) or class map; raw CSS in a
+  `<style>` inside a plain `return <div />` function is an error.
 - Use `pnpm` for all package management and workspace scripts.
 - Follow the conventions of the package you are changing. This repo mixes plain
   JavaScript, JSDoc-typed JavaScript, and TypeScript depending on package.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -87,6 +87,13 @@ pnpm rules:generate
   setup.
 - Use `@if`, `@for`, `@switch`, and `@try` for template control flow. Plain
   JavaScript control flow remains ordinary setup code.
+- A `<style>` block is scoped to its siblings: it styles the elements beside it
+  and everything below them, never the element that contains it. Put the block and
+  its markup side by side in a fragment or element, inside a `@{ ... }` body or a
+  control-flow branch. Blocks among the same children share one hash; nested
+  children lists with blocks are nested scopes. Assign a block to a variable for a
+  theme (`theme.$class`, `<style apply={theme} />`) or class map; raw CSS in a
+  `<style>` inside a plain `return <div />` function is an error.
 - Use `pnpm` for all package management and workspace scripts.
 - Follow the conventions of the package you are changing. This repo mixes plain
   JavaScript, JSDoc-typed JavaScript, and TypeScript depending on package.

--- a/.rulesync/rules/project.md
+++ b/.rulesync/rules/project.md
@@ -94,6 +94,13 @@ pnpm rules:generate
   setup.
 - Use `@if`, `@for`, `@switch`, and `@try` for template control flow. Plain
   JavaScript control flow remains ordinary setup code.
+- A `<style>` block is scoped to its siblings: it styles the elements beside it
+  and everything below them, never the element that contains it. Put the block and
+  its markup side by side in a fragment or element, inside a `@{ ... }` body or a
+  control-flow branch. Blocks among the same children share one hash; nested
+  children lists with blocks are nested scopes. Assign a block to a variable for a
+  theme (`theme.$class`, `<style apply={theme} />`) or class map; raw CSS in a
+  `<style>` inside a plain `return <div />` function is an error.
 - Use `pnpm` for all package management and workspace scripts.
 - Follow the conventions of the package you are changing. This repo mixes plain
   JavaScript, JSDoc-typed JavaScript, and TypeScript depending on package.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,13 @@ pnpm rules:generate
   setup.
 - Use `@if`, `@for`, `@switch`, and `@try` for template control flow. Plain
   JavaScript control flow remains ordinary setup code.
+- A `<style>` block is scoped to its siblings: it styles the elements beside it
+  and everything below them, never the element that contains it. Put the block and
+  its markup side by side in a fragment or element, inside a `@{ ... }` body or a
+  control-flow branch. Blocks among the same children share one hash; nested
+  children lists with blocks are nested scopes. Assign a block to a variable for a
+  theme (`theme.$class`, `<style apply={theme} />`) or class map; raw CSS in a
+  `<style>` inside a plain `return <div />` function is an error.
 - Use `pnpm` for all package management and workspace scripts.
 - Follow the conventions of the package you are changing. This repo mixes plain
   JavaScript, JSDoc-typed JavaScript, and TypeScript depending on package.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,13 @@ pnpm rules:generate
   setup.
 - Use `@if`, `@for`, `@switch`, and `@try` for template control flow. Plain
   JavaScript control flow remains ordinary setup code.
+- A `<style>` block is scoped to its siblings: it styles the elements beside it
+  and everything below them, never the element that contains it. Put the block and
+  its markup side by side in a fragment or element, inside a `@{ ... }` body or a
+  control-flow branch. Blocks among the same children share one hash; nested
+  children lists with blocks are nested scopes. Assign a block to a variable for a
+  theme (`theme.$class`, `<style apply={theme} />`) or class map; raw CSS in a
+  `<style>` inside a plain `return <div />` function is an error.
 - Use `pnpm` for all package management and workspace scripts.
 - Follow the conventions of the package you are changing. This repo mixes plain
   JavaScript, JSDoc-typed JavaScript, and TypeScript depending on package.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -91,6 +91,13 @@ pnpm rules:generate
   setup.
 - Use `@if`, `@for`, `@switch`, and `@try` for template control flow. Plain
   JavaScript control flow remains ordinary setup code.
+- A `<style>` block is scoped to its siblings: it styles the elements beside it
+  and everything below them, never the element that contains it. Put the block and
+  its markup side by side in a fragment or element, inside a `@{ ... }` body or a
+  control-flow branch. Blocks among the same children share one hash; nested
+  children lists with blocks are nested scopes. Assign a block to a variable for a
+  theme (`theme.$class`, `<style apply={theme} />`) or class map; raw CSS in a
+  `<style>` inside a plain `return <div />` function is an error.
 - Use `pnpm` for all package management and workspace scripts.
 - Follow the conventions of the package you are changing. This repo mixes plain
   JavaScript, JSDoc-typed JavaScript, and TypeScript depending on package.

--- a/README.md
+++ b/README.md
@@ -316,8 +316,9 @@ export function SearchBox() @{
 
 ### Scoped Styles
 
-`<style>` blocks are static CSS and are scoped to the template. Use CSS custom
-properties for runtime values.
+`<style>` blocks are static CSS scoped to their siblings: a block styles the
+elements beside it and everything below them, never the element that contains it.
+Use CSS custom properties for runtime values.
 
 ```tsx
 import { track } from 'ripple';
@@ -342,17 +343,36 @@ export function Notice() @{
 }
 ```
 
-Module-scope style expressions can expose scoped class names:
+A `<style>` block assigned to a variable becomes a theme: an object with `$class`,
+its hash class, plus one key per class selector. Pass the strings as props, apply
+the whole theme to a scope with `<style apply={theme} />`, or opt single elements
+in with `class={theme.$class}`:
 
 ```tsx
-const styles = <style>
+export const theme = <style>
+  article {
+    font-family: system-ui;
+  }
   .highlight {
     background: #e8f5e9;
   }
 </style>;
 
 export function Badge() {
-  return <span class={styles.highlight}>New</span>;
+  return <span class={theme.highlight}>New</span>;
+}
+
+export function Card() @{
+  <>
+    <style apply={theme}>
+      h2 {
+        margin: 0;
+      }
+    </style>
+    <article>
+      <h2>Themed, with a local override</h2>
+    </article>
+  </>
 }
 ```
 

--- a/packages/ripple/src/runtime/internal/client/render.js
+++ b/packages/ripple/src/runtime/internal/client/render.js
@@ -140,8 +140,9 @@ function set_attribute_helper(element, key, value, remove_listeners, prev) {
 	} else if (key === 'style') {
 		set_style(element, value, prev.style);
 	} else if (key === '#class') {
-		// Special case for static class when spreading props
-		element.classList.add(value);
+		// Special case for the scope classes of an element that spreads props:
+		// one token per scope hash and applied theme.
+		element.classList.add(...String(value).split(' ').filter(Boolean));
 	} else if (typeof key === 'string' && is_event_attribute(key)) {
 		// Handle event handlers in spread props
 		if (remove_listeners[key]) {

--- a/packages/ripple/src/runtime/internal/server/index.js
+++ b/packages/ripple/src/runtime/internal/server/index.js
@@ -1252,7 +1252,12 @@ export function set_output_target(target) {
  * @returns {void}
  */
 export function output_register_css(hash) {
-	/** @type {Block} */ (active_block).o.register_css(hash);
+	// A style class map is read wherever its value is used, including outside
+	// a render (a module-level `theme.$class` read); only a render has a
+	// request to register the CSS with.
+	if (active_block !== null) {
+		active_block.o.register_css(hash);
+	}
 }
 
 /**

--- a/packages/ripple/tests/client/basic/basic.styling.test.tsrx
+++ b/packages/ripple/tests/client/basic/basic.styling.test.tsrx
@@ -2,8 +2,8 @@ import { compile } from '@tsrx/ripple';
 
 describe('basic client > styling', () => {
 	it('renders with styling scoped to component', () => {
-		function Basic() {
-			return <>
+		function Basic() @{
+			<>
 				<div class="styled-container">
 					<h1>{'Styled heading'}</h1>
 					<p class="text">{'Styled paragraph'}</p>
@@ -24,7 +24,7 @@ describe('basic client > styling', () => {
 						font-size: 14px;
 					}
 				</style>
-			</>;
+			</>
 		}
 
 		render(Basic);

--- a/packages/ripple/tests/client/css/scoped-styles.test.tsrx
+++ b/packages/ripple/tests/client/css/scoped-styles.test.tsrx
@@ -1,0 +1,622 @@
+import { track, flushSync } from 'ripple';
+import { compile } from '@tsrx/ripple';
+import {
+	base as importedBase,
+	theme as importedTheme,
+} from '../../fixtures/scoped-styles/theme.tsrx';
+
+// RFC tsrx-org/RFCs#1: a `<style>` block is scoped to its siblings — it styles
+// the items beside it and everything below them, never the element that
+// contains it. Sibling blocks share one hash, nested children lists that hold
+// blocks are nested scopes, assigned blocks expose `$class`, and `apply`
+// attaches a theme to a whole scope.
+
+function hashes(element: Element | null): string[] {
+	return Array.from(element?.classList ?? []).filter((cls) => cls.startsWith('tsrx-'));
+}
+
+function tokens(value: string): string[] {
+	return value.split(' ').filter(Boolean);
+}
+
+const one = <style>
+	div {
+		color: red;
+	}
+	.one {
+		margin: 0;
+	}
+</style>;
+
+const two = <style>
+	div {
+		color: blue;
+	}
+</style>;
+
+const localBase = <style>
+	p {
+		margin: 0;
+	}
+</style>;
+
+const accent = <style apply={localBase}>
+	p {
+		color: purple;
+	}
+</style>;
+
+const bundle = <style apply={[two, accent]} />;
+
+describe('sibling-scoped style blocks', () => {
+	it('styles the items beside a block and everything below them, never the container', () => {
+		function Status() @{
+			let &[ready] = track(false);
+			<>
+				<button onClick={() => (ready = !ready)}>{'toggle'}</button>
+				<style>
+					.status {
+						padding: 0.5rem;
+					}
+				</style>
+				<section id="status" class="status">
+					<style>
+						.title {
+							font-weight: 700;
+						}
+						.status {
+							color: rgb(9, 9, 9);
+						}
+					</style>
+					<h2 id="title" class="title">{'Status'}</h2>
+					@if (ready) {
+						<>
+							<style>
+								.ok {
+									color: green;
+								}
+							</style>
+							<p id="ok" class="ok">{'Ready'}</p>
+						</>
+					} @else {
+						<>
+							<style>
+								.wait {
+									color: gray;
+								}
+							</style>
+							<p id="wait" class="wait">{'Waiting'}</p>
+						</>
+					}
+				</section>
+			</>
+		}
+
+		render(Status);
+
+		const section = container.querySelector('#status');
+		const title = container.querySelector('#title');
+		const wait = container.querySelector('#wait');
+
+		const [A] = hashes(section);
+		expect(A).toBeTruthy();
+		// The section carries only the fragment's scope: the block written
+		// inside it styles its children, not the section. The button is a
+		// sibling of the block too.
+		expect(hashes(section)).toEqual([A]);
+		expect(hashes(container.querySelector('button'))).toEqual([A]);
+		const B = hashes(title)[1];
+		expect(hashes(title)).toEqual([A, B]);
+		const D = hashes(wait)[2];
+		expect(hashes(wait)).toEqual([A, B, D]);
+		expect(new Set([A, B, D]).size).toBe(3);
+		expect(container.querySelector('#ok')).toBeNull();
+
+		container.querySelector('button')?.click();
+		flushSync();
+
+		const ok = container.querySelector('#ok');
+		const C = hashes(ok)[2];
+		expect(hashes(ok)).toEqual([A, B, C]);
+		expect([A, B, D]).not.toContain(C);
+		expect(container.querySelector('#wait')).toBeNull();
+		expect(hashes(container.querySelector('#status'))).toEqual([A]);
+	});
+
+	it('prunes a rule that only matches the container and emits the scopes in source order', () => {
+		const source = `
+export function Status({ ready }: { ready: boolean }) @{
+	<>
+		<style>.status { padding: 0.5rem; }</style>
+		<section class="status">
+			<style>
+				.title { font-weight: 700; }
+				.status { color: rgb(9, 9, 9); }
+			</style>
+			<h2 class="title">{'Status'}</h2>
+			@if (ready) {
+				<>
+					<style>.ok { color: green; }</style>
+					<p class="ok">{'Ready'}</p>
+				</>
+			} @else {
+				<>
+					<style>.wait { color: gray; }</style>
+					<p class="wait">{'Waiting'}</p>
+				</>
+			}
+		</section>
+	</>
+}`;
+		const { css, cssHash } = compile(source, 'test.tsrx');
+		const [A, B, C, D] = cssHash!.split(' ');
+		expect(new Set([A, B, C, D]).size).toBe(4);
+		expect(css).toContain(`.status.${A} { padding: 0.5rem; }`);
+		expect(css).toContain(`.title.${B} { font-weight: 700; }`);
+		expect(css).toContain('/* (unused) .status { color: rgb(9, 9, 9); }*/');
+		expect(css).not.toContain(`.status.${B}`);
+		expect(css).toContain(`.ok.${C}`);
+		expect(css).toContain(`.wait.${D}`);
+		expect(css.indexOf(`.status.${A}`)).toBeLessThan(css.indexOf(`.title.${B}`));
+		expect(css.indexOf(`.title.${B}`)).toBeLessThan(css.indexOf(`.ok.${C}`));
+		expect(css.indexOf(`.ok.${C}`)).toBeLessThan(css.indexOf(`.wait.${D}`));
+	});
+
+	it(
+		'shares one hash between the blocks of one children list, and none with the enclosing list',
+		() => {
+			function Two() @{
+				<>
+					<style>
+						.host {
+							margin: 0;
+						}
+					</style>
+					<div id="host" class="host">
+						<style>
+							.a {
+								color: red;
+							}
+						</style>
+						<i class="a">{'a'}</i>
+						<style>
+							.b {
+								color: blue;
+							}
+						</style>
+						<b class="b">{'b'}</b>
+					</div>
+				</>
+			}
+
+			render(Two);
+
+			const host = container.querySelector('#host');
+			const i = container.querySelector('i');
+			const b = container.querySelector('b');
+			const [H] = hashes(host);
+			expect(hashes(host)).toEqual([H]);
+			const [, C] = hashes(i);
+			expect(C).not.toBe(H);
+			expect(hashes(i)).toEqual([H, C]);
+			expect(hashes(b)).toEqual([H, C]);
+
+			const { css, cssHash } = compile(
+				`export function Two() @{
+	<>
+		<style>.host { margin: 0; }</style>
+		<div class="host">
+			<style>.a { color: red; }</style>
+			<i class="a">{'a'}</i>
+			<style>.b { color: blue; }</style>
+			<b class="b">{'b'}</b>
+		</div>
+	</>
+}`,
+				'test.tsrx',
+			);
+			const [outer, inner] = cssHash!.split(' ');
+			expect(cssHash!.split(' ')).toHaveLength(2);
+			expect(css).toContain(`.host.${outer}`);
+			expect(css).toContain(`.a.${inner}`);
+			expect(css).toContain(`.b.${inner}`);
+		},
+	);
+
+	it('reaches into a nested code block scope, and the nested block never reaches out', () => {
+		function Panel() @{
+			<>
+				<style>
+					div {
+						color: black;
+					}
+				</style>
+				<div id="outer">{'Black'}</div>
+				@{
+					<>
+						<style>
+							div {
+								font-weight: bold;
+							}
+						</style>
+						<div id="inner">{'Black and bold'}</div>
+					</>
+				}
+			</>
+		}
+
+		render(Panel);
+
+		const [A] = hashes(container.querySelector('#outer'));
+		expect(hashes(container.querySelector('#outer'))).toEqual([A]);
+		const inner = hashes(container.querySelector('#inner'));
+		expect(inner).toHaveLength(2);
+		expect(inner[0]).toBe(A);
+		expect(inner[1]).not.toBe(A);
+	});
+
+	it('scopes a block inside a @for branch to the items that branch renders', () => {
+		function List() @{
+			let items = track(['a', 'b']);
+			<>
+				<button onClick={() => (items.value = [])}>{'clear'}</button>
+				<style>
+					li {
+						list-style: none;
+					}
+				</style>
+				<ul>
+					@for (const item of items.value) {
+						<>
+							<style>
+								li {
+									padding: 0.75rem 0;
+								}
+							</style>
+							<li class="item">{item}</li>
+						</>
+					} @empty {
+						<li class="empty">{'none'}</li>
+					}
+				</ul>
+			</>
+		}
+
+		render(List);
+
+		const [first, second] = Array.from(container.querySelectorAll('li.item'));
+		const [A, B] = hashes(first);
+		expect(A).toBeTruthy();
+		expect(B).toBeTruthy();
+		expect(hashes(second)).toEqual([A, B]);
+		expect(hashes(container.querySelector('ul'))).toEqual([A]);
+
+		container.querySelector('button')?.click();
+		flushSync();
+
+		// The `@empty` branch holds no block of its own: only the outer scope.
+		expect(hashes(container.querySelector('li.empty'))).toEqual([A]);
+	});
+
+	it(
+		'keeps the block of an element assigned to a variable, styling its children and not its root',
+		() => {
+			function Templates() @{
+				const card = <div id="root" class="card-root">
+					<style>
+						.text {
+							margin: 0;
+						}
+					</style>
+					<p id="text" class="text">{'card'}</p>
+				</div>;
+				<>
+					{card}
+					<p id="outside">{'outside'}</p>
+				</>
+			}
+
+			render(Templates);
+
+			expect(hashes(container.querySelector('#root'))).toEqual([]);
+			expect(hashes(container.querySelector('#text'))).toHaveLength(1);
+			expect(hashes(container.querySelector('#outside'))).toEqual([]);
+		},
+	);
+
+	it('adds the scope classes of an element that spreads its props, one token per scope', () => {
+		function Button(&{ ...rest }: { id: string; class?: string }) @{
+			<>
+				<style>
+					button {
+						padding: 0;
+					}
+				</style>
+				<div>
+					<style>
+						button {
+							margin: 0;
+						}
+					</style>
+					<button {...rest}>{'b'}</button>
+				</div>
+			</>
+		}
+
+		function App() @{
+			<Button id="btn" class="authored" />
+		}
+
+		render(App);
+
+		const button = container.querySelector('#btn');
+		expect(button?.classList.contains('authored')).toBe(true);
+		expect(hashes(button)).toHaveLength(2);
+		expect(hashes(container.querySelector('div'))).toHaveLength(1);
+	});
+
+	it('keeps the scope classes while a dynamic class value changes', () => {
+		function App() @{
+			let &[active] = track(false);
+			<>
+				<style>
+					.on {
+						color: green;
+					}
+				</style>
+				<button id="toggle" onClick={() => (active = !active)}>{'toggle'}</button>
+				<p id="p" class={active ? 'on' : 'off'}>{'p'}</p>
+			</>
+		}
+
+		render(App);
+
+		const p = container.querySelector('#p');
+		const [A] = hashes(p);
+		expect(A).toBeTruthy();
+		expect(p?.className).toBe(`off ${A}`);
+
+		container.querySelector('#toggle')?.click();
+		flushSync();
+
+		expect(p?.className).toBe(`on ${A}`);
+	});
+});
+
+describe('$class and apply', () => {
+	it('exposes $class on an assigned block and applies it to a whole scope', () => {
+		expect(tokens(one.$class)).toHaveLength(1);
+		expect(one.one).toBe(`${one.$class} one`);
+
+		function SelfClosed() @{
+			<>
+				<style apply={one} />
+				<div id="a1">{'a'}</div>
+				<p id="a2">
+					<span id="a3">{'c'}</span>
+				</p>
+			</>
+		}
+
+		render(SelfClosed);
+
+		for (const id of ['a1', 'a2', 'a3']) {
+			expect(hashes(container.querySelector(`#${id}`))).toEqual(tokens(one.$class));
+		}
+	});
+
+	it('applies a theme and declares the scope block in one tag', () => {
+		function WithBody() @{
+			<>
+				<style apply={one}>
+					.c {
+						margin: 0;
+					}
+				</style>
+				<div id="c1" class="c">{'c'}</div>
+			</>
+		}
+
+		render(WithBody);
+
+		const div = container.querySelector('#c1');
+		const classes = hashes(div);
+		expect(classes).toHaveLength(2);
+		// The scope's own hash comes first, then the applied theme.
+		expect(classes[1]).toBe(one.$class);
+		expect(classes[0]).not.toBe(one.$class);
+		expect(div?.className).toBe(`c ${classes[0]} ${one.$class}`);
+	});
+
+	it('applies several themes with an array and with several blocks', () => {
+		function ArrayForm() @{
+			<>
+				<style apply={[one, two]} />
+				<div id="b1">{'b'}</div>
+			</>
+		}
+
+		function TwoApplies() @{
+			<>
+				<style apply={one} />
+				<style apply={two} />
+				<div id="d1">{'d'}</div>
+			</>
+		}
+
+		render(ArrayForm);
+		expect(hashes(container.querySelector('#b1'))).toEqual([one.$class, two.$class]);
+
+		render(TwoApplies);
+		expect(hashes(container.querySelector('#d1'))).toEqual([one.$class, two.$class]);
+	});
+
+	it('composes themes at their definition and bundles them without CSS of their own', () => {
+		expect(accent.$class).toBe(`${localBase.$class} ${tokens(accent.$class)[1]}`);
+		expect(tokens(accent.$class)).toHaveLength(2);
+		expect(bundle.$class).toBe(`${two.$class} ${accent.$class}`);
+
+		function Composed() @{
+			<>
+				<style apply={accent} />
+				<p id="p">{'composed'}</p>
+			</>
+		}
+
+		render(Composed);
+
+		expect(hashes(container.querySelector('#p'))).toEqual(tokens(accent.$class));
+	});
+
+	it('applies an imported theme through its $class at runtime', () => {
+		expect(importedTheme.$class).toBe(`${importedBase.$class} ${tokens(importedTheme.$class)[1]}`);
+
+		function Card() @{
+			<>
+				<style apply={importedTheme}>
+					h2 {
+						margin: 0;
+					}
+				</style>
+				<article id="card">
+					<h2 id="h2" class={importedTheme.dark}>{'Green, system-ui'}</h2>
+				</article>
+			</>
+		}
+
+		render(Card);
+
+		const card = container.querySelector('#card');
+		const [local] = hashes(card);
+		expect(hashes(card)).toEqual([local, ...tokens(importedTheme.$class)]);
+		expect(container.querySelector('#h2')?.className).toBe(
+			`${importedTheme.dark} ${local} ${importedTheme.$class}`,
+		);
+	});
+
+	it('opts single elements into a theme with $class, including a child through a prop', () => {
+		function Card({ parentClass }: { parentClass: string }) @{
+			<>
+				<style>
+					.local {
+						padding: 0;
+					}
+				</style>
+				<article id="article" class={['local', parentClass]}>
+					<h2 id="h2" class={parentClass}>{'title'}</h2>
+				</article>
+			</>
+		}
+
+		function App() @{
+			const theme = <style>
+				div {
+					color: blue;
+				}
+				.card {
+					color: red;
+				}
+			</style>;
+			<>
+				<Card parentClass={theme.$class} />
+				<div id="opted" class={theme.$class}>{'opted in'}</div>
+				<div id="card" class={theme.card}>{'card'}</div>
+				<p id="untouched">{'untouched'}</p>
+			</>
+		}
+
+		render(App);
+
+		const opted = container.querySelector('#opted');
+		const theme_hash = opted?.className;
+		expect(tokens(theme_hash!)).toHaveLength(1);
+		expect(container.querySelector('#card')?.className).toBe(`${theme_hash} card`);
+		expect(container.querySelector('#untouched')?.className).toBe('');
+
+		const article = container.querySelector('#article');
+		const local = hashes(article).find((cls) => cls !== theme_hash);
+		expect(article?.className).toBe(`local ${theme_hash} ${local}`);
+		expect(container.querySelector('#h2')?.className).toBe(`${theme_hash} ${local}`);
+	});
+
+	it('keeps every selector of a theme and only class selectors of a plain class map', () => {
+		const source = `
+export const theme = <style>
+	div { color: green; }
+	.dark { color: purple; }
+</style>;
+
+const plain = <style>
+	div { color: red; }
+	.card { color: blue; }
+</style>;
+
+const read = <style>
+	span { color: red; }
+</style>;
+
+export function App() @{
+	<>
+		<div class={plain.card}>{'card'}</div>
+		<span class={read.$class}>{'read'}</span>
+	</>
+}`;
+		const { css, code } = compile(source, 'test.tsrx');
+		const [theme_hash, plain_hash, read_hash] = [...css.matchAll(/\.(tsrx-[0-9a-f]+)/g)].map(
+			(match) => match[1],
+		).filter((hash, index, all) => all.indexOf(hash) === index);
+		expect(css).toContain(`div.${theme_hash} { color: green; }`);
+		expect(css).toContain(`.dark.${theme_hash} { color: purple; }`);
+		expect(css).toContain('/* (unused) div { color: red; }*/');
+		expect(css).toContain(`.card.${plain_hash} { color: blue; }`);
+		// Reading `read.$class` makes the block a theme.
+		expect(css).toContain(`span.${read_hash} { color: red; }`);
+		expect(code).toContain(`'$class': '${theme_hash}'`);
+		expect(code).toContain(`'dark': '${theme_hash} dark'`);
+	});
+
+	it(
+		'emits an applied theme before the scope that applies it, and a scope before the scopes nested in it',
+		() => {
+			const source = `
+const theme = <style>
+	div { color: green; }
+</style>;
+
+export function Precedence() @{
+	<>
+		<style apply={theme}>
+			div { color: black; }
+		</style>
+		<div class="outer">{'outer'}</div>
+		@{
+			<>
+				<style>
+					div { color: blue; }
+				</style>
+				<div class="inner">{'inner'}</div>
+			</>
+		}
+		<style>
+			div { font-style: italic; }
+		</style>
+	</>
+}`;
+			const { css, cssHash, code } = compile(source, 'test.tsrx');
+			const [theme_hash, outer, inner] = cssHash!.split(' ');
+			expect(cssHash!.split(' ')).toHaveLength(3);
+			const green = css.indexOf(`div.${theme_hash} { color: green; }`);
+			const black = css.indexOf(`div.${outer} { color: black; }`);
+			const italic = css.indexOf(`div.${outer} { font-style: italic; }`);
+			const blue = css.indexOf(`div.${inner} { color: blue; }`);
+			expect(green).toBeGreaterThanOrEqual(0);
+			expect(green).toBeLessThan(black);
+			// The outer scope's blocks stay one group, even though the second
+			// block is written after the nested scope.
+			expect(black).toBeLessThan(italic);
+			expect(italic).toBeLessThan(blue);
+			expect(code).toContain(`class="outer ${outer} ${theme_hash}"`);
+			expect(code).toContain(`class="inner ${outer} ${inner} ${theme_hash}"`);
+		},
+	);
+});

--- a/packages/ripple/tests/client/css/scoped-styles.test.tsrx
+++ b/packages/ripple/tests/client/css/scoped-styles.test.tsrx
@@ -355,6 +355,36 @@ export function Status({ ready }: { ready: boolean }) @{
 		expect(hashes(container.querySelector('div'))).toHaveLength(1);
 	});
 
+	it('keeps the scope classes of a static class when a spread brings its own class', () => {
+		function Card(&{ ...rest }: { class?: string }) @{
+			<>
+				<style apply={importedTheme}>
+					.box {
+						color: red;
+					}
+				</style>
+				<div id="box" class="box" {...rest}>{'x'}</div>
+				<style>
+					.plain {
+						margin: 0;
+					}
+				</style>
+			</>
+		}
+
+		function App() @{
+			<Card class="from-spread" />
+		}
+
+		render(App);
+
+		const box = container.querySelector('#box');
+		const [local] = hashes(box);
+		expect(local).toBeTruthy();
+		expect(hashes(box)).toEqual([local, ...tokens(importedTheme.$class)]);
+		expect(box?.classList.contains('box')).toBe(true);
+	});
+
 	it('keeps the scope classes while a dynamic class value changes', () => {
 		function App() @{
 			let &[active] = track(false);

--- a/packages/ripple/tests/client/dynamic-elements.test.tsrx
+++ b/packages/ripple/tests/client/dynamic-elements.test.tsrx
@@ -671,7 +671,9 @@ describe('dynamic DOM elements', () => {
 		expect(innerScopes).toHaveLength(1);
 		expect(innerScopes[0]).not.toBe(outerScope);
 
-		expect(innerInnerScopes).toHaveLength(0);
+		// Every element of the child's scope carries the child's hash, and none
+		// of the parent's.
+		expect(innerInnerScopes).toEqual(innerScopes);
 	});
 
 	it('doesn\'t add scoping class to dynamically rendered component', () => {
@@ -708,7 +710,8 @@ describe('dynamic DOM elements', () => {
 		const innerScopes = Array.from(p.classList).filter((c) => c.startsWith('tsrx-'));
 
 		expect(outerScopes).toHaveLength(1);
-		expect(innerScopes).toHaveLength(0);
+		// The child's own scope reaches its <p>; the parent's never does.
+		expect(innerScopes).toEqual(outerScopes);
 	});
 
 	it('handles ref on dynamic element passed through component with reactive props', () => {

--- a/packages/ripple/tests/fixtures/scoped-styles/theme.tsrx
+++ b/packages/ripple/tests/fixtures/scoped-styles/theme.tsrx
@@ -1,0 +1,20 @@
+// A theme module shared by the scoped-style tests: `base` is applied by
+// `theme`, so `theme.$class` carries both hashes and `theme` keeps every
+// selector (it is exported).
+export const base = <style>
+	article {
+		font-family: system-ui;
+	}
+	.muted {
+		color: gray;
+	}
+</style>;
+
+export const theme = <style apply={base}>
+	article {
+		color: green;
+	}
+	.dark {
+		color: purple;
+	}
+</style>;

--- a/packages/ripple/tests/server/dynamic-elements.test.tsrx
+++ b/packages/ripple/tests/server/dynamic-elements.test.tsrx
@@ -398,7 +398,9 @@ describe('server dynamic DOM elements', () => {
 		expect(innerScopes).toHaveLength(1);
 		expect(innerScopes[0]).not.toBe(outerScope);
 
-		expect(innerInnerScopes).toHaveLength(0);
+		// Every element of the child's scope carries the child's hash, and none
+		// of the parent's.
+		expect(innerInnerScopes).toEqual(innerScopes);
 	});
 
 	it('doesn\'t add scoping class to dynamically rendered component', async () => {
@@ -437,6 +439,7 @@ describe('server dynamic DOM elements', () => {
 		const innerScopes = Array.from(p.classList).filter((c) => c.startsWith('tsrx-'));
 
 		expect(outerScopes).toHaveLength(1);
-		expect(innerScopes).toHaveLength(0);
+		// The child's own scope reaches its <p>; the parent's never does.
+		expect(innerScopes).toEqual(outerScopes);
 	});
 });

--- a/packages/ripple/tests/server/scoped-styles.test.tsrx
+++ b/packages/ripple/tests/server/scoped-styles.test.tsrx
@@ -175,6 +175,35 @@ describe('sibling-scoped style blocks (server)', () => {
 	});
 });
 
+describe('spreads with an imported theme (server)', () => {
+	it('merges the scope classes of a static class into the spread once', async () => {
+		function Card(&{ ...rest }: { class?: string }) @{
+			<>
+				<style apply={importedTheme}>
+					.box {
+						color: red;
+					}
+				</style>
+				<div id="box" class="box" {...rest}>{'x'}</div>
+			</>
+		}
+
+		function App() @{
+			<Card class="from-spread" />
+		}
+
+		const { body } = await render(App);
+		expect(body.match(/class=/g)).toHaveLength(1);
+		const { document } = parseHtml(body);
+
+		const box = document.querySelector('#box');
+		const [local] = hashes(box);
+		expect(local).toBeTruthy();
+		expect(hashes(box)).toEqual([local, ...tokens(importedTheme.$class)]);
+		expect(box?.classList.contains('box')).toBe(true);
+	});
+});
+
 describe('$class and apply (server)', () => {
 	it(
 		'applies a same-module theme and registers its sheet before the scope that applies it',

--- a/packages/ripple/tests/server/scoped-styles.test.tsrx
+++ b/packages/ripple/tests/server/scoped-styles.test.tsrx
@@ -1,0 +1,270 @@
+import { getCss } from 'ripple/server';
+import { base as importedBase, theme as importedTheme } from '../fixtures/scoped-styles/theme.tsrx';
+
+// RFC tsrx-org/RFCs#1 on the server: the class table matches the client, and
+// a request collects the sheets of the scopes it rendered — an applied theme
+// before the scope that applies it, whichever module the theme lives in.
+
+function hashes(element: Element | null): string[] {
+	return Array.from(element?.classList ?? []).filter((cls) => cls.startsWith('tsrx-'));
+}
+
+function tokens(value: string): string[] {
+	return value.split(' ').filter(Boolean);
+}
+
+const one = <style>
+	div {
+		color: red;
+	}
+</style>;
+
+describe('sibling-scoped style blocks (server)', () => {
+	function Status({ ready }: { ready: boolean }) @{
+		<>
+			<style>
+				.status {
+					padding: 0.5rem;
+				}
+			</style>
+			<section id="status" class="status">
+				<style>
+					.title {
+						font-weight: 700;
+					}
+					.status {
+						color: rgb(9, 9, 9);
+					}
+				</style>
+				<h2 id="title" class="title">{'Status'}</h2>
+				@if (ready) {
+					<>
+						<style>
+							.ok {
+								color: green;
+							}
+						</style>
+						<p id="ok" class="ok">{'Ready'}</p>
+					</>
+				} @else {
+					<>
+						<style>
+							.wait {
+								color: gray;
+							}
+						</style>
+						<p id="wait" class="wait">{'Waiting'}</p>
+					</>
+				}
+			</section>
+		</>
+	}
+
+	it('renders the class table and collects every scope sheet in source order', async () => {
+		function Ready() @{
+			<Status ready={true} />
+		}
+
+		const { body, css } = await render(Ready);
+		const { document } = parseHtml(body);
+
+		const [A] = hashes(document.querySelector('#status'));
+		expect(hashes(document.querySelector('#status'))).toEqual([A]);
+		const B = hashes(document.querySelector('#title'))[1];
+		expect(hashes(document.querySelector('#title'))).toEqual([A, B]);
+		const C = hashes(document.querySelector('#ok'))[2];
+		expect(hashes(document.querySelector('#ok'))).toEqual([A, B, C]);
+		expect(document.querySelector('#wait')).toBeNull();
+
+		// Every scope's CSS ships, the branch never rendered included, and the
+		// sheets follow source order.
+		const collected = [...css];
+		expect(collected).toHaveLength(4);
+		expect(collected.slice(0, 3)).toEqual([A, B, C]);
+		const text = getCss(css);
+		expect(text).toContain(`.status.${A}`);
+		expect(text).toContain(`.title.${B}`);
+		expect(text).toContain('/* (unused) .status {');
+		expect(text).toContain(`.ok.${C}`);
+		expect(text).toContain(`.wait.${collected[3]}`);
+		expect(text.indexOf(`.status.${A}`)).toBeLessThan(text.indexOf(`.title.${B}`));
+		expect(text.indexOf(`.title.${B}`)).toBeLessThan(text.indexOf(`.ok.${C}`));
+	});
+
+	it('stamps the other branch with its own hash', async () => {
+		function Waiting() @{
+			<Status ready={false} />
+		}
+
+		const { body } = await render(Waiting);
+		const { document } = parseHtml(body);
+
+		const wait = hashes(document.querySelector('#wait'));
+		expect(wait).toHaveLength(3);
+		expect(wait.slice(0, 2)).toEqual(hashes(document.querySelector('#title')));
+		expect(document.querySelector('#ok')).toBeNull();
+	});
+
+	it('registers the blocks of one children list as one sheet', async () => {
+		function Two() @{
+			<>
+				<style>
+					.host {
+						margin: 0;
+					}
+				</style>
+				<div id="host" class="host">
+					<style>
+						.a {
+							color: red;
+						}
+					</style>
+					<i class="a">{'a'}</i>
+					<style>
+						.b {
+							color: blue;
+						}
+					</style>
+					<b class="b">{'b'}</b>
+				</div>
+			</>
+		}
+
+		const { body, css } = await render(Two);
+		const { document } = parseHtml(body);
+
+		const [H] = hashes(document.querySelector('#host'));
+		const [, C] = hashes(document.querySelector('i'));
+		expect(hashes(document.querySelector('b'))).toEqual([H, C]);
+		expect([...css]).toEqual([H, C]);
+		const text = getCss(css);
+		expect(text).toContain(`.a.${C}`);
+		expect(text).toContain(`.b.${C}`);
+		expect(text.match(new RegExp(`\\.a\\.${C}`, 'g'))).toHaveLength(1);
+	});
+
+	it('merges the scope classes into a spread', async () => {
+		function Button(&{ ...rest }: { id: string; class?: string }) @{
+			<>
+				<style>
+					button {
+						padding: 0;
+					}
+				</style>
+				<div>
+					<style>
+						button {
+							margin: 0;
+						}
+					</style>
+					<button {...rest}>{'b'}</button>
+				</div>
+			</>
+		}
+
+		function App() @{
+			<Button id="btn" class="authored" />
+		}
+
+		const { body } = await render(App);
+		const { document } = parseHtml(body);
+
+		const button = document.querySelector('#btn');
+		expect(button?.classList.contains('authored')).toBe(true);
+		expect(hashes(button)).toHaveLength(2);
+	});
+});
+
+describe('$class and apply (server)', () => {
+	it(
+		'applies a same-module theme and registers its sheet before the scope that applies it',
+		async () => {
+			function WithBody() @{
+				<>
+					<style apply={one}>
+						.c {
+							margin: 0;
+						}
+					</style>
+					<div id="c1" class="c">{'c'}</div>
+				</>
+			}
+
+			const { body, css } = await render(WithBody);
+			const { document } = parseHtml(body);
+
+			const div = document.querySelector('#c1');
+			const [local, applied] = hashes(div);
+			expect(div?.className).toBe(`c ${local} ${one.$class}`);
+			expect(applied).toBe(one.$class);
+			expect([...css]).toEqual([one.$class, local]);
+			const text = getCss(css);
+			expect(text.indexOf(`div.${one.$class}`)).toBeLessThan(text.indexOf(`.c.${local}`));
+		},
+	);
+
+	it('applies an imported theme through its $class and collects its sheets first', async () => {
+		function Card() @{
+			<>
+				<style apply={importedTheme}>
+					h2 {
+						margin: 0;
+					}
+				</style>
+				<article id="card">
+					<h2 id="h2" class={importedTheme.dark}>{'Green, system-ui'}</h2>
+				</article>
+			</>
+		}
+
+		const { body, css } = await render(Card);
+		const { document } = parseHtml(body);
+
+		const card = document.querySelector('#card');
+		const [local] = hashes(card);
+		expect(hashes(card)).toEqual([local, ...tokens(importedTheme.$class)]);
+		// The class list is normalized on the server, so the theme hash that
+		// `theme.dark` already carries appears once.
+		const h2 = Array.from(document.querySelector('#h2')?.classList ?? []);
+		expect(h2.slice(0, 2)).toEqual(tokens(importedTheme.dark));
+		expect(h2).toContain(local);
+		for (const token of tokens(importedTheme.$class)) expect(h2).toContain(token);
+		// base (applied by theme), theme, then the applying scope.
+		expect([...css]).toEqual([...tokens(importedTheme.$class), local]);
+		const text = getCss(css);
+		expect(text.indexOf(`article.${importedBase.$class}`)).toBeLessThan(
+			text.indexOf(`article.${tokens(importedTheme.$class)[1]}`),
+		);
+		expect(text.indexOf(`.dark.${tokens(importedTheme.$class)[1]}`)).toBeLessThan(
+			text.indexOf(`h2.${local}`),
+		);
+	});
+
+	it('registers a theme only when something reads it', async () => {
+		function App() @{
+			const unused = <style>
+				.u {
+					color: red;
+				}
+			</style>;
+			const theme = <style>
+				div {
+					color: blue;
+				}
+			</style>;
+			<>
+				<div id="opted" class={theme.$class}>{'opted in'}</div>
+				<p id="untouched">{'untouched'}</p>
+			</>
+		}
+
+		const { body, css } = await render(App);
+		const { document } = parseHtml(body);
+
+		const theme_hash = document.querySelector('#opted')?.className;
+		expect(tokens(theme_hash!)).toHaveLength(1);
+		expect(document.querySelector('#untouched')?.className).toBe('');
+		expect([...css]).toEqual([theme_hash]);
+		expect(getCss(css)).toContain(`div.${theme_hash}`);
+	});
+});

--- a/packages/tsrx-ripple/src/analyze/index.js
+++ b/packages/tsrx-ripple/src/analyze/index.js
@@ -11,7 +11,6 @@
 	Visitor,
 	Visitors,
 	Binding,
-	TopScopedClasses,
 } from '../../types/index';
  */
 /**
@@ -25,9 +24,6 @@ import {
 	ScopeRoot,
 	isVoidElement,
 	extractPaths,
-	analyzeCss,
-	pruneCss,
-	collectStyleRefAttributes,
 	error,
 	getReturnKeywordNode,
 	isEventAttribute,
@@ -60,7 +56,6 @@ import {
 	build_lazy_array_rest,
 	build_lazy_array_set,
 	build_lazy_array_update,
-	collect_tsrx_stylesheet,
 	get_native_tsrx_function_body,
 	is_native_tsrx_template_node,
 	is_native_tsrx_function_node,
@@ -88,6 +83,7 @@ import {
 	rendered_template_children,
 } from '../template-ast.js';
 import is_reference from 'is-reference';
+import { prepare_style_scopes } from '../style-scopes.js';
 
 const valid_in_head = new Set(['title', 'base', 'link', 'meta', 'style', 'script', 'noscript']);
 
@@ -1199,44 +1195,17 @@ function visit_function(node, context) {
 			}
 		}
 
-		/** @type {Array<AST.TSRXJSXElement | AST.JSXStyleElement>} */
-		const elements = [];
 		const metadata = {};
-		const styleClasses = new Map();
-		/** @type {TopScopedClasses} */
-		const topScopedClasses = new Map();
-		const render_body = get_native_tsrx_function_body(node, context.state.scopes);
+		// Memoize the render body now so the transforms share one expansion.
+		get_native_tsrx_function_body(node, context.state.scopes);
 		const component_state = {
 			...context.state,
 			component: node,
-			elements,
 			function_depth: (context.state.function_depth ?? 0) + 1,
 			metadata,
 		};
 
 		context.next(component_state);
-
-		const css = collect_tsrx_stylesheet(render_body);
-		node.metadata.component_css = css;
-
-		if (css !== null) {
-			analyzeCss(css);
-			const prune = () => {
-				for (const element of elements) {
-					pruneCss(css, element, styleClasses, topScopedClasses);
-				}
-			};
-			prune();
-			if (collectStyleRefAttributes(render_body).length > 0) {
-				for (const [className, classInfo] of topScopedClasses) {
-					styleClasses.set(className, classInfo.selector ?? classInfo);
-				}
-				prune();
-			}
-			if (topScopedClasses.size > 0) {
-				node.metadata.topScopedClasses = topScopedClasses;
-			}
-		}
 
 		if (node.type !== 'ArrowFunctionExpression' && node.id) {
 			context.state.analysis.component_metadata.push({
@@ -2342,11 +2311,8 @@ const visitors = {
 
 		mark_control_flow_has_template(context.path, node);
 
-		if (context.state.elements) {
-			context.state.elements.push(node);
-		}
-
-		// Children are stylesheet AST — nothing to analyze.
+		// Children are stylesheet AST — nothing to analyze; the style pre-pass
+		// (`style-scopes.js`) owns scoping, pruning, and `apply`.
 	},
 
 	JSXElement(node, context) {
@@ -2366,8 +2332,8 @@ const visitors = {
 		const is_dynamic = is_dynamic_element(node);
 		const is_dom_element = is_element_dom_element(node);
 		// Dynamic tags (`<{expr}>`) resolve at runtime: scoped CSS pruning must
-		// keep type selectors (the tag could be any element) and collect the
-		// element so its classes match and receive the scope hash.
+		// keep type selectors (the tag could be any element), and the element
+		// receives the scope classes like a DOM element.
 		if (is_dynamic) {
 			node.metadata.dynamicElement = true;
 		}
@@ -2452,10 +2418,6 @@ const visitors = {
 
 			const is_void = isVoidElement(/** @type {AST.Identifier} */ (element_id).name);
 
-			if (state.elements) {
-				state.elements.push(node);
-			}
-
 			for (const attr of element_attributes) {
 				if (attr.type === 'JSXAttribute') {
 					const attr_name = get_attribute_name_node(attr);
@@ -2537,10 +2499,6 @@ const visitors = {
 				);
 			}
 		} else {
-			if (is_dynamic && state.elements) {
-				state.elements.push(node);
-			}
-
 			for (const attr of element_attributes) {
 				if (attr.type === 'JSXAttribute') {
 					attribute_names.add(get_attribute_name_node(attr));
@@ -2783,6 +2741,7 @@ export function analyze(ast, filename, options = {}) {
 		},
 		errors,
 		comments,
+		stylesheets: [],
 	});
 
 	walk(
@@ -2806,6 +2765,10 @@ export function analyze(ast, filename, options = {}) {
 	);
 
 	validate_server_module_imports(analysis, filename, collect);
+
+	// Style scopes need every element's ancestor path, which the walk above
+	// records, so they are resolved last.
+	prepare_style_scopes(ast, analysis, filename, collect);
 
 	return analysis;
 }

--- a/packages/tsrx-ripple/src/style-scopes.js
+++ b/packages/tsrx-ripple/src/style-scopes.js
@@ -54,6 +54,7 @@ import {
 	builders,
 	clone_ast_node,
 	collectStyleRefAttributes,
+	createScopeRoot,
 	createStyleClassMap,
 	createStyleRefSetupStatements,
 	DIAGNOSTIC_CODES,
@@ -404,8 +405,10 @@ function collect_own_blocks(children) {
  * the list's items and their subtrees, nested scopes included, stopping at
  * function boundaries and skipping `<head>` and `<style>` hosts. Each element
  * comes with the ancestor chain it has INSIDE the scope, which `pruneCss`
- * reads for combinators — the containing element is not part of it, so a
- * selector that only matches the container is pruned.
+ * reads for combinators: rooted at a fragment holding the items, so `+` and
+ * `~` between top-level items find their siblings, while the containing
+ * element is not part of it and a selector that only matches the container
+ * is pruned.
  *
  * @param {AST.Node[]} items
  * @returns {Array<{ element: AST.TSRXJSXElement, path: AST.Node[] }>}
@@ -430,7 +433,8 @@ function collect_scope_elements(items) {
 		each_child(node, (child) => visit(child, child_path));
 	};
 
-	for (const item of items) visit(item, []);
+	const root = [createScopeRoot(items)];
+	for (const item of items) visit(item, root);
 	return elements;
 }
 

--- a/packages/tsrx-ripple/src/style-scopes.js
+++ b/packages/tsrx-ripple/src/style-scopes.js
@@ -1,0 +1,689 @@
+// @ts-check
+
+/**
+ * Sibling-scoped `<style>` blocks, `$class`, and `apply` for the Ripple target
+ * (RFC tsrx-org/RFCs#1). One pass over the analyzed program decides which
+ * blocks belong to which scope, in what order their CSS is emitted, and which
+ * classes every host element carries, so the client and server transforms
+ * only serialize what is already on the AST and agree by construction.
+ *
+ * Scope model (shared with `@tsrx/core`'s `transform/jsx/style-scopes.js`):
+ *
+ * - A standalone block is a child of a native element or fragment, and that
+ *   children list is its scope: the block styles the items beside it and
+ *   everything below them, never the element that contains it. A `@{ … }`
+ *   body or a directive branch body holds setup statements and one output
+ *   node; a block there is the parser's multiple-outputs error or the core
+ *   analyzer's `tsrx-style-standalone-needs-fragment`, so statement lists
+ *   are only searched for nested templates and assigned blocks.
+ * - Every block of one list shares the scope hash (the first bodied block's
+ *   position-derived hash). Lists nested in a scope that hold blocks are
+ *   nested scopes with hashes of their own.
+ * - A scope's sheets are pruned against the list's other children and their
+ *   subtrees, with ancestor paths that stop at the list, so a selector that
+ *   only matches the container renders as an `(unused)` comment.
+ * - Every host element (DOM elements and dynamic `<{tag}>` elements, not
+ *   components) carries `metadata.tsrx_scope_class`: the hashes of all its
+ *   enclosing scopes outer first, then the classes of every applied theme —
+ *   string literals for same-module themes whose class is statically known,
+ *   `theme.$class` reads otherwise. Function boundaries reset the chain.
+ * - CSS is emitted in lexical pre-order into `analysis.stylesheets`: a scope's
+ *   sheets sit where its first block is, after the assigned blocks declared
+ *   before it, before the scopes and assigned blocks nested in it.
+ * - Assigned blocks (`const theme = <style>…</style>`) are prepared here in
+ *   the render mode the core analyzer classified (`metadata.styleKind`), and
+ *   their `apply` targets resolve to `metadata.tsrx_style_class_parts`; the
+ *   transforms build the class-map object from that.
+ * - For the server, every component function records what its scopes need
+ *   registered with the request (applied themes before the scope that
+ *   applies them); see `get_style_registrations`.
+ *
+ * The pass runs after the Ripple analyzer walk and writes metadata only; the
+ * tree itself is left alone (the transforms drop `<style>` blocks when they
+ * render children).
+ */
+
+/**
+@import * as AST from 'estree';
+@import * as ESTreeJSX from 'estree-jsx';
+@import { AnalysisResult, CompileError, StyleRegistration } from '../types/index';
+*/
+
+import {
+	analyzeCss,
+	builders,
+	clone_ast_node,
+	collectStyleRefAttributes,
+	createStyleClassMap,
+	createStyleRefSetupStatements,
+	DIAGNOSTIC_CODES,
+	error,
+	getStyleElementStylesheet,
+	isFunctionNode as is_function_node,
+	isTemplateDirective as is_template_directive,
+	prepareStylesheetForRender,
+	pruneCss,
+} from '@tsrx/core';
+import {
+	get_attribute_name,
+	get_element_attributes,
+	get_element_identifier,
+	is_dynamic_element,
+	is_template_element,
+	is_template_fragment,
+} from './template-ast.js';
+import { is_element_dom_element, is_style_element } from './utils.js';
+
+const b = builders;
+
+const SKIP_KEYS = new Set(['loc', 'start', 'end', 'metadata', 'css', 'parent']);
+
+/**
+ * Per function, what the server registers with the active request before the
+ * function renders its template (see `record_registrations`).
+ * @type {WeakMap<AST.Function, StyleRegistration[]>}
+ */
+const style_registrations = new WeakMap();
+
+/**
+ * What a component registers with the request before rendering its template:
+ * each of its scopes' applied themes first — a hash to register, or a
+ * `theme.$class` read whose getter registers an imported theme's sheet — then
+ * the scope's own hash, so an applied theme's CSS always precedes the scope
+ * that applies it.
+ * @param {AST.Function} fn
+ * @returns {StyleRegistration[]}
+ */
+export function get_style_registrations(fn) {
+	return style_registrations.get(fn) ?? [];
+}
+
+/**
+ * @typedef {'statement' | 'expression'} WalkMode
+ * @typedef {{ hash: string | null, applied: Array<string | AST.Expression> }} ScopeEntry
+ * @typedef {{
+ *   analysis: AnalysisResult,
+ *   filename: string,
+ *   collect: boolean,
+ *   stack: ScopeEntry[],
+ *   fn: AST.Function | null,
+ *   static_classes: Map<AST.JSXStyleElement, string | null>,
+ * }} StyleScopeState `fn` is the nearest enclosing function of the parse AST:
+ *   the owner of the `ref` setup statements and server registrations of the
+ *   scopes found inside it.
+ */
+
+/**
+ * Run the pass over an analyzed program. Fills `analysis.stylesheets` in
+ * emission order and records every function's server registrations.
+ *
+ * @param {AST.Program} ast
+ * @param {AnalysisResult} analysis
+ * @param {string} filename
+ * @param {boolean} collect
+ * @returns {void}
+ */
+export function prepare_style_scopes(ast, analysis, filename, collect) {
+	/** @type {StyleScopeState} */
+	const state = {
+		analysis,
+		filename,
+		collect,
+		stack: [],
+		fn: null,
+		static_classes: new Map(),
+	};
+	// Module scope is not a template scope: a standalone block here is a core
+	// analyzer error, and its statements are only searched for scopes.
+	walk_list(ast.body, state);
+}
+
+/**
+ * @param {unknown} value
+ * @returns {value is AST.Node}
+ */
+function is_ast_node(value) {
+	return (
+		value !== null &&
+		typeof value === 'object' &&
+		!Array.isArray(value) &&
+		typeof (/** @type {{ type?: unknown }} */ (value).type) === 'string'
+	);
+}
+
+/**
+ * @param {AST.Node} node
+ * @param {string} key
+ * @returns {boolean}
+ */
+function is_statement_list_key(node, key) {
+	if (key === 'body') return node.type === 'BlockStatement' || node.type === 'Program';
+	if (key === 'consequent') return node.type === 'SwitchCase';
+	return false;
+}
+
+/**
+ * @template T
+ * @param {StyleScopeState} state
+ * @param {ScopeEntry[]} stack
+ * @param {() => T} run
+ * @returns {T}
+ */
+function with_stack(state, stack, run) {
+	const previous = state.stack;
+	state.stack = stack;
+	try {
+		return run();
+	} finally {
+		state.stack = previous;
+	}
+}
+
+/**
+ * Visit every child node of `node`.
+ *
+ * @param {AST.Node} node
+ * @param {(child: AST.Node, key: string) => void} visit
+ * @returns {void}
+ */
+function each_child(node, visit) {
+	for (const key of Object.keys(node)) {
+		if (SKIP_KEYS.has(key)) continue;
+		const value = /** @type {Record<string, unknown>} */ (/** @type {unknown} */ (node))[key];
+		if (Array.isArray(value)) {
+			for (const item of value) if (is_ast_node(item)) visit(item, key);
+		} else if (is_ast_node(value)) {
+			visit(value, key);
+		}
+	}
+}
+
+/**
+ * The main walk. `mode` says what a `<style>` found here is: a value slot
+ * holds an assigned block, a statement slot holds one the core analyzer
+ * already reported.
+ *
+ * @param {AST.Node} node
+ * @param {StyleScopeState} state
+ * @param {WalkMode} mode
+ * @returns {void}
+ */
+function walk(node, state, mode) {
+	if (!is_ast_node(node)) return;
+
+	switch (node.type) {
+		case 'JSXStyleElement':
+			if (mode === 'expression') prepare_assigned_style(node, state);
+			return;
+		case 'JSXCodeBlock':
+			walk_list(/** @type {AST.Node[]} */ (node.body ?? []), state);
+			if (node.render) walk_list_item(/** @type {AST.Node} */ (node.render), state);
+			return;
+		case 'JSXElement':
+		case 'JSXFragment':
+			if (is_template_element(node) || is_template_fragment(node)) {
+				walk_template(node, state);
+			} else {
+				// Raw JSX (an attribute value) is outside every scope: not
+				// stamped, not matched, but searched for assigned blocks.
+				each_child(node, (child) => walk(child, state, 'expression'));
+			}
+			return;
+		case 'JSXExpressionContainer':
+			walk(/** @type {AST.Node} */ (node.expression), state, 'expression');
+			return;
+		case 'ExpressionStatement':
+			walk(node.expression, state, 'statement');
+			return;
+		default:
+			break;
+	}
+
+	if (is_template_directive(node)) {
+		walk_directive(node, state);
+		return;
+	}
+
+	if (is_function_node(node)) {
+		// A function boundary: its template is not stamped by the enclosing
+		// scopes, but still hosts scopes and assigned blocks of its own.
+		const previous_fn = state.fn;
+		state.fn = node;
+		with_stack(state, [], () => each_child(node, (child) => walk(child, state, 'expression')));
+		state.fn = previous_fn;
+		return;
+	}
+
+	each_child(node, (child, key) =>
+		walk(child, state, is_statement_list_key(node, key) ? 'statement' : 'expression'),
+	);
+}
+
+/**
+ * A statement list (a `@{ … }` body, a directive branch body, a switch case,
+ * the program): not a scope of its own. Its items are searched for templates
+ * and assigned blocks in the current chain.
+ *
+ * @param {AST.Node[]} nodes
+ * @param {StyleScopeState} state
+ * @returns {void}
+ */
+function walk_list(nodes, state) {
+	for (const item of nodes) walk_list_item(item, state);
+}
+
+/**
+ * @param {AST.Node} item
+ * @param {StyleScopeState} state
+ * @returns {void}
+ */
+function walk_list_item(item, state) {
+	if (!is_ast_node(item)) return;
+	if (is_template_element(item) || is_template_fragment(item)) {
+		walk_template(item, state);
+		return;
+	}
+	if (is_style_element(item)) return;
+	if (item.type === 'JSXExpressionContainer') {
+		walk(/** @type {AST.Node} */ (item.expression), state, 'expression');
+		return;
+	}
+	walk(item, state, 'statement');
+}
+
+/**
+ * Each branch body of a directive is a statement list holding one output
+ * node; `@else if` chains parse as plain `IfStatement` alternates.
+ *
+ * @param {AST.Node} node
+ * @param {StyleScopeState} state
+ * @returns {void}
+ */
+function walk_directive(node, state) {
+	each_child(node, (child, key) => {
+		if (child.type === 'BlockStatement') {
+			walk_list(child.body, state);
+		} else if (child.type === 'CatchClause') {
+			if (child.param) walk(child.param, state, 'expression');
+			walk_list(child.body.body, state);
+		} else if (child.type === 'SwitchCase') {
+			if (child.test) walk(child.test, state, 'expression');
+			walk_list(child.consequent, state);
+		} else if (
+			key === 'alternate' &&
+			(is_template_directive(child) || child.type === 'IfStatement')
+		) {
+			walk_directive(child, state);
+		} else {
+			walk(child, state, 'expression');
+		}
+	});
+}
+
+/**
+ * A native element or fragment: stamp it with the CURRENT chain (host
+ * elements only — an element is never inside its own children's scope),
+ * search its attribute values, then walk its children list. When the list
+ * holds standalone blocks it is a scope, and the other children are walked
+ * with that scope pushed.
+ *
+ * @param {AST.TSRXJSXElement | AST.TSRXJSXFragment} node
+ * @param {StyleScopeState} state
+ * @returns {void}
+ */
+function walk_template(node, state) {
+	if (node.type === 'JSXElement') {
+		// `<head>` content is rendered verbatim (a `<style>` there is a plain
+		// document stylesheet), so nothing inside it is a scope or stamped.
+		if (get_element_identifier(node)?.name === 'head') return;
+		if (is_stamped_host(node)) stamp(node, state);
+		for (const attr of get_element_attributes(node)) {
+			if (attr.type === 'JSXAttribute') {
+				if (attr.value) walk(/** @type {AST.Node} */ (attr.value), state, 'expression');
+			} else {
+				walk(attr.argument, state, 'expression');
+			}
+		}
+	}
+
+	const children = /** @type {AST.Node[]} */ (node.children ?? []);
+	const own = collect_own_blocks(children);
+	const scope =
+		own.length > 0
+			? prepare_scope(
+					own,
+					children.filter((child) => !own.includes(/** @type {AST.JSXStyleElement} */ (child))),
+					state,
+				)
+			: null;
+
+	with_stack(state, scope === null ? state.stack : [...state.stack, scope], () => {
+		for (const child of children) {
+			if (is_style_element(child)) continue;
+			walk_list_item(child, state);
+		}
+	});
+}
+
+/**
+ * Whether the scope chain is stamped on this element: a DOM element or a
+ * dynamic `<{expr}>` tag. Components stop stamping (their host elements
+ * belong to their own scopes), and a `style` host element —
+ * `<style>{expr}</style>`, an ordinary element — is never stamped, like a
+ * `<style>` block.
+ *
+ * @param {AST.TSRXJSXElement} node
+ * @returns {boolean}
+ */
+function is_stamped_host(node) {
+	if (get_element_identifier(node)?.name === 'style') return false;
+	return is_element_dom_element(node) || is_dynamic_element(node);
+}
+
+/**
+ * The standalone blocks a children list owns: its direct `<style>` items, in
+ * source order. A `<style href>` resource is a plain element, not a block.
+ *
+ * @param {AST.Node[]} children
+ * @returns {AST.JSXStyleElement[]}
+ */
+function collect_own_blocks(children) {
+	return children
+		.filter(is_style_element)
+		.filter(
+			(block) =>
+				!get_element_attributes(block).some(
+					(attr) => attr.type === 'JSXAttribute' && get_attribute_name(attr) === 'href',
+				),
+		)
+		.sort((a, c) => /** @type {number} */ (a.start) - /** @type {number} */ (c.start));
+}
+
+/**
+ * The elements a scope's selectors can match: every template element among
+ * the list's items and their subtrees, nested scopes included, stopping at
+ * function boundaries and skipping `<head>` and `<style>` hosts. Each element
+ * comes with the ancestor chain it has INSIDE the scope, which `pruneCss`
+ * reads for combinators — the containing element is not part of it, so a
+ * selector that only matches the container is pruned.
+ *
+ * @param {AST.Node[]} items
+ * @returns {Array<{ element: AST.TSRXJSXElement, path: AST.Node[] }>}
+ */
+function collect_scope_elements(items) {
+	/** @type {Array<{ element: AST.TSRXJSXElement, path: AST.Node[] }>} */
+	const elements = [];
+
+	/**
+	 * @param {AST.Node} node
+	 * @param {AST.Node[]} path
+	 */
+	const visit = (node, path) => {
+		if (!is_ast_node(node)) return;
+		if (is_function_node(node) || is_style_element(node)) return;
+		if (node.type === 'JSXElement') {
+			const name = get_element_identifier(node)?.name;
+			if (name === 'head' || name === 'style') return;
+			if (is_template_element(node)) elements.push({ element: node, path });
+		}
+		const child_path = [...path, node];
+		each_child(node, (child) => visit(child, child_path));
+	};
+
+	for (const item of items) visit(item, []);
+	return elements;
+}
+
+/**
+ * Render a scope's sheets and compute what its elements carry.
+ *
+ * @param {AST.JSXStyleElement[]} own the list's standalone blocks
+ * @param {AST.Node[]} items the list's other children — what the blocks reach
+ * @param {StyleScopeState} state
+ * @returns {ScopeEntry}
+ */
+function prepare_scope(own, items, state) {
+	const { analysis } = state;
+	/** @type {Array<[AST.JSXStyleElement, AST.CSS.StyleSheet]>} */
+	const sheets = [];
+	for (const block of own) {
+		const sheet = getStyleElementStylesheet(block);
+		if (sheet) sheets.push([block, sheet]);
+	}
+	const hash = sheets.length > 0 ? sheets[0][1].hash : null;
+	// The first block's metadata accumulates the scope's class map (for
+	// `<style ref>`), so two scopes never share a map.
+	const holder = own[0];
+	const refs = collectStyleRefAttributes(own);
+
+	/** @type {AST.CSS.StyleSheet | null} */
+	let first_sheet = null;
+	if (sheets.length > 0) {
+		const elements = collect_scope_elements(items);
+		/** @type {Map<string, unknown>} */
+		const style_classes = new Map();
+		const top_scoped_classes = holder.metadata.topScopedClasses ?? new Map();
+		const saved_paths = elements.map(({ element }) => element.metadata.path);
+		for (const { element, path } of elements) element.metadata.path = path;
+		try {
+			for (const [block, sheet] of sheets) {
+				const region_hash = sheet.hash;
+				sheet.hash = /** @type {string} */ (hash);
+				if (!analyze_scope_css(block, sheet, state)) continue;
+				const prune = () => {
+					for (const { element } of elements) {
+						pruneCss(
+							sheet,
+							element,
+							/** @type {any} */ (style_classes),
+							top_scoped_classes,
+							region_hash,
+						);
+					}
+				};
+				prune();
+				if (refs.length > 0) {
+					for (const [class_name, class_info] of top_scoped_classes) {
+						style_classes.set(class_name, class_info.selector ?? class_info);
+					}
+					prune();
+				}
+				analysis.stylesheets.push(sheet);
+				first_sheet ??= sheet;
+			}
+		} finally {
+			elements.forEach(({ element }, i) => {
+				element.metadata.path = saved_paths[i];
+			});
+		}
+		if (top_scoped_classes.size > 0) holder.metadata.topScopedClasses = top_scoped_classes;
+	}
+
+	/** @type {Array<string | AST.Expression>} */
+	const applied = [];
+	for (const block of own) {
+		for (const part of resolve_style_applies(block, state)) {
+			if (typeof part !== 'string' || !applied.includes(part)) applied.push(part);
+		}
+	}
+
+	if (refs.length > 0 && state.fn !== null) {
+		const statements = createStyleRefSetupStatements(
+			refs,
+			createStyleClassMap(holder, first_sheet, { applied, hash }),
+			{
+				allowMutableRefTarget: true,
+				createTempIdentifier: () => b.id(analysis.scope.generate('style_ref')),
+			},
+		);
+		const metadata = state.fn.metadata;
+		metadata.tsrx_style_ref_statements = [
+			...(metadata.tsrx_style_ref_statements ?? []),
+			...statements,
+		];
+	}
+
+	if (state.fn !== null) record_registrations(state.fn, applied, hash);
+
+	return { hash, applied };
+}
+
+/**
+ * Record a scope's server registrations on its function: the applied themes'
+ * class parts (static hashes to register, or `theme.$class` reads), then the
+ * scope's own hash.
+ *
+ * @param {AST.Function} fn
+ * @param {Array<string | AST.Expression>} applied
+ * @param {string | null} hash
+ * @returns {void}
+ */
+function record_registrations(fn, applied, hash) {
+	const registrations = style_registrations.get(fn) ?? [];
+	/** @param {StyleRegistration} entry */
+	const add = (entry) => {
+		if (typeof entry === 'string' && registrations.includes(entry)) return;
+		registrations.push(entry);
+	};
+	for (const part of applied) add(part);
+	if (hash !== null) add(hash);
+	style_registrations.set(fn, registrations);
+}
+
+/**
+ * `analyzeCss` reports `:global` placement through a coded fatal error with
+ * CSS-relative positions; re-anchor it on the block so editors can place it,
+ * and keep going in collect mode.
+ *
+ * @param {AST.JSXStyleElement} block
+ * @param {AST.CSS.StyleSheet} sheet
+ * @param {StyleScopeState} state
+ * @returns {boolean} whether the sheet is usable
+ */
+function analyze_scope_css(block, sheet, state) {
+	try {
+		analyzeCss(sheet);
+		return true;
+	} catch (thrown) {
+		const compile_error = /** @type {CompileError} */ (thrown);
+		if (compile_error?.code !== DIAGNOSTIC_CODES.CSS_GLOBAL_PLACEMENT) throw thrown;
+		error(
+			compile_error.message,
+			state.filename,
+			block,
+			state.collect ? state.analysis.errors : undefined,
+			state.analysis.comments,
+			compile_error.code,
+		);
+		return false;
+	}
+}
+
+/**
+ * The class parts a block's `apply` contributes: a literal for a same-module
+ * theme whose class is statically known, otherwise a runtime `<target>.$class`
+ * read. Memoized on the block's metadata for the assigned-block lowering.
+ *
+ * @param {AST.JSXStyleElement} block
+ * @param {StyleScopeState} state
+ * @returns {Array<string | AST.Expression>}
+ */
+function resolve_style_applies(block, state) {
+	if (block.metadata.tsrx_style_class_parts) return block.metadata.tsrx_style_class_parts;
+	/** @type {Array<string | AST.Expression>} */
+	const parts = [];
+	for (const resolution of block.metadata.styleApplies ?? []) {
+		const static_class = resolution.target ? static_style_class(resolution.target, state) : null;
+		if (static_class !== null) {
+			// One entry per hash so a diamond (`a` applied directly and through
+			// `b`) stamps each hash once.
+			for (const hash of static_class.split(' ')) {
+				if (hash && !parts.includes(hash)) parts.push(hash);
+			}
+			continue;
+		}
+		parts.push(b.member(clone_ast_node(resolution.expression), b.id('$class')));
+	}
+	block.metadata.tsrx_style_class_parts = parts;
+	return parts;
+}
+
+/**
+ * The `$class` value of an assigned block when every applied theme in its
+ * chain is a same-module block: applied classes first, own hash last.
+ *
+ * @param {AST.JSXStyleElement} block
+ * @param {StyleScopeState} state
+ * @returns {string | null}
+ */
+function static_style_class(block, state) {
+	const cached = state.static_classes.get(block);
+	if (cached !== undefined) return cached;
+	/** @type {string[]} */
+	const parts = [];
+	/** @type {string | null} */
+	let result = '';
+	for (const resolution of block.metadata.styleApplies ?? []) {
+		const applied = resolution.target ? static_style_class(resolution.target, state) : null;
+		if (applied === null) {
+			result = null;
+			break;
+		}
+		for (const hash of applied.split(' ')) {
+			if (hash && !parts.includes(hash)) parts.push(hash);
+		}
+	}
+	if (result !== null) {
+		const sheet = getStyleElementStylesheet(block);
+		if (sheet && !parts.includes(sheet.hash)) parts.push(sheet.hash);
+		result = parts.join(' ');
+	}
+	state.static_classes.set(block, result);
+	return result;
+}
+
+/**
+ * Prepare an assigned block's sheet at its declaration position so it lands
+ * in lexical order with the scopes around it; the transforms build the
+ * class-map object later from the same sheet and `tsrx_style_class_parts`.
+ *
+ * @param {AST.JSXStyleElement} node
+ * @param {StyleScopeState} state
+ * @returns {void}
+ */
+function prepare_assigned_style(node, state) {
+	if (node.metadata.tsrx_style_prepared) return;
+	node.metadata.tsrx_style_prepared = true;
+	resolve_style_applies(node, state);
+	const sheet = getStyleElementStylesheet(node);
+	if (!sheet) return;
+	if (!analyze_scope_css(node, sheet, state)) return;
+	state.analysis.stylesheets.push(
+		prepareStylesheetForRender(sheet, node.metadata.styleKind === 'theme' ? 'theme' : 'class-map'),
+	);
+}
+
+/**
+ * Stamp the current chain on a host element: scope hashes outer first, then
+ * applied theme classes, each once.
+ *
+ * @param {AST.TSRXJSXElement} node
+ * @param {StyleScopeState} state
+ * @returns {void}
+ */
+function stamp(node, state) {
+	/** @type {string[]} */
+	const hashes = [];
+	/** @type {Array<string | AST.Expression>} */
+	const applied = [];
+	for (const entry of state.stack) {
+		if (entry.hash !== null && !hashes.includes(entry.hash)) hashes.push(entry.hash);
+		for (const part of entry.applied) {
+			if (typeof part !== 'string' || (!applied.includes(part) && !hashes.includes(part))) {
+				applied.push(part);
+			}
+		}
+	}
+	if (hashes.length === 0 && applied.length === 0) return;
+	node.metadata.tsrx_scope_class = { base: null, hashes, applied };
+}

--- a/packages/tsrx-ripple/src/transform/client/index.js
+++ b/packages/tsrx-ripple/src/transform/client/index.js
@@ -30,7 +30,6 @@ import tsx from 'esrap/languages/tsx';
 import {
 	builders,
 	clone_ast_node,
-	analyzeCss,
 	IS_CONTROLLED,
 	IS_INDEXED,
 	ROOT_CONTROLLED,
@@ -43,11 +42,8 @@ import {
 	obfuscateIdentifier,
 	object,
 	renderCssResult,
-	prepareStylesheetForRender,
-	collectStyleRefAttributes,
-	createStyleClassMap,
+	buildStyleClassMap,
 	createStyleClassMapFromStylesheet,
-	createStyleRefSetupStatements,
 	getStyleElementStylesheet,
 	getOriginalEventName,
 	has_location,
@@ -117,6 +113,8 @@ import {
 	is_text_primitive_expression,
 	collect_head_elements,
 	is_flattenable_template_fragment,
+	get_scope_class_chain,
+	build_scope_class_expression,
 } from '../../utils.js';
 import {
 	get_attribute_name,
@@ -142,45 +140,91 @@ import {
 import is_reference from 'is-reference';
 
 /**
- * @param {TransformClientState} state
- * @returns {AST.CSS.StyleSheet | null}
- */
-function get_component_css(state) {
-	return state.component?.metadata.component_css ?? null;
-}
-
-/**
- * @param {TransformClientState} state
- * @returns {string | null}
- */
-function get_component_css_hash(state) {
-	return get_component_css(state)?.hash ?? null;
-}
-
-/**
+ * The class-map object of an assigned block (`const theme = <style>…</style>`):
+ * `$class` first — the applied themes' classes, then the block's own hash —
+ * followed by one entry per standalone class selector. The sheet itself was
+ * prepared by the style pre-pass at its declaration position.
  * @param {AST.JSXStyleElement} node
  * @param {TransformClientContext} context
- * @returns {AST.ObjectExpression | null}
+ * @returns {AST.ObjectExpression}
  */
 function build_style_class_map_expression(node, context) {
 	const stylesheet = getStyleElementStylesheet(node);
-	if (!stylesheet) {
-		return null;
+	const applied = node.metadata.tsrx_style_class_parts ?? [];
+	const class_map = stylesheet
+		? createStyleClassMapFromStylesheet(stylesheet, { applied })
+		: buildStyleClassMap(new Map(), null, { applied });
+	if (context.state.to_ts) {
+		add_type_only_style_anchor(node, context);
 	}
-
-	analyzeCss(stylesheet);
-	context.state.stylesheets.push(prepareStylesheetForRender(stylesheet, true));
-	const class_map = createStyleClassMapFromStylesheet(stylesheet);
-	if (!context.state.to_ts) {
-		return class_map;
-	}
-
-	add_type_only_style_anchor(node, context);
 	return class_map;
 }
 
 /**
- * @param {ESTreeJSX.JSXElement | AST.JSXStyleElement} node
+ * The synthesized `$class` read of a type-only `apply` target borrows the
+ * target's position for verification only, so a TypeScript error on it (the
+ * target is not a style object) lands on the authored identifier, while
+ * hover and navigation on that identifier stay the target's own.
+ * @param {AST.Node} target
+ * @returns {AST.Identifier}
+ */
+function type_only_class_read(target) {
+	const id = b.id('$class', has_location(target) ? target : undefined);
+	if (has_location(target)) {
+		id.metadata = {
+			...id.metadata,
+			verify_only: true,
+			source_length: target.end - target.start,
+		};
+	}
+	return id;
+}
+
+/**
+ * The attributes of a type-only `<style>` stand-in: `apply` becomes a
+ * `data-tsrx-apply` attribute reading `$class` of each target, so TypeScript
+ * checks that every target is a style object. Other attributes carry no
+ * type information and are dropped.
+ * @param {AST.JSXStyleElement} node
+ * @returns {ESTreeJSX.JSXAttribute[]}
+ */
+function type_only_style_attributes(node) {
+	/** @type {ESTreeJSX.JSXAttribute[]} */
+	const attributes = [];
+	for (const attr of get_element_attributes(node)) {
+		if (attr.type !== 'JSXAttribute' || get_attribute_name(attr) !== 'apply') continue;
+		const value = attr.value;
+		if (
+			value?.type !== 'JSXExpressionContainer' ||
+			value.expression.type === 'JSXEmptyExpression'
+		) {
+			continue;
+		}
+		/** @param {AST.Expression} target */
+		const read = (target) => b.member(clone_ast_node(target), type_only_class_read(target));
+		const expression = value.expression;
+		const reads =
+			expression.type === 'ArrayExpression'
+				? b.array(
+						expression.elements.map((element) =>
+							element && element.type !== 'SpreadElement' ? read(element) : element,
+						),
+					)
+				: read(expression);
+		attributes.push(
+			b.jsx_attribute(b.jsx_id('data-tsrx-apply'), b.jsx_expression_container(reads)),
+		);
+	}
+	return attributes;
+}
+
+/**
+ * The hoisted stand-in of an assigned block, so the `<style>` tag keeps a
+ * mapping. It carries no `apply` reads: hoisting them above the declarations
+ * they name would be a use before declaration, and the class-map object
+ * already reads an imported target's `$class` (a same-module target is
+ * resolved by the analyzer).
+ * @param {AST.JSXStyleElement} node
  * @param {TransformClientContext} context
  * @returns {void}
  */
@@ -639,17 +683,9 @@ function transform_native_tsrx_function(node, context) {
 	const node_id = node.type !== 'ArrowFunctionExpression' ? (node.id ?? null) : null;
 	const is_synthetic_children = node.metadata?.synthetic_children === true;
 	const raw_render_body = get_native_tsrx_function_body(node, context.state.scopes);
-	const css = get_component_css({ ...context.state, component: node });
-	const style_ref_setup = css
-		? createStyleRefSetupStatements(
-				collectStyleRefAttributes(raw_render_body),
-				createStyleClassMap(node, css),
-				{
-					allowMutableRefTarget: true,
-					createTempIdentifier: () => b.id(component_scope.generate('style_ref')),
-				},
-			)
-		: [];
+	// `<style ref>` class maps of the scopes inside this function (see
+	// `style-scopes.js`) are assigned before the template renders.
+	const style_ref_setup = node.metadata.tsrx_style_ref_statements ?? [];
 	const render_body = strip_tsrx_style_elements(
 		insert_style_ref_setup_statements(raw_render_body, style_ref_setup, context.state.scopes),
 		context.state.scopes,
@@ -671,13 +707,8 @@ function transform_native_tsrx_function(node, context) {
 			scope: component_scope,
 			is_tsrx_element: false,
 			regular_js: false,
-			applyParentCssScope: is_synthetic_children ? context.state.applyParentCssScope : undefined,
 		},
 	});
-
-	if (css) {
-		context.state.stylesheets.push(css);
-	}
 
 	const value_params = [...node.params];
 	if (value_params.length > 0) {
@@ -2362,12 +2393,10 @@ const visitors = {
 			is_regular_js_statement_position(context.path)
 		) {
 			const expression = build_style_class_map_expression(node, context);
-			if (expression) {
-				if (is_regular_js_statement_position(context.path)) {
-					return b.stmt(expression);
-				}
-				return expression;
+			if (is_regular_js_statement_position(context.path)) {
+				return b.stmt(expression);
 			}
+			return expression;
 		}
 
 		if (state.to_ts) {
@@ -2520,9 +2549,10 @@ const visitors = {
 			const local_updates = [];
 			const element_name = /** @type {AST.Identifier} */ (element_id).name;
 			const is_void = is_void_element(element_name);
-			/** @type {AST.CSS.StyleSheet['hash'] | null} */
-			const scoping_hash =
-				state.applyParentCssScope ?? (node.metadata.scoped ? get_component_css_hash(state) : null);
+			// The scope hashes and applied theme classes the style pre-pass
+			// stamped on this element: a literal, or a runtime concatenation
+			// when an imported theme's `$class` is part of it.
+			const scope_class = build_scope_class_expression(get_scope_class_chain(node));
 			const inner_html_attribute = get_inner_html_attribute(node);
 
 			state.template?.push(`<${element_name}`);
@@ -2781,16 +2811,36 @@ const visitors = {
 				}
 			}
 
+			const is_html_class =
+				context.state.namespace === 'html' &&
+				/** @type {AST.Identifier} */ (element_id).name !== 'svg';
+
 			if (class_attribute !== null) {
 				const attr_value = /** @type {AST.Expression} */ (get_attribute_value(class_attribute));
 				if (attr_value.type === 'Literal') {
-					let value = attr_value.value;
-
-					if (scoping_hash) {
-						value = `${scoping_hash} ${value}`;
+					if (scope_class === null || scope_class.type === 'Literal') {
+						handle_static_attr(
+							'class',
+							scope_class === null
+								? attr_value.value
+								: `${attr_value.value} ${/** @type {string} */ (scope_class.value)}`,
+						);
+					} else {
+						// An applied theme is read at runtime, so the class is set
+						// when the element renders.
+						const id = state.flush_node?.();
+						state.init?.push(
+							b.stmt(
+								b.call(
+									'_$_.set_class',
+									id,
+									b.literal(attr_value.value),
+									scope_class,
+									b.literal(is_html_class),
+								),
+							),
+						);
 					}
-
-					handle_static_attr('class', value);
 				} else {
 					const id = state.flush_node?.();
 					const metadata = { tracking: false };
@@ -2798,27 +2848,38 @@ const visitors = {
 						visit(attr_value, { ...state, metadata })
 					);
 
-					const hash_arg = scoping_hash ? b.literal(scoping_hash) : undefined;
-					const is_html =
-						context.state.namespace === 'html' &&
-						/** @type {AST.Identifier} */ (element_id).name !== 'svg';
+					const hash_arg = scope_class ?? undefined;
 
 					if (metadata.tracking) {
 						local_updates.push({
 							operation: (key) =>
-								b.stmt(b.call('_$_.set_class', id, key, hash_arg, b.literal(is_html))),
+								b.stmt(b.call('_$_.set_class', id, key, hash_arg, b.literal(is_html_class))),
 							expression,
 							identity: attr_value,
 							initial: b.call(b.id('Symbol')),
 						});
 					} else {
 						state.init?.push(
-							b.stmt(b.call('_$_.set_class', id, expression, hash_arg, b.literal(is_html))),
+							b.stmt(b.call('_$_.set_class', id, expression, hash_arg, b.literal(is_html_class))),
 						);
 					}
 				}
-			} else if (scoping_hash) {
-				handle_static_attr(is_spreading ? '#class' : 'class', scoping_hash);
+			} else if (scope_class !== null) {
+				if (scope_class.type === 'Literal') {
+					handle_static_attr(
+						is_spreading ? '#class' : 'class',
+						/** @type {string} */ (scope_class.value),
+					);
+				} else if (is_spreading) {
+					spread_attributes?.push(b.prop('init', b.literal('#class'), scope_class));
+				} else {
+					const id = state.flush_node?.();
+					state.init?.push(
+						b.stmt(
+							b.call('_$_.set_class', id, b.literal(null), scope_class, b.literal(is_html_class)),
+						),
+					);
+				}
 			}
 
 			if (style_attribute !== null) {
@@ -2953,7 +3014,9 @@ const visitors = {
 				state.template?.push('<!>');
 			}
 
-			const apply_parent_css_scope = state.applyParentCssScope;
+			// Only a dynamic `<{tag}>` element carries scope classes here; a
+			// component's host elements belong to its own scopes.
+			const scope_class = build_scope_class_expression(get_scope_class_chain(node));
 
 			const is_spreading = element_attributes.some((attr) => attr.type === 'JSXSpreadAttribute');
 			/** @type {(AST.Property | AST.SpreadElement)[]} */
@@ -2989,13 +3052,11 @@ const visitors = {
 							}
 						}
 
-						const scoped_hash = get_component_css_hash(state);
-						if (attr_name === 'class' && node.metadata.scoped && scoped_hash) {
-							if (property.type === 'Literal') {
-								property = b.literal(`${scoped_hash} ${property.value}`);
-							} else {
-								property = b.array([property, b.literal(scoped_hash)]);
-							}
+						if (attr_name === 'class' && scope_class !== null) {
+							property =
+								property.type === 'Literal' && scope_class.type === 'Literal'
+									? b.literal(`${property.value} ${/** @type {string} */ (scope_class.value)}`)
+									: b.array([property, scope_class]);
 						}
 
 						if (metadata.tracking) {
@@ -3052,14 +3113,12 @@ const visitors = {
 				}
 			}
 
-			if (node.metadata.scoped && get_component_css(state)) {
+			if (scope_class !== null) {
 				const hasClassAttr = element_attributes.some(
 					(attr) => attr.type === 'JSXAttribute' && get_attribute_name(attr) === 'class',
 				);
 				if (!hasClassAttr) {
-					const name = is_spreading ? '#class' : 'class';
-					const value = /** @type {string} */ (get_component_css_hash(state));
-					props.push(b.prop('init', b.key(name), b.literal(value)));
+					props.push(b.prop('init', b.key(is_spreading ? '#class' : 'class'), scope_class));
 				}
 			}
 
@@ -3087,13 +3146,6 @@ const visitors = {
 						visit(children_component, {
 							...state,
 							regular_js: false,
-							...(apply_parent_css_scope || get_component_css(state)
-								? {
-										applyParentCssScope:
-											apply_parent_css_scope ||
-											/** @type {string} */ (get_component_css_hash(state)),
-									}
-								: {}),
 							scope: /** @type {ScopeInterface} */ (component_scope),
 							namespace: child_namespace,
 							is_tsrx_element: true,
@@ -4433,9 +4485,9 @@ function transform_ts_child(node, context) {
 		);
 	} else if (node.type === 'JSXStyleElement') {
 		// to_ts: emit an empty `<style>` element for type-only mappings. The CSS
-		// children are TSRX stylesheet AST, never printed as TSX children, and
-		// style attributes were never carried over.
-		const jsxElement = b.jsx_element(node, [], []);
+		// children are TSRX stylesheet AST, never printed as TSX children; only
+		// `apply` carries type information (see type_only_style_attributes).
+		const jsxElement = b.jsx_element(node, type_only_style_attributes(node), []);
 		disable_style_anchor_verification(jsxElement);
 		if (!state.init) {
 			return jsxElement;
@@ -4951,6 +5003,20 @@ function is_rendered_template_child(parent, node) {
 			is_rendered_template_child(/** @type {AST.Node} */ (child), node)
 		) {
 			return true;
+		}
+		// A `@{ … }` child renders through its lowered template child (see
+		// lower_code_block_children), which stands in the parent's children
+		// list in its place.
+		const item = /** @type {AST.Node} */ (child);
+		if (item.type === 'JSXCodeBlock') {
+			const lowered = item.metadata?.tsrx_template_child?.child ?? item.render ?? null;
+			if (lowered === node) return true;
+			if (
+				is_flattenable_template_fragment(/** @type {AST.Node} */ (lowered), false) &&
+				is_rendered_template_child(/** @type {AST.Node} */ (lowered), node)
+			) {
+				return true;
+			}
 		}
 	}
 	return false;
@@ -6903,7 +6969,8 @@ export function transform_client(filename, source, analysis, to_ts, minify_css, 
 		scopes: analysis.scopes,
 		ancestor_server_block: undefined,
 		server_block_locals: [],
-		stylesheets: [],
+		// Filled by the style pre-pass in CSS emission order.
+		stylesheets: analysis.stylesheets,
 		to_ts,
 		filename,
 		namespace: 'html',

--- a/packages/tsrx-ripple/src/transform/client/index.js
+++ b/packages/tsrx-ripple/src/transform/client/index.js
@@ -2818,7 +2818,17 @@ const visitors = {
 			if (class_attribute !== null) {
 				const attr_value = /** @type {AST.Expression} */ (get_attribute_value(class_attribute));
 				if (attr_value.type === 'Literal') {
-					if (scope_class === null || scope_class.type === 'Literal') {
+					if (is_spreading && scope_class !== null) {
+						// The spread may carry a `class` of its own that replaces this
+						// one, so the scope classes ride separately as `#class`, which
+						// the runtime adds after every other attribute.
+						handle_static_attr('class', attr_value.value);
+						if (scope_class.type === 'Literal') {
+							handle_static_attr('#class', /** @type {string} */ (scope_class.value));
+						} else {
+							spread_attributes?.push(b.prop('init', b.literal('#class'), scope_class));
+						}
+					} else if (scope_class === null || scope_class.type === 'Literal') {
 						handle_static_attr(
 							'class',
 							scope_class === null

--- a/packages/tsrx-ripple/src/transform/server/index.js
+++ b/packages/tsrx-ripple/src/transform/server/index.js
@@ -16,18 +16,13 @@
 import {
 	builders,
 	escape,
-	analyzeCss,
 	isEventAttribute,
 	isInsideComponent as is_inside_component,
 	renderCssResult,
 	renderStylesheets,
-	prepareStylesheetForRender,
-	collectStyleRefAttributes,
-	createStyleClassMap,
+	buildStyleClassMap,
 	createStyleClassMapFromStylesheet,
-	createStyleRefSetupStatements,
 	getStyleElementStylesheet,
-	CSS_HASH_IDENTIFIER,
 	obfuscateIdentifier,
 	BLOCK_CLOSE,
 	BLOCK_OPEN,
@@ -41,6 +36,7 @@ import ts from 'esrap/languages/ts';
 import path from 'node:path';
 import { print } from 'esrap';
 import is_reference from 'is-reference';
+import { get_style_registrations } from '../../style-scopes.js';
 import {
 	determine_namespace_for_children,
 	escape_html,
@@ -84,6 +80,8 @@ import {
 	is_text_primitive_expression,
 	collect_head_elements,
 	is_flattenable_template_fragment,
+	get_scope_class_chain,
+	build_scope_class_expression,
 } from '../../utils.js';
 import {
 	get_attribute_name,
@@ -117,48 +115,41 @@ function is_traversable_ast_node(value) {
 }
 
 /**
- * @param {TransformServerState} state
- * @returns {AST.CSS.StyleSheet | null}
- */
-function get_component_css(state) {
-	return state.component?.metadata.component_css ?? null;
-}
-
-/**
- * @param {TransformServerState} state
- * @returns {string | null}
- */
-function get_component_css_hash(state) {
-	return get_component_css(state)?.hash ?? null;
-}
-
-/**
+ * The class-map object of an assigned block (`const theme = <style>…</style>`)
+ * on the server: every entry is a getter that registers the CSS it stands for
+ * with the active request before returning the class string, so a request
+ * collects exactly the sheets it rendered. `$class` registers the applied
+ * themes' sheets before the block's own (their runtime reads register
+ * themselves through the same getters); a named entry carries only the
+ * block's own hash. The sheet itself was prepared by the style pre-pass at
+ * its declaration position.
  * @param {AST.JSXStyleElement} node
- * @param {TransformServerContext} context
- * @returns {AST.ObjectExpression | null}
- */
-function build_style_class_map_expression(node, context) {
-	const stylesheet = getStyleElementStylesheet(node);
-	if (!stylesheet) {
-		return null;
-	}
-
-	analyzeCss(stylesheet);
-	context.state.stylesheets.push(prepareStylesheetForRender(stylesheet, true));
-	return create_server_style_class_map_expression(stylesheet);
-}
-
-/**
- * @param {AST.CSS.StyleSheet} stylesheet
  * @returns {AST.ObjectExpression}
  */
-function create_server_style_class_map_expression(stylesheet) {
-	const style_map = createStyleClassMapFromStylesheet(stylesheet);
+function build_style_class_map_expression(node) {
+	const stylesheet = getStyleElementStylesheet(node);
+	const applied = node.metadata.tsrx_style_class_parts ?? [];
+	const style_map = stylesheet
+		? createStyleClassMapFromStylesheet(stylesheet, { applied })
+		: buildStyleClassMap(new Map(), null, { applied });
+	const own_hash = stylesheet?.hash ?? null;
+	/** @type {string[]} */
+	const class_hashes = [];
+	for (const part of applied) {
+		if (typeof part === 'string' && !class_hashes.includes(part)) class_hashes.push(part);
+	}
+	if (own_hash !== null && !class_hashes.includes(own_hash)) class_hashes.push(own_hash);
+
 	return b.object(
 		style_map.properties.map((property) => {
 			if (property.type !== 'Property') {
 				return property;
 			}
+			const is_class =
+				property.key.type === 'Literal'
+					? property.key.value === '$class'
+					: property.key.type === 'Identifier' && property.key.name === '$class';
+			const hashes = is_class ? class_hashes : own_hash === null ? [] : [own_hash];
 			return b.prop(
 				'get',
 				/** @type {AST.Expression} */ (property.key),
@@ -166,13 +157,30 @@ function create_server_style_class_map_expression(stylesheet) {
 					null,
 					[],
 					b.block([
-						b.stmt(b.call('_$_.output_register_css', b.literal(stylesheet.hash))),
+						...hashes.map((hash) => b.stmt(b.call('_$_.output_register_css', b.literal(hash)))),
 						b.return(/** @type {AST.Expression} */ (property.value)),
 					]),
 				),
 				property.computed,
 			);
 		}),
+	);
+}
+
+/**
+ * What a component registers with the request before rendering its template
+ * (see `style-scopes.js`): each scope's applied themes first — a hash to
+ * register, or a `theme.$class` read whose getter registers an imported
+ * theme's sheet — then the scope's own hash, so an applied theme's CSS
+ * always precedes the scope that applies it.
+ * @param {AST.Function} node
+ * @returns {AST.Statement[]}
+ */
+function build_style_registration_statements(node) {
+	return get_style_registrations(node).map((entry) =>
+		typeof entry === 'string'
+			? b.stmt(b.call('_$_.output_register_css', b.literal(entry)))
+			: b.stmt(b.unary('void', clone_ast_node(entry, false))),
 	);
 }
 
@@ -1261,14 +1269,7 @@ function transform_native_tsrx_function(node, context) {
 	}
 
 	/** @type {AST.Statement[]} */
-	const body_statements = [];
-	const css = get_component_css({ ...context.state, component: node });
-	if (css !== null) {
-		const hash_id = b.id(CSS_HASH_IDENTIFIER);
-		const hash = b.var(hash_id, b.literal(css.hash));
-		context.state.stylesheets.push(css);
-		body_statements.push(hash, b.stmt(b.call(b.id('_$_.output_register_css'), hash_id)));
-	}
+	const body_statements = build_style_registration_statements(node);
 
 	const raw_render_body = get_native_tsrx_function_body(node, context.state.scopes);
 	const node_id = node.type !== 'ArrowFunctionExpression' ? (node.id ?? null) : null;
@@ -1280,16 +1281,9 @@ function transform_native_tsrx_function(node, context) {
 		(render_scope_node && context.state.scopes.get(render_scope_node)) ||
 		context.state.scopes.get(node) ||
 		context.state.scope;
-	const style_ref_setup = css
-		? createStyleRefSetupStatements(
-				collectStyleRefAttributes(raw_render_body),
-				createStyleClassMap(node, css),
-				{
-					allowMutableRefTarget: true,
-					createTempIdentifier: () => b.id(component_scope.generate('style_ref')),
-				},
-			)
-		: [];
+	// `<style ref>` class maps of the scopes inside this function (see
+	// `style-scopes.js`) are assigned before the template renders.
+	const style_ref_setup = node.metadata.tsrx_style_ref_statements ?? [];
 	const render_body = strip_tsrx_style_elements(
 		insert_style_ref_setup_statements(raw_render_body, style_ref_setup, context.state.scopes),
 		context.state.scopes,
@@ -1303,10 +1297,6 @@ function transform_native_tsrx_function(node, context) {
 				scope: component_scope,
 				is_tsrx_element: false,
 				regular_js: false,
-				applyParentCssScope:
-					node.metadata?.synthetic_children === true
-						? context.state.applyParentCssScope
-						: undefined,
 			},
 		}),
 	);
@@ -2227,13 +2217,11 @@ const visitors = {
 			is_native_tsrx_value_position(context.path, node) ||
 			is_regular_js_statement_position(context.path)
 		) {
-			const expression = build_style_class_map_expression(node, context);
-			if (expression) {
-				if (is_regular_js_statement_position(context.path)) {
-					return b.stmt(expression);
-				}
-				return expression;
+			const expression = build_style_class_map_expression(node);
+			if (is_regular_js_statement_position(context.path)) {
+				return b.stmt(expression);
 			}
+			return expression;
 		}
 
 		// Component styles render nothing on the server — their CSS is extracted
@@ -2293,9 +2281,10 @@ const visitors = {
 			const is_void = is_void_element(/** @type {AST.Identifier} */ (element_id).name);
 			const use_self_closing_syntax = is_self_closing(node) && is_void;
 			const tag_name = b.literal(/** @type {AST.Identifier} */ (element_id).name);
-			/** @type {AST.CSS.StyleSheet['hash'] | null} */
-			const scoping_hash =
-				state.applyParentCssScope ?? (node.metadata.scoped ? get_component_css_hash(state) : null);
+			// The scope hashes and applied theme classes the style pre-pass
+			// stamped on this element: a literal, or a runtime concatenation
+			// when an imported theme's `$class` is part of it.
+			const scope_class = build_scope_class_expression(get_scope_class_chain(node));
 			/** @type {AST.Expression | null} */
 			let inner_html_expression = null;
 			/** @type {AST.Identifier | null} */
@@ -2410,23 +2399,26 @@ const visitors = {
 
 			if (class_attribute !== null) {
 				const attr_value = /** @type {AST.Expression} */ (get_attribute_value(class_attribute));
-				if (attr_value.type === 'Literal') {
-					let value = attr_value.value;
-
-					if (scoping_hash) {
-						value = `${scoping_hash} ${value}`;
-					}
-
-					handle_static_attr('class', value);
+				if (
+					attr_value.type === 'Literal' &&
+					(scope_class === null || scope_class.type === 'Literal')
+				) {
+					handle_static_attr(
+						'class',
+						scope_class === null
+							? attr_value.value
+							: `${attr_value.value} ${/** @type {string} */ (scope_class.value)}`,
+					);
 				} else {
 					const metadata = { tracking: false };
-					let expression = /** @type {AST.Expression} */ (
-						visit(attr_value, { ...state, metadata })
-					);
+					let expression =
+						attr_value.type === 'Literal'
+							? b.literal(attr_value.value)
+							: /** @type {AST.Expression} */ (visit(attr_value, { ...state, metadata }));
 
-					if (scoping_hash) {
+					if (scope_class !== null) {
 						// Pass array to clsx so it can handle objects properly
-						expression = b.array([expression, b.literal(scoping_hash)]);
+						expression = b.array([expression, scope_class]);
 					}
 
 					state.init?.push(
@@ -2435,8 +2427,26 @@ const visitors = {
 						),
 					);
 				}
-			} else if (scoping_hash) {
-				handle_static_attr('class', scoping_hash, is_spreading ? 'unshift' : 'push');
+			} else if (scope_class !== null) {
+				if (scope_class.type === 'Literal') {
+					handle_static_attr(
+						'class',
+						/** @type {string} */ (scope_class.value),
+						is_spreading ? 'unshift' : 'push',
+					);
+				} else if (is_spreading) {
+					// A `class` in the spread overrides this one, and `spread_attrs`
+					// then merges the scope classes back in.
+					/** @type {(AST.Property | AST.SpreadElement)[]} */ (spread_attributes).unshift(
+						b.prop('init', b.literal('class'), scope_class),
+					);
+				} else {
+					state.init?.push(
+						b.stmt(
+							b.call(b.id('_$_.output_push'), b.call('_$_.attr', b.literal('class'), scope_class)),
+						),
+					);
+				}
 			}
 
 			if (spread_attributes !== null && spread_attributes.length > 0) {
@@ -2446,11 +2456,7 @@ const visitors = {
 					b.stmt(
 						b.call(
 							b.id('_$_.output_push'),
-							b.call(
-								'_$_.spread_attrs',
-								spread_attributes_id,
-								scoping_hash ? b.literal(scoping_hash) : undefined,
-							),
+							b.call('_$_.spread_attrs', spread_attributes_id, scope_class ?? undefined),
 						),
 					),
 				);
@@ -2512,12 +2518,6 @@ const visitors = {
 							state: {
 								...state,
 								init,
-								...(state.applyParentCssScope
-									? {
-											applyParentCssScope:
-												state.applyParentCssScope || get_component_css_hash(state),
-										}
-									: {}),
 							},
 						}),
 					);
@@ -2539,12 +2539,6 @@ const visitors = {
 							state: {
 								...state,
 								init,
-								...(state.applyParentCssScope
-									? {
-											applyParentCssScope:
-												state.applyParentCssScope || get_component_css_hash(state),
-										}
-									: {}),
 							},
 						}),
 					);
@@ -2576,7 +2570,9 @@ const visitors = {
 			/** @type {AST.Property | null} */
 			let children_prop = null;
 
-			const apply_parent_css_scope = state.applyParentCssScope;
+			// Only a dynamic `<{tag}>` element carries scope classes here; a
+			// component's host elements belong to its own scopes.
+			const scope_class = build_scope_class_expression(get_scope_class_chain(node));
 
 			for (const attr of element_attributes) {
 				if (attr.type === 'JSXAttribute') {
@@ -2599,13 +2595,11 @@ const visitors = {
 										})
 									);
 
-						const scoped_hash = get_component_css_hash(state);
-						if (attr_name === 'class' && node.metadata.scoped && scoped_hash) {
-							if (property.type === 'Literal') {
-								property = b.literal(`${scoped_hash} ${property.value}`);
-							} else {
-								property = b.array([property, b.literal(scoped_hash)]);
-							}
+						if (attr_name === 'class' && scope_class !== null) {
+							property =
+								property.type === 'Literal' && scope_class.type === 'Literal'
+									? b.literal(`${property.value} ${/** @type {string} */ (scope_class.value)}`)
+									: b.array([property, scope_class]);
 						}
 
 						if (attr_name === 'children') {
@@ -2631,14 +2625,12 @@ const visitors = {
 				}
 			}
 
-			if (node.metadata.scoped && get_component_css(state)) {
+			if (scope_class !== null) {
 				const hasClassAttr = element_attributes.some(
 					(attr) => attr.type === 'JSXAttribute' && get_attribute_name(attr) === 'class',
 				);
 				if (!hasClassAttr) {
-					const name = is_spreading ? '#class' : 'class';
-					const value = /** @type {string} */ (get_component_css_hash(state));
-					props.push(b.prop('init', b.key(name), b.literal(value)));
+					props.push(b.prop('init', b.key(is_spreading ? '#class' : 'class'), scope_class));
 				}
 			}
 
@@ -2665,12 +2657,6 @@ const visitors = {
 						visit(create_native_tsrx_render_function([], children_filtered, node), {
 							...context.state,
 							regular_js: false,
-							...(apply_parent_css_scope || get_component_css(state)
-								? {
-										applyParentCssScope:
-											apply_parent_css_scope || get_component_css_hash(state) || undefined,
-									}
-								: {}),
 							scope: component_scope,
 							namespace: child_namespace,
 						})
@@ -3569,7 +3555,8 @@ export function transform_server(filename, source, analysis, minify_css, dev = f
 		init: null,
 		scope: analysis.scope,
 		scopes: analysis.scopes,
-		stylesheets: [],
+		// Filled by the style pre-pass in CSS emission order.
+		stylesheets: analysis.stylesheets,
 		component_metadata,
 		ancestor_server_block: undefined,
 		server_block_locals: [],
@@ -3601,14 +3588,19 @@ export function transform_server(filename, source, analysis, minify_css, dev = f
 
 	body.push(...program.body);
 
-	// Register each stylesheet's CSS so the runtime can serialize it
+	// Register each scope's CSS by hash so the runtime can serialize it. The
+	// blocks of one scope share a hash and register as one sheet, in order.
 	if (css) {
+		/** @type {Map<string, AST.CSS.StyleSheet[]>} */
+		const sheets_by_hash = new Map();
 		for (const stylesheet of state.stylesheets) {
-			const css_for_component = renderStylesheets([stylesheet]);
+			const group = sheets_by_hash.get(stylesheet.hash);
+			if (group) group.push(stylesheet);
+			else sheets_by_hash.set(stylesheet.hash, [stylesheet]);
+		}
+		for (const [hash, sheets] of sheets_by_hash) {
 			body.push(
-				b.stmt(
-					b.call('_$_.register_css', b.literal(stylesheet.hash), b.literal(css_for_component)),
-				),
+				b.stmt(b.call('_$_.register_css', b.literal(hash), b.literal(renderStylesheets(sheets)))),
 			);
 		}
 	}

--- a/packages/tsrx-ripple/src/transform/server/index.js
+++ b/packages/tsrx-ripple/src/transform/server/index.js
@@ -2399,7 +2399,12 @@ const visitors = {
 
 			if (class_attribute !== null) {
 				const attr_value = /** @type {AST.Expression} */ (get_attribute_value(class_attribute));
-				if (
+				if (attr_value.type === 'Literal' && is_spreading && scope_class !== null) {
+					// The spread may carry a `class` of its own; `spread_attrs` merges
+					// the scope classes into whichever `class` wins, so they are not
+					// written here as well.
+					handle_static_attr('class', attr_value.value);
+				} else if (
 					attr_value.type === 'Literal' &&
 					(scope_class === null || scope_class.type === 'Literal')
 				) {

--- a/packages/tsrx-ripple/src/utils.js
+++ b/packages/tsrx-ripple/src/utils.js
@@ -1059,63 +1059,51 @@ export function is_style_element(node) {
 }
 
 /**
- * @param {AST.Node[]} nodes
- * @returns {AST.CSS.StyleSheet | null}
+ * The classes the style pre-pass stamped on an element (see
+ * `style-scopes.js`): the hash of every enclosing sibling scope, outer first,
+ * then the applied themes' classes — string literals when statically known,
+ * `theme.$class` reads otherwise. Empty for an element outside every scope.
+ * @param {AST.Node} node
+ * @returns {Array<string | AST.Expression>}
  */
-export function collect_tsrx_stylesheet(nodes) {
-	/** @type {AST.CSS.StyleSheet[]} */
-	const styles = [];
-	collect_style_elements(nodes, styles, false);
-	if (styles.length === 0) return null;
-	if (styles.length > 1) {
-		throw new Error('TSRX fragments can only have one style tag');
-	}
-	return styles[0];
+export function get_scope_class_chain(node) {
+	const parts = node.metadata?.tsrx_scope_class;
+	return parts ? [...parts.hashes, ...parts.applied] : [];
 }
 
 /**
- * @param {AST.Node | AST.Node[]} node
- * @param {AST.CSS.StyleSheet[]} styles
- * @param {boolean} inside_head
- * @returns {void}
+ * One expression for a class chain: a string literal when every part is
+ * static, otherwise a `+` concatenation with the static runs folded together
+ * (`'a b ' + theme.$class + ' c'`). Runtime reads are cloned so every use
+ * prints on its own. `null` for an empty chain.
+ * @param {Array<string | AST.Expression>} chain
+ * @returns {AST.Expression | null}
  */
-function collect_style_elements(node, styles, inside_head) {
-	if (!node) return;
-	if (Array.isArray(node)) {
-		for (const child of node) collect_style_elements(child, styles, inside_head);
-		return;
-	}
-	if (node.metadata?.regular_js) {
-		return;
-	}
-	if (is_style_element(node)) {
-		if (!inside_head) {
-			const stylesheet = node.children?.find((child) => child.type === 'StyleSheet');
-			if (stylesheet) {
-				styles.push(stylesheet);
-			}
+export function build_scope_class_expression(chain) {
+	if (chain.length === 0) return null;
+	/** @type {AST.Expression | null} */
+	let result = null;
+	let pending = '';
+	/** @param {AST.Expression} expression */
+	const append = (expression) => {
+		result = result ? b.binary('+', result, expression) : expression;
+	};
+	for (const part of chain) {
+		if (typeof part === 'string') {
+			pending = pending ? `${pending} ${part}` : part;
+			continue;
 		}
-		return;
+		if (result) {
+			append(b.literal(pending ? ` ${pending} ` : ' '));
+		} else if (pending) {
+			append(b.literal(`${pending} `));
+		}
+		pending = '';
+		append(clone_ast_node(part, false));
 	}
-	if (
-		node.type === 'FunctionDeclaration' ||
-		node.type === 'FunctionExpression' ||
-		node.type === 'ArrowFunctionExpression'
-	) {
-		return;
-	}
-	const next_inside_head =
-		inside_head || (is_template_element(node) && get_element_identifier(node)?.name === 'head');
-	if ('children' in node && Array.isArray(node.children)) {
-		collect_style_elements(/** @type {AST.Node[]} */ (node.children), styles, next_inside_head);
-	}
-	if (node.type === 'BlockStatement') {
-		collect_style_elements(node.body, styles, next_inside_head);
-	}
-	if (node.type === 'IfStatement') {
-		collect_style_elements(node.consequent, styles, next_inside_head);
-		if (node.alternate) collect_style_elements(node.alternate, styles, next_inside_head);
-	}
+	if (!result) return b.literal(pending);
+	if (pending) append(b.literal(` ${pending}`));
+	return result;
 }
 
 /**

--- a/packages/tsrx-ripple/tests/basic.test.js
+++ b/packages/tsrx-ripple/tests/basic.test.js
@@ -318,7 +318,7 @@ describe('@tsrx/ripple dynamic tag syntax', () => {
 		expect(css).toContain(`div.${cssHash} { color: red; }`);
 		expect(css).toContain(`.host.${cssHash} { color: blue; }`);
 		expect(css).toContain('/* (unused) .unused { color: green; }*/');
-		expect(code).toContain(`class: '${cssHash} host'`);
+		expect(code).toContain(`class: 'host ${cssHash}'`);
 	});
 
 	it('emits valid to_ts output for dynamic tags', () => {

--- a/packages/tsrx-ripple/tests/jsx-runtime-types.test.js
+++ b/packages/tsrx-ripple/tests/jsx-runtime-types.test.js
@@ -59,6 +59,28 @@ function get_variable_types(code) {
 }
 
 describe('@tsrx/ripple Volar JSX expression types', () => {
+	it('types a style class map with $class and verifies apply targets on the style stand-in', () => {
+		const { code } = compile_to_volar_mappings(
+			`
+const base = <style>div { color: red; }</style>;
+const theme = <style apply={base}>.dark { color: purple; }</style>;
+const cls = theme.$class;
+const dark = theme.dark;
+export function App() @{
+	<>
+		<style apply={[base, theme]}>.in { margin: 0; }</style>
+		<div class={theme.$class}>{'in'}</div>
+	</>
+}`,
+			'App.tsrx',
+			{ loose: true },
+		);
+		expect(code).toContain('<style data-tsrx-apply={[base.$class, theme.$class]}></style>');
+		const types = get_variable_types(code);
+		expect(types.get('cls')).toBe('string');
+		expect(types.get('dark')).toBe('string');
+	});
+
 	it('types JSX expression values as TSRXElement', () => {
 		const source = `
 function App() @{

--- a/packages/tsrx-ripple/tests/scoped-styles.test.js
+++ b/packages/tsrx-ripple/tests/scoped-styles.test.js
@@ -1,0 +1,239 @@
+/**
+ * Scoped-style conformance fixtures (RFC tsrx-org/RFCs#1) compiled through
+ * the Ripple target. The fixtures and their `expected.json` contracts come
+ * from the `@tsrx/core` test harness; the schema is described in the README
+ * next to them (`SCOPED_STYLES_FIXTURES_DIR/README.md`). Every `.tsrx`
+ * compiles on its own in both `client` and `server` mode (imports are never
+ * resolved) and the output is checked for:
+ *
+ * - `cssOrder`: the marker rules `.<label>.<hash>` in emission order, one
+ *   hash per scope, and `cssHash` as the distinct hashes in that order;
+ * - `elements`: every authored class value rendered with its scope chain
+ *   (outer → inner) followed by the applied themes;
+ * - `classMaps`: the `$class` composition of assigned blocks and their own
+ *   entry;
+ * - `pruned`: `(unused)` comments in emission order — standalone blocks prune
+ *   what matches nothing among the list's other children, assigned blocks
+ *   what their class map does not expose.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+	load_scoped_styles_fixtures,
+	SCOPED_STYLES_FIXTURES_DIR,
+} from '@tsrx/core/test-harness/scoped-styles-fixtures';
+import { compile } from '../src/index.js';
+
+const MODES = /** @type {const} */ (['client', 'server']);
+const HASH = 'tsrx-[0-9a-f]+';
+const RUNTIME_PREFIX = 'import:';
+
+const fixtures = load_scoped_styles_fixtures();
+
+/** @param {string} text */
+function escape_regexp(text) {
+	return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/** @param {string} label */
+function is_runtime(label) {
+	return label.startsWith(RUNTIME_PREFIX);
+}
+
+/** @param {string} label */
+function runtime_expression(label) {
+	return label.slice(RUNTIME_PREFIX.length);
+}
+
+/**
+ * Every static label a fixture refers to.
+ * @param {import('@tsrx/core/test-harness/scoped-styles-fixtures').ScopedStylesFixture['expected']} expected
+ */
+function collect_labels(expected) {
+	const labels = new Set(expected.cssOrder);
+	for (const chain of Object.values(expected.elements)) {
+		for (const label of chain) if (!is_runtime(label)) labels.add(label);
+	}
+	for (const [name, chain] of Object.entries(expected.classMaps)) {
+		for (const label of chain) {
+			if (is_runtime(label)) continue;
+			labels.add(label === 'own' ? name : label);
+		}
+	}
+	return labels;
+}
+
+/**
+ * Resolve each label to the hash of its marker selector `.label.<hash>`.
+ * @param {string} css
+ * @param {Set<string>} labels
+ */
+function resolve_labels(css, labels) {
+	/** @type {Map<string, string>} */
+	const hashes = new Map();
+	for (const label of labels) {
+		const matches = [...css.matchAll(new RegExp(`\\.${escape_regexp(label)}\\.(${HASH})`, 'g'))];
+		if (matches.length === 0) {
+			throw new Error(`no scoped marker selector for label "${label}" in:\n${css}`);
+		}
+		for (const match of matches) expect(match[1]).toBe(matches[0][1]);
+		hashes.set(label, matches[0][1]);
+	}
+	return hashes;
+}
+
+/**
+ * @param {string} label
+ * @param {Map<string, string>} hashes
+ */
+function hash_of(label, hashes) {
+	const hash = hashes.get(label);
+	if (!hash) throw new Error(`label "${label}" was not resolved`);
+	return hash;
+}
+
+/**
+ * The class chain as the compiled code spells it: static hashes folded into
+ * one literal, runtime `$class` reads concatenated with `+`.
+ * @param {string[]} chain
+ * @param {Map<string, string>} hashes
+ * @param {string | null} own the block's own label for `own` entries
+ */
+function chain_text(chain, hashes, own = null) {
+	/** @type {string[]} */
+	const out = [];
+	/** @type {string | null} */
+	let literal = null;
+	let previous_runtime = false;
+	for (const label of chain) {
+		if (is_runtime(label)) {
+			if (literal !== null) {
+				out.push(`'${literal} '`);
+				literal = null;
+			} else if (previous_runtime) {
+				out.push(`' '`);
+			}
+			out.push(`${runtime_expression(label)}.$class`);
+			previous_runtime = true;
+		} else {
+			const hash = hash_of(label === 'own' && own ? own : label, hashes);
+			literal = literal === null ? (previous_runtime ? ` ${hash}` : hash) : `${literal} ${hash}`;
+			previous_runtime = false;
+		}
+	}
+	if (literal !== null) out.push(`'${literal}'`);
+	return out.join(' + ');
+}
+
+/** @param {string} code */
+function normalize(code) {
+	return code.replace(/\s+/g, ' ');
+}
+
+/**
+ * The text forms the compiled code may use for an element's class: a static
+ * chain on a static value lands in the HTML (`class="…"`) or, for a dynamic
+ * `<{tag}>`, in its props (`class: '…'`); anything with a runtime part is set
+ * at render time from the authored value and the chain expression, which
+ * both the client (`_$_.set_class(el, value, chain)`) and the server
+ * (`_$_.attr('class', [value, chain])`) spell as `value, chain`.
+ * @param {string} key
+ * @param {string[]} chain
+ * @param {Map<string, string>} hashes
+ */
+function class_candidates(key, chain, hashes) {
+	const is_expression = key.startsWith('{') && key.endsWith('}');
+	const has_runtime = chain.some(is_runtime);
+	if (!is_expression) {
+		if (!has_runtime) {
+			const value = [key, ...chain.map((label) => hash_of(label, hashes))].join(' ');
+			return [`class="${value}"`, `class: '${value}'`];
+		}
+		return [`'${key}', ${chain_text(chain, hashes)}`];
+	}
+	const expression = key.slice(1, -1);
+	if (chain.length === 0) {
+		// The authored value is used as is; a call in it may be wrapped
+		// (`_$_.with_scope(__block, helper).inFunction`), so its property
+		// read is what survives verbatim.
+		const property = expression.match(/\.[A-Za-z_$][\w$]*$/)?.[0];
+		return property ? [expression, property] : [expression];
+	}
+	return [`${expression}, ${chain_text(chain, hashes)}`];
+}
+
+/** @param {string} css */
+function pruned_selectors(css) {
+	return [...css.matchAll(/\/\* \(unused\) ([\s\S]*?)\*\//g)].map((match) =>
+		match[1].split('{')[0].trim(),
+	);
+}
+
+describe('scoped-style conformance fixtures', () => {
+	expect(fixtures.length).toBeGreaterThan(0);
+
+	for (const fixture of fixtures) {
+		describe(fixture.name, () => {
+			const labels = collect_labels(fixture.expected);
+
+			for (const mode of MODES) {
+				it(`[${mode}] emits the sheets in order and prunes what nothing reaches`, () => {
+					const { css, cssHash } = compile(fixture.source, fixture.path, { mode });
+					const hashes = resolve_labels(css, labels);
+
+					const markers = [...css.matchAll(new RegExp(`\\.([A-Za-z_][\\w-]*)\\.${HASH}`, 'g'))]
+						.map((match) => match[1])
+						.filter((label) => labels.has(label));
+					expect(markers).toEqual(fixture.expected.cssOrder);
+
+					const distinct = [
+						...new Set(fixture.expected.cssOrder.map((label) => hash_of(label, hashes))),
+					];
+					expect(cssHash).toBe(distinct.join(' '));
+
+					expect(pruned_selectors(css)).toEqual(fixture.expected.pruned);
+				});
+
+				it(`[${mode}] stamps every element with its scope chain and applied themes`, () => {
+					const { code, css } = compile(fixture.source, fixture.path, { mode });
+					const hashes = resolve_labels(css, labels);
+					const text = normalize(code);
+					for (const [key, chain] of Object.entries(fixture.expected.elements)) {
+						const candidates = class_candidates(key, chain, hashes);
+						expect(
+							candidates.some((candidate) => text.includes(candidate)),
+							`${key} → ${JSON.stringify(candidates)} in:\n${code}`,
+						).toBe(true);
+					}
+				});
+
+				it(`[${mode}] composes $class on assigned blocks`, () => {
+					const { code, css } = compile(fixture.source, fixture.path, { mode });
+					const hashes = resolve_labels(css, labels);
+					const text = normalize(code);
+					for (const [name, chain] of Object.entries(fixture.expected.classMaps)) {
+						const value = chain_text(chain, hashes, name);
+						// The client map is a plain object; the server map reads through
+						// getters that register the CSS with the request.
+						const forms = [`'$class': ${value}`, `return ${value};`];
+						expect(
+							forms.some((form) => text.includes(form)),
+							`${name}.$class → ${value} in:\n${code}`,
+						).toBe(true);
+						if (chain.includes('own') || chain.includes(name)) {
+							const entry = `'${hash_of(name, hashes)} ${name}'`;
+							expect(
+								text.includes(`'${name}': ${entry}`) || text.includes(`return ${entry};`),
+								`${name}.${name} → ${entry} in:\n${code}`,
+							).toBe(true);
+						}
+					}
+				});
+			}
+		});
+	}
+
+	it('reads the fixtures shipped with @tsrx/core', () => {
+		expect(SCOPED_STYLES_FIXTURES_DIR).toContain('scoped-styles');
+	});
+});

--- a/packages/tsrx-ripple/tests/style-diagnostics.test.js
+++ b/packages/tsrx-ripple/tests/style-diagnostics.test.js
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import { compile, compile_to_volar_mappings } from '../src/index.js';
+
+// The style diagnostics of RFC tsrx-org/RFCs#1 come from the shared analyzer
+// in @tsrx/core; these tests pin that the Ripple target surfaces them, with
+// their codes, in both strict and collect mode.
+
+/**
+ * @param {string} source
+ * @returns {string[]}
+ */
+function error_codes(source) {
+	return compile(source, 'App.tsrx', { collect: true }).errors.map((error) => error.code);
+}
+
+describe('@tsrx/ripple scoped-style diagnostics', () => {
+	it('rejects an apply target declared after the block that applies it', () => {
+		const source = `
+export function App() @{
+	<>
+		<style apply={theme} />
+		<div>{'x'}</div>
+	</>
+}
+const theme = <style>div { color: red; }</style>;
+`;
+		expect(error_codes(source)).toEqual(['tsrx-style-apply-before-declaration']);
+		expect(() => compile(source, 'App.tsrx')).toThrow(/before its declaration/);
+	});
+
+	it('rejects an apply target that is not a style block, and a literal apply value', () => {
+		expect(
+			error_codes(`
+const theme = { $class: 'x' };
+export function App() @{
+	<>
+		<style apply={theme} />
+		<div>{'x'}</div>
+	</>
+}`),
+		).toEqual(['tsrx-style-apply-target']);
+		expect(
+			error_codes(`
+const theme = <style>div { color: red; }</style>;
+export function App() @{
+	<>
+		<style apply="theme" />
+		<div>{'x'}</div>
+	</>
+}`),
+		).toEqual(['tsrx-style-apply-value']);
+	});
+
+	it('rejects a lone <style> as the output of a code block and a raw block in plain TSX', () => {
+		expect(
+			error_codes(`
+export function App() @{
+	<style>div { color: red; }</style>
+}`),
+		).toEqual(['tsrx-style-standalone-needs-fragment']);
+		expect(
+			error_codes(`
+export function App() {
+	return <>
+		<style>div { color: red; }</style>
+		<div>{'x'}</div>
+	</>;
+}`),
+		).toEqual(['tsrx-style-standalone-outside-template']);
+	});
+
+	it('leaves <style>{css}</style> alone as an ordinary element', () => {
+		const { code, css } = compile(
+			`
+export function App({ css }: { css: string }) {
+	return <div><style>{css}</style></div>;
+}`,
+			'App.tsrx',
+		);
+		expect(css).toBe('');
+		expect(code).toContain('<style>');
+		expect(code).not.toContain('tsrx-');
+	});
+});
+
+describe('@tsrx/ripple scoped styles in type-only output', () => {
+	it('verifies apply targets through a $class read on the style stand-in', () => {
+		const source = `
+import { theme } from './theme.tsrx';
+const local = <style apply={theme}>.a { color: red; }</style>;
+export function App() @{
+	<>
+		<style apply={[theme, local]}>.in { margin: 0; }</style>
+		<div class="in">{'in'}</div>
+	</>
+}`;
+		const { code, errors } = compile_to_volar_mappings(source, 'App.tsrx', { loose: true });
+		expect(errors).toEqual([]);
+		// The assigned block's class map reads the imported target itself; its
+		// hoisted stand-in carries no reads (they would sit above `theme`).
+		expect(code).toContain("'$class': theme.$class + ' tsrx-");
+		expect(code).toContain('const style_anchor = <style></style>;');
+		expect(code).toContain('<style data-tsrx-apply={[theme.$class, local.$class]}></style>');
+		// The stamped scope classes are a runtime detail: the authored class
+		// stays as written in the type-only view.
+		expect(code).toContain('<div class="in">');
+	});
+});

--- a/packages/tsrx-ripple/types/index.d.ts
+++ b/packages/tsrx-ripple/types/index.d.ts
@@ -5,6 +5,7 @@
  */
 import type * as AST from 'estree';
 import type {
+	AnalysisResult as CoreAnalysisResult,
 	CompileFn,
 	CompileOptions,
 	CompileResult,
@@ -14,6 +15,22 @@ import type {
 } from '@tsrx/core/types';
 
 export type * from '@tsrx/core/types';
+
+/**
+ * One thing the server registers with the active request before a component
+ * renders its template: a stylesheet hash, or a `theme.$class` read whose
+ * getter registers an imported theme's sheet (see `src/style-scopes.js`).
+ */
+export type StyleRegistration = string | AST.Expression;
+
+/**
+ * Ripple's analysis result: the shared shape plus what the style pre-pass
+ * (`src/style-scopes.js`) computed for the module.
+ */
+export interface AnalysisResult extends CoreAnalysisResult {
+	/** Every stylesheet of the module, in CSS emission order. */
+	stylesheets: AST.CSS.StyleSheet[];
+}
 
 /**
  * Ripple's compile result extends the shared {@link CompileResult} with a

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,32 +25,32 @@ catalogs:
       specifier: ^4.1.12
       version: 4.2.1
     '@tsrx/core':
-      specifier: ^0.1.66
-      version: 0.1.66
+      specifier: ^0.1.67
+      version: 0.1.67
     '@tsrx/eslint-plugin':
-      specifier: ^0.3.132
-      version: 0.3.132
+      specifier: ^0.3.133
+      version: 0.3.133
     '@tsrx/language-server':
-      specifier: ^0.3.132
-      version: 0.3.132
+      specifier: ^0.3.133
+      version: 0.3.133
     '@tsrx/prettier-plugin':
-      specifier: ^0.3.132
-      version: 0.3.132
+      specifier: ^0.3.133
+      version: 0.3.133
     '@tsrx/react':
-      specifier: ^0.2.66
-      version: 0.2.66
+      specifier: ^0.2.67
+      version: 0.2.67
     '@tsrx/solid':
-      specifier: ^0.1.66
-      version: 0.1.66
+      specifier: ^0.1.67
+      version: 0.1.67
     '@tsrx/typescript-plugin':
-      specifier: ^0.3.132
-      version: 0.3.132
+      specifier: ^0.3.133
+      version: 0.3.133
     '@tsrx/vite-plugin-react':
-      specifier: ^0.0.99
-      version: 0.0.99
+      specifier: ^0.0.100
+      version: 0.0.100
     '@tsrx/vite-plugin-solid':
-      specifier: ^0.0.96
-      version: 0.0.96
+      specifier: ^0.0.97
+      version: 0.0.97
     '@types/bun':
       specifier: ^1.3.9
       version: 1.3.10
@@ -212,10 +212,10 @@ importers:
         version: link:packages/vite-plugin
       '@tsrx/core':
         specifier: catalog:default
-        version: 0.1.66(@typescript-eslint/types@8.56.1)
+        version: 0.1.67(@typescript-eslint/types@8.56.1)
       '@tsrx/prettier-plugin':
         specifier: catalog:default
-        version: 0.3.132(@typescript-eslint/types@8.56.1)(prettier@3.9.6)
+        version: 0.3.133(@typescript-eslint/types@8.56.1)(prettier@3.9.6)
       '@tsrx/ripple':
         specifier: workspace:*
         version: link:packages/tsrx-ripple
@@ -304,10 +304,10 @@ importers:
     devDependencies:
       '@tsrx/react':
         specifier: catalog:default
-        version: 0.2.66(@typescript-eslint/types@8.56.1)(react@19.2.4)
+        version: 0.2.67(@typescript-eslint/types@8.56.1)(react@19.2.4)
       '@tsrx/vite-plugin-react':
         specifier: catalog:default
-        version: 0.0.99(@typescript-eslint/types@8.56.1)(react@19.2.4)(vite@8.1.5(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1))
+        version: 0.0.100(@typescript-eslint/types@8.56.1)(react@19.2.4)(vite@8.1.5(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1))
       vite:
         specifier: catalog:default
         version: 8.1.5(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)
@@ -336,10 +336,10 @@ importers:
     devDependencies:
       '@tsrx/solid':
         specifier: catalog:default
-        version: 0.1.66(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(@typescript-eslint/types@8.56.1)(solid-js@2.0.0-beta.15)
+        version: 0.1.67(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(@typescript-eslint/types@8.56.1)(solid-js@2.0.0-beta.15)
       '@tsrx/vite-plugin-solid':
         specifier: catalog:default
-        version: 0.0.96(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(@typescript-eslint/types@8.56.1)(solid-js@2.0.0-beta.15)(vite@8.1.5(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1))
+        version: 0.0.97(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(@typescript-eslint/types@8.56.1)(solid-js@2.0.0-beta.15)(vite@8.1.5(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1))
       vite:
         specifier: catalog:default
         version: 8.1.5(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)
@@ -462,7 +462,7 @@ importers:
         version: link:../../packages/tsrx-ripple
       '@tsrx/solid':
         specifier: catalog:default
-        version: 0.1.66(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(@typescript-eslint/types@8.56.1)(solid-js@2.0.0-beta.15)
+        version: 0.1.67(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(@typescript-eslint/types@8.56.1)(solid-js@2.0.0-beta.15)
       babel-preset-solid:
         specifier: 2.0.0-beta.15
         version: 2.0.0-beta.15(@babel/core@7.29.0(supports-color@7.2.0))(solid-js@2.0.0-beta.15)
@@ -566,7 +566,7 @@ importers:
     dependencies:
       '@tsrx/core':
         specifier: catalog:default
-        version: 0.1.66(@typescript-eslint/types@8.56.1)
+        version: 0.1.67(@typescript-eslint/types@8.56.1)
       '@tsrx/ripple':
         specifier: workspace:*
         version: link:../tsrx-ripple
@@ -616,7 +616,7 @@ importers:
     dependencies:
       '@tsrx/core':
         specifier: catalog:default
-        version: 0.1.66(@typescript-eslint/types@8.56.1)
+        version: 0.1.67(@typescript-eslint/types@8.56.1)
       esrap:
         specifier: ^2.3.2
         version: 2.3.2(@typescript-eslint/types@8.56.1)
@@ -656,7 +656,7 @@ importers:
         version: link:../adapter
       '@tsrx/core':
         specifier: catalog:default
-        version: 0.1.66(@typescript-eslint/types@8.56.1)
+        version: 0.1.67(@typescript-eslint/types@8.56.1)
       '@tsrx/ripple':
         specifier: workspace:*
         version: link:../tsrx-ripple
@@ -688,13 +688,13 @@ importers:
         version: 4.2.1(vite@8.1.5(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1))
       '@tsrx/eslint-plugin':
         specifier: catalog:default
-        version: 0.3.132(@tsrx/eslint-parser@0.3.132(@typescript-eslint/types@8.56.1)(eslint@10.3.0(jiti@2.6.1)(supports-color@7.2.0)))(@typescript-eslint/parser@8.56.1(eslint@10.3.0(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint@10.3.0(jiti@2.6.1)(supports-color@7.2.0))
+        version: 0.3.133(@tsrx/eslint-parser@0.3.133(@typescript-eslint/types@8.56.1)(eslint@10.3.0(jiti@2.6.1)(supports-color@7.2.0)))(@typescript-eslint/parser@8.56.1(eslint@10.3.0(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint@10.3.0(jiti@2.6.1)(supports-color@7.2.0))
       '@tsrx/language-server':
         specifier: catalog:default
-        version: 0.3.132(@tsrx/react@0.2.66(@typescript-eslint/types@8.56.1)(react@19.2.4))(@tsrx/ripple@0.1.62(@typescript-eslint/types@8.56.1))(@tsrx/solid@0.1.66(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(@typescript-eslint/types@8.56.1)(solid-js@2.0.0-rc.3))(@typescript-eslint/types@8.56.1)(@volar/language-service@2.4.28)(octane@0.1.6(@typescript-eslint/types@8.56.1))(typescript@5.9.3)
+        version: 0.3.133(@tsrx/react@0.2.67(@typescript-eslint/types@8.56.1)(react@19.2.4))(@tsrx/ripple@0.1.62(@typescript-eslint/types@8.56.1))(@tsrx/solid@0.1.67(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(@typescript-eslint/types@8.56.1)(solid-js@2.0.0-rc.3))(@typescript-eslint/types@8.56.1)(@volar/language-service@2.4.28)(octane@0.1.6(@typescript-eslint/types@8.56.1))(typescript@5.9.3)
       '@tsrx/typescript-plugin':
         specifier: catalog:default
-        version: 0.3.132(@tsrx/react@0.2.66(@typescript-eslint/types@8.56.1)(react@19.2.4))(@tsrx/ripple@0.1.62(@typescript-eslint/types@8.56.1))(@tsrx/solid@0.1.66(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(@typescript-eslint/types@8.56.1)(solid-js@2.0.0-rc.3))(octane@0.1.6(@typescript-eslint/types@8.56.1))(typescript@5.9.3)
+        version: 0.3.133(@tsrx/react@0.2.67(@typescript-eslint/types@8.56.1)(react@19.2.4))(@tsrx/ripple@0.1.62(@typescript-eslint/types@8.56.1))(@tsrx/solid@0.1.67(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(@typescript-eslint/types@8.56.1)(solid-js@2.0.0-rc.3))(octane@0.1.6(@typescript-eslint/types@8.56.1))(typescript@5.9.3)
       '@typescript-eslint/parser':
         specifier: catalog:default
         version: 8.56.1(eslint@10.3.0(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
@@ -756,7 +756,7 @@ importers:
         version: link:../packages/vite-plugin
       '@tsrx/typescript-plugin':
         specifier: catalog:default
-        version: 0.3.132(@tsrx/react@0.2.66(@typescript-eslint/types@8.56.1)(react@19.2.4))(@tsrx/ripple@0.1.62(@typescript-eslint/types@8.56.1))(@tsrx/solid@0.1.66(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(@typescript-eslint/types@8.56.1)(solid-js@2.0.0-rc.3))(octane@0.1.6(@typescript-eslint/types@8.56.1))(typescript@5.9.3)
+        version: 0.3.133(@tsrx/react@0.2.67(@typescript-eslint/types@8.56.1)(react@19.2.4))(@tsrx/ripple@0.1.62(@typescript-eslint/types@8.56.1))(@tsrx/solid@0.1.67(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(@typescript-eslint/types@8.56.1)(solid-js@2.0.0-rc.3))(octane@0.1.6(@typescript-eslint/types@8.56.1))(typescript@5.9.3)
       ripple:
         specifier: workspace:*
         version: link:../packages/ripple
@@ -2031,35 +2031,32 @@ packages:
   '@toon-format/toon@2.1.0':
     resolution: {integrity: sha512-JwWptdF5eOA0HaQxbKAzkpQtR4wSWTEfDlEy/y3/4okmOAX1qwnpLZMmtEWr+ncAhTTY1raCKH0kteHhSXnQqg==}
 
-  '@tsrx/core@0.1.61':
-    resolution: {integrity: sha512-JOGLL9iiuFbx6vcbjRziVddDJO6CZFtH5idWn0Mw4Rt92O5oPMPM0GeyqD5fFuGFo7K6zu7f+74jUGlYv56doQ==}
+  '@tsrx/core@0.1.67':
+    resolution: {integrity: sha512-6QUOOX6hQdmGsQy2/pj6eKHLibmsD1kOjQh/N7UVzWCaehiIoQy7R/BbX0BlD2f25+uAUR4jzCMBfgYHfTmGdQ==}
 
-  '@tsrx/core@0.1.66':
-    resolution: {integrity: sha512-u5EfjVPYJFnuMhPXnkaqELs7KFWFowX4KaaS374JGmNnXIzI/m8jDg1RvlLbaD4OwfYMWChVg//hxFYQeQNBlQ==}
-
-  '@tsrx/eslint-parser@0.3.132':
-    resolution: {integrity: sha512-qNLKYYUhMCaU4vjQhjb9k1M6u0rR5dVoRHRYVLFU1nbuHp0FbOtHjI7G+2hQ3x6FnHLDihafSVyazChWEBca8Q==}
+  '@tsrx/eslint-parser@0.3.133':
+    resolution: {integrity: sha512-j57ut0HlCsw8h4FRt+Jul3dBAB5Iv2zA3RWZ6fwn/HmYwVOK1yaQ3mcq1C83xgYKZk2b0BL5jabCy+QiG1xLQQ==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       eslint: '>=9.0.0'
 
-  '@tsrx/eslint-plugin@0.3.132':
-    resolution: {integrity: sha512-E72tvMaQIjkS29F4cVm0s9o58dRKgC+ZAhae3biOpOTx1pMXf+BPkbJ2mr9f4l7ber6LMsV758GSMPyX/LdWRg==}
+  '@tsrx/eslint-plugin@0.3.133':
+    resolution: {integrity: sha512-4HkF/6SBY2n1JvhtABhEYYKMZbEc0idEvgInRxNiFwmTd7TbgVLMKmF8mIjarJ49udbAURc3jpTl/SYErHn1zQ==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
-      '@tsrx/eslint-parser': 0.3.132
+      '@tsrx/eslint-parser': 0.3.133
       '@typescript-eslint/parser': ^8.56.1
       eslint: '>=9.0.0'
 
-  '@tsrx/language-server@0.3.132':
-    resolution: {integrity: sha512-onSYF4tsyGCOzyGymqMFLEeRAty7hCjGarZuTrRLUWDXWJQEZ/anStuFPIuK5noWsvcTO5SqxJeUg55wlzdauA==}
+  '@tsrx/language-server@0.3.133':
+    resolution: {integrity: sha512-LrMI4jh4ZE0MBOrM6FgE+IenrBloOz5bqja+h7P6aOLDTs9t2CaHFC7Q3GCTssLOrM9X8tuu+tdYUn9JL8wWiQ==}
     engines: {node: '>=22.0.0'}
     hasBin: true
     peerDependencies:
       typescript: ^5.9.3
 
-  '@tsrx/prettier-plugin@0.3.132':
-    resolution: {integrity: sha512-/BCi+akaKz1QD8TwrSm/zbh1zX+M7eXR9cwz270BSB4M7zpvi5ASKkw0CUTgiYQHM9R+BpAPrOLRtet9u6JLzw==}
+  '@tsrx/prettier-plugin@0.3.133':
+    resolution: {integrity: sha512-anhEuvYlwTIOWLquHdYzIixbB1Cxv1z0jACb6Si/3Lx5dH6W6wSWer3fN93xfjXQiyn0NDWVohoAInN0PLoz1A==}
     peerDependencies:
       prettier: '>=2.0.0'
 
@@ -2068,16 +2065,13 @@ packages:
     peerDependencies:
       react: '>=18'
 
-  '@tsrx/react@0.2.66':
-    resolution: {integrity: sha512-sRUbrKpKmpdfhx5rQai5wYGcyietn/c7L9q5lXQxPKla7+rBkGLEp6rrzcClH5ufGRY71jIUno3aB1+Pzwfxuw==}
+  '@tsrx/react@0.2.67':
+    resolution: {integrity: sha512-ztEZIOGfKYYvcNos606r27+euDkO1f6lPs+xL21hKCq1tJhpBLTQGs3fripsIU/pDukb6dAiZLTGgH9U3A+Sxg==}
     peerDependencies:
       react: '>=18'
 
   '@tsrx/ripple@0.1.62':
     resolution: {integrity: sha512-903lYUwLNXrtMYOsMtOlrPgdZ9OL0MS06jG4Qbpc2enG3y2sGfwXrZfKnDdKn+1rdtkw5Eb5WGOnN1KxUGuZpw==}
-
-  '@tsrx/runtime@0.1.1':
-    resolution: {integrity: sha512-R7n2forc2XQvqCYpYMqGij1tCwoPILBubRczQ2Kbjj3d6naiseEq6qfMmljEkKp14ERYHstx7ISrw2wY7Ml0DA==}
 
   '@tsrx/runtime@0.1.5':
     resolution: {integrity: sha512-sZHTOr2OOGg+EcebZoTeznomydrA4FdvJDfp95lPTj+mq5KpfRT4W6gnO6RoEESrSfL/Ti+V0xzZbA5BYTDBKw==}
@@ -2088,21 +2082,21 @@ packages:
       '@solidjs/web': 2.0.0-rc.3
       solid-js: 2.0.0-rc.3
 
-  '@tsrx/solid@0.1.66':
-    resolution: {integrity: sha512-YJMpvrP+8dieKyD302J5pupGr0KdbfubABa8zSeKWzZuJZbBkL3Z+fBFxxAMZrKLsiXLEM0c00b2ukezjT5l8w==}
+  '@tsrx/solid@0.1.67':
+    resolution: {integrity: sha512-g+1OGcLqgjlPuwsyyu0vrTsDXgq+IH1mOocCMQ6ILdsc7lW0XXsplEIHlhhu/UXffCYNy7ndUK5jroah65yLSQ==}
     peerDependencies:
       '@solidjs/web': 2.0.0-rc.3
       solid-js: 2.0.0-rc.3
 
-  '@tsrx/typescript-plugin@0.3.132':
-    resolution: {integrity: sha512-ruMhyh7N7EC6oA/PyhmQTkOU6RDVrzbrxiWUnFcNuEzHooeZgkHuNSItPIDSr3At2tx0LpiiJkyWV8kvfj0IhA==}
+  '@tsrx/typescript-plugin@0.3.133':
+    resolution: {integrity: sha512-IncamGk0y+rj3oRe286UBFTZRrMlJIzqUEIYeAOMA60YCI/yh6jB623fc0pwqFK+BDahJubvbbsAQzboTGSzpg==}
     hasBin: true
     peerDependencies:
-      '@tsrx/preact': 0.1.66
-      '@tsrx/react': 0.2.66
+      '@tsrx/preact': 0.1.67
+      '@tsrx/react': 0.2.67
       '@tsrx/ripple': ^0.1.61
-      '@tsrx/solid': 0.1.66
-      '@tsrx/vue': 0.1.66
+      '@tsrx/solid': 0.1.67
+      '@tsrx/vue': 0.1.67
       octane: '*'
       typescript: ^5.9.3
     peerDependenciesMeta:
@@ -2119,13 +2113,13 @@ packages:
       octane:
         optional: true
 
-  '@tsrx/vite-plugin-react@0.0.99':
-    resolution: {integrity: sha512-ovSq1rqSkPBZSOX+eGOXlXiqEsp9YljHiiElfqnIQXeVobXoahMzUSmL2/S0jJ2t23Lmft+kgww61H4K3LQGGQ==}
+  '@tsrx/vite-plugin-react@0.0.100':
+    resolution: {integrity: sha512-kI9d6dgG51EYGADdMucce5Y4bC5HRQznk8b4227267gWOLkLWVKXmhmeInMZiX1Jh6LIZhgaB2cGrUUUR2QaZg==}
     peerDependencies:
       vite: '*'
 
-  '@tsrx/vite-plugin-solid@0.0.96':
-    resolution: {integrity: sha512-G3X8yT28xu6XsdweiHSzb3ZVH2WARnF6tFDUB/2dApPfwEsyfnPZkfbcHZz0817sedPgkdqoRh/7wH98r/1nOg==}
+  '@tsrx/vite-plugin-solid@0.0.97':
+    resolution: {integrity: sha512-t0N4u23HdVTMN5/W32l/nS+0TvnwgHEWhgfEfy/o84nfHePZf19SxgSrBfcFQwDG53Iop5OfXS6kJi6/dqTepA==}
     peerDependencies:
       vite: '*'
 
@@ -6200,24 +6194,7 @@ snapshots:
 
   '@toon-format/toon@2.1.0': {}
 
-  '@tsrx/core@0.1.61(@typescript-eslint/types@8.56.1)':
-    dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.5
-      '@noble/hashes': 2.2.0
-      '@sveltejs/acorn-typescript': 1.0.13(acorn@8.17.0)
-      '@tsrx/runtime': 0.1.1
-      '@types/estree': 1.0.8
-      '@types/estree-jsx': 1.0.5
-      acorn: 8.17.0
-      esrap: 2.3.2(@typescript-eslint/types@8.56.1)
-      is-reference: 3.0.3
-      magic-string: 0.30.21
-      zimmerframe: 1.1.4
-    transitivePeerDependencies:
-      - '@typescript-eslint/types'
-    optional: true
-
-  '@tsrx/core@0.1.66(@typescript-eslint/types@8.56.1)':
+  '@tsrx/core@0.1.67(@typescript-eslint/types@8.56.1)':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
       '@noble/hashes': 2.2.0
@@ -6232,23 +6209,23 @@ snapshots:
     transitivePeerDependencies:
       - '@typescript-eslint/types'
 
-  '@tsrx/eslint-parser@0.3.132(@typescript-eslint/types@8.56.1)(eslint@10.3.0(jiti@2.6.1)(supports-color@7.2.0))':
+  '@tsrx/eslint-parser@0.3.133(@typescript-eslint/types@8.56.1)(eslint@10.3.0(jiti@2.6.1)(supports-color@7.2.0))':
     dependencies:
-      '@tsrx/core': 0.1.66(@typescript-eslint/types@8.56.1)
+      '@tsrx/core': 0.1.67(@typescript-eslint/types@8.56.1)
       eslint: 10.3.0(jiti@2.6.1)(supports-color@7.2.0)
     transitivePeerDependencies:
       - '@typescript-eslint/types'
 
-  '@tsrx/eslint-plugin@0.3.132(@tsrx/eslint-parser@0.3.132(@typescript-eslint/types@8.56.1)(eslint@10.3.0(jiti@2.6.1)(supports-color@7.2.0)))(@typescript-eslint/parser@8.56.1(eslint@10.3.0(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint@10.3.0(jiti@2.6.1)(supports-color@7.2.0))':
+  '@tsrx/eslint-plugin@0.3.133(@tsrx/eslint-parser@0.3.133(@typescript-eslint/types@8.56.1)(eslint@10.3.0(jiti@2.6.1)(supports-color@7.2.0)))(@typescript-eslint/parser@8.56.1(eslint@10.3.0(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint@10.3.0(jiti@2.6.1)(supports-color@7.2.0))':
     dependencies:
-      '@tsrx/eslint-parser': 0.3.132(@typescript-eslint/types@8.56.1)(eslint@10.3.0(jiti@2.6.1)(supports-color@7.2.0))
+      '@tsrx/eslint-parser': 0.3.133(@typescript-eslint/types@8.56.1)(eslint@10.3.0(jiti@2.6.1)(supports-color@7.2.0))
       '@typescript-eslint/parser': 8.56.1(eslint@10.3.0(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
       eslint: 10.3.0(jiti@2.6.1)(supports-color@7.2.0)
 
-  '@tsrx/language-server@0.3.132(@tsrx/react@0.2.66(@typescript-eslint/types@8.56.1)(react@19.2.4))(@tsrx/ripple@0.1.62(@typescript-eslint/types@8.56.1))(@tsrx/solid@0.1.66(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(@typescript-eslint/types@8.56.1)(solid-js@2.0.0-rc.3))(@typescript-eslint/types@8.56.1)(@volar/language-service@2.4.28)(octane@0.1.6(@typescript-eslint/types@8.56.1))(typescript@5.9.3)':
+  '@tsrx/language-server@0.3.133(@tsrx/react@0.2.67(@typescript-eslint/types@8.56.1)(react@19.2.4))(@tsrx/ripple@0.1.62(@typescript-eslint/types@8.56.1))(@tsrx/solid@0.1.67(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(@typescript-eslint/types@8.56.1)(solid-js@2.0.0-rc.3))(@typescript-eslint/types@8.56.1)(@volar/language-service@2.4.28)(octane@0.1.6(@typescript-eslint/types@8.56.1))(typescript@5.9.3)':
     dependencies:
-      '@tsrx/core': 0.1.66(@typescript-eslint/types@8.56.1)
-      '@tsrx/typescript-plugin': 0.3.132(@tsrx/react@0.2.66(@typescript-eslint/types@8.56.1)(react@19.2.4))(@tsrx/ripple@0.1.62(@typescript-eslint/types@8.56.1))(@tsrx/solid@0.1.66(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(@typescript-eslint/types@8.56.1)(solid-js@2.0.0-rc.3))(octane@0.1.6(@typescript-eslint/types@8.56.1))(typescript@5.9.3)
+      '@tsrx/core': 0.1.67(@typescript-eslint/types@8.56.1)
+      '@tsrx/typescript-plugin': 0.3.133(@tsrx/react@0.2.67(@typescript-eslint/types@8.56.1)(react@19.2.4))(@tsrx/ripple@0.1.62(@typescript-eslint/types@8.56.1))(@tsrx/solid@0.1.67(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(@typescript-eslint/types@8.56.1)(solid-js@2.0.0-rc.3))(octane@0.1.6(@typescript-eslint/types@8.56.1))(typescript@5.9.3)
       '@volar/language-server': 2.4.28
       typescript: 5.9.3
       volar-service-css: 0.0.70(@volar/language-service@2.4.28)
@@ -6265,9 +6242,9 @@ snapshots:
       - '@volar/language-service'
       - octane
 
-  '@tsrx/prettier-plugin@0.3.132(@typescript-eslint/types@8.56.1)(prettier@3.9.6)':
+  '@tsrx/prettier-plugin@0.3.133(@typescript-eslint/types@8.56.1)(prettier@3.9.6)':
     dependencies:
-      '@tsrx/core': 0.1.66(@typescript-eslint/types@8.56.1)
+      '@tsrx/core': 0.1.67(@typescript-eslint/types@8.56.1)
       prettier: 3.9.6
     transitivePeerDependencies:
       - '@typescript-eslint/types'
@@ -6277,9 +6254,9 @@ snapshots:
       '@tsrx/runtime': 0.1.5
       react: 19.2.4
 
-  '@tsrx/react@0.2.66(@typescript-eslint/types@8.56.1)(react@19.2.4)':
+  '@tsrx/react@0.2.67(@typescript-eslint/types@8.56.1)(react@19.2.4)':
     dependencies:
-      '@tsrx/core': 0.1.66(@typescript-eslint/types@8.56.1)
+      '@tsrx/core': 0.1.67(@typescript-eslint/types@8.56.1)
       '@tsrx/react-runtime': 0.1.5(react@19.2.4)
       esrap: 2.3.2(@typescript-eslint/types@8.56.1)
       react: 19.2.4
@@ -6289,16 +6266,13 @@ snapshots:
 
   '@tsrx/ripple@0.1.62(@typescript-eslint/types@8.56.1)':
     dependencies:
-      '@tsrx/core': 0.1.61(@typescript-eslint/types@8.56.1)
+      '@tsrx/core': 0.1.67(@typescript-eslint/types@8.56.1)
       esrap: 2.3.2(@typescript-eslint/types@8.56.1)
       is-reference: 3.0.3
       source-map: 0.7.6
       zimmerframe: 1.1.4
     transitivePeerDependencies:
       - '@typescript-eslint/types'
-    optional: true
-
-  '@tsrx/runtime@0.1.1':
     optional: true
 
   '@tsrx/runtime@0.1.5': {}
@@ -6316,10 +6290,10 @@ snapshots:
       solid-js: 2.0.0-rc.3
     optional: true
 
-  '@tsrx/solid@0.1.66(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(@typescript-eslint/types@8.56.1)(solid-js@2.0.0-beta.15)':
+  '@tsrx/solid@0.1.67(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(@typescript-eslint/types@8.56.1)(solid-js@2.0.0-beta.15)':
     dependencies:
       '@solidjs/web': 2.0.0-beta.15(solid-js@2.0.0-beta.15)
-      '@tsrx/core': 0.1.66(@typescript-eslint/types@8.56.1)
+      '@tsrx/core': 0.1.67(@typescript-eslint/types@8.56.1)
       '@tsrx/solid-runtime': 0.1.5(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(solid-js@2.0.0-beta.15)
       esrap: 2.3.2(@typescript-eslint/types@8.56.1)
       solid-js: 2.0.0-beta.15
@@ -6327,10 +6301,10 @@ snapshots:
     transitivePeerDependencies:
       - '@typescript-eslint/types'
 
-  '@tsrx/solid@0.1.66(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(@typescript-eslint/types@8.56.1)(solid-js@2.0.0-rc.3)':
+  '@tsrx/solid@0.1.67(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(@typescript-eslint/types@8.56.1)(solid-js@2.0.0-rc.3)':
     dependencies:
       '@solidjs/web': 2.0.0-rc.3(solid-js@2.0.0-rc.3)
-      '@tsrx/core': 0.1.66(@typescript-eslint/types@8.56.1)
+      '@tsrx/core': 0.1.67(@typescript-eslint/types@8.56.1)
       '@tsrx/solid-runtime': 0.1.5(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)
       esrap: 2.3.2(@typescript-eslint/types@8.56.1)
       solid-js: 2.0.0-rc.3
@@ -6339,30 +6313,30 @@ snapshots:
       - '@typescript-eslint/types'
     optional: true
 
-  '@tsrx/typescript-plugin@0.3.132(@tsrx/react@0.2.66(@typescript-eslint/types@8.56.1)(react@19.2.4))(@tsrx/ripple@0.1.62(@typescript-eslint/types@8.56.1))(@tsrx/solid@0.1.66(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(@typescript-eslint/types@8.56.1)(solid-js@2.0.0-rc.3))(octane@0.1.6(@typescript-eslint/types@8.56.1))(typescript@5.9.3)':
+  '@tsrx/typescript-plugin@0.3.133(@tsrx/react@0.2.67(@typescript-eslint/types@8.56.1)(react@19.2.4))(@tsrx/ripple@0.1.62(@typescript-eslint/types@8.56.1))(@tsrx/solid@0.1.67(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(@typescript-eslint/types@8.56.1)(solid-js@2.0.0-rc.3))(octane@0.1.6(@typescript-eslint/types@8.56.1))(typescript@5.9.3)':
     dependencies:
       '@volar/language-core': 2.4.28
       '@volar/typescript': 2.4.28
       typescript: 5.9.3
     optionalDependencies:
-      '@tsrx/react': 0.2.66(@typescript-eslint/types@8.56.1)(react@19.2.4)
+      '@tsrx/react': 0.2.67(@typescript-eslint/types@8.56.1)(react@19.2.4)
       '@tsrx/ripple': 0.1.62(@typescript-eslint/types@8.56.1)
-      '@tsrx/solid': 0.1.66(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(@typescript-eslint/types@8.56.1)(solid-js@2.0.0-rc.3)
+      '@tsrx/solid': 0.1.67(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(@typescript-eslint/types@8.56.1)(solid-js@2.0.0-rc.3)
       octane: 0.1.6(@typescript-eslint/types@8.56.1)
 
-  '@tsrx/vite-plugin-react@0.0.99(@typescript-eslint/types@8.56.1)(react@19.2.4)(vite@8.1.5(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1))':
+  '@tsrx/vite-plugin-react@0.0.100(@typescript-eslint/types@8.56.1)(react@19.2.4)(vite@8.1.5(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1))':
     dependencies:
-      '@tsrx/core': 0.1.66(@typescript-eslint/types@8.56.1)
-      '@tsrx/react': 0.2.66(@typescript-eslint/types@8.56.1)(react@19.2.4)
+      '@tsrx/core': 0.1.67(@typescript-eslint/types@8.56.1)
+      '@tsrx/react': 0.2.67(@typescript-eslint/types@8.56.1)(react@19.2.4)
       vite: 8.1.5(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)
     transitivePeerDependencies:
       - '@typescript-eslint/types'
       - react
 
-  '@tsrx/vite-plugin-solid@0.0.96(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(@typescript-eslint/types@8.56.1)(solid-js@2.0.0-beta.15)(vite@8.1.5(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1))':
+  '@tsrx/vite-plugin-solid@0.0.97(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(@typescript-eslint/types@8.56.1)(solid-js@2.0.0-beta.15)(vite@8.1.5(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1))':
     dependencies:
-      '@tsrx/core': 0.1.66(@typescript-eslint/types@8.56.1)
-      '@tsrx/solid': 0.1.66(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(@typescript-eslint/types@8.56.1)(solid-js@2.0.0-beta.15)
+      '@tsrx/core': 0.1.67(@typescript-eslint/types@8.56.1)
+      '@tsrx/solid': 0.1.67(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(@typescript-eslint/types@8.56.1)(solid-js@2.0.0-beta.15)
       vite: 8.1.5(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)
     transitivePeerDependencies:
       - '@solidjs/web'
@@ -8207,7 +8181,7 @@ snapshots:
 
   octane@0.1.6(@typescript-eslint/types@8.56.1):
     dependencies:
-      '@tsrx/core': 0.1.61(@typescript-eslint/types@8.56.1)
+      '@tsrx/core': 0.1.67(@typescript-eslint/types@8.56.1)
       devalue: 5.8.1
       esrap: 2.3.2(@typescript-eslint/types@8.56.1)
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,32 +25,32 @@ catalogs:
       specifier: ^4.1.12
       version: 4.2.1
     '@tsrx/core':
-      specifier: ^0.1.61
-      version: 0.1.61
+      specifier: ^0.1.66
+      version: 0.1.66
     '@tsrx/eslint-plugin':
-      specifier: ^0.3.126
-      version: 0.3.126
+      specifier: ^0.3.132
+      version: 0.3.132
     '@tsrx/language-server':
-      specifier: ^0.3.126
-      version: 0.3.126
+      specifier: ^0.3.132
+      version: 0.3.132
     '@tsrx/prettier-plugin':
-      specifier: ^0.3.126
-      version: 0.3.126
+      specifier: ^0.3.132
+      version: 0.3.132
     '@tsrx/react':
-      specifier: ^0.2.61
-      version: 0.2.61
+      specifier: ^0.2.66
+      version: 0.2.66
     '@tsrx/solid':
-      specifier: ^0.1.61
-      version: 0.1.61
+      specifier: ^0.1.66
+      version: 0.1.66
     '@tsrx/typescript-plugin':
-      specifier: ^0.3.126
-      version: 0.3.126
+      specifier: ^0.3.132
+      version: 0.3.132
     '@tsrx/vite-plugin-react':
-      specifier: ^0.0.94
-      version: 0.0.94
+      specifier: ^0.0.99
+      version: 0.0.99
     '@tsrx/vite-plugin-solid':
-      specifier: ^0.0.91
-      version: 0.0.91
+      specifier: ^0.0.96
+      version: 0.0.96
     '@types/bun':
       specifier: ^1.3.9
       version: 1.3.10
@@ -212,10 +212,10 @@ importers:
         version: link:packages/vite-plugin
       '@tsrx/core':
         specifier: catalog:default
-        version: 0.1.61(@typescript-eslint/types@8.56.1)
+        version: 0.1.66(@typescript-eslint/types@8.56.1)
       '@tsrx/prettier-plugin':
         specifier: catalog:default
-        version: 0.3.126(@typescript-eslint/types@8.56.1)(prettier@3.9.6)
+        version: 0.3.132(@typescript-eslint/types@8.56.1)(prettier@3.9.6)
       '@tsrx/ripple':
         specifier: workspace:*
         version: link:packages/tsrx-ripple
@@ -304,10 +304,10 @@ importers:
     devDependencies:
       '@tsrx/react':
         specifier: catalog:default
-        version: 0.2.61(@typescript-eslint/types@8.56.1)(react@19.2.4)
+        version: 0.2.66(@typescript-eslint/types@8.56.1)(react@19.2.4)
       '@tsrx/vite-plugin-react':
         specifier: catalog:default
-        version: 0.0.94(@typescript-eslint/types@8.56.1)(react@19.2.4)(vite@8.1.5(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1))
+        version: 0.0.99(@typescript-eslint/types@8.56.1)(react@19.2.4)(vite@8.1.5(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1))
       vite:
         specifier: catalog:default
         version: 8.1.5(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)
@@ -336,10 +336,10 @@ importers:
     devDependencies:
       '@tsrx/solid':
         specifier: catalog:default
-        version: 0.1.61(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(@typescript-eslint/types@8.56.1)(solid-js@2.0.0-beta.15)
+        version: 0.1.66(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(@typescript-eslint/types@8.56.1)(solid-js@2.0.0-beta.15)
       '@tsrx/vite-plugin-solid':
         specifier: catalog:default
-        version: 0.0.91(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(@typescript-eslint/types@8.56.1)(solid-js@2.0.0-beta.15)(vite@8.1.5(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1))
+        version: 0.0.96(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(@typescript-eslint/types@8.56.1)(solid-js@2.0.0-beta.15)(vite@8.1.5(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1))
       vite:
         specifier: catalog:default
         version: 8.1.5(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)
@@ -462,7 +462,7 @@ importers:
         version: link:../../packages/tsrx-ripple
       '@tsrx/solid':
         specifier: catalog:default
-        version: 0.1.61(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(@typescript-eslint/types@8.56.1)(solid-js@2.0.0-beta.15)
+        version: 0.1.66(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(@typescript-eslint/types@8.56.1)(solid-js@2.0.0-beta.15)
       babel-preset-solid:
         specifier: 2.0.0-beta.15
         version: 2.0.0-beta.15(@babel/core@7.29.0(supports-color@7.2.0))(solid-js@2.0.0-beta.15)
@@ -566,7 +566,7 @@ importers:
     dependencies:
       '@tsrx/core':
         specifier: catalog:default
-        version: 0.1.61(@typescript-eslint/types@8.56.1)
+        version: 0.1.66(@typescript-eslint/types@8.56.1)
       '@tsrx/ripple':
         specifier: workspace:*
         version: link:../tsrx-ripple
@@ -616,7 +616,7 @@ importers:
     dependencies:
       '@tsrx/core':
         specifier: catalog:default
-        version: 0.1.61(@typescript-eslint/types@8.56.1)
+        version: 0.1.66(@typescript-eslint/types@8.56.1)
       esrap:
         specifier: ^2.3.2
         version: 2.3.2(@typescript-eslint/types@8.56.1)
@@ -656,7 +656,7 @@ importers:
         version: link:../adapter
       '@tsrx/core':
         specifier: catalog:default
-        version: 0.1.61(@typescript-eslint/types@8.56.1)
+        version: 0.1.66(@typescript-eslint/types@8.56.1)
       '@tsrx/ripple':
         specifier: workspace:*
         version: link:../tsrx-ripple
@@ -688,13 +688,13 @@ importers:
         version: 4.2.1(vite@8.1.5(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1))
       '@tsrx/eslint-plugin':
         specifier: catalog:default
-        version: 0.3.126(@tsrx/eslint-parser@0.3.126(@typescript-eslint/types@8.56.1)(eslint@10.3.0(jiti@2.6.1)(supports-color@7.2.0)))(@typescript-eslint/parser@8.56.1(eslint@10.3.0(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint@10.3.0(jiti@2.6.1)(supports-color@7.2.0))
+        version: 0.3.132(@tsrx/eslint-parser@0.3.132(@typescript-eslint/types@8.56.1)(eslint@10.3.0(jiti@2.6.1)(supports-color@7.2.0)))(@typescript-eslint/parser@8.56.1(eslint@10.3.0(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint@10.3.0(jiti@2.6.1)(supports-color@7.2.0))
       '@tsrx/language-server':
         specifier: catalog:default
-        version: 0.3.126(@tsrx/react@0.2.61(@typescript-eslint/types@8.56.1)(react@19.2.4))(@tsrx/ripple@0.1.61(@typescript-eslint/types@8.56.1))(@tsrx/solid@0.1.61(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(@typescript-eslint/types@8.56.1)(solid-js@2.0.0-beta.15))(@typescript-eslint/types@8.56.1)(@volar/language-service@2.4.28)(octane@0.1.6(@typescript-eslint/types@8.56.1))(typescript@5.9.3)
+        version: 0.3.132(@tsrx/react@0.2.66(@typescript-eslint/types@8.56.1)(react@19.2.4))(@tsrx/ripple@0.1.62(@typescript-eslint/types@8.56.1))(@tsrx/solid@0.1.66(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(@typescript-eslint/types@8.56.1)(solid-js@2.0.0-rc.3))(@typescript-eslint/types@8.56.1)(@volar/language-service@2.4.28)(octane@0.1.6(@typescript-eslint/types@8.56.1))(typescript@5.9.3)
       '@tsrx/typescript-plugin':
         specifier: catalog:default
-        version: 0.3.126(@tsrx/react@0.2.61(@typescript-eslint/types@8.56.1)(react@19.2.4))(@tsrx/ripple@0.1.61(@typescript-eslint/types@8.56.1))(@tsrx/solid@0.1.61(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(@typescript-eslint/types@8.56.1)(solid-js@2.0.0-beta.15))(octane@0.1.6(@typescript-eslint/types@8.56.1))(typescript@5.9.3)
+        version: 0.3.132(@tsrx/react@0.2.66(@typescript-eslint/types@8.56.1)(react@19.2.4))(@tsrx/ripple@0.1.62(@typescript-eslint/types@8.56.1))(@tsrx/solid@0.1.66(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(@typescript-eslint/types@8.56.1)(solid-js@2.0.0-rc.3))(octane@0.1.6(@typescript-eslint/types@8.56.1))(typescript@5.9.3)
       '@typescript-eslint/parser':
         specifier: catalog:default
         version: 8.56.1(eslint@10.3.0(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
@@ -756,7 +756,7 @@ importers:
         version: link:../packages/vite-plugin
       '@tsrx/typescript-plugin':
         specifier: catalog:default
-        version: 0.3.126(@tsrx/react@0.2.61(@typescript-eslint/types@8.56.1)(react@19.2.4))(@tsrx/ripple@0.1.61(@typescript-eslint/types@8.56.1))(@tsrx/solid@0.1.61(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(@typescript-eslint/types@8.56.1)(solid-js@2.0.0-beta.15))(octane@0.1.6(@typescript-eslint/types@8.56.1))(typescript@5.9.3)
+        version: 0.3.132(@tsrx/react@0.2.66(@typescript-eslint/types@8.56.1)(react@19.2.4))(@tsrx/ripple@0.1.62(@typescript-eslint/types@8.56.1))(@tsrx/solid@0.1.66(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(@typescript-eslint/types@8.56.1)(solid-js@2.0.0-rc.3))(octane@0.1.6(@typescript-eslint/types@8.56.1))(typescript@5.9.3)
       ripple:
         specifier: workspace:*
         version: link:../packages/ripple
@@ -1906,10 +1906,18 @@ packages:
   '@solidjs/signals@2.0.0-beta.15':
     resolution: {integrity: sha512-lw4a4frNajnmVjILbyfrgJ4ksqU+YKhkepZ8glKK9Q68O3zq7W8qDLOtsz5v1mt0o3TB11/rozJFpgMTmnYegg==}
 
+  '@solidjs/signals@2.0.0-rc.3':
+    resolution: {integrity: sha512-/yPhTf3xS1FRR4MX8kTYCd4MjsFxzwkO+KyOTfbu35lTEiaJ4Fxy+JL91XonDzt31GV1mYaZ9CGD2TQIzvXuNA==}
+
   '@solidjs/web@2.0.0-beta.15':
     resolution: {integrity: sha512-+LvmzzN5CHxQ+TeCGgA8DKuB8S4t0EHVlmDUlAp4hkLnh7My3ZGuKYHKWsFMd8w08nPgF6LdBZkH+c5iNcmcSA==}
     peerDependencies:
       solid-js: ^2.0.0-beta.15
+
+  '@solidjs/web@2.0.0-rc.3':
+    resolution: {integrity: sha512-5ckKgOjem1pN5ADycOk6TjHmTtjbbN2fukqxo6RW3Oe3H7z0gaXWAdt8dLISto5/O4Nn8VxprFXFWpfy31+DUg==}
+    peerDependencies:
+      solid-js: ^2.0.0-rc.3
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -2023,75 +2031,78 @@ packages:
   '@toon-format/toon@2.1.0':
     resolution: {integrity: sha512-JwWptdF5eOA0HaQxbKAzkpQtR4wSWTEfDlEy/y3/4okmOAX1qwnpLZMmtEWr+ncAhTTY1raCKH0kteHhSXnQqg==}
 
-  '@tsrx/core@0.1.60':
-    resolution: {integrity: sha512-t/lb8wWrJUsiwGTz3NI2GqF5be9kojmemfur6SdJqhbrMccx8TkHtZh6N8mE9gh2PTiGPuNf6HTZIomOpamA7Q==}
-
   '@tsrx/core@0.1.61':
     resolution: {integrity: sha512-JOGLL9iiuFbx6vcbjRziVddDJO6CZFtH5idWn0Mw4Rt92O5oPMPM0GeyqD5fFuGFo7K6zu7f+74jUGlYv56doQ==}
 
-  '@tsrx/eslint-parser@0.3.126':
-    resolution: {integrity: sha512-wAqtBNqwhmCnDVPSQSVRF3ZA7q19QH1bn67pnXrBV0uvhROWojmycaz5nmWGnLs9ucQocIOOq6Xx+r7RdyyK8A==}
+  '@tsrx/core@0.1.66':
+    resolution: {integrity: sha512-u5EfjVPYJFnuMhPXnkaqELs7KFWFowX4KaaS374JGmNnXIzI/m8jDg1RvlLbaD4OwfYMWChVg//hxFYQeQNBlQ==}
+
+  '@tsrx/eslint-parser@0.3.132':
+    resolution: {integrity: sha512-qNLKYYUhMCaU4vjQhjb9k1M6u0rR5dVoRHRYVLFU1nbuHp0FbOtHjI7G+2hQ3x6FnHLDihafSVyazChWEBca8Q==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       eslint: '>=9.0.0'
 
-  '@tsrx/eslint-plugin@0.3.126':
-    resolution: {integrity: sha512-EfClZzg0qFqdMFVthF1cQT4eV0VD5UNx4zLm9Wq2givqn/m5uKxB/aFgTvhbKikkUONZRxhuAFGV8MYJ0OpBoA==}
+  '@tsrx/eslint-plugin@0.3.132':
+    resolution: {integrity: sha512-E72tvMaQIjkS29F4cVm0s9o58dRKgC+ZAhae3biOpOTx1pMXf+BPkbJ2mr9f4l7ber6LMsV758GSMPyX/LdWRg==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
-      '@tsrx/eslint-parser': 0.3.126
+      '@tsrx/eslint-parser': 0.3.132
       '@typescript-eslint/parser': ^8.56.1
       eslint: '>=9.0.0'
 
-  '@tsrx/language-server@0.3.126':
-    resolution: {integrity: sha512-GTG1PJt8YIMNYNOIn9zTCI4i70MVu09iJUKzPDt5WHxLnGV9utJrOsGJbf+MnTskqItKzLuG4a77y5k6PyawSw==}
+  '@tsrx/language-server@0.3.132':
+    resolution: {integrity: sha512-onSYF4tsyGCOzyGymqMFLEeRAty7hCjGarZuTrRLUWDXWJQEZ/anStuFPIuK5noWsvcTO5SqxJeUg55wlzdauA==}
     engines: {node: '>=22.0.0'}
     hasBin: true
     peerDependencies:
       typescript: ^5.9.3
 
-  '@tsrx/prettier-plugin@0.3.126':
-    resolution: {integrity: sha512-LGR5a+DnY5xYHOKU6R9EcmL0Ro5fdfj+w66PJtFIN4nJfj+XbiM7TRXeD7EfDtnjO0NvX6yI/Rio7JyRD+TOEg==}
+  '@tsrx/prettier-plugin@0.3.132':
+    resolution: {integrity: sha512-/BCi+akaKz1QD8TwrSm/zbh1zX+M7eXR9cwz270BSB4M7zpvi5ASKkw0CUTgiYQHM9R+BpAPrOLRtet9u6JLzw==}
     peerDependencies:
       prettier: '>=2.0.0'
 
-  '@tsrx/react-runtime@0.1.1':
-    resolution: {integrity: sha512-N6PCKZg138N0umti5hpfCye1uVu9re4pjWHxE0yYPU3CeJ8tPlKHHcuxmz4qPZUMi2gf1JKz4TCewYHkZUAFLQ==}
+  '@tsrx/react-runtime@0.1.5':
+    resolution: {integrity: sha512-bm2uv/FTWDayDS84GzVRS2JJbTMtLSLvBL22UNImszxfOndozFLZr7ZYT48MIdwAL/9dPo88L3reuaYH9aJ8ew==}
     peerDependencies:
       react: '>=18'
 
-  '@tsrx/react@0.2.61':
-    resolution: {integrity: sha512-TyAZgo5lEkFDdl7V2hM/A+3jQds8se1RMyvnse94wn9HL2KZ0Q+gOqmHebSXA6NqF7Opp16YgRkWtsnTHby05w==}
+  '@tsrx/react@0.2.66':
+    resolution: {integrity: sha512-sRUbrKpKmpdfhx5rQai5wYGcyietn/c7L9q5lXQxPKla7+rBkGLEp6rrzcClH5ufGRY71jIUno3aB1+Pzwfxuw==}
     peerDependencies:
       react: '>=18'
 
-  '@tsrx/ripple@0.1.61':
-    resolution: {integrity: sha512-5T9tEHFhVpBcpWdrcGGFO02rT62gEhYxVkB88Y7OLXAgojk1sN3grxC6qaqvkAEN+qgN7KspFlobbzYa3+wjPg==}
+  '@tsrx/ripple@0.1.62':
+    resolution: {integrity: sha512-903lYUwLNXrtMYOsMtOlrPgdZ9OL0MS06jG4Qbpc2enG3y2sGfwXrZfKnDdKn+1rdtkw5Eb5WGOnN1KxUGuZpw==}
 
   '@tsrx/runtime@0.1.1':
     resolution: {integrity: sha512-R7n2forc2XQvqCYpYMqGij1tCwoPILBubRczQ2Kbjj3d6naiseEq6qfMmljEkKp14ERYHstx7ISrw2wY7Ml0DA==}
 
-  '@tsrx/solid-runtime@0.1.1':
-    resolution: {integrity: sha512-Q6Pc6VMDxnY8iKBCBDlEtWNHn7Q6XlD+TKWPDHqB99YVLlPnPjxKLHQKLc9eYpSCsO0yaQey1TUeKPx3qiAjHg==}
-    peerDependencies:
-      '@solidjs/web': 2.0.0-beta.15
-      solid-js: 2.0.0-beta.15
+  '@tsrx/runtime@0.1.5':
+    resolution: {integrity: sha512-sZHTOr2OOGg+EcebZoTeznomydrA4FdvJDfp95lPTj+mq5KpfRT4W6gnO6RoEESrSfL/Ti+V0xzZbA5BYTDBKw==}
 
-  '@tsrx/solid@0.1.61':
-    resolution: {integrity: sha512-xDDucPlrUILpgtCo3Tnt5LSem48jQh1zupnO2qWeQIIiYn2nL6+I5px/t0eNStce4AEGKZbql0UAp5ClpzngQQ==}
+  '@tsrx/solid-runtime@0.1.5':
+    resolution: {integrity: sha512-92fUVBXvKEq/SGWlqH+0FFfnnHDwaER8WJx4D20IX9DgGkwEQr1LvE91eeJXok+HyDUwQGWMbQ7QmoSRR81UJA==}
     peerDependencies:
-      '@solidjs/web': 2.0.0-beta.15
-      solid-js: 2.0.0-beta.15
+      '@solidjs/web': 2.0.0-rc.3
+      solid-js: 2.0.0-rc.3
 
-  '@tsrx/typescript-plugin@0.3.126':
-    resolution: {integrity: sha512-PFmaZOK/PZcQIrGH6lfrwywVSbrf0QjrRqmpEn6whCnbLILVsiq+S7xKs1IuHPKAT33/G1zOjNvmoP4D3kmC/w==}
+  '@tsrx/solid@0.1.66':
+    resolution: {integrity: sha512-YJMpvrP+8dieKyD302J5pupGr0KdbfubABa8zSeKWzZuJZbBkL3Z+fBFxxAMZrKLsiXLEM0c00b2ukezjT5l8w==}
+    peerDependencies:
+      '@solidjs/web': 2.0.0-rc.3
+      solid-js: 2.0.0-rc.3
+
+  '@tsrx/typescript-plugin@0.3.132':
+    resolution: {integrity: sha512-ruMhyh7N7EC6oA/PyhmQTkOU6RDVrzbrxiWUnFcNuEzHooeZgkHuNSItPIDSr3At2tx0LpiiJkyWV8kvfj0IhA==}
     hasBin: true
     peerDependencies:
-      '@tsrx/preact': 0.1.61
-      '@tsrx/react': 0.2.61
+      '@tsrx/preact': 0.1.66
+      '@tsrx/react': 0.2.66
       '@tsrx/ripple': ^0.1.61
-      '@tsrx/solid': 0.1.61
-      '@tsrx/vue': 0.1.61
+      '@tsrx/solid': 0.1.66
+      '@tsrx/vue': 0.1.66
       octane: '*'
       typescript: ^5.9.3
     peerDependenciesMeta:
@@ -2108,13 +2119,13 @@ packages:
       octane:
         optional: true
 
-  '@tsrx/vite-plugin-react@0.0.94':
-    resolution: {integrity: sha512-IaefzGsfzH7Oj1MuUEBysbP2OFy9D1lVBuApfvWxPVUsYRbk4TAgkyhWPVpVr/CWpv2szZ7RfcMa5sNk2tGX8Q==}
+  '@tsrx/vite-plugin-react@0.0.99':
+    resolution: {integrity: sha512-ovSq1rqSkPBZSOX+eGOXlXiqEsp9YljHiiElfqnIQXeVobXoahMzUSmL2/S0jJ2t23Lmft+kgww61H4K3LQGGQ==}
     peerDependencies:
       vite: '*'
 
-  '@tsrx/vite-plugin-solid@0.0.91':
-    resolution: {integrity: sha512-QNXrMM4q4GYWmnypCZEPrzl3QDlSkr/G8IusqHKguetjDnXenI1Mk+PVY2MJt7CyCRls8XqOJ7arOtMrMgtxrw==}
+  '@tsrx/vite-plugin-solid@0.0.96':
+    resolution: {integrity: sha512-G3X8yT28xu6XsdweiHSzb3ZVH2WARnF6tFDUB/2dApPfwEsyfnPZkfbcHZz0817sedPgkdqoRh/7wH98r/1nOg==}
     peerDependencies:
       vite: '*'
 
@@ -4258,8 +4269,18 @@ packages:
     peerDependencies:
       seroval: ^1.0
 
+  seroval-plugins@1.5.6:
+    resolution: {integrity: sha512-HXuLAX2pu/UByPpaeo/TaMfvMIi+1QqIoPJYCcAtU8QkVNwgR6MPlGuCQTErV1JwraaMbYaWVIBX7mppzGLATQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      seroval: ^1.0
+
   seroval@1.5.2:
     resolution: {integrity: sha512-xcRN39BdsnO9Tf+VzsE7b3JyTJASItIV1FVFewJKCFcW4s4haIKS3e6vj8PGB9qBwC7tnuOywQMdv5N4qkzi7Q==}
+    engines: {node: '>=10'}
+
+  seroval@1.5.6:
+    resolution: {integrity: sha512-rVQVWjjSvlINzaQPZH5JFqsqEsIWdTxY3iJZCnTL/5gQbXIRooVZKI60tVCkOVfzcRPejboxO2t0P89dg5mQaA==}
     engines: {node: '>=10'}
 
   serve-static@2.2.1:
@@ -4324,6 +4345,9 @@ packages:
 
   solid-js@2.0.0-beta.15:
     resolution: {integrity: sha512-3hvcmEFUgDlahc++/ulrPhnc5IM7aJbW1P4TUaKsMZpDY5qGcOagtL4nbXGdUPnVP0JsJhMuE9bXEcLdLE+2SA==}
+
+  solid-js@2.0.0-rc.3:
+    resolution: {integrity: sha512-pmW6bRoTvfp/rN4jN7JmLvSaoIpFt7wm0Hi3j508S/smuJqUbRg3dQEjOPTkAwHW+McYnXrMG7cJ4AMNpLevtQ==}
 
   solid-refresh@0.8.0-next.7:
     resolution: {integrity: sha512-fqkPRAeiE0tqfo2ZljeQBIXwfYssU2w1FmaWFrXmnV33B/CfGfez7BjtOF0Y1/orUNRXI/DZcJlJThHllcCMsA==}
@@ -6075,11 +6099,21 @@ snapshots:
 
   '@solidjs/signals@2.0.0-beta.15': {}
 
+  '@solidjs/signals@2.0.0-rc.3':
+    optional: true
+
   '@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15)':
     dependencies:
       seroval: 1.5.2
       seroval-plugins: 1.5.2(seroval@1.5.2)
       solid-js: 2.0.0-beta.15
+
+  '@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3)':
+    dependencies:
+      seroval: 1.5.6
+      seroval-plugins: 1.5.6(seroval@1.5.6)
+      solid-js: 2.0.0-rc.3
+    optional: true
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -6166,7 +6200,7 @@ snapshots:
 
   '@toon-format/toon@2.1.0': {}
 
-  '@tsrx/core@0.1.60(@typescript-eslint/types@8.56.1)':
+  '@tsrx/core@0.1.61(@typescript-eslint/types@8.56.1)':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
       '@noble/hashes': 2.2.0
@@ -6183,39 +6217,38 @@ snapshots:
       - '@typescript-eslint/types'
     optional: true
 
-  '@tsrx/core@0.1.61(@typescript-eslint/types@8.56.1)':
+  '@tsrx/core@0.1.66(@typescript-eslint/types@8.56.1)':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
       '@noble/hashes': 2.2.0
       '@sveltejs/acorn-typescript': 1.0.13(acorn@8.17.0)
-      '@tsrx/runtime': 0.1.1
+      '@tsrx/runtime': 0.1.5
       '@types/estree': 1.0.8
       '@types/estree-jsx': 1.0.5
       acorn: 8.17.0
       esrap: 2.3.2(@typescript-eslint/types@8.56.1)
-      is-reference: 3.0.3
       magic-string: 0.30.21
       zimmerframe: 1.1.4
     transitivePeerDependencies:
       - '@typescript-eslint/types'
 
-  '@tsrx/eslint-parser@0.3.126(@typescript-eslint/types@8.56.1)(eslint@10.3.0(jiti@2.6.1)(supports-color@7.2.0))':
+  '@tsrx/eslint-parser@0.3.132(@typescript-eslint/types@8.56.1)(eslint@10.3.0(jiti@2.6.1)(supports-color@7.2.0))':
     dependencies:
-      '@tsrx/core': 0.1.61(@typescript-eslint/types@8.56.1)
+      '@tsrx/core': 0.1.66(@typescript-eslint/types@8.56.1)
       eslint: 10.3.0(jiti@2.6.1)(supports-color@7.2.0)
     transitivePeerDependencies:
       - '@typescript-eslint/types'
 
-  '@tsrx/eslint-plugin@0.3.126(@tsrx/eslint-parser@0.3.126(@typescript-eslint/types@8.56.1)(eslint@10.3.0(jiti@2.6.1)(supports-color@7.2.0)))(@typescript-eslint/parser@8.56.1(eslint@10.3.0(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint@10.3.0(jiti@2.6.1)(supports-color@7.2.0))':
+  '@tsrx/eslint-plugin@0.3.132(@tsrx/eslint-parser@0.3.132(@typescript-eslint/types@8.56.1)(eslint@10.3.0(jiti@2.6.1)(supports-color@7.2.0)))(@typescript-eslint/parser@8.56.1(eslint@10.3.0(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint@10.3.0(jiti@2.6.1)(supports-color@7.2.0))':
     dependencies:
-      '@tsrx/eslint-parser': 0.3.126(@typescript-eslint/types@8.56.1)(eslint@10.3.0(jiti@2.6.1)(supports-color@7.2.0))
+      '@tsrx/eslint-parser': 0.3.132(@typescript-eslint/types@8.56.1)(eslint@10.3.0(jiti@2.6.1)(supports-color@7.2.0))
       '@typescript-eslint/parser': 8.56.1(eslint@10.3.0(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
       eslint: 10.3.0(jiti@2.6.1)(supports-color@7.2.0)
 
-  '@tsrx/language-server@0.3.126(@tsrx/react@0.2.61(@typescript-eslint/types@8.56.1)(react@19.2.4))(@tsrx/ripple@0.1.61(@typescript-eslint/types@8.56.1))(@tsrx/solid@0.1.61(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(@typescript-eslint/types@8.56.1)(solid-js@2.0.0-beta.15))(@typescript-eslint/types@8.56.1)(@volar/language-service@2.4.28)(octane@0.1.6(@typescript-eslint/types@8.56.1))(typescript@5.9.3)':
+  '@tsrx/language-server@0.3.132(@tsrx/react@0.2.66(@typescript-eslint/types@8.56.1)(react@19.2.4))(@tsrx/ripple@0.1.62(@typescript-eslint/types@8.56.1))(@tsrx/solid@0.1.66(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(@typescript-eslint/types@8.56.1)(solid-js@2.0.0-rc.3))(@typescript-eslint/types@8.56.1)(@volar/language-service@2.4.28)(octane@0.1.6(@typescript-eslint/types@8.56.1))(typescript@5.9.3)':
     dependencies:
-      '@tsrx/core': 0.1.61(@typescript-eslint/types@8.56.1)
-      '@tsrx/typescript-plugin': 0.3.126(@tsrx/react@0.2.61(@typescript-eslint/types@8.56.1)(react@19.2.4))(@tsrx/ripple@0.1.61(@typescript-eslint/types@8.56.1))(@tsrx/solid@0.1.61(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(@typescript-eslint/types@8.56.1)(solid-js@2.0.0-beta.15))(octane@0.1.6(@typescript-eslint/types@8.56.1))(typescript@5.9.3)
+      '@tsrx/core': 0.1.66(@typescript-eslint/types@8.56.1)
+      '@tsrx/typescript-plugin': 0.3.132(@tsrx/react@0.2.66(@typescript-eslint/types@8.56.1)(react@19.2.4))(@tsrx/ripple@0.1.62(@typescript-eslint/types@8.56.1))(@tsrx/solid@0.1.66(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(@typescript-eslint/types@8.56.1)(solid-js@2.0.0-rc.3))(octane@0.1.6(@typescript-eslint/types@8.56.1))(typescript@5.9.3)
       '@volar/language-server': 2.4.28
       typescript: 5.9.3
       volar-service-css: 0.0.70(@volar/language-service@2.4.28)
@@ -6232,81 +6265,104 @@ snapshots:
       - '@volar/language-service'
       - octane
 
-  '@tsrx/prettier-plugin@0.3.126(@typescript-eslint/types@8.56.1)(prettier@3.9.6)':
+  '@tsrx/prettier-plugin@0.3.132(@typescript-eslint/types@8.56.1)(prettier@3.9.6)':
     dependencies:
-      '@tsrx/core': 0.1.61(@typescript-eslint/types@8.56.1)
+      '@tsrx/core': 0.1.66(@typescript-eslint/types@8.56.1)
       prettier: 3.9.6
     transitivePeerDependencies:
       - '@typescript-eslint/types'
 
-  '@tsrx/react-runtime@0.1.1(react@19.2.4)':
+  '@tsrx/react-runtime@0.1.5(react@19.2.4)':
     dependencies:
-      '@tsrx/runtime': 0.1.1
+      '@tsrx/runtime': 0.1.5
       react: 19.2.4
 
-  '@tsrx/react@0.2.61(@typescript-eslint/types@8.56.1)(react@19.2.4)':
+  '@tsrx/react@0.2.66(@typescript-eslint/types@8.56.1)(react@19.2.4)':
     dependencies:
-      '@tsrx/core': 0.1.61(@typescript-eslint/types@8.56.1)
-      '@tsrx/react-runtime': 0.1.1(react@19.2.4)
+      '@tsrx/core': 0.1.66(@typescript-eslint/types@8.56.1)
+      '@tsrx/react-runtime': 0.1.5(react@19.2.4)
       esrap: 2.3.2(@typescript-eslint/types@8.56.1)
       react: 19.2.4
       zimmerframe: 1.1.4
     transitivePeerDependencies:
       - '@typescript-eslint/types'
 
-  '@tsrx/ripple@0.1.61(@typescript-eslint/types@8.56.1)':
+  '@tsrx/ripple@0.1.62(@typescript-eslint/types@8.56.1)':
     dependencies:
-      '@tsrx/core': 0.1.60(@typescript-eslint/types@8.56.1)
+      '@tsrx/core': 0.1.61(@typescript-eslint/types@8.56.1)
       esrap: 2.3.2(@typescript-eslint/types@8.56.1)
       is-reference: 3.0.3
+      source-map: 0.7.6
       zimmerframe: 1.1.4
     transitivePeerDependencies:
       - '@typescript-eslint/types'
     optional: true
 
-  '@tsrx/runtime@0.1.1': {}
+  '@tsrx/runtime@0.1.1':
+    optional: true
 
-  '@tsrx/solid-runtime@0.1.1(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(solid-js@2.0.0-beta.15)':
+  '@tsrx/runtime@0.1.5': {}
+
+  '@tsrx/solid-runtime@0.1.5(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(solid-js@2.0.0-beta.15)':
     dependencies:
       '@solidjs/web': 2.0.0-beta.15(solid-js@2.0.0-beta.15)
-      '@tsrx/runtime': 0.1.1
+      '@tsrx/runtime': 0.1.5
       solid-js: 2.0.0-beta.15
 
-  '@tsrx/solid@0.1.61(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(@typescript-eslint/types@8.56.1)(solid-js@2.0.0-beta.15)':
+  '@tsrx/solid-runtime@0.1.5(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)':
+    dependencies:
+      '@solidjs/web': 2.0.0-rc.3(solid-js@2.0.0-rc.3)
+      '@tsrx/runtime': 0.1.5
+      solid-js: 2.0.0-rc.3
+    optional: true
+
+  '@tsrx/solid@0.1.66(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(@typescript-eslint/types@8.56.1)(solid-js@2.0.0-beta.15)':
     dependencies:
       '@solidjs/web': 2.0.0-beta.15(solid-js@2.0.0-beta.15)
-      '@tsrx/core': 0.1.61(@typescript-eslint/types@8.56.1)
-      '@tsrx/solid-runtime': 0.1.1(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(solid-js@2.0.0-beta.15)
+      '@tsrx/core': 0.1.66(@typescript-eslint/types@8.56.1)
+      '@tsrx/solid-runtime': 0.1.5(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(solid-js@2.0.0-beta.15)
       esrap: 2.3.2(@typescript-eslint/types@8.56.1)
       solid-js: 2.0.0-beta.15
       zimmerframe: 1.1.4
     transitivePeerDependencies:
       - '@typescript-eslint/types'
 
-  '@tsrx/typescript-plugin@0.3.126(@tsrx/react@0.2.61(@typescript-eslint/types@8.56.1)(react@19.2.4))(@tsrx/ripple@0.1.61(@typescript-eslint/types@8.56.1))(@tsrx/solid@0.1.61(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(@typescript-eslint/types@8.56.1)(solid-js@2.0.0-beta.15))(octane@0.1.6(@typescript-eslint/types@8.56.1))(typescript@5.9.3)':
+  '@tsrx/solid@0.1.66(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(@typescript-eslint/types@8.56.1)(solid-js@2.0.0-rc.3)':
+    dependencies:
+      '@solidjs/web': 2.0.0-rc.3(solid-js@2.0.0-rc.3)
+      '@tsrx/core': 0.1.66(@typescript-eslint/types@8.56.1)
+      '@tsrx/solid-runtime': 0.1.5(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(solid-js@2.0.0-rc.3)
+      esrap: 2.3.2(@typescript-eslint/types@8.56.1)
+      solid-js: 2.0.0-rc.3
+      zimmerframe: 1.1.4
+    transitivePeerDependencies:
+      - '@typescript-eslint/types'
+    optional: true
+
+  '@tsrx/typescript-plugin@0.3.132(@tsrx/react@0.2.66(@typescript-eslint/types@8.56.1)(react@19.2.4))(@tsrx/ripple@0.1.62(@typescript-eslint/types@8.56.1))(@tsrx/solid@0.1.66(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(@typescript-eslint/types@8.56.1)(solid-js@2.0.0-rc.3))(octane@0.1.6(@typescript-eslint/types@8.56.1))(typescript@5.9.3)':
     dependencies:
       '@volar/language-core': 2.4.28
       '@volar/typescript': 2.4.28
       typescript: 5.9.3
     optionalDependencies:
-      '@tsrx/react': 0.2.61(@typescript-eslint/types@8.56.1)(react@19.2.4)
-      '@tsrx/ripple': 0.1.61(@typescript-eslint/types@8.56.1)
-      '@tsrx/solid': 0.1.61(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(@typescript-eslint/types@8.56.1)(solid-js@2.0.0-beta.15)
+      '@tsrx/react': 0.2.66(@typescript-eslint/types@8.56.1)(react@19.2.4)
+      '@tsrx/ripple': 0.1.62(@typescript-eslint/types@8.56.1)
+      '@tsrx/solid': 0.1.66(@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3))(@typescript-eslint/types@8.56.1)(solid-js@2.0.0-rc.3)
       octane: 0.1.6(@typescript-eslint/types@8.56.1)
 
-  '@tsrx/vite-plugin-react@0.0.94(@typescript-eslint/types@8.56.1)(react@19.2.4)(vite@8.1.5(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1))':
+  '@tsrx/vite-plugin-react@0.0.99(@typescript-eslint/types@8.56.1)(react@19.2.4)(vite@8.1.5(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1))':
     dependencies:
-      '@tsrx/core': 0.1.61(@typescript-eslint/types@8.56.1)
-      '@tsrx/react': 0.2.61(@typescript-eslint/types@8.56.1)(react@19.2.4)
+      '@tsrx/core': 0.1.66(@typescript-eslint/types@8.56.1)
+      '@tsrx/react': 0.2.66(@typescript-eslint/types@8.56.1)(react@19.2.4)
       vite: 8.1.5(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)
     transitivePeerDependencies:
       - '@typescript-eslint/types'
       - react
 
-  '@tsrx/vite-plugin-solid@0.0.91(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(@typescript-eslint/types@8.56.1)(solid-js@2.0.0-beta.15)(vite@8.1.5(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1))':
+  '@tsrx/vite-plugin-solid@0.0.96(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(@typescript-eslint/types@8.56.1)(solid-js@2.0.0-beta.15)(vite@8.1.5(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1))':
     dependencies:
-      '@tsrx/core': 0.1.61(@typescript-eslint/types@8.56.1)
-      '@tsrx/solid': 0.1.61(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(@typescript-eslint/types@8.56.1)(solid-js@2.0.0-beta.15)
+      '@tsrx/core': 0.1.66(@typescript-eslint/types@8.56.1)
+      '@tsrx/solid': 0.1.66(@solidjs/web@2.0.0-beta.15(solid-js@2.0.0-beta.15))(@typescript-eslint/types@8.56.1)(solid-js@2.0.0-beta.15)
       vite: 8.1.5(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)
     transitivePeerDependencies:
       - '@solidjs/web'
@@ -8581,7 +8637,15 @@ snapshots:
     dependencies:
       seroval: 1.5.2
 
+  seroval-plugins@1.5.6(seroval@1.5.6):
+    dependencies:
+      seroval: 1.5.6
+    optional: true
+
   seroval@1.5.2: {}
+
+  seroval@1.5.6:
+    optional: true
 
   serve-static@2.2.1(supports-color@7.2.0):
     dependencies:
@@ -8668,6 +8732,14 @@ snapshots:
       csstype: 3.2.3
       seroval: 1.5.2
       seroval-plugins: 1.5.2(seroval@1.5.2)
+
+  solid-js@2.0.0-rc.3:
+    dependencies:
+      '@solidjs/signals': 2.0.0-rc.3
+      csstype: 3.2.3
+      seroval: 1.5.6
+      seroval-plugins: 1.5.6(seroval@1.5.6)
+    optional: true
 
   solid-refresh@0.8.0-next.7(solid-js@2.0.0-beta.15):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,16 +4,19 @@
 minimumReleaseAge: 1440
 minimumReleaseAgeExclude:
   - '@sveltejs/acorn-typescript@1.0.13'
-  - '@tsrx/core@0.1.61'
-  - '@tsrx/eslint-parser@0.3.126'
-  - '@tsrx/eslint-plugin@0.3.126'
-  - '@tsrx/language-server@0.3.126'
-  - '@tsrx/prettier-plugin@0.3.126'
-  - '@tsrx/react@0.2.61'
-  - '@tsrx/solid@0.1.61'
-  - '@tsrx/typescript-plugin@0.3.126'
-  - '@tsrx/vite-plugin-react@0.0.94'
-  - '@tsrx/vite-plugin-solid@0.0.91'
+  - '@tsrx/core@0.1.66'
+  - '@tsrx/eslint-parser@0.3.132'
+  - '@tsrx/eslint-plugin@0.3.132'
+  - '@tsrx/language-server@0.3.132'
+  - '@tsrx/prettier-plugin@0.3.132'
+  - '@tsrx/react@0.2.66'
+  - '@tsrx/solid@0.1.66'
+  - '@tsrx/typescript-plugin@0.3.132'
+  - '@tsrx/vite-plugin-react@0.0.99'
+  - '@tsrx/vite-plugin-solid@0.0.96'
+  - '@tsrx/react-runtime@0.1.5'
+  - '@tsrx/runtime@0.1.5'
+  - '@tsrx/solid-runtime@0.1.5'
 minimumReleaseAgeIgnoreMissingTime: true
 minimumReleaseAgeStrict: false
 trustPolicy: no-downgrade
@@ -79,15 +82,15 @@ catalogs:
     '@types/estree-jsx': ^1.0.5
     '@types/node': ^24.3.0
     '@types/prompts': ^2.4.9
-    '@tsrx/core': ^0.1.61
-    '@tsrx/eslint-plugin': ^0.3.126
-    '@tsrx/language-server': ^0.3.126
-    '@tsrx/prettier-plugin': ^0.3.126
-    '@tsrx/react': ^0.2.61
-    '@tsrx/solid': ^0.1.61
-    '@tsrx/typescript-plugin': ^0.3.126
-    '@tsrx/vite-plugin-react': ^0.0.94
-    '@tsrx/vite-plugin-solid': ^0.0.91
+    '@tsrx/core': ^0.1.66
+    '@tsrx/eslint-plugin': ^0.3.132
+    '@tsrx/language-server': ^0.3.132
+    '@tsrx/prettier-plugin': ^0.3.132
+    '@tsrx/react': ^0.2.66
+    '@tsrx/solid': ^0.1.66
+    '@tsrx/typescript-plugin': ^0.3.132
+    '@tsrx/vite-plugin-react': ^0.0.99
+    '@tsrx/vite-plugin-solid': ^0.0.96
     '@typescript-eslint/parser': *ts_eslint_parser
     '@typescript-eslint/types': ^8.40.0
     '@vercel/nft': ^1.3.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,16 +4,16 @@
 minimumReleaseAge: 1440
 minimumReleaseAgeExclude:
   - '@sveltejs/acorn-typescript@1.0.13'
-  - '@tsrx/core@0.1.66'
-  - '@tsrx/eslint-parser@0.3.132'
-  - '@tsrx/eslint-plugin@0.3.132'
-  - '@tsrx/language-server@0.3.132'
-  - '@tsrx/prettier-plugin@0.3.132'
-  - '@tsrx/react@0.2.66'
-  - '@tsrx/solid@0.1.66'
-  - '@tsrx/typescript-plugin@0.3.132'
-  - '@tsrx/vite-plugin-react@0.0.99'
-  - '@tsrx/vite-plugin-solid@0.0.96'
+  - '@tsrx/core@0.1.67'
+  - '@tsrx/eslint-parser@0.3.133'
+  - '@tsrx/eslint-plugin@0.3.133'
+  - '@tsrx/language-server@0.3.133'
+  - '@tsrx/prettier-plugin@0.3.133'
+  - '@tsrx/react@0.2.67'
+  - '@tsrx/solid@0.1.67'
+  - '@tsrx/typescript-plugin@0.3.133'
+  - '@tsrx/vite-plugin-react@0.0.100'
+  - '@tsrx/vite-plugin-solid@0.0.97'
   - '@tsrx/react-runtime@0.1.5'
   - '@tsrx/runtime@0.1.5'
   - '@tsrx/solid-runtime@0.1.5'
@@ -82,15 +82,15 @@ catalogs:
     '@types/estree-jsx': ^1.0.5
     '@types/node': ^24.3.0
     '@types/prompts': ^2.4.9
-    '@tsrx/core': ^0.1.66
-    '@tsrx/eslint-plugin': ^0.3.132
-    '@tsrx/language-server': ^0.3.132
-    '@tsrx/prettier-plugin': ^0.3.132
-    '@tsrx/react': ^0.2.66
-    '@tsrx/solid': ^0.1.66
-    '@tsrx/typescript-plugin': ^0.3.132
-    '@tsrx/vite-plugin-react': ^0.0.99
-    '@tsrx/vite-plugin-solid': ^0.0.96
+    '@tsrx/core': ^0.1.67
+    '@tsrx/eslint-plugin': ^0.3.133
+    '@tsrx/language-server': ^0.3.133
+    '@tsrx/prettier-plugin': ^0.3.133
+    '@tsrx/react': ^0.2.67
+    '@tsrx/solid': ^0.1.67
+    '@tsrx/typescript-plugin': ^0.3.133
+    '@tsrx/vite-plugin-react': ^0.0.100
+    '@tsrx/vite-plugin-solid': ^0.0.97
     '@typescript-eslint/parser': *ts_eslint_parser
     '@typescript-eslint/types': ^8.40.0
     '@vercel/nft': ^1.3.2

--- a/website-new/src/components/actions.tsrx
+++ b/website-new/src/components/actions.tsrx
@@ -1,5 +1,5 @@
-export function Actions({ playgroundVisible = false }: { playgroundVisible: boolean }) {
-	return <>
+export function Actions({ playgroundVisible = false }: { playgroundVisible: boolean }) @{
+	<>
 		<div class="social-links">
 			<a
 				href="https://github.com/Ripple-TS/ripple"
@@ -147,5 +147,5 @@ export function Actions({ playgroundVisible = false }: { playgroundVisible: bool
 				fill: currentColor;
 			}
 		</style>
-	</>;
+	</>
 }

--- a/website-new/src/components/content.tsrx
+++ b/website-new/src/components/content.tsrx
@@ -1,5 +1,5 @@
-export function Content() {
-	return <>
+export function Content() @{
+	<>
 		<div class="content-section">
 			<h2 class="description">
 				Ripple is a TypeScript UI framework that combines the best parts of React, Solid, and Svelte
@@ -124,5 +124,5 @@ export function Content() {
 				font-size: 0.9em;
 			}
 		</style>
-	</>;
+	</>
 }

--- a/website-new/src/components/docs-footer.tsrx
+++ b/website-new/src/components/docs-footer.tsrx
@@ -1,5 +1,5 @@
-export function DocsFooter() {
-	return <>
+export function DocsFooter() @{
+	<>
 		<footer class="docs-footer">
 			<div class="footer-content">
 				<p class="footer-message">Released under the MIT License.</p>
@@ -26,5 +26,5 @@ export function DocsFooter() {
 				line-height: 24px;
 			}
 		</style>
-	</>;
+	</>
 }

--- a/website-new/src/components/docs-header.tsrx
+++ b/website-new/src/components/docs-header.tsrx
@@ -1,5 +1,5 @@
-export function DocsHeader() {
-	return <>
+export function DocsHeader() @{
+	<>
 		<header class="Header">
 			<div class="HeaderBar has-sidebar">
 				<div class="wrapper">
@@ -493,5 +493,5 @@ export function DocsHeader() {
 				}
 			}
 		</style>
-	</>;
+	</>
 }

--- a/website-new/src/components/docs-layout.tsrx
+++ b/website-new/src/components/docs-layout.tsrx
@@ -18,8 +18,8 @@ export function DocsLayout({
 	nextLink?: { href: string; text: string } | null;
 	toc?: { href: string; text: string }[];
 	currentPath?: string;
-}) {
-	return <>
+}) @{
+	<>
 		<head>
 			<title>{title} | Ripple</title>
 			<link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -934,5 +934,5 @@ export function DocsLayout({
 				}
 			}
 		</style>
-	</>;
+	</>
 }

--- a/website-new/src/components/header.tsrx
+++ b/website-new/src/components/header.tsrx
@@ -1,5 +1,5 @@
-export function Header() {
-	return <>
+export function Header() @{
+	<>
 		<h1 class="sr-only">Ripple</h1>
 		<img
 			src="/images/ripple-logo-horizontal.png"
@@ -53,5 +53,5 @@ export function Header() {
 				}
 			}
 		</style>
-	</>;
+	</>
 }

--- a/website-new/src/components/layout.tsrx
+++ b/website-new/src/components/layout.tsrx
@@ -1,5 +1,5 @@
-export function Layout({ children }) {
-	return <>
+export function Layout({ children }) @{
+	<>
 		<main>
 			<div class="container">{children}</div>
 
@@ -176,5 +176,5 @@ export function Layout({ children }) {
 				}
 			}
 		</style>
-	</>;
+	</>
 }

--- a/website-new/src/components/sidebar.tsrx
+++ b/website-new/src/components/sidebar.tsrx
@@ -1,7 +1,7 @@
 import { track } from 'ripple';
 
-export function Sidebar({ currentPath = '/docs/introduction' }: { currentPath?: string }) {
-	return <>
+export function Sidebar({ currentPath = '/docs/introduction' }: { currentPath?: string }) @{
+	<>
 		<aside class="Sidebar">
 			<div class="curtain" />
 			<nav class="nav" id="SidebarNav" aria-labelledby="sidebar-aria-label" tabindex="-1">
@@ -203,7 +203,7 @@ export function Sidebar({ currentPath = '/docs/introduction' }: { currentPath?: 
 				}
 			}
 		</style>
-	</>;
+	</>
 }
 
 function SidebarGroup({

--- a/website/docs/best-practices.md
+++ b/website/docs/best-practices.md
@@ -14,6 +14,7 @@ A summary:
 3. **Effects**: Use `effect()` for side effects that depend on reactive values
 4. **Components**: Keep components focused and type props with TypeScript
    interfaces or type aliases
-5. **Styling**: Use scoped `<style>` elements for component-specific styles
+5. **Styling**: Put a scoped `<style>` block beside the elements it styles, and
+   assign a block to a variable to share it as a theme (`apply`) or class map
 6. **Collections**: Use `RippleArray`, `RippleObject`, `RippleMap`, and
    `RippleSet` for reactive collections instead of regular mutable objects

--- a/website/docs/examples.ts
+++ b/website/docs/examples.ts
@@ -74,6 +74,157 @@ function DynamicClasses() @{
 }`,
 	},
 	{
+		title: 'Scoped Styles & Themes',
+		code: `import { track } from 'ripple';
+
+// A <style> block styles the elements beside it and everything below them,
+// never the element that contains it. Assigned to a variable it becomes a
+// theme: an object with $class (its hash class) plus one key per class
+// selector. Exported, applied, or $class-read blocks keep every selector.
+const base = <style>
+	article {
+		font-family: system-ui, sans-serif;
+		border-radius: 12px;
+		padding: 1rem 1.25rem;
+	}
+	h2 {
+		margin: 0 0 0.5rem;
+		font-size: 1.1rem;
+	}
+</style>;
+
+// A theme can apply another theme: light.$class carries base's hash too.
+const light = <style apply={base}>
+	article {
+		background: #f6f7fb;
+		color: #1a1c2c;
+	}
+	.accent {
+		color: #5b4bff;
+	}
+</style>;
+
+const dark = <style apply={base}>
+	article {
+		background: #1a1c2c;
+		color: #f6f7fb;
+	}
+	.accent {
+		color: #ffb454;
+	}
+</style>;
+
+// Reading accent.$class makes this block a theme, so its element rules
+// survive, and only the elements that carry accent.$class pick them up.
+const accent = <style>
+	p {
+		border-left: 3px solid #5b4bff;
+		padding-left: 0.5rem;
+	}
+	strong {
+		color: #5b4bff;
+	}
+</style>;
+
+// A child puts a passed class on the elements it chooses; its own scope
+// hash follows, so its local rules still reach them.
+function Footnote({ parentClass }: { parentClass: string }) @{
+	<>
+		<style>
+			p {
+				margin: 0;
+				font-size: 0.9rem;
+			}
+		</style>
+		<p class={parentClass}>
+			<strong class={parentClass}>Footnote:</strong> a child opted in through a prop.
+		</p>
+	</>
+}
+
+// Each card applies a theme to its own scope: the theme's article and h2
+// rules reach every element here, while the card's local rules stay local.
+function LightCard() @{
+	<>
+		<style apply={light}>
+			p {
+				margin: 0;
+			}
+		</style>
+		<article>
+			<h2>Light card</h2>
+			<p>{'Accent class: ' + light.accent}</p>
+			<p class={light.accent}>A class-map entry carries its hash.</p>
+		</article>
+	</>
+}
+
+function DarkCard() @{
+	<>
+		<style apply={dark}>
+			p {
+				margin: 0;
+			}
+		</style>
+		<article>
+			<h2>Dark card</h2>
+			<p class={dark.accent}>Same markup, other theme.</p>
+		</article>
+	</>
+}
+
+export default function App() @{
+	let &[expanded] = track(false);
+
+	<>
+		<style>
+			.stack {
+				display: grid;
+				gap: 0.75rem;
+				justify-items: start;
+			}
+			button {
+				padding: 0.4rem 0.9rem;
+				border-radius: 8px;
+				border: 1px solid #8886;
+				background: transparent;
+				color: inherit;
+				cursor: pointer;
+			}
+		</style>
+		<div class="stack">
+			<LightCard />
+			<DarkCard />
+			<p class={accent.$class}>Opted in with accent.$class; apply would stamp every element.</p>
+			<p>An untouched sibling.</p>
+			<Footnote parentClass={accent.$class} />
+			<button onClick={() => (expanded = !expanded)}>
+				{expanded ? 'Collapse' : 'Expand'}
+			</button>
+			@if (expanded) {
+				<>
+					<style>
+						.note {
+							color: #17803d;
+						}
+					</style>
+					<p class="note">Rules in a branch reach only that branch.</p>
+				</>
+			} @else {
+				<>
+					<style>
+						.note {
+							opacity: 0.6;
+						}
+					</style>
+					<p class="note">Same class name, a different scope.</p>
+				</>
+			}
+		</div>
+	</>
+}`,
+	},
+	{
 		title: 'Components',
 		code: `
 function Card() @{

--- a/website/docs/guide/styling.md
+++ b/website/docs/guide/styling.md
@@ -336,13 +336,32 @@ function Child() {
 `:global(...)` may only start or end a selector. In the middle,
 `.card :global(.x) .title`, it is the `tsrx-css-global-placement` error.
 
-Reach for `:global` only when a prop cannot do the job. To style a child you own,
-pass it a class from a theme (see [Apply a theme](#apply-a-theme-to-a-scope) and
-[Passing scoped classes](#passing-scoped-classes-to-child-components)) instead:
-the dependency is a visible prop, and the child decides which of its elements
-take the class. Keep `:global` for a child you cannot change, always with a scoped
-selector in front, and put page-wide rules such as `body` resets in a `.css` file
-the page links.
+### Which one to use
+
+Reach for `:global` only when a prop cannot do the job. Start from what you want:
+
+| I want to …                                                                        | Use …                                                                                                                                                                                 |
+| ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Style my own elements                                                              | A block beside them. Nothing global.                                                                                                                                                  |
+| Share a look across several of my own components                                   | Assign a theme and `<style apply={theme} />` in each ([how](#apply-a-theme-to-a-scope)).                                                                                              |
+| Let a child component pick up my styles                                            | Pass `theme.$class`, or a class-map entry such as `theme.card`, as a prop ([how](#opt-single-elements-in-with-class)). A child you own can also take its own block beside its markup. |
+| Style a child I cannot change (a third-party component, rendered HTML or markdown) | `.wrapper :global(.their-class)`, or `.wrapper { :global { … } }` for several classes, with a scoped selector in front.                                                               |
+| React to page-level state (a theme class or attribute on `<html>`)                 | `:global(.theme-dark) .card` or `:global([data-theme='dark']) .card`.                                                                                                                 |
+| Style my element with a class another library toggles on it                        | `.card:global(.is-open)`.                                                                                                                                                             |
+| Write page-wide rules (`body`, resets, fonts)                                      | A `.css` file the page links, not a bare `:global`.                                                                                                                                   |
+
+For a child you own, pass the class instead of reaching in with `:global`. With
+a prop, the dependency is visible in code, the child decides which of its
+elements take the class, renaming a class inside the child cannot silently break
+the parent, and the hash keeps the rule on the elements that carry it. With
+`.wrapper :global(.their-class)` the child has no say and cannot see who styles
+it, so keep that form for children you cannot change, and always put a scoped
+selector in front so the rule cannot reach ancestors or unrelated components.
+
+A bare `:global(.toast)` is a global stylesheet hidden inside a component: it
+matches anywhere on the page, and nothing on the matched element points back to
+the file that wrote it. Keep it for page-level elements, and prefer a `.css` file
+the page links for those.
 
 ### Global Keyframes
 

--- a/website/docs/guide/styling.md
+++ b/website/docs/guide/styling.md
@@ -4,76 +4,88 @@ title: Styling in Ripple
 
 # Styling
 
-Ripple supports native CSS styling that's scoped (localized) to the returned
-TSRX template using the `<style>` element.
+A `<style>` block styles the elements beside it and everything below them, and
+never the element that contains it. The CSS is scoped: the compiler adds a hash
+class to every selector in the block and to every element the block reaches, so
+the rules cannot leak into a parent, an outer sibling, a child component, or the
+page around it.
 
 ```tsrx
-function MyComponent() @{
+export function Card({ title, summary }: { title: string; summary: string }) @{
   <>
-    <div class="container">
-      <h1>Hello World</h1>
-    </div>
-
     <style>
-      .container {
-        background: blue;
-        padding: 1rem;
+      .card {
+        padding: 1.5rem;
+        border: 1px solid gray;
       }
-      h1 {
-        color: white;
-        font-size: 2rem;
+      h2 {
+        margin: 0 0 0.5rem;
       }
     </style>
+    <article class="card">
+      <h2>{title}</h2>
+      <p>{summary}</p>
+    </article>
   </>
 }
 ```
 
-::: info Bare scoped `<style>` blocks should be top-level within a returned TSRX template. Assign a `<style>` expression to a variable when you want a reusable class map.
-:::
+`.card` becomes `.card.tsrx-1a20093c`, `h2` becomes `h2.tsrx-1a20093c`, and the
+article and its children get the class `tsrx-1a20093c`. That class is the block's
+**hash class**: the class the compiler adds to an element so the block's selectors
+match only there.
 
-`<style>` blocks contain static CSS. TSRX template rules for JavaScript
-expressions and directives do not apply inside them, so do not put `{expr}`,
-`@if`, `@for`, or declarations in a style block. Use CSS custom properties for
-runtime values.
+To style an element, put the block beside it, as siblings in a fragment. A block
+written inside `<article>` would style the article's children, not the article.
 
-## Dynamic Classes
+## Wrap the block and its markup in a fragment
 
-In Ripple, the `class` attribute can accept more than just a string — it also
-supports objects and arrays. Truthy values are included as class names, while
-falsy values are omitted. This behavior is powered by the `clsx` library.
-
-Examples:
+A `@{ … }` body and every `@if`, `@for`, `@switch`, and `@try` branch hold setup
+statements and exactly one output node, and a `<style>` block counts as an output
+node. Written beside the output node it is the multiple-outputs error; written as
+the only output it styles nothing (`tsrx-style-standalone-needs-fragment`).
 
 ```tsrx
-import { track } from 'ripple';
+// Error: two output nodes.
+export function Broken() @{
+  <style>
+    p {
+      margin: 0;
+    }
+  </style>
+  <p>Hello</p>
+}
 
-function App() @{
-  let &[includeBaz] = track(true);
-  let &[count] = track(3);
-
+// Works: one fragment holding both.
+export function Note() @{
   <>
-    <div class={{ foo: true, bar: false, baz: includeBaz }} />
-    // becomes: class="foo baz"
-
-    <div class={['foo', { baz: false }, 0 && 'bar', [true && 'bat']]} />
-    // becomes: class="foo bat"
-
-    <div class={['foo', { bar: count > 2 }, count > 3 && 'bat']} />
-    // becomes: class="foo bar"
+    <style>
+      p {
+        margin: 0;
+      }
+    </style>
+    <p>Hello</p>
   </>
 }
 ```
 
-## Dynamic CSS Values
+A block with CSS text in it is TSRX template syntax, so it needs a `@{ … }` body
+or a control-flow branch around it. In a plain function that returns JSX, a
+`<style>` is an ordinary element whose content is an expression,
+`<style>{css}</style>`, and the compiler leaves it alone
+(`tsrx-style-standalone-outside-template` otherwise).
 
-Styles in `<style>` blocks are static CSS. When a value needs to change at
-runtime, put that value in a CSS custom property on the element and read it with
-`var(...)` from your static CSS:
+## The CSS is static
+
+A block holds plain CSS. TSRX template rules for JavaScript expressions and
+directives do not apply inside it, so do not put `{expr}`, `@if`, `@for`, or
+declarations in a style block. Put a runtime value in a CSS custom property on the
+element and read it with `var(...)`:
 
 ```tsrx
 import { track } from 'ripple';
 
-function App() @{
+export function App() @{
   let &[color] = track('red');
 
   <>
@@ -95,10 +107,170 @@ function App() @{
 }
 ```
 
+A scoped block accepts only two attributes, `ref` and `apply`.
+
+## Dynamic Classes
+
+The `class` attribute accepts more than a string: objects and arrays work too.
+Truthy values are included as class names and falsy values are omitted, powered
+by the `clsx` library. The scope's hash class is added after whatever the value
+produces.
+
+```tsrx
+import { track } from 'ripple';
+
+export function App() @{
+  let &[includeBaz] = track(true);
+  let &[count] = track(3);
+
+  <>
+    <div class={{ foo: true, bar: false, baz: includeBaz }} />
+    // becomes: class="foo baz"
+
+    <div class={['foo', { baz: false }, 0 && 'bar', [true && 'bat']]} />
+    // becomes: class="foo bat"
+
+    <div class={['foo', { bar: count > 2 }, count > 3 && 'bat']} />
+    // becomes: class="foo bar"
+  </>
+}
+```
+
+## What a scope is
+
+A scope is one list of children, the children of an element or of a fragment,
+that holds at least one block. The block belongs to the list it is written in and
+styles the other items of that list and their descendants. These lists count:
+
+- The children of a DOM element.
+- The children of a fragment, including the fragment that a `@{ … }` block or an
+  `@if`, `@else if`, `@else`, `@for`, `@empty`, `@case`, `@default`, `@try`,
+  `@pending`, or `@catch` branch renders.
+- The children of an element or fragment used as a value inside a component
+  body: a template assigned to a variable, or one written inside a `{ … }`
+  expression.
+
+Scopes nest. An element gets the hash class of every scope around it, outermost
+first, so an outer block's rules reach into nested scopes and an inner block's
+rules never reach out. A child component's own elements, and elements returned
+from a callback such as `items.map((item) => <li />)`, get no hash class from
+the parent.
+
+```tsrx
+export function Panel() @{
+  <>
+    <style>
+      div {
+        color: black;
+      }
+    </style>
+    <div class="outer">Black</div>
+    @{
+      <>
+        <style>
+          div {
+            font-weight: bold;
+          }
+        </style>
+        <div class="inner">Black and bold</div>
+      </>
+    }
+  </>
+}
+```
+
+With `A` and `B` as the two hash classes, the compiled classes are `outer A` and
+`inner A B`. The nested `div` matches both rules; the outer one matches only its
+own.
+
+## Several blocks, one scope
+
+Blocks written among the same children share one hash class and behave like one
+block split for readability. Use that to keep each rule next to the element it
+styles:
+
+```tsrx
+export function Toolbar() @{
+  <>
+    <style>
+      .toolbar {
+        display: flex;
+        gap: 0.5rem;
+      }
+    </style>
+    <div class="toolbar">
+      <style>
+        .save {
+          font-weight: 600;
+        }
+      </style>
+      <button class="save">Save</button>
+      <style>
+        .cancel {
+          opacity: 0.7;
+        }
+      </style>
+      <button class="cancel">Cancel</button>
+    </div>
+  </>
+}
+```
+
+The two blocks inside the toolbar share a hash and style the buttons beside them.
+The `.toolbar` rule sits beside the toolbar in the fragment because a block never
+styles the element that contains it. A scope's blocks always come out together as
+one group in the CSS, even when other scopes sit between them in the source.
+
+## Styles inside `@if` and `@for`
+
+A `<style>` block inside a branch applies only to the elements that branch
+renders. Its CSS is still always part of the file's stylesheet, whether or not the
+branch ever renders, because CSS is static. Rules you want everywhere belong
+outside the branch.
+
+```tsrx
+export function Status({ ready }: { ready: boolean }) @{
+  <>
+    <style>
+      .status {
+        padding: 0.5rem;
+      }
+    </style>
+    <section class="status">
+      @if (ready) {
+        <>
+          <style>
+            .ok {
+              color: green;
+            }
+          </style>
+          <p class="ok">Ready</p>
+        </>
+      } @else {
+        <>
+          <style>
+            .wait {
+              color: gray;
+            }
+          </style>
+          <p class="wait">Waiting</p>
+        </>
+      }
+    </section>
+  </>
+}
+```
+
+With `A`, `B`, and `C` as the hash classes of the fragment and the two branches,
+the compiled classes are `status A`, `ok A B`, and `wait A C`, and the three
+sheets come out in that order. The same class name can mean different things in
+`@if` and `@else`.
+
 ## Global Styles
 
-By default, all styles in Ripple are scoped to the component. To apply global
-styles, use the `:global()` pseudo-class or `:global` block:
+By default, every rule is scoped. To reach outside the scope, use the
+`:global(...)` pseudo-class or a `:global` block. Where the `:global` sits decides
+how far the rule reaches:
 
 <Code>
 
@@ -110,7 +282,7 @@ export function App() @{
     </div>
 
     <style>
-      /* Scoped to Parent only */
+      /* Scoped to App only */
       .container {
         padding: 1rem;
       }
@@ -121,7 +293,7 @@ export function App() @{
         font-weight: bold;
       }
 
-      /* Global: - Recommended - scoped parent with global child selector */
+      /* Global - Recommended - scoped parent with global child selector */
       .container :global(.nested) {
         margin-left: 2rem;
       }
@@ -137,7 +309,6 @@ export function App() @{
 }
 
 function Child() {
-  // The div should have its font-size at 2rem from parent
   return <div>
     <h2 class="header">This is a header with font-size 3rem</h2>
     <span class="highlight">This will be red and bold</span>
@@ -147,6 +318,31 @@ function Child() {
 ```
 
 </Code>
+
+- **Bare** `:global(.toast)` becomes `.toast`: a page-wide rule that matches
+  anywhere, exactly like a rule in a global stylesheet.
+- **Prefixed** `.container :global(.nested)` becomes
+  `.container.tsrx-1a20093c .nested`: only elements below your scoped
+  container, a child component's internals included. It can never climb up.
+- **Leading** `:global(.theme-dark) .card` becomes `.theme-dark .card.tsrx-1a20093c`:
+  your own element, only when an ancestor carries the class.
+- **Compound** `.card:global(.is-open)` becomes `.card.tsrx-1a20093c.is-open`:
+  your own element, with a class another library toggles on it.
+- **Block** `:global { … }` drops the wrapper and leaves every rule inside it
+  unscoped. Nested under a scoped rule, `.post { :global { pre { … } } }`, it
+  reaches only below that rule, like the prefixed form with the prefix written
+  once.
+
+`:global(...)` may only start or end a selector. In the middle,
+`.card :global(.x) .title`, it is the `tsrx-css-global-placement` error.
+
+Reach for `:global` only when a prop cannot do the job. To style a child you own,
+pass it a class from a theme (see [Apply a theme](#apply-a-theme-to-a-scope) and
+[Passing scoped classes](#passing-scoped-classes-to-child-components)) instead:
+the dependency is a visible prop, and the child decides which of its elements
+take the class. Keep `:global` for a child you cannot change, always with a scoped
+selector in front, and put page-wide rules such as `body` resets in a `.css` file
+the page links.
 
 ### Global Keyframes
 
@@ -163,7 +359,7 @@ export function App() @{
     </div>
 
     <style>
-      /* Scoped keyframe - only usable within Parent */
+      /* Scoped keyframe - only usable within App */
       @keyframes slideIn {
         from {
           transform: translateX(-100%);
@@ -196,7 +392,7 @@ function Child() @{
 
     <style>
       .child {
-        animation: fadeIn 1s; /* Uses global fadeIn from Parent */
+        animation: fadeIn 1s; /* Uses global fadeIn from App */
       }
     </style>
   </>
@@ -205,17 +401,47 @@ function Child() @{
 
 </Code>
 
-## Passing Scoped Classes to Child Components (`<style>` Expressions)
+## Assign a block to get a class map
 
-Scoped styles only apply to DOM elements within the same component. If you want a
-parent to influence how a child component looks, assign a `<style>` expression to
-a variable and pass entries from that class map as props.
+Assign a `<style>` block to a variable and it becomes a plain object of class
+names instead of a scoped block. The object has `$class`, the block's hash class
+(after the classes of any theme it applies), plus one key per standalone class
+selector whose value is the hash class and the class name together:
 
-Each map entry contains both the CSS scope hash and the class name (for example
-`"ripple-abc123 highlight"`), which the child applies to its own elements via the
-`class` attribute.
+```tsrx
+export const theme = <style>
+  div {
+    color: green;
+  }
+  .dark {
+    color: purple;
+  }
+</style>;
+// theme.$class → 'tsrx-fe4e37b1'
+// theme.dark   → 'tsrx-fe4e37b1 dark'
 
-### Basic Usage
+export function Badge({ label }: { label: string }) {
+  return <span class={theme.dark}>{label}</span>;
+}
+```
+
+Pass these strings to child components as ordinary props; the hash class is
+already in them. The declaration can sit at module scope or anywhere a
+declaration is legal inside a component body. `$class` is reserved, so a block
+cannot declare a `.$class` selector, and a standalone `<style>` at module scope is
+an error: assign it to a variable.
+
+A block that is exported, applied, or whose `$class` is read anywhere in the
+module is a **theme** and keeps every selector, element and descendant selectors
+included. A local block used only through its class keys is a plain class map: it
+keeps only the selectors that are a single class, such as `.dark`, and every other
+selector is removed as unused and left as a `/* (unused) … */` comment in the
+compiled CSS.
+
+## Passing Scoped Classes to Child Components
+
+Scoped styles only apply to elements inside the same scope. If you want a parent
+to influence how a child component looks, pass entries from a class map as props.
 
 ```tsrx
 function Child({ class: className }: { class: string }) {
@@ -233,69 +459,18 @@ function Parent() @{
 }
 ```
 
-You can pass multiple classes:
-
-```tsrx
-function Child({ primary, secondary }: { primary: string; secondary: string }) @{
-  <>
-    <div class={primary}>primary</div>
-    <span class={secondary}>secondary</span>
-  </>
-}
-
-function Parent() @{
-  const styles = <style>
-    .primary {
-      color: blue;
-    }
-    .secondary {
-      color: gray;
-    }
-  </style>;
-
-  <Child primary={styles.primary} secondary={styles.secondary} />
-}
-```
-
-### With Dynamic Components
-
-Style expression maps also work when rendering dynamic components with the
-`<{expression}>` tag syntax:
-
-```tsrx
-import { track } from 'ripple';
-
-function Child({ cls }: { cls: string }) {
-  return <span class={cls}>text</span>
-}
-
-function Parent() @{
-  const styles = <style>
-    .text {
-      color: red;
-    }
-  </style>;
-
-  let &[Current] = track(() => Child);
-  <{Current} cls={styles.text} />
-}
-```
-
-### Combining Parent and Child Styles
-
-A child component can combine classes it receives from a parent with its own
-scoped classes:
+Style maps also work when rendering dynamic components with the `<{expression}>`
+tag syntax, and a child can combine a received class with its own scoped classes:
 
 ```tsrx
 function Card({ class: className }: { class?: string }) @{
   <>
-    <div class={['card-base', className ?? '']}>card content</div>
-
     <style>
       .card-base {
         border: 1px solid black;
       }
     </style>
+    <div class={['card-base', className ?? '']}>card content</div>
   </>
 }
 
@@ -310,49 +485,174 @@ function App() @{
 }
 ```
 
-### Standalone Requirement
+Classes exposed by a class map come from **standalone** selectors in the block.
+A class that only appears inside a compound, descendant, or combinator selector is
+not exported on the map, so `styles.nested` is undefined for a block whose only
+rule is `.wrapper .nested { … }`. To hand a child the block's element and
+descendant rules as well, pass `styles.$class` instead (see
+[Opt single elements in](#opt-single-elements-in-with-class)).
 
-Classes exposed by a style expression map come from **standalone** selectors in
-the `<style>` block. Classes that only appear inside compound, descendant, or
-combinator selectors are not exported on the map.
+## Apply a theme to a scope
 
-If a class appears both standalone and in a descendant selector, it can still be
-used through the style expression map:
+`<style apply={theme} />` adds the theme's `$class` to the items beside it and
+everything below them, the same elements a block's own rules reach, so the
+theme's element and descendant rules match those elements as if the theme had
+been written there. A self-closing apply adds no hash class of its own. A block
+with CSS in it, `<style apply={theme}>…</style>`, applies the theme and declares
+the scope's own block in one tag:
 
 ```tsrx
-function App() @{
-  const styles = <style>
-    /* Standalone rule — exposes styles.dual */
-    .dual {
-      color: blue;
-    }
+// theme.tsrx
+const base = <style>
+  div {
+    font-family: system-ui;
+  }
+</style>;
 
-    /* Also applies when .dual is inside .parent */
-    .parent .dual {
-      font-weight: bold;
-    }
-  </style>;
+export const theme = <style apply={base}>
+  div {
+    color: green;
+  }
+  .dark {
+    color: purple;
+  }
+</style>;
+// theme.$class → base's hash, then theme's own hash
+```
 
-  <div class="parent">
-    <Child cls={styles.dual} />
-  </div>
+```tsrx
+// Panel.tsrx
+import { theme } from './theme.tsrx';
+
+export function Panel() @{
+  <>
+    <style apply={theme}>
+      div {
+        color: black;
+      }
+    </style>
+    <span class={theme.dark}>Purple</span>
+    <div>Black: the local rule beats the theme's green</div>
+  </>
+}
+
+export function Card() @{
+  <>
+    <style apply={theme} />
+    <article>
+      <h2>Green, system-ui</h2>
+    </article>
+  </>
 }
 ```
 
-The following will **not** work because the class has no standalone rule:
+- `apply={[a, b]}` applies several themes, and a theme can apply another theme:
+  its `$class` then lists the applied classes first and its own hash class last.
+- `export const bundle = <style apply={[a, b]} />;` composes themes with no CSS
+  of its own; `bundle.$class` is the two themes' classes.
+- The `apply` value must be an identifier, a member expression, or an array of
+  those, naming a style block declared earlier in the same module or imported.
+- A theme declared in the same module becomes a string literal in the class
+  attribute, so the element's static HTML is still built once, up front. An
+  imported theme is read at runtime through `theme.$class`, so that element's
+  class is set when it renders.
+
+An element's final class list is: its own classes, then the hash class of each
+enclosing scope outer to inner, then the applied theme classes.
+
+### Opt single elements in with `$class`
+
+`apply` covers a whole scope. When only some elements should pick up a theme,
+give those elements `class={theme.$class}` and leave `apply` out: the theme's
+element and descendant rules match exactly the elements that carry the class,
+and their siblings stay untouched. Because `$class` is a plain string, a child
+component can receive it through a prop and put it on its own elements; the
+passed class lands before the child's own hash class.
 
 ```tsrx
-// ❌ .nested only exists in a descendant selector
-function App() @{
-  const styles = <style>
-    .wrapper .nested {
+function Card({ parentClass }: { parentClass: string }) @{
+  <>
+    <style>
+      .local {
+        padding: 0;
+      }
+    </style>
+    <article class={['local', parentClass]}>
+      <h2 class={parentClass}>Blue, from the parent's theme</h2>
+    </article>
+  </>
+}
+
+export function App() @{
+  const theme = <style>
+    div,
+    h2 {
+      color: blue;
+    }
+    .card {
       color: red;
     }
   </style>;
-
-  <Child cls={styles.nested} />
+  <>
+    <Card parentClass={theme.$class} />
+    <div class={theme.$class}>Blue: opted in</div>
+    <div class={theme.card}>Red: a class entry carries the hash too</div>
+    <p>Untouched</p>
+  </>
 }
 ```
 
-The map is available wherever the variable is in scope, so declare it before the
-returned template when you need to pass classes into child components.
+Reading `theme.$class` is what makes `theme` a theme: the `div, h2` rule survives
+even though nothing exports or applies the block. Opt one element into several
+themes with `class={[a.$class, b.$class]}`.
+
+## Which rule wins
+
+Every hash is a single class, so a scoped rule has the specificity of its selector
+plus one class, and at equal specificity the rule that comes later in the CSS
+wins. The CSS comes out in source order, outer scope first: a scope's sheet goes
+where its first block is, after the assigned blocks declared before it, and before
+the scopes and assigned blocks nested inside it. Sibling scopes follow source
+order. An applied theme's sheet always comes before the block that applies it,
+because you can only apply a block you already declared or imported, so a local
+rule wins over the theme's rule at equal specificity. That is why the `div` in
+`Panel` above is black, not the theme's green.
+
+## Where the CSS goes at runtime
+
+- **On the client**, the Vite plugin turns each `.tsrx` file's CSS into one
+  virtual CSS module, imported by the compiled module after its own imports. An
+  imported theme's stylesheet is therefore in the document before the stylesheet
+  of the file that applies it. Inside one file the sheets are in the order above.
+- **On the server**, a render collects the hashes of the scopes it rendered and
+  returns them as the `css` set of the result, in the same order: an applied
+  theme's hash before the scope that applies it, whichever module the theme
+  lives in. A class map registers its sheet when one of its entries is read, so a
+  theme that nothing renders sends no CSS. `getCss(css)` turns the set into CSS
+  text for a `<style data-ripple-ssr>` tag; see
+  [Server-side rendering](/docs/guide/application#server-side-rendering).
+
+A `<style>` rendered inside `<head>` is a plain document stylesheet: it is not
+scoped and adds no class to any element.
+
+## Diagnostics
+
+Style errors stop the compile and carry one of these codes:
+
+- `tsrx-style-standalone-needs-fragment`: a `<style>` as the lone output of a
+  `@{ … }` body or a control-flow branch. Wrap it with the output it styles in a
+  fragment.
+- `tsrx-style-standalone-outside-template`: raw CSS in a `<style>` outside every
+  `@{ … }` or control-flow body, such as a plain function returning JSX. Use a
+  `@{ … }` body, write `<style>{css}</style>`, or assign the block.
+- `tsrx-style-standalone-at-module-scope`: a bare `<style>` statement at module
+  scope. Assign it to a variable.
+- `tsrx-style-apply-value`, `tsrx-style-apply-target`,
+  `tsrx-style-apply-before-declaration`, `tsrx-style-apply-duplicate`,
+  `tsrx-style-apply-unsupported-host`: `apply` needs one expression value naming
+  style blocks declared before it, and cannot sit on a `<head>` style.
+- `tsrx-style-reserved-class-key`: an assigned block declares a `.$class`
+  selector.
+- `tsrx-style-unknown-attribute`: an attribute other than `ref` and `apply` on a
+  scoped block.
+- `tsrx-css-global-placement`: `:global(...)` in the middle of a selector.

--- a/website/docs/guide/syntax.md
+++ b/website/docs/guide/syntax.md
@@ -33,7 +33,9 @@ element directly. When a template scope mixes TypeScript setup and rendered
 output, wrap the scope in `@{...}`. Setup comes first and the container must
 finish with exactly one output node: a JSX element, a JSX fragment, or JSX
 control flow such as `@if`, `@for`, `@switch`, or `@try`. CSS text inside
-`<style>` blocks keeps CSS rules, not template rules.
+`<style>` blocks keeps CSS rules, not template rules, and a block styles the
+elements beside it, so it sits next to them in a fragment or element (see
+[Styling](/docs/guide/styling)).
 
 ```tsrx
 export function MyComponent({ name }: { name: string | null }) @{

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -404,7 +404,17 @@ export function Card() @{
   another library toggles. `:global { ... }` does the same for every rule inside
   it. `:global` may only start or end a selector. Prefer passing a class from a
   theme to a child you own; keep `:global` for children you cannot change, with
-  a scoped selector in front.
+  a scoped selector in front:
+
+  | I want to ...                                              | Use ...                                                                                  |
+  | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+  | Style my own elements                                      | A `<style>` block beside them; nothing global                                            |
+  | Share a look across my own components                      | A theme and `<style apply={theme} />` in each                                            |
+  | Let a child component pick up my styles                    | Pass `theme.$class` or `theme.card` as a prop                                            |
+  | Style a child I cannot change (third-party, rendered HTML) | `.wrapper :global(.their-class)`, or `.wrapper { :global { ... } }`; scoped prefix first |
+  | React to page-level state                                  | `:global(.theme-dark) .card` or `:global([data-theme='dark']) .card`                     |
+  | Style my element with a class another library toggles     | `.card:global(.is-open)`                                                                 |
+  | Page-wide rules (`body`, resets, fonts)                    | A `.css` file the page links, not a bare `:global`                                       |
 - CSS comes out in source order, outer scope first: a scope's blocks stay one
   group, nested scopes follow their parent, sibling scopes follow source order,
   an assigned block sits at its declaration, and an applied theme comes before

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -355,8 +355,11 @@ names. Do not use removed dynamic tag syntax such as `<@tag />`,
 
 ## Styles
 
-`<style>` blocks are static CSS scoped to the current template. Use CSS custom
-properties for runtime values.
+A `<style>` block is static CSS scoped to its siblings: it styles the items
+written beside it and everything below them, never the element that contains
+it. The compiler adds a hash class to every selector in the block and to every
+element the block reaches, so rules do not leak into parents, outer siblings,
+child components, or the page. Use CSS custom properties for runtime values.
 
 ```tsrx
 import { track } from 'ripple';
@@ -365,33 +368,115 @@ export function Card() @{
 	let &[tone] = track('rebeccapurple');
 
 	<>
-		<section class="card" style={{ '--tone': tone }}>
-			<h2>Card</h2>
-		</section>
 		<style>
 			.card {
 				border: 1px solid var(--tone);
 				padding: 1rem;
 			}
 		</style>
+		<section class="card" style={{ '--tone': tone }}>
+			<h2>Card</h2>
+		</section>
 	</>
 }
 ```
 
-Use `:global(...)` to opt out of scoping. Module-scope style expressions expose
-scoped class names that can be passed as props.
+- A block lives in the children list of an element or fragment, beside the
+  output it styles. A `@{ ... }` body or an `@if`/`@for`/`@switch`/`@try` branch
+  renders one output node and a block counts as one, so wrap the block and its
+  markup in a fragment: `<><style>...</style><div /></>`.
+- Raw CSS in `<style>` is TSRX syntax: it needs a `@{ ... }` body or a branch
+  around it. In a plain function that returns JSX, write `<style>{css}</style>`,
+  an ordinary element the compiler leaves alone.
+- Blocks among the same children share one hash class and one stylesheet. A
+  nested element or fragment whose children hold a block is a nested scope with
+  its own hash; elements carry the hash of every scope around them, outer first.
+  Outer rules reach nested scopes; inner rules never reach out.
+- A block inside an `@if`/`@for` branch styles only the elements that branch
+  renders, but its CSS always ships, because CSS is static.
+- A selector that matches nothing the block can reach, including a selector
+  that only matches the containing element, is removed as unused and left as a
+  `/* (unused) ... */` comment.
+- A scoped block accepts only the `ref` and `apply` attributes.
+- Use `:global(...)` to reach outside the scope: `:global(.x)` is page-wide,
+  `.card :global(.x)` reaches only below your scoped `.card`, `:global(.dark)
+  .card` reacts to an ancestor's class, `.card:global(.is-open)` matches a class
+  another library toggles. `:global { ... }` does the same for every rule inside
+  it. `:global` may only start or end a selector. Prefer passing a class from a
+  theme to a child you own; keep `:global` for children you cannot change, with
+  a scoped selector in front.
+- CSS comes out in source order, outer scope first: a scope's blocks stay one
+  group, nested scopes follow their parent, sibling scopes follow source order,
+  an assigned block sits at its declaration, and an applied theme comes before
+  the block that applies it. At equal specificity the later rule wins.
+
+Assigning a `<style>` block to a variable produces a **class map** instead of a
+scoped block: `$class` is the block's hash class (after the classes of any theme
+it applies) and every standalone class selector becomes a key whose value is
+the hash class plus the class name. The declaration can sit at module scope or
+inside a component body. Pass these strings to child components as props.
 
 ```tsrx
-const styles = <style>
-	.highlight {
-		background: #e8f5e9;
+export const theme = <style>
+	div {
+		color: green;
+	}
+	.dark {
+		color: purple;
 	}
 </style>;
+// theme.$class -> 'tsrx-1a2b3c4d'
+// theme.dark -> 'tsrx-1a2b3c4d dark'
 
 export function Badge() {
-	return <span class={styles.highlight}>New</span>;
+	return <span class={theme.dark}>New</span>;
 }
 ```
+
+- A block that is exported, applied, or whose `$class` is read is a **theme**
+  and keeps every selector, element and descendant selectors included. A block
+  only read through its class keys keeps only its standalone class selectors.
+- `$class` is reserved; a standalone `<style>` at module scope is an error.
+
+`<style apply={theme} />` adds the theme's `$class` to every element of the
+scope it sits in, so the theme's element and descendant rules reach them as if
+the theme had been written there. `<style apply={theme}>...</style>` applies the
+theme and declares the scope's own block in one tag.
+
+```tsrx
+import { theme } from './theme.tsrx';
+
+export function Panel() @{
+	<>
+		<style apply={theme}>
+			div {
+				color: black;
+			}
+		</style>
+		<span class={theme.dark}>Purple</span>
+		<div>Black: the local rule beats the theme's green</div>
+	</>
+}
+```
+
+- `apply={[a, b]}` applies several themes; `const accent = <style apply={base}>`
+  composes at the definition, and `accent.$class` lists `base`'s classes first;
+  `export const bundle = <style apply={[a, b]} />;` bundles themes with no CSS
+  of its own.
+- The target must be an identifier, member expression, or array of those,
+  naming a block declared earlier in the module or imported. A same-module theme
+  becomes a string literal in the class attribute; an imported theme is read at
+  runtime through `theme.$class`.
+- To opt single elements in instead of a whole scope, give them
+  `class={theme.$class}`; a child component can receive `theme.$class` through a
+  prop and put it on its own elements.
+- An element's class list is: its own classes, the hash classes of the scopes
+  around it outer to inner, then the applied themes' classes.
+- On the client the Vite plugin emits one virtual CSS module per `.tsrx` file,
+  imported after the module's own imports. On the server, `render` returns the
+  hashes of the scopes it rendered as `css` (an applied theme before the scope
+  that applies it); a class map registers its sheet when one of its entries is
+  read. Style errors are compile errors with `tsrx-style-*` codes.
 
 ## Context
 
@@ -581,6 +666,9 @@ Do:
 - Use JSX text for literal children.
 - Use `@for` for rendered lists and `@if` for conditional rendering.
 - Use Ripple collections for reactive collection state.
+- Put a `<style>` block beside the elements it styles, inside a fragment or
+  element; assign a block to a variable to share it as a theme (`apply`,
+  `$class`) or class map.
 
 Do not:
 
@@ -588,6 +676,8 @@ Do not:
 - Use raw `if`, `for`, `switch`, or `try` as rendered control flow.
 - Treat plain text inside a template as JavaScript; it is JSX text.
 - Put JavaScript expressions inside `<style>` blocks.
+- Expect a `<style>` block to style the element that contains it, or write raw
+  CSS in a `<style>` inside a plain function that returns JSX.
 - Invent imports or runtime APIs outside the `ripple` package or the active
   bundler integration.
 


### PR DESCRIPTION
Implements [TSRX RFC #1](https://github.com/tsrx-org/RFCs/discussions/1) (sibling-scoped `<style>` blocks, `$class`, and `apply`) for the Ripple target, on top of `@tsrx/core` 0.1.66. Closes tsrx-org/tsrx#50.

## Compiler (`@tsrx/ripple`)

- New `src/style-scopes.js` pre-pass, run at the end of the Ripple analyzer: discovers scopes (a children list of an element or fragment that holds blocks, including control-flow branch fragments and templates assigned to variables), prunes each scope's sheets against the list's other items only, emits CSS in lexical order, stamps every host element with its scope chain (`metadata.tsrx_scope_class`: enclosing hashes outer first, then applied theme classes), resolves `apply` targets (same-module themes inline as literals, imports become `theme.$class` reads), and prepares assigned blocks in the render mode the core analyzer classified (theme vs class map).
- Client and server transforms read the stamped chain instead of the old per-component `component_css` / `applyParentCssScope` model. Static chains land in the template HTML; chains with runtime reads are set at render time (`set_class` / `attr`), including for spreads and dynamic `<{tag}>` elements.
- Server: each component registers the sheets its scopes need before rendering (applied themes first), class-map getters register the block's own sheet and, for `$class`, the applied ones; sheets that share a scope hash register as one; reading `theme.$class` outside a render is a no-op instead of a crash.
- Assigned blocks expose `$class`; a body-less `<style apply={…} />` bundle is a `$class`-only map.
- Type-only output keeps `$class` on class maps and rewrites `apply` on template stand-ins to `data-tsrx-apply={theme.$class}` so TypeScript checks the target.
- Fixed a pre-existing bug found along the way: a `@{ … }` block rendered as the child of a DOM element was dropped on the client (`<p>@{ <b/> }</p>` rendered `<p></p>`).

## Runtime (`ripple`)

- `#class` spread attribute accepts several tokens (nested scopes).
- `output_register_css` tolerates being called outside a render.

## Behavior changes

- Raw CSS in a `<style>` inside a plain `return <div />` function is now the core analyzer's `tsrx-style-standalone-outside-template` error; use `@{ … }` or `<style>{css}</style>`.
- Every element of a scope carries the hash class (not only elements a selector matched), placed after the authored classes.
- A block nested inside an element styles that element's children, not the element.

## Tests

- `packages/tsrx-ripple/tests/scoped-styles.test.js` runs the shared conformance fixtures from `@tsrx/core/test-harness/scoped-styles-fixtures` in client and server mode (css order, `cssHash`, element chains, `$class` composition, pruning).
- `style-diagnostics.test.js` pins the `tsrx-style-*` codes and the type-only output; `jsx-runtime-types.test.js` checks `$class` types.
- Runtime suites: `packages/ripple/tests/client/css/scoped-styles.test.tsrx` and `packages/ripple/tests/server/scoped-styles.test.tsrx` (sibling scopes, multi-block hashes, nested scopes, branches, element-rooted templates, spreads, dynamic classes, apply forms, composition, imported themes, `$class` opt-in, SSR CSS registration order).
- Existing tests updated for the new placement rule and stamping order.

## Docs

- `website/docs/guide/styling.md` rewritten around the RFC; `syntax.md`, `best-practices.md`, `README.md`, `website/public/llms.txt`, and the RuleSync rule (regenerated) updated.
- New playground example "Scoped Styles & Themes" (single-file version of Octane's example) in `website/docs/examples.ts`.
- `website-new` components migrated from `return <>…<style>` to `@{ … }` bodies so they compile under the new rule (no other `website-new` work).

## Dependencies

- `@tsrx/*` catalog entries bumped to the versions that ship the RFC (`@tsrx/core` 0.1.66, tooling 0.3.132).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large change to compile-time styling, class stamping, and SSR CSS registration across client and server; incorrect scope or apply ordering could cause hydration mismatches or missing/wrong styles.
> 
> **Overview**
> Implements **TSRX RFC #1** for Ripple: `<style>` blocks scope to **siblings** (not the parent), with **`$class`**, **`<style apply={theme} />`**, nested scopes, and lexical CSS emission. The old per-component `component_css` / single-hash model is replaced by a **`style-scopes.js` analyzer pre-pass** that prunes rules, stamps hosts with outer→inner scope hashes plus applied themes, and drives client/server codegen.
> 
> **Compiler/runtime:** Transforms merge scope classes into `class` or `#class` (including spreads and dynamic tags); SSR registers sheets in apply-then-scope order and tolerates `theme.$class` outside a render. **Fixes:** `@{ … }` as a DOM child no longer drops on the client; `#class` accepts multiple tokens.
> 
> **Breaking-ish behavior:** Raw `<style>` in a plain `return` JSX function errors (`tsrx-style-standalone-outside-template`); every element in a scope gets the hash class after authored classes. Docs, agent rules, examples, and broad client/server/conformance tests cover the new semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c128953ce50512bc5b97740f82be71847e475d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->