### PR TITLE
fix(types): align JSX component types with Component

### DIFF
--- a/.changeset/align-jsx-component-types.md
+++ b/.changeset/align-jsx-component-types.md
@@ -1,0 +1,6 @@
+---
+'ripple': patch
+---
+
+Align JSX component types with the public `Component` type so component props and
+functions returning renderable primitives or arrays are accepted as JSX tags.

--- a/packages/ripple/src/jsx-runtime.d.ts
+++ b/packages/ripple/src/jsx-runtime.d.ts
@@ -1,4 +1,11 @@
-import type { AddEventObject, FragmentProps, RefKey, RefValue, TSRXElement } from '#public';
+import type {
+	AddEventObject,
+	Component,
+	FragmentProps,
+	RefKey,
+	RefValue,
+	TSRXElement,
+} from '#public';
 import type { Nullable } from '@tsrx/core/types/helpers';
 export type { RefValue } from '#public';
 
@@ -8,8 +15,8 @@ export type { RefValue } from '#public';
  * renderable TSRX values when used in expression positions.
  */
 
-// Ripple components are usually imperative, but helpers can return TSRX values.
-export type ComponentType<P = {}> = (props: P) => void | TSRXElement;
+// JSX accepts the same component return values as the public runtime APIs.
+export type ComponentType<P = {}> = Component<P>;
 
 /**
  * Create a JSX element (for elements with children)

--- a/packages/tsrx-ripple/tests/jsx-runtime-types.test.js
+++ b/packages/tsrx-ripple/tests/jsx-runtime-types.test.js
@@ -13,6 +13,7 @@ function get_variable_types(code) {
 		moduleResolution: ts.ModuleResolutionKind.Bundler,
 		target: ts.ScriptTarget.ESNext,
 		noEmit: true,
+		strictNullChecks: true,
 		skipLibCheck: true,
 		skipDefaultLibCheck: true,
 		types: [],
@@ -59,6 +60,68 @@ function get_variable_types(code) {
 }
 
 describe('@tsrx/ripple Volar JSX expression types', () => {
+	it('accepts public Component props and renderable return values as JSX components', () => {
+		const source = `
+import type { Component } from 'ripple';
+
+function Composite({ PropComp }: { PropComp: Component<{ label: string }> }) @{
+	<PropComp label="hello" />
+}
+
+const Text: Component<{ label: string }> = ({ label }) => label;
+const StringValue = () => 'hello';
+const NumberValue = () => 42;
+const BigIntValue = () => 1n;
+const BooleanValue = () => false;
+const NullValue = () => null;
+const UndefinedValue = () => undefined;
+const VoidValue = () => {};
+const ArrayValue = () => [<p>hello</p>, ['world', 42, null]] as const;
+
+export function App() @{
+	<>
+		<Composite PropComp={Text} />
+		<StringValue />
+		<NumberValue />
+		<BigIntValue />
+		<BooleanValue />
+		<NullValue />
+		<UndefinedValue />
+		<VoidValue />
+		<ArrayValue />
+	</>
+}
+`;
+		const { code } = compile_to_volar_mappings(source, 'App.tsrx', { loose: true });
+		get_variable_types(`import 'ripple/jsx-runtime';\n${code}`);
+	});
+
+	it('preserves JSX prop checking and rejects non-renderable component types', () => {
+		get_variable_types(`
+import 'ripple/jsx-runtime';
+import type { Component } from 'ripple';
+
+declare const Text: Component<{ label: string }>;
+// @ts-expect-error required component props must be supplied
+const missing = <Text />;
+// @ts-expect-error component props retain their declared types
+const wrong = <Text label={42} />;
+
+const PromiseValue = async () => 'hello';
+const FunctionValue = () => () => 'hello';
+const SymbolValue = () => Symbol('hello');
+const ElementValue = <p>hello</p>;
+// @ts-expect-error promises are not renderable
+const promise = <PromiseValue />;
+// @ts-expect-error returned functions are not renderable
+const fn = <FunctionValue />;
+// @ts-expect-error symbols are not renderable
+const symbol = <SymbolValue />;
+// @ts-expect-error an element value is not a component function
+const element = <ElementValue />;
+`);
+	});
+
 	it('types a style class map with $class and verifies apply targets on the style stand-in', () => {
 		const { code } = compile_to_volar_mappings(
 			`


### PR DESCRIPTION
Fixes #1443.

A prop typed as Ripple's public `Component` is rejected when used as `<PropComp />`: `Component` allows `Renderable | void`, but JSX's separate `ComponentType` still allows only `TSRXElement | void`. Reuse `Component<P>` for the JSX type so component props and functions returning supported primitives or arrays typecheck consistently with the runtime.

Add regression coverage with strict null checks for component props and renderable returns, plus checks that required props, prop types, and invalid component types remain enforced. Includes a patch changeset for `ripple`. No runtime changes or breaking changes.

The reproduction also passes a JSX element value as a `Component` prop. That usage still correctly fails: an element should be typed as `TSRXElement` and rendered with `{PropComp}`, or the caller should pass a function for `<PropComp />`.

Validation:

- `pnpm test --project tsrx-ripple` — 331 tests passed.
- `pnpm typecheck`
- `pnpm format:check`
- `pnpm changeset:check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Declaration-only change with no runtime behavior; it widens accepted JSX component types to match existing public types and is guarded by new compile-time tests.
> 
> **Overview**
> Fixes a mismatch where JSX used a narrower `ComponentType` (`void | TSRXElement`) than the public `Component` (`Renderable | void`), so props typed as `Component` and components returning primitives or arrays could fail in JSX even though the runtime allows them.
> 
> **`ComponentType` in `jsx-runtime.d.ts` is now an alias of `Component<P>`**, so JSX tags accept the same component shapes and return values as the public APIs. A patch changeset is added for `ripple`.
> 
> Regression tests turn on **`strictNullChecks`** in the type harness and cover passing `Component` props as tags, using functions that return supported renderable values, and still rejecting missing/wrong props plus non-renderable returns (promises, nested functions, symbols, element values used as components).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff62fa14e2774815ed70352c787c549058d42a27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->