### PR TITLE
fix(website): keep the playground snippets compilable in LiveCodes

### DIFF
--- a/website/.vitepress/components/LiveCodes.vue
+++ b/website/.vitepress/components/LiveCodes.vue
@@ -243,10 +243,10 @@ const getRippleRuntimeImports = async (
 const defaultContent = `
 import { track } from 'ripple';
 
-export default function Counter() {
+export default function Counter() @{
   let &[count] = track(0);
   let &[double] = track(() => count * 2);
-  return <>
+  <>
     <div class="container">
       <h2>"Counter"</h2>
       <p>"Count: "{count}</p>
@@ -279,7 +279,7 @@ export default function Counter() {
         background-color: #e0e0e0;
       }
     </style>
-  </>;
+  </>
 }
 `.trimStart();
 

--- a/website/docs/examples.ts
+++ b/website/docs/examples.ts
@@ -77,7 +77,7 @@ function DynamicClasses() @{
 		title: 'Scoped Styles & Themes',
 		code: `import { track } from 'ripple';
 
-// A <style> block styles the elements beside it and everything below them,
+// A style block styles the elements beside it and everything below them,
 // never the element that contains it. Assigned to a variable it becomes a
 // theme: an object with $class (its hash class) plus one key per class
 // selector. Exported, applied, or $class-read blocks keep every selector.


### PR DESCRIPTION
Two playground failures after #1441 shipped, both caused by how LiveCodes hands code to the compiler rather than by the compiler itself (the snippets compile with `@tsrx/ripple@0.1.63` locally and through the esm.sh bundle when called directly).

- **"Scoped Styles & Themes" example: `SyntaxError: Unexpected token (4:6)`.** LiveCodes' `compileBlocks` scans the raw text with a `<style …>…</style>` regular expression before compiling, so the literal `<style>` in the example's first comment line opened a bogus block that ran to the first real `</style>`. The comment now says "style block".
- **Default Counter snippet: `tsrx-style-standalone-outside-template`.** It used `return <>…<style>…</style></>` in a plain function, which the shared analyzer now rejects. It is a `@{ … }` body now.

Still broken, upstream: the same LiveCodes pass re-emits matched blocks with `blocks.pop()`, i.e. in reversed order, so any file with two or more `<style>` blocks gets its CSS swapped between blocks. On the live playground the "Styling" example already renders both rules as `/* (unused) */` (black text instead of blue). That is `src/livecodes/compiler/compile-blocks.ts` on LiveCodes' `ripple` branch and needs `blocks.shift()` (or a parser-aware scan); with sibling-scoped blocks this will show up more often.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and default playground strings only; no production runtime or compiler code paths in this diff.
> 
> **Overview**
> Fixes two LiveCodes playground compile failures introduced after stricter Ripple analysis and LiveCodes’ block pre-scan, without changing the compiler.
> 
> The **default Counter** snippet in `LiveCodes.vue` now uses a **`@{ … }` template body** instead of `return <>…</>`, so the inline `<style>` block lives in a valid template context and no longer triggers **`tsrx-style-standalone-outside-template`**.
> 
> In **`examples.ts`**, the **Scoped Styles & Themes** intro comment no longer contains the literal substring **`<style>`** (it says “style block” instead), so LiveCodes’ **`compileBlocks`** regex does not treat the comment as an opening tag and blow up with **`SyntaxError: Unexpected token`**.
> 
> These are string-only edits to embedded demo code; behavior on the site is “snippets compile again in the iframe playground.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 996dfab8fb4398fed7308d87b194dd9310dcc447. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->