### PR TITLE
fix: preserve lazy destructuring in loops and nested declarations

### DIFF
--- a/.changeset/tidy-lazy-loops.md
+++ b/.changeset/tidy-lazy-loops.md
@@ -1,0 +1,6 @@
+---
+'@tsrx/ripple': patch
+---
+
+Fix lazy destructuring in bare JavaScript loop targets and nested declaration
+patterns in client and server output, with corresponding TypeScript editor output.

--- a/packages/tsrx-ripple/src/analyze/index.js
+++ b/packages/tsrx-ripple/src/analyze/index.js
@@ -65,6 +65,7 @@ import {
 	get_directive_value_wrapper,
 	analyze_directive_wrapping_values,
 	is_tsrx_component_function,
+	has_lazy_pattern,
 } from '../utils.js';
 import {
 	get_attribute_name_node,
@@ -1079,12 +1080,20 @@ function is_param_tracked_type(type_annotation, context) {
 }
 
 /**
- * Sets up lazy transforms for any lazy subpatterns nested inside a function or component param.
+ * Sets up lazy transforms for declarations and function or component parameters.
  * @param {AST.Pattern} pattern
  * @param {AnalysisContext} context
  * @param {AST.TypeNode | undefined} [type_annotation]
+ * @param {boolean} [writable]
+ * @param {boolean} [is_track_call]
  */
-function setup_nested_lazy_param_transforms(pattern, context, type_annotation = undefined) {
+function setup_lazy_pattern_transforms(
+	pattern,
+	context,
+	type_annotation = undefined,
+	writable = true,
+	is_track_call = false,
+) {
 	const pattern_type_annotation = get_pattern_type_annotation(pattern) ?? type_annotation;
 
 	switch (pattern.type) {
@@ -1102,11 +1111,11 @@ function setup_nested_lazy_param_transforms(pattern, context, type_annotation = 
 		}
 
 		case 'AssignmentPattern':
-			setup_nested_lazy_param_transforms(pattern.left, context, pattern_type_annotation);
+			setup_lazy_pattern_transforms(pattern.left, context, pattern_type_annotation, writable);
 			return;
 
 		case 'RestElement':
-			setup_nested_lazy_param_transforms(pattern.argument, context, pattern_type_annotation);
+			setup_lazy_pattern_transforms(pattern.argument, context, pattern_type_annotation, writable);
 			return;
 
 		case 'ObjectPattern':
@@ -1117,7 +1126,13 @@ function setup_nested_lazy_param_transforms(pattern, context, type_annotation = 
 					pattern.type === 'ArrayPattern' &&
 					is_param_tracked_type(pattern_type_annotation, context);
 
-				setup_lazy_transforms(pattern, param_id, context.state, true, is_tracked_type);
+				setup_lazy_transforms(
+					pattern,
+					param_id,
+					context.state,
+					writable,
+					is_track_call || is_tracked_type,
+				);
 				pattern.metadata = { ...pattern.metadata, lazy_id: param_id.name };
 				return;
 			}
@@ -1129,20 +1144,26 @@ function setup_nested_lazy_param_transforms(pattern, context, type_annotation = 
 						property,
 					);
 					if (property.type === 'RestElement') {
-						setup_nested_lazy_param_transforms(
+						setup_lazy_pattern_transforms(
 							property.argument,
 							context,
 							property_type_annotation,
+							writable,
 						);
 					} else {
-						setup_nested_lazy_param_transforms(property.value, context, property_type_annotation);
+						setup_lazy_pattern_transforms(
+							property.value,
+							context,
+							property_type_annotation,
+							writable,
+						);
 					}
 				}
 			} else {
 				for (let i = 0; i < pattern.elements.length; i += 1) {
 					const element = pattern.elements[i];
 					if (element !== null) {
-						setup_nested_lazy_param_transforms(
+						setup_lazy_pattern_transforms(
 							element,
 							context,
 							get_array_element_type_annotation(
@@ -1150,6 +1171,7 @@ function setup_nested_lazy_param_transforms(pattern, context, type_annotation = 
 								i,
 								element.type === 'RestElement',
 							),
+							writable,
 						);
 					}
 				}
@@ -1182,7 +1204,7 @@ function visit_function(node, context) {
 				if (props.lazy) {
 					setup_lazy_transforms(props, b.id('__props'), context.state, true, false);
 				} else {
-					setup_nested_lazy_param_transforms(props, context, get_pattern_type_annotation(props));
+					setup_lazy_pattern_transforms(props, context, get_pattern_type_annotation(props));
 				}
 			} else if (props.type === 'AssignmentPattern') {
 				error(
@@ -1227,7 +1249,7 @@ function visit_function(node, context) {
 			get_pattern_type_annotation(param) ?? param_node.typeAnnotation?.typeAnnotation;
 
 		if (param.type === 'ObjectPattern' || param.type === 'ArrayPattern') {
-			setup_nested_lazy_param_transforms(param, context, param_type_annotation);
+			setup_lazy_pattern_transforms(param, context, param_type_annotation);
 		}
 	}
 
@@ -1796,21 +1818,16 @@ const visitors = {
 				}
 				visit(declarator, state);
 			} else {
-				// Handle lazy destructuring patterns
-				if (
-					(declarator.id.type === 'ObjectPattern' || declarator.id.type === 'ArrayPattern') &&
-					declarator.id.lazy
-				) {
-					const lazy_id = b.id(state.scope.generate('lazy'));
-					const writable = node.kind !== 'const';
-					const call_name =
-						declarator.init?.type === 'CallExpression' &&
-						is_ripple_track_call(declarator.init.callee, context);
-					const init_is_track = call_name === 'track' || call_name === 'trackAsync';
-					setup_lazy_transforms(declarator.id, lazy_id, state, writable, !!init_is_track);
-					// Store the generated identifier name on the pattern for the transform phase
-					declarator.id.metadata = { ...declarator.id.metadata, lazy_id: lazy_id.name };
-				}
+				const call_name =
+					declarator.init?.type === 'CallExpression' &&
+					is_ripple_track_call(declarator.init.callee, context);
+				setup_lazy_pattern_transforms(
+					declarator.id,
+					context,
+					undefined,
+					node.kind !== 'const',
+					call_name === 'track' || call_name === 'trackAsync',
+				);
 
 				visit(declarator, state);
 			}
@@ -2720,6 +2737,26 @@ export function analyze(ast, filename, options = {}) {
 	const errors = options.errors ?? [];
 	const comments = options.comments ?? [];
 	const collect = !!(options.collect || options.loose);
+
+	// Bare lazy loop targets introduce per-iteration bindings. Give them a
+	// declaration before scope creation so references and shadowing are analyzed
+	// exactly like the explicit declaration form.
+	/** @type {Visitor<AST.ForOfStatement | AST.ForInStatement, null, AST.Node>} */
+	const normalize_loop = (node, context) => {
+		if (node.left.type === 'VariableDeclaration' || !has_lazy_pattern(node.left)) {
+			return context.next();
+		}
+		return context.visit({
+			...node,
+			left: b.declaration('const', [b.declarator(/** @type {AST.Pattern} */ (node.left))]),
+		});
+	};
+	ast = /** @type {AST.Program} */ (
+		walk(ast, null, {
+			ForOfStatement: normalize_loop,
+			ForInStatement: normalize_loop,
+		})
+	);
 
 	const { scope, scopes } = createScopes(ast, scope_root, null, {
 		collect,

--- a/packages/tsrx-ripple/src/transform/client/index.js
+++ b/packages/tsrx-ripple/src/transform/client/index.js
@@ -83,7 +83,8 @@ import {
 	flatten_switch_consequent,
 	get_ripple_namespace_call_name,
 	is_ripple_import,
-	replace_lazy_param_pattern,
+	replace_lazy_pattern,
+	has_lazy_pattern,
 	ripple_import_requires_block,
 	strip_class_typescript_syntax,
 	strip_typescript_expression_wrappers,
@@ -528,7 +529,7 @@ function visit_function(node, context) {
 		}
 		const pattern = param_out.type === 'AssignmentPattern' ? param_out.left : param_out;
 		if (pattern.type === 'ObjectPattern' || pattern.type === 'ArrayPattern') {
-			const transformed_pattern = replace_lazy_param_pattern(pattern);
+			const transformed_pattern = replace_lazy_pattern(pattern);
 			if (param_out.type === 'AssignmentPattern') {
 				return /** @type {AST.AssignmentPattern} */ ({ ...param_out, left: transformed_pattern });
 			}
@@ -661,7 +662,7 @@ function transform_native_tsrx_function(node, context) {
 				: props_param;
 		} else if (props_param.type === 'ObjectPattern' || props_param.type === 'ArrayPattern') {
 			if (!props_param.lazy) {
-				props = replace_lazy_param_pattern(
+				props = replace_lazy_pattern(
 					/** @type {AST.Pattern} */ (
 						props_param.typeAnnotation ? { ...props_param, typeAnnotation: undefined } : props_param
 					),
@@ -2171,14 +2172,8 @@ const visitors = {
 			let id = declarator.id;
 
 			if (!context.state.to_ts) {
-				// Replace lazy destructuring patterns with the generated identifier
-				if (
-					(id.type === 'ObjectPattern' || id.type === 'ArrayPattern') &&
-					id.lazy &&
-					id.metadata?.lazy_id
-				) {
-					id = b.id(id.metadata.lazy_id);
-				} else if (id.typeAnnotation) {
+				id = replace_lazy_pattern(id);
+				if (id.typeAnnotation) {
 					id = { ...id, typeAnnotation: undefined };
 				}
 			} else if ((id.type === 'ObjectPattern' || id.type === 'ArrayPattern') && id.lazy) {
@@ -3351,6 +3346,37 @@ const visitors = {
 		}
 
 		context.next();
+	},
+
+	ForInStatement(node, context) {
+		if (
+			!context.state.to_ts ||
+			node.left.type !== 'VariableDeclaration' ||
+			!node.left.declarations.some((declarator) => has_lazy_pattern(declarator.id))
+		) {
+			return context.next();
+		}
+
+		// TypeScript disallows destructuring in a for-in header. Keep the
+		// authored pattern in the body so its bindings still infer from the key.
+		const key = b.id(context.state.scope.generate('key'));
+		const declaration = /** @type {AST.VariableDeclaration} */ (context.visit(node.left));
+		const body = /** @type {AST.Statement} */ (context.visit(node.body));
+		return {
+			...node,
+			left: b.declaration('const', [b.declarator(key)]),
+			right: /** @type {AST.Expression} */ (context.visit(node.right)),
+			body: b.block([
+				{
+					...declaration,
+					declarations: declaration.declarations.map((declarator) => ({
+						...declarator,
+						init: key,
+					})),
+				},
+				body,
+			]),
+		};
 	},
 
 	ForOfStatement: visit_for_of_statement,

--- a/packages/tsrx-ripple/src/transform/server/index.js
+++ b/packages/tsrx-ripple/src/transform/server/index.js
@@ -48,7 +48,7 @@ import {
 	is_binding_function,
 	is_ripple_track_call,
 	is_ripple_import,
-	replace_lazy_param_pattern,
+	replace_lazy_pattern,
 	create_native_tsrx_render_function,
 	get_native_tsrx_function_body,
 	is_native_tsrx_function_node,
@@ -997,13 +997,8 @@ function transform_variable_declaration(node, context) {
 	for (const declarator of node.declarations) {
 		let declarator_id = declarator.id;
 		if (!context.state.to_ts) {
-			if (
-				(declarator_id.type === 'ObjectPattern' || declarator_id.type === 'ArrayPattern') &&
-				declarator_id.lazy &&
-				declarator_id.metadata?.lazy_id
-			) {
-				declarator_id = b.id(declarator_id.metadata.lazy_id);
-			} else if (declarator_id.typeAnnotation) {
+			declarator_id = replace_lazy_pattern(declarator_id);
+			if (declarator_id.typeAnnotation) {
 				declarator_id = { ...declarator_id, typeAnnotation: undefined };
 			}
 		}
@@ -1259,7 +1254,7 @@ function transform_native_tsrx_function(node, context) {
 			if (props_param.lazy) {
 				props_param_output = b.id('__props');
 			} else {
-				props_param_output = replace_lazy_param_pattern(
+				props_param_output = replace_lazy_pattern(
 					props_param.typeAnnotation ? { ...props_param, typeAnnotation: undefined } : props_param,
 				);
 			}
@@ -1357,7 +1352,7 @@ function strip_function_params(params) {
 		// Replace lazy destructuring params with generated identifiers
 		const pattern = stripped.type === 'AssignmentPattern' ? stripped.left : stripped;
 		if (pattern.type === 'ObjectPattern' || pattern.type === 'ArrayPattern') {
-			const transformed_pattern = replace_lazy_param_pattern(pattern);
+			const transformed_pattern = replace_lazy_pattern(pattern);
 			return stripped.type === 'AssignmentPattern'
 				? /** @type {AST.AssignmentPattern} */ ({ ...stripped, left: transformed_pattern })
 				: transformed_pattern;

--- a/packages/tsrx-ripple/src/utils.js
+++ b/packages/tsrx-ripple/src/utils.js
@@ -2411,16 +2411,43 @@ function normalize_child(node, normalized, context) {
 }
 
 /**
- * Replaces any lazy subpatterns in a parameter pattern with their generated identifiers.
+ * @param {AST.Pattern | AST.MemberExpression} pattern
+ * @returns {boolean}
+ */
+export function has_lazy_pattern(pattern) {
+	switch (pattern.type) {
+		case 'ObjectPattern':
+			return (
+				!!pattern.lazy ||
+				pattern.properties.some((property) =>
+					has_lazy_pattern(property.type === 'RestElement' ? property.argument : property.value),
+				)
+			);
+		case 'ArrayPattern':
+			return (
+				!!pattern.lazy ||
+				pattern.elements.some((element) => element !== null && has_lazy_pattern(element))
+			);
+		case 'AssignmentPattern':
+			return has_lazy_pattern(pattern.left);
+		case 'RestElement':
+			return has_lazy_pattern(pattern.argument);
+		default:
+			return false;
+	}
+}
+
+/**
+ * Replaces lazy subpatterns in declarations and parameters with their generated identifiers.
  * This is used by client and server transforms so nested lazy destructuring can coexist
- * with otherwise normal object/array params.
+ * with otherwise normal object/array patterns.
  * @param {AST.Pattern} pattern
  * @returns {AST.Pattern}
  */
-export function replace_lazy_param_pattern(pattern) {
+export function replace_lazy_pattern(pattern) {
 	switch (pattern.type) {
 		case 'AssignmentPattern':
-			return { ...pattern, left: replace_lazy_param_pattern(pattern.left) };
+			return { ...pattern, left: replace_lazy_pattern(pattern.left) };
 
 		case 'ObjectPattern':
 			if (pattern.lazy && pattern.metadata?.lazy_id) {
@@ -2431,8 +2458,8 @@ export function replace_lazy_param_pattern(pattern) {
 				...pattern,
 				properties: pattern.properties.map((property) =>
 					property.type === 'RestElement'
-						? { ...property, argument: replace_lazy_param_pattern(property.argument) }
-						: { ...property, value: replace_lazy_param_pattern(property.value) },
+						? { ...property, argument: replace_lazy_pattern(property.argument) }
+						: { ...property, value: replace_lazy_pattern(property.value) },
 				),
 			};
 
@@ -2444,12 +2471,12 @@ export function replace_lazy_param_pattern(pattern) {
 			return {
 				...pattern,
 				elements: pattern.elements.map((element) =>
-					element === null ? null : replace_lazy_param_pattern(element),
+					element === null ? null : replace_lazy_pattern(element),
 				),
 			};
 
 		case 'RestElement':
-			return { ...pattern, argument: replace_lazy_param_pattern(pattern.argument) };
+			return { ...pattern, argument: replace_lazy_pattern(pattern.argument) };
 
 		default:
 			return pattern;

--- a/packages/tsrx-ripple/tests/lazy-destructuring.test.js
+++ b/packages/tsrx-ripple/tests/lazy-destructuring.test.js
@@ -1,0 +1,226 @@
+import { describe, expect, it } from 'vitest';
+import * as client from '../../ripple/src/runtime/internal/client/index.js';
+import * as server from '../../ripple/src/runtime/internal/server/index.js';
+import { compile, compile_to_volar_mappings } from '../src/index.js';
+import { check_types, find_exact_mapping } from './test-utils.js';
+
+function compile_test(source, mode) {
+	const { code, errors } = compile(source, 'lazy.tsrx', { mode });
+	expect(errors).toEqual([]);
+	const body = code.replace(/^import \* as _\$_ from 'ripple\/internal\/(?:client|server)';\n/, '');
+	return new Function('_$_', `${body}\nreturn test;`)(mode === 'client' ? client : server);
+}
+
+for (const mode of ['client', 'server']) {
+	describe(`lazy destructuring in ${mode} output`, () => {
+		it.each(['const &{ value }', 'let &{ value }', '&{ value }'])(
+			'keeps %s loop reads lazy and captures each iteration',
+			(target) => {
+				const test = compile_test(
+					`function test(items) {
+					const value = 'outer';
+					const reads = [];
+					for (${target} of items) {
+						reads.push(() => value);
+					}
+					items[0].value = 10;
+					items[1].value = 20;
+					return [reads.map(read => read()), value];
+				}`,
+					mode,
+				);
+				expect(test([{ value: 1 }, { value: 2 }])).toEqual([[10, 20], 'outer']);
+			},
+		);
+
+		it.each(['const &[first]', '&[first]'])(
+			'handles %s in for-in loops with a non-block body',
+			(target) => {
+				const test = compile_test(
+					`function test(items) {
+					const result = [];
+					for (${target} in items) result.push(first);
+					return result;
+				}`,
+					mode,
+				);
+				expect(test({ apple: 1, banana: 2 })).toEqual(['a', 'b']);
+			},
+		);
+
+		it.each(['const [&{ value }]', '[&{ value }]'])('handles nested %s loop targets', (target) => {
+			const test = compile_test(
+				`function test(items) {
+					const reads = [];
+					for (${target} of items) reads.push(() => value);
+					items[0][0].value = 5;
+					return reads.map(read => read());
+				}`,
+				mode,
+			);
+			expect(test([[{ value: 1 }]])).toEqual([5]);
+		});
+
+		it('supports bare for-await targets', async () => {
+			const test = compile_test(
+				`async function test(items) {
+				const reads = [];
+				for await (&{ value } of items) reads.push(() => value);
+				items[0].value = 9;
+				return reads.map(read => read());
+			}`,
+				mode,
+			);
+			expect(await test([{ value: 1 }])).toEqual([9]);
+		});
+
+		it('preserves eager assignment loop targets', () => {
+			const test = compile_test(
+				`function test(items) {
+				let value;
+				for ({ value } of items) {}
+				return value;
+			}`,
+				mode,
+			);
+			expect(test([{ value: 4 }])).toBe(4);
+		});
+
+		it('rewrites classic loop initializers, tests, updates and bodies', () => {
+			const test = compile_test(
+				`function test(pair) {
+				const result = [];
+				for (let &[i] = pair, start = i; i < 3; i++) {
+					result.push([start, i]);
+				}
+				return result;
+			}`,
+				mode,
+			);
+			const pair = [0];
+			expect(test(pair)).toEqual([
+				[0, 0],
+				[0, 1],
+				[0, 2],
+			]);
+			expect(pair).toEqual([3]);
+		});
+
+		it('preserves defaults, computed keys and nested writable declarations', () => {
+			const test = compile_test(
+				`function test(item) {
+				const key = 'value';
+				let { child: &{ [key]: value = 2 } } = item;
+				value++;
+				value += 3;
+				return value;
+			}`,
+				mode,
+			);
+			const item = { child: {} };
+			expect(test(item)).toBe(6);
+			expect(item.child.value).toBe(6);
+		});
+
+		it('keeps nested array defaults lazy', () => {
+			const test = compile_test(
+				`function test(pair, fallback) {
+				const [&{ value } = fallback] = pair;
+				fallback.value = 7;
+				return value;
+			}`,
+				mode,
+			);
+			expect(test([], { value: 1 })).toBe(7);
+		});
+
+		it('keeps body shadowing separate from the loop binding', () => {
+			const test = compile_test(
+				`function test(items) {
+				const result = [];
+				for (&{ value } of items) {
+					result.push(value);
+					{ const value = 'inner'; result.push(value); }
+				}
+				return result;
+			}`,
+				mode,
+			);
+			expect(test([{ value: 3 }])).toEqual([3, 'inner']);
+		});
+
+		it.each([
+			'if (cond) &{ value } = item;',
+			'while (cond) &{ value } = item;',
+			'label: &{ value } = item;',
+			'[&{ value }] = items;',
+			'[&{ value }] = items, done();',
+			'result = [&{ value }] = items;',
+		])('rejects unsupported assignment position: %s', (statement) => {
+			expect(() => compile(`function test() { ${statement} }`, 'lazy.tsrx', { mode })).toThrow(
+				'Lazy destructuring assignments require',
+			);
+		});
+	});
+}
+
+it('preserves author bindings in editor output for bare and nested loop targets', () => {
+	const source = `function test(items: { value: number }[]) {
+		const result: number[] = [];
+		for (&{ value } of items) result.push(value);
+		for (const [&{ value }] of [items]) result.push(value);
+		return result;
+	}`;
+	const result = compile_to_volar_mappings(source, 'lazy.tsrx');
+	expect(result.errors).toEqual([]);
+	expect(result.code).toContain('for (const { value } of items)');
+	expect(result.code).toContain('for (const [{ value }] of [items])');
+	expect(check_types(result.code).errors).toEqual([]);
+});
+
+it.each([
+	'for (&[first] in { apple: 1 }) { const letter: string = first; }',
+	'for (const &{ length } in { apple: 1 }) { const size: number = length; }',
+	'for (let &[first] in { apple: 1 }) { first = \"b\"; { const first = 1; } }',
+	'for (let &[i] = [0]; i < 3; i++) { const value: number = i; }',
+	'let { child: &{ value = 2 } } = { child: { value: 1 } }; value++;',
+	'const [&{ value } = { value: 1 }] = []; const result: number = value;',
+	'for await (&{ value } of [{ value: 1 }]) { const result: number = value; }',
+])('typechecks lazy patterns in client to_ts output: %s', (statement) => {
+	const result = compile_to_volar_mappings(`async function test() { ${statement} }`, 'lazy.tsrx');
+	expect(result.errors).toEqual([]);
+	expect(check_types(result.code).errors).toEqual([]);
+});
+
+it.each(['of', 'in'])(
+	'maps bare for-%s bindings and references to their authored identifiers',
+	(operator) => {
+		const source = `function test(items: { value: number }[]) {
+		for (&{ value } ${operator} items) { console.log(value); }
+	}`;
+		const result = compile_to_volar_mappings(source, 'lazy.tsrx');
+		for (const needle of ['value }', 'value);']) {
+			expect(
+				find_exact_mapping(
+					result.mappings,
+					source.indexOf(needle),
+					result.code.indexOf(needle),
+					'value'.length,
+				),
+			).toBeDefined();
+		}
+	},
+);
+
+it.each(['of', 'in'])('reports binding type errors in for-%s editor output', (operator) => {
+	const pattern = operator === 'of' ? '&{ value }' : '&{ length: value }';
+	const source = `function test() {
+		for (${pattern} ${operator} [{ value: 1 }]) {
+			const invalid: string = value;
+		}
+	}`;
+	const result = compile_to_volar_mappings(source, 'lazy.tsrx');
+	expect(check_types(result.code).errors).toEqual([
+		"Type 'number' is not assignable to type 'string'.",
+	]);
+});


### PR DESCRIPTION
Bare lazy loop targets and lazy patterns nested inside declarations were emitted as eager destructuring. Normalize bare targets into loop-local declarations and reuse recursive pattern analysis and lowering so reads stay lazy in client and server output.

Support client `to_ts` output with inferred binding types and source mappings. For `for…in`, move destructuring into the generated loop body because TypeScript rejects destructuring in the header. Add 50 regression tests covering loop forms, mutation, closures, shadowing, defaults, diagnostics, and editor output, plus a patch changeset for `@tsrx/ripple`.

Closes #1439.

Validation:
- `pnpm test --project tsrx-ripple` — 329 tests passed.
- `pnpm test --project ripple-client --project ripple-server lazy-array compiler` — 135 tests passed.
- `pnpm typecheck` and `pnpm changeset:check` passed.
- Prettier checks for changed source and tests, and `git diff --check`, passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core compiler analysis and client/server lowering for bindings and loops; behavior changes are broad but focused on lazy destructuring with extensive regression tests.
> 
> **Overview**
> **Fixes lazy `&` destructuring** when it appears on bare `for…of` / `for…in` / `for await` loop targets and inside nested declaration patterns, which previously lowered to eager destructuring in client and server output.
> 
> Analysis now **normalizes bare lazy loop left-hand sides** into `const` declarations before scopes are built, and **routes all lazy patterns** (params, `let`/`const`, nested subpatterns) through shared `setup_lazy_pattern_transforms` / `replace_lazy_pattern` / `has_lazy_pattern` instead of param-only helpers. Variable declarators pick up the same recursive lazy setup as functions, including `track`/`trackAsync` fast paths and `const` vs `let` writability.
> 
> **Editor (`to_ts`) output** keeps authored loop bindings and mappings; **`for…in` with lazy destructuring** is rewritten so destructuring lives in the loop body (TypeScript cannot parse it in the header). Regression tests cover runtime behavior, typechecking, Volar mappings, and rejected assignment positions. Patch changeset for `@tsrx/ripple`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2aa24de75e014d1e95b4ec711bae4c75b4697e2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->