### PR TITLE
fix(hydration): leave the cursor on a node's last DOM node after fragments, expressions, and branches

### DIFF
--- a/.changeset/hydration-fragment-cursor.md
+++ b/.changeset/hydration-fragment-cursor.md
@@ -1,0 +1,6 @@
+---
+'ripple': patch
+'@tsrx/ripple': patch
+---
+
+Fix hydration when a fragment root or a slot is followed by siblings. The compiler's closing `next(n)` for a fragment root now counts from wherever the cursor was last positioned, so a trailing element navigated to for an event or attribute, tracked text, a control-flow block, a component, or a `{expression}` no longer makes the cursor overshoot or fall short of the fragment's last node; a trailing element that was descended into is popped back to. Control-flow bodies nested inside an element now emit that `next(n)` too. At runtime, a `{expression}` leaves the cursor on its own end marker like every other block, and a multi-node branch or `@for` item steps to its block's end marker after appending, so the next sibling, item, or component adopts the right node.

--- a/packages/ripple/src/runtime/internal/client/expression.js
+++ b/packages/ripple/src/runtime/internal/client/expression.js
@@ -257,7 +257,7 @@ function run_expression(s) {
 		if (next_is_collection || is_tsrx_element(next_value)) {
 			if (s.i && s.e && s.v === next_value) {
 				if (end !== null) {
-					advance_hydration(end);
+					settle_hydration(end);
 				}
 				return;
 			}
@@ -326,7 +326,7 @@ function run_expression(s) {
 			s.e = true;
 			s.i = true;
 			if (end !== null) {
-				advance_hydration(end);
+				settle_hydration(end);
 			}
 			return;
 		}
@@ -336,7 +336,7 @@ function run_expression(s) {
 
 	if (s.i && !s.e && s.v === next_text) {
 		if (end !== null) {
-			advance_hydration(end);
+			settle_hydration(end);
 		}
 		return;
 	}
@@ -384,7 +384,7 @@ function run_expression(s) {
 	s.e = false;
 	s.i = true;
 	if (end !== null) {
-		advance_hydration(end);
+		settle_hydration(end);
 	}
 }
 
@@ -473,17 +473,14 @@ function clear_expression_range(anchor, end) {
 }
 
 /**
+ * Leaves the hydration cursor on the expression's end marker, the last node
+ * the expression owns: the parent steps past it with its own sibling
+ * navigation, exactly as it does after an element or a control-flow block.
  * @param {Comment} end
  * @returns {void}
  */
-function advance_hydration(end) {
-	if (!hydrating) {
-		return;
-	}
-
-	var next = get_next_sibling(end);
-
-	if (next !== null) {
-		set_hydrate_node(next);
+function settle_hydration(end) {
+	if (hydrating) {
+		set_hydrate_node(end);
 	}
 }

--- a/packages/ripple/src/runtime/internal/client/template.js
+++ b/packages/ripple/src/runtime/internal/client/template.js
@@ -1,9 +1,6 @@
 /** @import { AppendIntoAnchor, Block } from '#client' */
 
 import {
-	COMMENT_NODE,
-	HYDRATION_END,
-	HYDRATION_START,
 	TEMPLATE_FRAGMENT,
 	TEMPLATE_USE_IMPORT_NODE,
 	TEMPLATE_SVG_NAMESPACE,
@@ -151,76 +148,55 @@ export function template(content, flags, count = 1) {
  * The hydration path of {@link append}: repositions the hydration cursor
  * instead of inserting. Kept out of the insert path so a client-only mount
  * never compiles it.
+ *
+ * Every hydrated node, block, and component leaves the cursor on its last
+ * DOM node, and whoever owns the next node steps past it: a parent element
+ * with its sibling traversal, a control-flow block by reaching its end
+ * marker, an append-into sentinel by adopting the cursor as the next
+ * component's first node.
  * @param {ChildNode | AppendIntoAnchor} anchor
  * @param {Node} dom
- * @param {boolean} [skip_advance]
  */
-function hydrate_append(anchor, dom, skip_advance) {
-	// When skip_advance is true, the caller (e.g., a fragment component) has already
-	// used next() to position hydrate_node correctly. We must NOT reset it.
-	if (skip_advance) {
-		return;
-	}
-
-	// During hydration, if anchor === dom, we're hydrating a child component
-	// where the "anchor" IS the content. If the cursor is still somewhere
-	// inside dom (at any depth), reset it to dom's level so sibling traversal
-	// works. But if the cursor has advanced past dom (e.g., because internal
-	// control flow blocks like switch/if/for advanced it through their
-	// hydration markers), preserve the advanced position.
-	if (anchor === dom) {
-		if (hydrate_node !== null && hydrate_node !== dom && dom.contains(hydrate_node)) {
-			pop(dom);
-		}
-		return;
-	}
-
-	// If the hydration cursor has descended into dom's children (e.g. after
-	// child()/sibling() traversal inside a single-node template), we need
-	// pop() to reset back to dom's sibling level before advancing.
-	// But if the cursor is already at dom's sibling level (e.g. because
-	// nested control flow blocks advanced it past dom via sibling traversal),
-	// pop() would incorrectly reset backwards — so we skip it.
+function hydrate_append(anchor, dom) {
+	// The cursor descended into dom's children (child()/sibling() traversal
+	// inside a single-node template) without a compiler-emitted pop(): bring it
+	// back up to dom before deciding where to leave it.
 	if (hydrate_node !== null && hydrate_node !== dom && dom.contains(hydrate_node)) {
 		pop(dom);
-	} else if (hydrate_node !== dom) {
-		// Cursor has advanced past dom via sibling traversal (due to nested
-		// block processing). Update the branch block's end to reflect the
-		// actual extent, which may be past the statically-assigned end from
-		// the template's assign_nodes call.
+	}
+
+	// A child component renders into the anchor it was handed, which is its
+	// own first node. Its content is hydrated, so leave the cursor on the
+	// content's last node for the parent's sibling traversal.
+	if (anchor === dom) {
+		return;
+	}
+
+	if (hydrate_node !== dom) {
+		// A fragment's cursor sits on its last top-level node, past the
+		// template's first node: widen the block's end to cover the whole
+		// fragment rather than only the node assign_nodes saw.
 		var block = /** @type {Block} */ (active_block);
 		var s = block.s;
 		if (s !== null) {
 			s.end = /** @type {Node} */ (hydrate_node);
 		}
-
-		if (is_after_hydration_block(dom, hydrate_node)) {
-			// The cursor sits on the block's end marker. A parent normally steps
-			// past it with its own sibling navigation, but an append-into
-			// sentinel has none: the next component starts wherever this one
-			// leaves the cursor, so step past the marker here.
-			if (/** @type {AppendIntoAnchor} */ (anchor).into === true) {
-				hydrate_advance();
-			}
-			return;
-		}
 	}
 
-	// Only advance if there's a next sibling. At the end of a component's
-	// content, there might not be more siblings, and that's fine.
+	// Step past the content: a branch lands on its block's end marker, the
+	// root on the boundary's end marker, an append-into sentinel on the next
+	// component's first node.
 	hydrate_advance();
-	return;
 }
 
 /**
  * Appends a DOM node before the anchor node.
  * @param {ChildNode | AppendIntoAnchor} anchor - The anchor node.
  * @param {Node} dom - The DOM node to append.
- * @param {boolean} [skip_advance] - If true, don't advance hydrate_node (used when next() already positioned it).
  */
-export function append(anchor, dom, skip_advance) {
+export function append(anchor, dom) {
 	if (hydrating) {
-		hydrate_append(anchor, dom, skip_advance);
+		hydrate_append(anchor, dom);
 		return;
 	}
 	if (/** @type {AppendIntoAnchor} */ (anchor).into === true) {
@@ -232,45 +208,6 @@ export function append(anchor, dom, skip_advance) {
 		return;
 	}
 	/** @type {ChildNode} */ (anchor).before(/** @type {Node} */ (dom));
-}
-
-/**
- * @param {Node} start
- * @param {Node | null} target
- * @returns {boolean}
- */
-function is_after_hydration_block(start, target) {
-	if (
-		target === null ||
-		start.nodeType !== COMMENT_NODE ||
-		/** @type {Comment} */ (start).data !== HYDRATION_START
-	) {
-		return false;
-	}
-
-	var current = get_next_sibling(start);
-	var depth = 0;
-
-	while (current !== null && current !== target) {
-		if (current.nodeType === COMMENT_NODE) {
-			var data = /** @type {Comment} */ (current).data;
-
-			// `[`-prefixed covers plain block starts and streaming slot markers
-			if (data.startsWith(HYDRATION_START)) {
-				depth += 1;
-			} else if (data === HYDRATION_END) {
-				if (depth === 0) {
-					return true;
-				}
-
-				depth -= 1;
-			}
-		}
-
-		current = get_next_sibling(current);
-	}
-
-	return false;
 }
 
 export function text(data = '') {

--- a/packages/ripple/tests/hydration/compiled/client/basic.js
+++ b/packages/ripple/tests/hydration/compiled/client/basic.js
@@ -100,7 +100,7 @@ export function MultipleElements() {
 			var fragment_1 = root_2();
 
 			_$_.next(2);
-			_$_.append(__anchor, fragment_1, true);
+			_$_.append(__anchor, fragment_1);
 		}));
 
 		_$_.append(__anchor, fragment);
@@ -124,7 +124,7 @@ export function WithAttributes() {
 			var fragment_3 = root_5();
 
 			_$_.next();
-			_$_.append(__anchor, fragment_3, true);
+			_$_.append(__anchor, fragment_3);
 		}));
 
 		_$_.append(__anchor, fragment_2);
@@ -242,8 +242,7 @@ export function ExpressionContent() {
 				_$_.pop(span_1);
 			}
 
-			_$_.next();
-			_$_.append(__anchor, fragment_7, true);
+			_$_.append(__anchor, fragment_7);
 		}));
 
 		_$_.append(__anchor, fragment_6);
@@ -731,7 +730,7 @@ function StaticHeader() {
 			var fragment_24 = root_56();
 
 			_$_.next(2);
-			_$_.append(__anchor, fragment_24, true);
+			_$_.append(__anchor, fragment_24);
 		}));
 
 		_$_.append(__anchor, fragment_23);
@@ -768,8 +767,7 @@ export function StaticChildWithSiblings() {
 				_$_.pop(span_7);
 			}
 
-			_$_.next();
-			_$_.append(__anchor, fragment_26, true);
+			_$_.append(__anchor, fragment_26);
 		}));
 
 		_$_.append(__anchor, fragment_25);
@@ -785,7 +783,7 @@ function Header() {
 			var fragment_28 = root_60();
 
 			_$_.next(2);
-			_$_.append(__anchor, fragment_28, true);
+			_$_.append(__anchor, fragment_28);
 		}));
 
 		_$_.append(__anchor, fragment_27);
@@ -988,6 +986,7 @@ function OpaqueLead(props) {
 			var expression_30 = _$_.first_child_frag(fragment_31);
 
 			_$_.expression(expression_30, () => props.header);
+			_$_.next();
 			_$_.append(__anchor, fragment_31);
 		}));
 
@@ -1018,6 +1017,8 @@ function PrimitiveCallLead() {
 		_$_.expression(node_27, () => _$_.tsrx_element((__anchor, __block) => {
 			var fragment_33 = root_77();
 			var expression_31 = _$_.first_child_frag(fragment_33, true);
+
+			_$_.next();
 
 			_$_.render(() => {
 				_$_.set_text(expression_31, String(_$_.with_scope(__block, fetchLabel)));

--- a/packages/ripple/tests/hydration/compiled/client/composite.js
+++ b/packages/ripple/tests/hydration/compiled/client/composite.js
@@ -58,7 +58,7 @@ export function MultiRootChild() {
 			var fragment_1 = root_4();
 
 			_$_.next();
-			_$_.append(__anchor, fragment_1, true);
+			_$_.append(__anchor, fragment_1);
 		}));
 
 		_$_.append(__anchor, fragment);
@@ -89,6 +89,7 @@ export function LayoutWithMultipleChildren() {
 				var node_1 = _$_.first_child_frag(fragment_2);
 
 				_$_.render_component(SingleChild, node_1, {});
+				_$_.next();
 				_$_.append(__anchor, fragment_2);
 			})
 		});

--- a/packages/ripple/tests/hydration/compiled/client/for.js
+++ b/packages/ripple/tests/hydration/compiled/client/for.js
@@ -225,8 +225,7 @@ export function ReactiveForLoopAdd() {
 				_$_.pop(ul_3);
 			}
 
-			_$_.next();
-			_$_.append(__anchor, fragment_1, true);
+			_$_.append(__anchor, fragment_1);
 		}));
 
 		_$_.append(__anchor, fragment);
@@ -271,8 +270,7 @@ export function ReactiveForLoopRemove() {
 				_$_.pop(ul_4);
 			}
 
-			_$_.next();
-			_$_.append(__anchor, fragment_3, true);
+			_$_.append(__anchor, fragment_3);
 		}));
 
 		_$_.append(__anchor, fragment_2);
@@ -517,8 +515,7 @@ export function KeyedForLoopReorder() {
 				_$_.pop(ul_5);
 			}
 
-			_$_.next();
-			_$_.append(__anchor, fragment_5, true);
+			_$_.append(__anchor, fragment_5);
 		}));
 
 		_$_.append(__anchor, fragment_4);
@@ -568,8 +565,7 @@ export function KeyedForLoopUpdate() {
 				_$_.pop(ul_6);
 			}
 
-			_$_.next();
-			_$_.append(__anchor, fragment_7, true);
+			_$_.append(__anchor, fragment_7);
 		}));
 
 		_$_.append(__anchor, fragment_6);
@@ -616,8 +612,7 @@ export function ForLoopMixedOperations() {
 				_$_.pop(ul_7);
 			}
 
-			_$_.next();
-			_$_.append(__anchor, fragment_9, true);
+			_$_.append(__anchor, fragment_9);
 		}));
 
 		_$_.append(__anchor, fragment_8);
@@ -726,8 +721,7 @@ export function ForLoopEmptyToPopulated() {
 				_$_.pop(ul_9);
 			}
 
-			_$_.next();
-			_$_.append(__anchor, fragment_13, true);
+			_$_.append(__anchor, fragment_13);
 		}));
 
 		_$_.append(__anchor, fragment_12);
@@ -772,8 +766,7 @@ export function ForLoopPopulatedToEmpty() {
 				_$_.pop(ul_10);
 			}
 
-			_$_.next();
-			_$_.append(__anchor, fragment_15, true);
+			_$_.append(__anchor, fragment_15);
 		}));
 
 		_$_.append(__anchor, fragment_14);
@@ -1018,8 +1011,7 @@ export function ForLoopIndexUpdate() {
 				_$_.pop(ul_12);
 			}
 
-			_$_.next();
-			_$_.append(__anchor, fragment_17, true);
+			_$_.append(__anchor, fragment_17);
 		}));
 
 		_$_.append(__anchor, fragment_16);
@@ -1097,8 +1089,7 @@ export function KeyedForLoopWithIndex() {
 				_$_.pop(ul_13);
 			}
 
-			_$_.next();
-			_$_.append(__anchor, fragment_19, true);
+			_$_.append(__anchor, fragment_19);
 		}));
 
 		_$_.append(__anchor, fragment_18);
@@ -1148,8 +1139,7 @@ export function ForLoopWithSiblings() {
 				_$_.set(lazy_13, [...lazy_13.value, 'C']);
 			};
 
-			_$_.next();
-			_$_.append(__anchor, fragment_21, true);
+			_$_.append(__anchor, fragment_21);
 		}));
 
 		_$_.append(__anchor, fragment_20);
@@ -1322,8 +1312,7 @@ export function ForLoopAddAtBeginning() {
 				_$_.pop(ul_15);
 			}
 
-			_$_.next();
-			_$_.append(__anchor, fragment_23, true);
+			_$_.append(__anchor, fragment_23);
 		}));
 
 		_$_.append(__anchor, fragment_22);
@@ -1373,8 +1362,7 @@ export function ForLoopAddInMiddle() {
 				_$_.pop(ul_16);
 			}
 
-			_$_.next();
-			_$_.append(__anchor, fragment_25, true);
+			_$_.append(__anchor, fragment_25);
 		}));
 
 		_$_.append(__anchor, fragment_24);
@@ -1421,8 +1409,7 @@ export function ForLoopRemoveFromMiddle() {
 				_$_.pop(ul_17);
 			}
 
-			_$_.next();
-			_$_.append(__anchor, fragment_27, true);
+			_$_.append(__anchor, fragment_27);
 		}));
 
 		_$_.append(__anchor, fragment_26);
@@ -1507,8 +1494,7 @@ export function ForLoopSwap() {
 				_$_.pop(ul_19);
 			}
 
-			_$_.next();
-			_$_.append(__anchor, fragment_29, true);
+			_$_.append(__anchor, fragment_29);
 		}));
 
 		_$_.append(__anchor, fragment_28);
@@ -1555,8 +1541,7 @@ export function ForLoopReverse() {
 				_$_.pop(ul_20);
 			}
 
-			_$_.next();
-			_$_.append(__anchor, fragment_31, true);
+			_$_.append(__anchor, fragment_31);
 		}));
 
 		_$_.append(__anchor, fragment_30);

--- a/packages/ripple/tests/hydration/compiled/client/fragment-cursor.js
+++ b/packages/ripple/tests/hydration/compiled/client/fragment-cursor.js
@@ -1,0 +1,2099 @@
+// @ts-nocheck
+import * as _$_ from 'ripple/internal/client';
+
+var root = _$_.template(`<i class="leaf">leaf</i>`, 0);
+var root_2 = _$_.template(`<div class="count"> </div><button class="inc">inc</button><button class="dec">dec</button>`, 1, 3);
+var root_1 = _$_.template(`<!>`, 1, 1);
+var root_4 = _$_.template(`<div class="host">static</div><button class="inc">inc</button><button class="dec">dec</button>`, 1, 3);
+var root_3 = _$_.template(`<!>`, 1, 1);
+var root_6 = _$_.template(`<div class="host">static</div><button class="inc">inc</button><div class="a">a</div><div class="b">b</div>`, 1, 4);
+var root_5 = _$_.template(`<!>`, 1, 1);
+var root_8 = _$_.template(`<button class="inc">inc</button><div class="a">a</div><div class="b">b</div>`, 1, 3);
+var root_7 = _$_.template(`<!>`, 1, 1);
+var root_10 = _$_.template(`<div class="host">static</div><div class="wrap"><button class="inc">inc</button></div>`, 1, 2);
+var root_9 = _$_.template(`<!>`, 1, 1);
+var root_12 = _$_.template(`<div class="wrap"><button class="inc">inc</button></div><div class="a">a</div><div class="b">b</div>`, 1, 3);
+var root_11 = _$_.template(`<!>`, 1, 1);
+var root_14 = _$_.template(` <div class="a">a</div><div class="b">b</div>`, 1, 3);
+var root_13 = _$_.template(`<!>`, 1, 1);
+var root_16 = _$_.template(`<div class="a">a</div><div class="b">b</div> `, 1, 3);
+var root_15 = _$_.template(`<!>`, 1, 1);
+var root_18 = _$_.template(`<div class="a">a</div><div class="wrap"><span>x</span></div><div class="b">b</div><div class="c">c</div>`, 1, 4);
+var root_17 = _$_.template(`<!>`, 1, 1);
+var root_20 = _$_.template(`<div class="a">a</div><div class="b">b</div><div class="c">c</div>`, 1, 3);
+var root_19 = _$_.template(`<!>`, 1, 1);
+var root_22 = _$_.template(`<div class="a">a</div><div class="count"> </div>`, 1, 2);
+var root_21 = _$_.template(`<!>`, 1, 1);
+var root_24 = _$_.template(`<div class="count"> </div><div class="a">a</div><div class="b">b</div>`, 1, 3);
+var root_23 = _$_.template(`<!>`, 1, 1);
+var root_27 = _$_.template(`<b class="if">x</b>`, 0);
+var root_26 = _$_.template(`<!><div class="a">a</div><div class="b">b</div>`, 1, 3);
+var root_25 = _$_.template(`<!>`, 1, 1);
+var root_30 = _$_.template(`<b class="if">x</b>`, 0);
+var root_29 = _$_.template(`<div class="a">a</div><div class="b">b</div><!>`, 1, 3);
+var root_28 = _$_.template(`<!>`, 1, 1);
+var root_32 = _$_.template(`<!><div class="a">a</div><div class="b">b</div>`, 1, 3);
+var root_31 = _$_.template(`<!>`, 1, 1);
+var root_34 = _$_.template(`<div class="a">a</div><div class="b">b</div><!>`, 1, 3);
+var root_33 = _$_.template(`<!>`, 1, 1);
+var root_36 = _$_.template(`<!><!>`, 1, 2);
+var root_35 = _$_.template(`<!>`, 1, 1);
+var root_37 = _$_.template(`<div class="outer"><!><span class="after"> </span><button class="outer-inc">outer</button></div>`, 0);
+var root_38 = _$_.template(`<div class="outer"><!><span class="after"> </span><button class="outer-inc">outer</button></div>`, 0);
+var root_39 = _$_.template(`<div class="outer"><!><span class="after"> </span><button class="outer-inc">outer</button></div>`, 0);
+var root_40 = _$_.template(`<div class="outer"><!><span class="after"> </span><button class="outer-inc">outer</button></div>`, 0);
+var root_41 = _$_.template(`<div class="outer"><!><span class="after"> </span><button class="outer-inc">outer</button></div>`, 0);
+var root_42 = _$_.template(`<div class="outer"><!><span class="after"> </span><button class="outer-inc">outer</button></div>`, 0);
+var root_43 = _$_.template(`<div class="outer"><!><span class="after"> </span><button class="outer-inc">outer</button></div>`, 0);
+var root_44 = _$_.template(`<div class="outer"><!><span class="after"> </span><button class="outer-inc">outer</button></div>`, 0);
+var root_45 = _$_.template(`<div class="outer"><!><span class="after"> </span><button class="outer-inc">outer</button></div>`, 0);
+var root_46 = _$_.template(`<div class="outer"><!><span class="after"> </span><button class="outer-inc">outer</button></div>`, 0);
+var root_47 = _$_.template(`<div class="outer"><!><span class="after"> </span><button class="outer-inc">outer</button></div>`, 0);
+var root_48 = _$_.template(`<div class="outer"><!><span class="after"> </span><button class="outer-inc">outer</button></div>`, 0);
+var root_49 = _$_.template(`<div class="outer"><!><span class="after"> </span><button class="outer-inc">outer</button></div>`, 0);
+var root_50 = _$_.template(`<div class="outer"><!><span class="after"> </span><button class="outer-inc">outer</button></div>`, 0);
+var root_51 = _$_.template(`<div class="outer"><!><span class="after"> </span><button class="outer-inc">outer</button></div>`, 0);
+var root_52 = _$_.template(`<div class="outer"><!><span class="after"> </span><button class="outer-inc">outer</button></div>`, 0);
+var root_53 = _$_.template(`<div class="outer"><!><span class="after"> </span><button class="outer-inc">outer</button></div>`, 0);
+var root_55 = _$_.template(`<!><div class="a">a</div><div class="b">b</div>`, 1, 3);
+var root_54 = _$_.template(`<!>`, 1, 1);
+var root_58 = _$_.template(`<span class="x">x</span><span class="y">y</span>`, 1, 2);
+var root_57 = _$_.template(`<div class="a">a</div><!><div class="b">b</div><div class="c">c</div>`, 1, 4);
+var root_56 = _$_.template(`<!>`, 1, 1);
+var root_61 = _$_.template(`<span class="x">x</span><button class="inc">inc</button>`, 1, 2);
+var root_60 = _$_.template(`<div class="count"> </div><!>`, 1, 2);
+var root_59 = _$_.template(`<!>`, 1, 1);
+var root_64 = _$_.template(`<b class="item"> </b>`, 0);
+var root_63 = _$_.template(`<!><div class="a">a</div><div class="b">b</div>`, 1, 3);
+var root_62 = _$_.template(`<!>`, 1, 1);
+var root_67 = _$_.template(`<b class="zero">zero</b>`, 0);
+var root_68 = _$_.template(`<b class="other">other</b>`, 0);
+var root_66 = _$_.template(`<!><div class="a">a</div><div class="b">b</div>`, 1, 3);
+var root_65 = _$_.template(`<!>`, 1, 1);
+var root_71 = _$_.template(`<b class="try">try</b>`, 0);
+var root_72 = _$_.template(`<b class="catch">catch</b>`, 0);
+var root_70 = _$_.template(`<!><div class="a">a</div><div class="b">b</div>`, 1, 3);
+var root_69 = _$_.template(`<!>`, 1, 1);
+var root_74 = _$_.template(`<style>.styled { color: red; }</style><div class="styled a">a</div><div class="styled b">b</div>`, 1, 3);
+var root_73 = _$_.template(`<!>`, 1, 1);
+var root_76 = _$_.template(`<b class="item"> </b>`, 0);
+var root_77 = _$_.template(`<!><div class="a">a</div><div class="b">b</div>`, 1, 3);
+var root_75 = _$_.template(`<!>`, 1, 1);
+var root_79 = _$_.template(`<b class="inline">inline</b>`, 0);
+var root_80 = _$_.template(`<!><div class="a">a</div><div class="b">b</div>`, 1, 3);
+var root_78 = _$_.template(`<!>`, 1, 1);
+var root_81 = _$_.template(`<div class="outer"><!><span class="after"> </span><button class="outer-inc">outer</button></div>`, 0);
+var root_82 = _$_.template(`<div class="outer"><!><span class="after"> </span><button class="outer-inc">outer</button></div>`, 0);
+var root_83 = _$_.template(`<div class="outer"><!><span class="after"> </span><button class="outer-inc">outer</button></div>`, 0);
+var root_84 = _$_.template(`<div class="outer"><!><span class="after"> </span><button class="outer-inc">outer</button></div>`, 0);
+var root_85 = _$_.template(`<div class="outer"><!><span class="after"> </span><button class="outer-inc">outer</button></div>`, 0);
+var root_86 = _$_.template(`<div class="outer"><!><span class="after"> </span><button class="outer-inc">outer</button></div>`, 0);
+var root_87 = _$_.template(`<div class="outer"><!><span class="after"> </span><button class="outer-inc">outer</button></div>`, 0);
+var root_88 = _$_.template(`<div class="outer"><!><span class="after"> </span><button class="outer-inc">outer</button></div>`, 0);
+var root_89 = _$_.template(`<div class="outer"><!><span class="after"> </span><button class="outer-inc">outer</button></div>`, 0);
+var root_91 = _$_.template(`<b class="if">x</b>`, 0);
+var root_90 = _$_.template(`<!>`, 1, 1);
+var root_94 = _$_.template(`<b class="if">x</b>`, 0);
+var root_93 = _$_.template(`<!><div class="a">a</div>`, 1, 2);
+var root_92 = _$_.template(`<!>`, 1, 1);
+var root_96 = _$_.template(`<b class="if">x</b>`, 0);
+var root_95 = _$_.template(`<div class="root"><!></div>`, 0);
+var root_97 = _$_.template(`<div class="outer"><!><span class="after"> </span><button class="outer-inc">outer</button></div>`, 0);
+var root_98 = _$_.template(`<div class="outer"><!><span class="after"> </span><button class="outer-inc">outer</button></div>`, 0);
+var root_99 = _$_.template(`<div class="outer"><!><span class="after"> </span><button class="outer-inc">outer</button></div>`, 0);
+var root_100 = _$_.template(`<div class="outer"><!><span class="after"> </span><button class="outer-inc">outer</button></div>`, 0);
+var root_103 = _$_.template(`<b class="if">x</b><i class="if2">y</i>`, 1, 2);
+var root_102 = _$_.template(`<!><div class="a">a</div><div class="b">b</div>`, 1, 3);
+var root_101 = _$_.template(`<!>`, 1, 1);
+var root_105 = _$_.template(`<b class="if">x</b><i class="if2">y</i>`, 1, 2);
+var root_104 = _$_.template(`<div class="outer"><!><span class="after"> </span><button class="outer-inc">outer</button></div>`, 0);
+var root_106 = _$_.template(`<div class="outer"><!><span class="after"> </span><button class="outer-inc">outer</button></div>`, 0);
+var root_108 = _$_.template(`<b class="item"> </b><i class="sep">|</i>`, 1, 2);
+var root_107 = _$_.template(`<div class="outer"><!><span class="after">after</span></div>`, 0);
+var root_109 = _$_.template(`<b class="made">made</b>`, 0);
+var root_111 = _$_.template(`<!><div class="a">a</div><div class="b">b</div>`, 1, 3);
+var root_110 = _$_.template(`<!>`, 1, 1);
+var root_113 = _$_.template(`<div class="a">a</div><style>.styled2 { color: blue; }</style><div class="styled2 b">b</div><div class="styled2 c">c</div>`, 1, 4);
+var root_112 = _$_.template(`<!>`, 1, 1);
+var root_114 = _$_.template(`<div class="outer"><!><span class="after"> </span><button class="outer-inc">outer</button></div>`, 0);
+var root_115 = _$_.template(`<div class="outer"><!><span class="after"> </span><button class="outer-inc">outer</button></div>`, 0);
+
+import { track } from 'ripple';
+
+function Leaf() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		var i = root();
+
+		_$_.append(__anchor, i);
+	});
+}
+
+export function TrailingNavigatedElements() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		let lazy = _$_.track(0, __block, 'a695c021');
+		var fragment = root_1();
+		var node = _$_.first_child_frag(fragment);
+
+		_$_.expression(node, () => _$_.tsrx_element((__anchor, __block) => {
+			var fragment_1 = root_2();
+			var div = _$_.first_child_frag(fragment_1);
+
+			{
+				var expression = _$_.hydrating ? _$_.hydrate_child(true) : div.firstChild;
+
+				_$_.pop(div);
+			}
+
+			var button = _$_.hydrating ? _$_.hydrate_sibling() : div.nextSibling;
+
+			button.__click = () => _$_.update(lazy);
+
+			var button_1 = _$_.hydrating ? _$_.hydrate_sibling() : button.nextSibling;
+
+			button_1.__click = () => _$_.update(lazy, -1);
+
+			_$_.render(() => {
+				_$_.set_text(expression, lazy.value);
+			});
+
+			_$_.append(__anchor, fragment_1);
+		}));
+
+		_$_.append(__anchor, fragment);
+	});
+}
+
+export function TrailingStaticNavigatedElements() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		let lazy_1 = _$_.track(0, __block, '0afd9398');
+		var fragment_2 = root_3();
+		var node_1 = _$_.first_child_frag(fragment_2);
+
+		_$_.expression(node_1, () => _$_.tsrx_element((__anchor, __block) => {
+			var fragment_3 = root_4();
+			var div_1 = _$_.first_child_frag(fragment_3);
+			var button_2 = _$_.hydrating ? _$_.hydrate_sibling() : div_1.nextSibling;
+
+			button_2.__click = () => _$_.update(lazy_1);
+
+			var button_3 = _$_.hydrating ? _$_.hydrate_sibling() : button_2.nextSibling;
+
+			button_3.__click = () => _$_.update(lazy_1, -1);
+			_$_.append(__anchor, fragment_3);
+		}));
+
+		_$_.append(__anchor, fragment_2);
+	});
+}
+
+export function NavigatedThenStatic() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		let lazy_2 = _$_.track(0, __block, '3cea07db');
+		var fragment_4 = root_5();
+		var node_2 = _$_.first_child_frag(fragment_4);
+
+		_$_.expression(node_2, () => _$_.tsrx_element((__anchor, __block) => {
+			var fragment_5 = root_6();
+			var div_2 = _$_.first_child_frag(fragment_5);
+			var button_4 = _$_.hydrating ? _$_.hydrate_sibling() : div_2.nextSibling;
+
+			button_4.__click = () => _$_.update(lazy_2);
+			_$_.next(2);
+			_$_.append(__anchor, fragment_5);
+		}));
+
+		_$_.append(__anchor, fragment_4);
+	});
+}
+
+export function LeadingNavigatedThenStatic() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		let lazy_3 = _$_.track(0, __block, '8ca89613');
+		var fragment_6 = root_7();
+		var node_3 = _$_.first_child_frag(fragment_6);
+
+		_$_.expression(node_3, () => _$_.tsrx_element((__anchor, __block) => {
+			var fragment_7 = root_8();
+			var button_5 = _$_.first_child_frag(fragment_7);
+
+			button_5.__click = () => _$_.update(lazy_3);
+			_$_.next(2);
+			_$_.append(__anchor, fragment_7);
+		}));
+
+		_$_.append(__anchor, fragment_6);
+	});
+}
+
+export function TrailingNestedNavigated() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		let lazy_4 = _$_.track(0, __block, 'f0f5a337');
+		var fragment_8 = root_9();
+		var node_4 = _$_.first_child_frag(fragment_8);
+
+		_$_.expression(node_4, () => _$_.tsrx_element((__anchor, __block) => {
+			var fragment_9 = root_10();
+			var div_4 = _$_.first_child_frag(fragment_9);
+			var div_3 = _$_.hydrating ? _$_.hydrate_sibling() : div_4.nextSibling;
+
+			{
+				var button_6 = _$_.hydrating ? _$_.hydrate_child() : div_3.firstChild;
+
+				button_6.__click = () => _$_.update(lazy_4);
+			}
+
+			_$_.pop(div_3);
+			_$_.append(__anchor, fragment_9);
+		}));
+
+		_$_.append(__anchor, fragment_8);
+	});
+}
+
+export function NestedNavigatedThenStatic() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		let lazy_5 = _$_.track(0, __block, '2a6293f9');
+		var fragment_10 = root_11();
+		var node_5 = _$_.first_child_frag(fragment_10);
+
+		_$_.expression(node_5, () => _$_.tsrx_element((__anchor, __block) => {
+			var fragment_11 = root_12();
+			var div_5 = _$_.first_child_frag(fragment_11);
+
+			{
+				var button_7 = _$_.hydrating ? _$_.hydrate_child() : div_5.firstChild;
+
+				button_7.__click = () => _$_.update(lazy_5);
+			}
+
+			_$_.pop(div_5);
+			_$_.next(2);
+			_$_.append(__anchor, fragment_11);
+		}));
+
+		_$_.append(__anchor, fragment_10);
+	});
+}
+
+export function TrackedTextThenStatic() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		let lazy_6 = _$_.track(0, __block, 'db93f6f0');
+		var fragment_12 = root_13();
+		var node_6 = _$_.first_child_frag(fragment_12);
+
+		_$_.expression(node_6, () => _$_.tsrx_element((__anchor, __block) => {
+			var fragment_13 = root_14();
+			var expression_1 = _$_.first_child_frag(fragment_13, true);
+
+			_$_.next(2);
+
+			_$_.render(() => {
+				_$_.set_text(expression_1, lazy_6.value);
+			});
+
+			_$_.append(__anchor, fragment_13);
+		}));
+
+		_$_.append(__anchor, fragment_12);
+	});
+}
+
+export function StaticThenTrackedText() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		let lazy_7 = _$_.track(0, __block, '84cf2507');
+		var fragment_14 = root_15();
+		var node_7 = _$_.first_child_frag(fragment_14);
+
+		_$_.expression(node_7, () => _$_.tsrx_element((__anchor, __block) => {
+			var fragment_15 = root_16();
+			var div_7 = _$_.first_child_frag(fragment_15);
+			var div_6 = _$_.hydrating ? _$_.hydrate_sibling() : div_7.nextSibling;
+			var expression_2 = _$_.hydrating ? _$_.hydrate_sibling(true) : div_6.nextSibling;
+
+			_$_.render(() => {
+				_$_.set_text(expression_2, lazy_7.value);
+			});
+
+			_$_.append(__anchor, fragment_15);
+		}));
+
+		_$_.append(__anchor, fragment_14);
+	});
+}
+
+export function StaticNestedThenStatic() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		var fragment_16 = root_17();
+		var node_8 = _$_.first_child_frag(fragment_16);
+
+		_$_.expression(node_8, () => _$_.tsrx_element((__anchor, __block) => {
+			var fragment_17 = root_18();
+
+			_$_.next(3);
+			_$_.append(__anchor, fragment_17);
+		}));
+
+		_$_.append(__anchor, fragment_16);
+	});
+}
+
+export function AllStatic() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		var fragment_18 = root_19();
+		var node_9 = _$_.first_child_frag(fragment_18);
+
+		_$_.expression(node_9, () => _$_.tsrx_element((__anchor, __block) => {
+			var fragment_19 = root_20();
+
+			_$_.next(2);
+			_$_.append(__anchor, fragment_19);
+		}));
+
+		_$_.append(__anchor, fragment_18);
+	});
+}
+
+export function TrailingDynamicChild() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		let lazy_8 = _$_.track(0, __block, '9be343a7');
+		var fragment_20 = root_21();
+		var node_10 = _$_.first_child_frag(fragment_20);
+
+		_$_.expression(node_10, () => _$_.tsrx_element((__anchor, __block) => {
+			var fragment_21 = root_22();
+			var div_9 = _$_.first_child_frag(fragment_21);
+			var div_8 = _$_.hydrating ? _$_.hydrate_sibling() : div_9.nextSibling;
+
+			{
+				var expression_3 = _$_.hydrating ? _$_.hydrate_child(true) : div_8.firstChild;
+
+				_$_.pop(div_8);
+			}
+
+			_$_.render(() => {
+				_$_.set_text(expression_3, lazy_8.value);
+			});
+
+			_$_.append(__anchor, fragment_21);
+		}));
+
+		_$_.append(__anchor, fragment_20);
+	});
+}
+
+export function DynamicChildThenStatic() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		let lazy_9 = _$_.track(0, __block, 'c76dd5a9');
+		var fragment_22 = root_23();
+		var node_11 = _$_.first_child_frag(fragment_22);
+
+		_$_.expression(node_11, () => _$_.tsrx_element((__anchor, __block) => {
+			var fragment_23 = root_24();
+			var div_10 = _$_.first_child_frag(fragment_23);
+
+			{
+				var expression_4 = _$_.hydrating ? _$_.hydrate_child(true) : div_10.firstChild;
+
+				_$_.pop(div_10);
+			}
+
+			_$_.next(2);
+
+			_$_.render(() => {
+				_$_.set_text(expression_4, lazy_9.value);
+			});
+
+			_$_.append(__anchor, fragment_23);
+		}));
+
+		_$_.append(__anchor, fragment_22);
+	});
+}
+
+export function IfThenStatic() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		let lazy_10 = _$_.track(0, __block, 'fb175ecd');
+		var fragment_24 = root_25();
+		var node_13 = _$_.first_child_frag(fragment_24);
+
+		_$_.expression(node_13, () => _$_.tsrx_element((__anchor, __block) => {
+			var fragment_25 = root_26();
+			var node_12 = _$_.first_child_frag(fragment_25);
+
+			{
+				var consequent = (__anchor) => {
+					var b = root_27();
+
+					_$_.append(__anchor, b);
+				};
+
+				_$_.if(node_12, (__render) => {
+					if (lazy_10.value >= 0) __render(consequent);
+				});
+			}
+
+			_$_.next(2);
+			_$_.append(__anchor, fragment_25);
+		}));
+
+		_$_.append(__anchor, fragment_24);
+	});
+}
+
+export function StaticThenIf() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		let lazy_11 = _$_.track(0, __block, 'c8563a58');
+		var fragment_26 = root_28();
+		var node_15 = _$_.first_child_frag(fragment_26);
+
+		_$_.expression(node_15, () => _$_.tsrx_element((__anchor, __block) => {
+			var fragment_27 = root_29();
+			var div_12 = _$_.first_child_frag(fragment_27);
+			var div_11 = _$_.hydrating ? _$_.hydrate_sibling() : div_12.nextSibling;
+			var node_14 = _$_.hydrating ? _$_.hydrate_sibling() : div_11.nextSibling;
+
+			{
+				var consequent_1 = (__anchor) => {
+					var b_1 = root_30();
+
+					_$_.append(__anchor, b_1);
+				};
+
+				_$_.if(node_14, (__render) => {
+					if (lazy_11.value >= 0) __render(consequent_1);
+				});
+			}
+
+			_$_.append(__anchor, fragment_27);
+		}));
+
+		_$_.append(__anchor, fragment_26);
+	});
+}
+
+export function CompThenStatic() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		var fragment_28 = root_31();
+		var node_17 = _$_.first_child_frag(fragment_28);
+
+		_$_.expression(node_17, () => _$_.tsrx_element((__anchor, __block) => {
+			var fragment_29 = root_32();
+			var node_16 = _$_.first_child_frag(fragment_29);
+
+			_$_.render_component(Leaf, node_16, {});
+			_$_.next(2);
+			_$_.append(__anchor, fragment_29);
+		}));
+
+		_$_.append(__anchor, fragment_28);
+	});
+}
+
+export function StaticThenComp() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		var fragment_30 = root_33();
+		var node_19 = _$_.first_child_frag(fragment_30);
+
+		_$_.expression(node_19, () => _$_.tsrx_element((__anchor, __block) => {
+			var fragment_31 = root_34();
+			var div_14 = _$_.first_child_frag(fragment_31);
+			var div_13 = _$_.hydrating ? _$_.hydrate_sibling() : div_14.nextSibling;
+			var node_18 = _$_.hydrating ? _$_.hydrate_sibling() : div_13.nextSibling;
+
+			_$_.render_component(Leaf, node_18, {});
+			_$_.append(__anchor, fragment_31);
+		}));
+
+		_$_.append(__anchor, fragment_30);
+	});
+}
+
+export function SiblingComps() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		var fragment_32 = root_35();
+		var node_22 = _$_.first_child_frag(fragment_32);
+
+		_$_.expression(node_22, () => _$_.tsrx_element((__anchor, __block) => {
+			var fragment_33 = root_36();
+			var node_20 = _$_.first_child_frag(fragment_33);
+
+			_$_.render_component(Leaf, node_20, {});
+
+			var node_21 = _$_.hydrating ? _$_.hydrate_sibling() : node_20.nextSibling;
+
+			_$_.render_component(Leaf, node_21, {});
+			_$_.append(__anchor, fragment_33);
+		}));
+
+		_$_.append(__anchor, fragment_32);
+	});
+}
+
+export function WrapTrailingNavigatedElements() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		let lazy_12 = _$_.track(0, __block, '1032dbec');
+		var div_15 = root_37();
+
+		{
+			var node_23 = _$_.hydrating ? _$_.hydrate_child() : div_15.firstChild;
+
+			_$_.render_component(TrailingNavigatedElements, node_23, {});
+
+			var span = _$_.hydrating ? _$_.hydrate_sibling() : node_23.nextSibling;
+
+			{
+				var expression_5 = _$_.hydrating ? _$_.hydrate_child(true) : span.firstChild;
+
+				_$_.pop(span);
+			}
+
+			var button_8 = _$_.hydrating ? _$_.hydrate_sibling() : span.nextSibling;
+
+			button_8.__click = () => _$_.update(lazy_12);
+			_$_.pop(div_15);
+		}
+
+		_$_.render(() => {
+			_$_.set_text(expression_5, lazy_12.value);
+		});
+
+		_$_.append(__anchor, div_15);
+	});
+}
+
+export function WrapTrailingStaticNavigatedElements() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		let lazy_13 = _$_.track(0, __block, 'c2e2a938');
+		var div_16 = root_38();
+
+		{
+			var node_24 = _$_.hydrating ? _$_.hydrate_child() : div_16.firstChild;
+
+			_$_.render_component(TrailingStaticNavigatedElements, node_24, {});
+
+			var span_1 = _$_.hydrating ? _$_.hydrate_sibling() : node_24.nextSibling;
+
+			{
+				var expression_6 = _$_.hydrating ? _$_.hydrate_child(true) : span_1.firstChild;
+
+				_$_.pop(span_1);
+			}
+
+			var button_9 = _$_.hydrating ? _$_.hydrate_sibling() : span_1.nextSibling;
+
+			button_9.__click = () => _$_.update(lazy_13);
+			_$_.pop(div_16);
+		}
+
+		_$_.render(() => {
+			_$_.set_text(expression_6, lazy_13.value);
+		});
+
+		_$_.append(__anchor, div_16);
+	});
+}
+
+export function WrapNavigatedThenStatic() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		let lazy_14 = _$_.track(0, __block, 'b4046e87');
+		var div_17 = root_39();
+
+		{
+			var node_25 = _$_.hydrating ? _$_.hydrate_child() : div_17.firstChild;
+
+			_$_.render_component(NavigatedThenStatic, node_25, {});
+
+			var span_2 = _$_.hydrating ? _$_.hydrate_sibling() : node_25.nextSibling;
+
+			{
+				var expression_7 = _$_.hydrating ? _$_.hydrate_child(true) : span_2.firstChild;
+
+				_$_.pop(span_2);
+			}
+
+			var button_10 = _$_.hydrating ? _$_.hydrate_sibling() : span_2.nextSibling;
+
+			button_10.__click = () => _$_.update(lazy_14);
+			_$_.pop(div_17);
+		}
+
+		_$_.render(() => {
+			_$_.set_text(expression_7, lazy_14.value);
+		});
+
+		_$_.append(__anchor, div_17);
+	});
+}
+
+export function WrapLeadingNavigatedThenStatic() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		let lazy_15 = _$_.track(0, __block, 'bed7f7ef');
+		var div_18 = root_40();
+
+		{
+			var node_26 = _$_.hydrating ? _$_.hydrate_child() : div_18.firstChild;
+
+			_$_.render_component(LeadingNavigatedThenStatic, node_26, {});
+
+			var span_3 = _$_.hydrating ? _$_.hydrate_sibling() : node_26.nextSibling;
+
+			{
+				var expression_8 = _$_.hydrating ? _$_.hydrate_child(true) : span_3.firstChild;
+
+				_$_.pop(span_3);
+			}
+
+			var button_11 = _$_.hydrating ? _$_.hydrate_sibling() : span_3.nextSibling;
+
+			button_11.__click = () => _$_.update(lazy_15);
+			_$_.pop(div_18);
+		}
+
+		_$_.render(() => {
+			_$_.set_text(expression_8, lazy_15.value);
+		});
+
+		_$_.append(__anchor, div_18);
+	});
+}
+
+export function WrapTrailingNestedNavigated() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		let lazy_16 = _$_.track(0, __block, 'eddbe7bc');
+		var div_19 = root_41();
+
+		{
+			var node_27 = _$_.hydrating ? _$_.hydrate_child() : div_19.firstChild;
+
+			_$_.render_component(TrailingNestedNavigated, node_27, {});
+
+			var span_4 = _$_.hydrating ? _$_.hydrate_sibling() : node_27.nextSibling;
+
+			{
+				var expression_9 = _$_.hydrating ? _$_.hydrate_child(true) : span_4.firstChild;
+
+				_$_.pop(span_4);
+			}
+
+			var button_12 = _$_.hydrating ? _$_.hydrate_sibling() : span_4.nextSibling;
+
+			button_12.__click = () => _$_.update(lazy_16);
+			_$_.pop(div_19);
+		}
+
+		_$_.render(() => {
+			_$_.set_text(expression_9, lazy_16.value);
+		});
+
+		_$_.append(__anchor, div_19);
+	});
+}
+
+export function WrapNestedNavigatedThenStatic() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		let lazy_17 = _$_.track(0, __block, '1bdc4523');
+		var div_20 = root_42();
+
+		{
+			var node_28 = _$_.hydrating ? _$_.hydrate_child() : div_20.firstChild;
+
+			_$_.render_component(NestedNavigatedThenStatic, node_28, {});
+
+			var span_5 = _$_.hydrating ? _$_.hydrate_sibling() : node_28.nextSibling;
+
+			{
+				var expression_10 = _$_.hydrating ? _$_.hydrate_child(true) : span_5.firstChild;
+
+				_$_.pop(span_5);
+			}
+
+			var button_13 = _$_.hydrating ? _$_.hydrate_sibling() : span_5.nextSibling;
+
+			button_13.__click = () => _$_.update(lazy_17);
+			_$_.pop(div_20);
+		}
+
+		_$_.render(() => {
+			_$_.set_text(expression_10, lazy_17.value);
+		});
+
+		_$_.append(__anchor, div_20);
+	});
+}
+
+export function WrapTrackedTextThenStatic() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		let lazy_18 = _$_.track(0, __block, '97e02c24');
+		var div_21 = root_43();
+
+		{
+			var node_29 = _$_.hydrating ? _$_.hydrate_child() : div_21.firstChild;
+
+			_$_.render_component(TrackedTextThenStatic, node_29, {});
+
+			var span_6 = _$_.hydrating ? _$_.hydrate_sibling() : node_29.nextSibling;
+
+			{
+				var expression_11 = _$_.hydrating ? _$_.hydrate_child(true) : span_6.firstChild;
+
+				_$_.pop(span_6);
+			}
+
+			var button_14 = _$_.hydrating ? _$_.hydrate_sibling() : span_6.nextSibling;
+
+			button_14.__click = () => _$_.update(lazy_18);
+			_$_.pop(div_21);
+		}
+
+		_$_.render(() => {
+			_$_.set_text(expression_11, lazy_18.value);
+		});
+
+		_$_.append(__anchor, div_21);
+	});
+}
+
+export function WrapStaticThenTrackedText() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		let lazy_19 = _$_.track(0, __block, 'd5526861');
+		var div_22 = root_44();
+
+		{
+			var node_30 = _$_.hydrating ? _$_.hydrate_child() : div_22.firstChild;
+
+			_$_.render_component(StaticThenTrackedText, node_30, {});
+
+			var span_7 = _$_.hydrating ? _$_.hydrate_sibling() : node_30.nextSibling;
+
+			{
+				var expression_12 = _$_.hydrating ? _$_.hydrate_child(true) : span_7.firstChild;
+
+				_$_.pop(span_7);
+			}
+
+			var button_15 = _$_.hydrating ? _$_.hydrate_sibling() : span_7.nextSibling;
+
+			button_15.__click = () => _$_.update(lazy_19);
+			_$_.pop(div_22);
+		}
+
+		_$_.render(() => {
+			_$_.set_text(expression_12, lazy_19.value);
+		});
+
+		_$_.append(__anchor, div_22);
+	});
+}
+
+export function WrapStaticNestedThenStatic() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		let lazy_20 = _$_.track(0, __block, '7e2d3fad');
+		var div_23 = root_45();
+
+		{
+			var node_31 = _$_.hydrating ? _$_.hydrate_child() : div_23.firstChild;
+
+			_$_.render_component(StaticNestedThenStatic, node_31, {});
+
+			var span_8 = _$_.hydrating ? _$_.hydrate_sibling() : node_31.nextSibling;
+
+			{
+				var expression_13 = _$_.hydrating ? _$_.hydrate_child(true) : span_8.firstChild;
+
+				_$_.pop(span_8);
+			}
+
+			var button_16 = _$_.hydrating ? _$_.hydrate_sibling() : span_8.nextSibling;
+
+			button_16.__click = () => _$_.update(lazy_20);
+			_$_.pop(div_23);
+		}
+
+		_$_.render(() => {
+			_$_.set_text(expression_13, lazy_20.value);
+		});
+
+		_$_.append(__anchor, div_23);
+	});
+}
+
+export function WrapAllStatic() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		let lazy_21 = _$_.track(0, __block, 'b894f45a');
+		var div_24 = root_46();
+
+		{
+			var node_32 = _$_.hydrating ? _$_.hydrate_child() : div_24.firstChild;
+
+			_$_.render_component(AllStatic, node_32, {});
+
+			var span_9 = _$_.hydrating ? _$_.hydrate_sibling() : node_32.nextSibling;
+
+			{
+				var expression_14 = _$_.hydrating ? _$_.hydrate_child(true) : span_9.firstChild;
+
+				_$_.pop(span_9);
+			}
+
+			var button_17 = _$_.hydrating ? _$_.hydrate_sibling() : span_9.nextSibling;
+
+			button_17.__click = () => _$_.update(lazy_21);
+			_$_.pop(div_24);
+		}
+
+		_$_.render(() => {
+			_$_.set_text(expression_14, lazy_21.value);
+		});
+
+		_$_.append(__anchor, div_24);
+	});
+}
+
+export function WrapTrailingDynamicChild() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		let lazy_22 = _$_.track(0, __block, '038446ca');
+		var div_25 = root_47();
+
+		{
+			var node_33 = _$_.hydrating ? _$_.hydrate_child() : div_25.firstChild;
+
+			_$_.render_component(TrailingDynamicChild, node_33, {});
+
+			var span_10 = _$_.hydrating ? _$_.hydrate_sibling() : node_33.nextSibling;
+
+			{
+				var expression_15 = _$_.hydrating ? _$_.hydrate_child(true) : span_10.firstChild;
+
+				_$_.pop(span_10);
+			}
+
+			var button_18 = _$_.hydrating ? _$_.hydrate_sibling() : span_10.nextSibling;
+
+			button_18.__click = () => _$_.update(lazy_22);
+			_$_.pop(div_25);
+		}
+
+		_$_.render(() => {
+			_$_.set_text(expression_15, lazy_22.value);
+		});
+
+		_$_.append(__anchor, div_25);
+	});
+}
+
+export function WrapDynamicChildThenStatic() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		let lazy_23 = _$_.track(0, __block, '3ec460c3');
+		var div_26 = root_48();
+
+		{
+			var node_34 = _$_.hydrating ? _$_.hydrate_child() : div_26.firstChild;
+
+			_$_.render_component(DynamicChildThenStatic, node_34, {});
+
+			var span_11 = _$_.hydrating ? _$_.hydrate_sibling() : node_34.nextSibling;
+
+			{
+				var expression_16 = _$_.hydrating ? _$_.hydrate_child(true) : span_11.firstChild;
+
+				_$_.pop(span_11);
+			}
+
+			var button_19 = _$_.hydrating ? _$_.hydrate_sibling() : span_11.nextSibling;
+
+			button_19.__click = () => _$_.update(lazy_23);
+			_$_.pop(div_26);
+		}
+
+		_$_.render(() => {
+			_$_.set_text(expression_16, lazy_23.value);
+		});
+
+		_$_.append(__anchor, div_26);
+	});
+}
+
+export function WrapIfThenStatic() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		let lazy_24 = _$_.track(0, __block, '95b417dd');
+		var div_27 = root_49();
+
+		{
+			var node_35 = _$_.hydrating ? _$_.hydrate_child() : div_27.firstChild;
+
+			_$_.render_component(IfThenStatic, node_35, {});
+
+			var span_12 = _$_.hydrating ? _$_.hydrate_sibling() : node_35.nextSibling;
+
+			{
+				var expression_17 = _$_.hydrating ? _$_.hydrate_child(true) : span_12.firstChild;
+
+				_$_.pop(span_12);
+			}
+
+			var button_20 = _$_.hydrating ? _$_.hydrate_sibling() : span_12.nextSibling;
+
+			button_20.__click = () => _$_.update(lazy_24);
+			_$_.pop(div_27);
+		}
+
+		_$_.render(() => {
+			_$_.set_text(expression_17, lazy_24.value);
+		});
+
+		_$_.append(__anchor, div_27);
+	});
+}
+
+export function WrapStaticThenIf() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		let lazy_25 = _$_.track(0, __block, '1f01fa6f');
+		var div_28 = root_50();
+
+		{
+			var node_36 = _$_.hydrating ? _$_.hydrate_child() : div_28.firstChild;
+
+			_$_.render_component(StaticThenIf, node_36, {});
+
+			var span_13 = _$_.hydrating ? _$_.hydrate_sibling() : node_36.nextSibling;
+
+			{
+				var expression_18 = _$_.hydrating ? _$_.hydrate_child(true) : span_13.firstChild;
+
+				_$_.pop(span_13);
+			}
+
+			var button_21 = _$_.hydrating ? _$_.hydrate_sibling() : span_13.nextSibling;
+
+			button_21.__click = () => _$_.update(lazy_25);
+			_$_.pop(div_28);
+		}
+
+		_$_.render(() => {
+			_$_.set_text(expression_18, lazy_25.value);
+		});
+
+		_$_.append(__anchor, div_28);
+	});
+}
+
+export function WrapCompThenStatic() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		let lazy_26 = _$_.track(0, __block, 'e6bdb91d');
+		var div_29 = root_51();
+
+		{
+			var node_37 = _$_.hydrating ? _$_.hydrate_child() : div_29.firstChild;
+
+			_$_.render_component(CompThenStatic, node_37, {});
+
+			var span_14 = _$_.hydrating ? _$_.hydrate_sibling() : node_37.nextSibling;
+
+			{
+				var expression_19 = _$_.hydrating ? _$_.hydrate_child(true) : span_14.firstChild;
+
+				_$_.pop(span_14);
+			}
+
+			var button_22 = _$_.hydrating ? _$_.hydrate_sibling() : span_14.nextSibling;
+
+			button_22.__click = () => _$_.update(lazy_26);
+			_$_.pop(div_29);
+		}
+
+		_$_.render(() => {
+			_$_.set_text(expression_19, lazy_26.value);
+		});
+
+		_$_.append(__anchor, div_29);
+	});
+}
+
+export function WrapStaticThenComp() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		let lazy_27 = _$_.track(0, __block, '89d5704c');
+		var div_30 = root_52();
+
+		{
+			var node_38 = _$_.hydrating ? _$_.hydrate_child() : div_30.firstChild;
+
+			_$_.render_component(StaticThenComp, node_38, {});
+
+			var span_15 = _$_.hydrating ? _$_.hydrate_sibling() : node_38.nextSibling;
+
+			{
+				var expression_20 = _$_.hydrating ? _$_.hydrate_child(true) : span_15.firstChild;
+
+				_$_.pop(span_15);
+			}
+
+			var button_23 = _$_.hydrating ? _$_.hydrate_sibling() : span_15.nextSibling;
+
+			button_23.__click = () => _$_.update(lazy_27);
+			_$_.pop(div_30);
+		}
+
+		_$_.render(() => {
+			_$_.set_text(expression_20, lazy_27.value);
+		});
+
+		_$_.append(__anchor, div_30);
+	});
+}
+
+export function WrapSiblingComps() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		let lazy_28 = _$_.track(0, __block, 'c5c51af6');
+		var div_31 = root_53();
+
+		{
+			var node_39 = _$_.hydrating ? _$_.hydrate_child() : div_31.firstChild;
+
+			_$_.render_component(SiblingComps, node_39, {});
+
+			var span_16 = _$_.hydrating ? _$_.hydrate_sibling() : node_39.nextSibling;
+
+			{
+				var expression_21 = _$_.hydrating ? _$_.hydrate_child(true) : span_16.firstChild;
+
+				_$_.pop(span_16);
+			}
+
+			var button_24 = _$_.hydrating ? _$_.hydrate_sibling() : span_16.nextSibling;
+
+			button_24.__click = () => _$_.update(lazy_28);
+			_$_.pop(div_31);
+		}
+
+		_$_.render(() => {
+			_$_.set_text(expression_21, lazy_28.value);
+		});
+
+		_$_.append(__anchor, div_31);
+	});
+}
+
+export function UntrackedTextThenStatic() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		const label = 'label';
+		var fragment_34 = root_54();
+		var node_40 = _$_.first_child_frag(fragment_34);
+
+		_$_.expression(node_40, () => _$_.tsrx_element((__anchor, __block) => {
+			var fragment_35 = root_55();
+			var expression_22 = _$_.first_child_frag(fragment_35);
+
+			_$_.expression(expression_22, () => _$_.with_scope(__block, () => label.toUpperCase()));
+			_$_.next(2);
+			_$_.append(__anchor, fragment_35);
+		}));
+
+		_$_.append(__anchor, fragment_34);
+	});
+}
+
+export function NestedFragmentThenStatic() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		var fragment_36 = root_56();
+		var node_42 = _$_.first_child_frag(fragment_36);
+
+		_$_.expression(node_42, () => _$_.tsrx_element((__anchor, __block) => {
+			var fragment_37 = root_57();
+			var div_32 = _$_.first_child_frag(fragment_37);
+			var node_41 = _$_.hydrating ? _$_.hydrate_sibling() : div_32.nextSibling;
+
+			_$_.expression(node_41, () => _$_.tsrx_element((__anchor, __block) => {
+				var fragment_38 = root_58();
+
+				_$_.next();
+				_$_.append(__anchor, fragment_38);
+			}));
+
+			_$_.next(2);
+			_$_.append(__anchor, fragment_37);
+		}));
+
+		_$_.append(__anchor, fragment_36);
+	});
+}
+
+export function TrailingNestedFragment() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		let lazy_29 = _$_.track(0, __block, '82cbc65f');
+		var fragment_39 = root_59();
+		var node_44 = _$_.first_child_frag(fragment_39);
+
+		_$_.expression(node_44, () => _$_.tsrx_element((__anchor, __block) => {
+			var fragment_40 = root_60();
+			var div_33 = _$_.first_child_frag(fragment_40);
+
+			{
+				var expression_23 = _$_.hydrating ? _$_.hydrate_child(true) : div_33.firstChild;
+
+				_$_.pop(div_33);
+			}
+
+			var node_43 = _$_.hydrating ? _$_.hydrate_sibling() : div_33.nextSibling;
+
+			_$_.expression(node_43, () => _$_.tsrx_element((__anchor, __block) => {
+				var fragment_41 = root_61();
+				var span_17 = _$_.first_child_frag(fragment_41);
+				var button_25 = _$_.hydrating ? _$_.hydrate_sibling() : span_17.nextSibling;
+
+				button_25.__click = () => _$_.update(lazy_29);
+				_$_.append(__anchor, fragment_41);
+			}));
+
+			_$_.render(() => {
+				_$_.set_text(expression_23, lazy_29.value);
+			});
+
+			_$_.append(__anchor, fragment_40);
+		}));
+
+		_$_.append(__anchor, fragment_39);
+	});
+}
+
+export function ForThenStatic() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		const items = [1, 2];
+		var fragment_42 = root_62();
+		var node_46 = _$_.first_child_frag(fragment_42);
+
+		_$_.expression(node_46, () => _$_.tsrx_element((__anchor, __block) => {
+			var fragment_43 = root_63();
+			var node_45 = _$_.first_child_frag(fragment_43);
+
+			_$_.for(
+				node_45,
+				() => items,
+				(__anchor, item) => {
+					var b_2 = root_64();
+
+					{
+						var expression_24 = _$_.hydrating ? _$_.hydrate_child() : b_2.firstChild;
+
+						_$_.expression(expression_24, () => item);
+						_$_.pop(b_2);
+					}
+
+					_$_.append(__anchor, b_2);
+				},
+				0
+			);
+
+			_$_.next(2);
+			_$_.append(__anchor, fragment_43);
+		}));
+
+		_$_.append(__anchor, fragment_42);
+	});
+}
+
+export function SwitchThenStatic() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		let lazy_30 = _$_.track(0, __block, '800f9ff3');
+		var fragment_44 = root_65();
+		var node_48 = _$_.first_child_frag(fragment_44);
+
+		_$_.expression(node_48, () => _$_.tsrx_element((__anchor, __block) => {
+			var fragment_45 = root_66();
+			var node_47 = _$_.first_child_frag(fragment_45);
+
+			{
+				var switch_case_0 = (__anchor) => {
+					var b_3 = root_67();
+
+					_$_.append(__anchor, b_3);
+				};
+
+				var switch_case_default = (__anchor) => {
+					var b_4 = root_68();
+
+					_$_.append(__anchor, b_4);
+				};
+
+				_$_.switch(node_47, () => {
+					var result = [];
+
+					switch (lazy_30.value) {
+						case 0:
+							result.push(switch_case_0);
+							return result;
+
+						default:
+							result.push(switch_case_default);
+							return result;
+					}
+				});
+			}
+
+			_$_.next(2);
+			_$_.append(__anchor, fragment_45);
+		}));
+
+		_$_.append(__anchor, fragment_44);
+	});
+}
+
+export function TryThenStatic() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		var fragment_46 = root_69();
+		var node_50 = _$_.first_child_frag(fragment_46);
+
+		_$_.expression(node_50, () => _$_.tsrx_element((__anchor, __block) => {
+			var fragment_47 = root_70();
+			var node_49 = _$_.first_child_frag(fragment_47);
+
+			_$_.try(
+				node_49,
+				(__anchor) => {
+					var b_5 = root_71();
+
+					_$_.append(__anchor, b_5);
+				},
+				(__anchor, e) => {
+					var b_6 = root_72();
+
+					_$_.append(__anchor, b_6);
+				}
+			);
+
+			_$_.next(2);
+			_$_.append(__anchor, fragment_47);
+		}));
+
+		_$_.append(__anchor, fragment_46);
+	});
+}
+
+export function StyleThenStatic() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		var fragment_48 = root_73();
+		var node_51 = _$_.first_child_frag(fragment_48);
+
+		_$_.expression(node_51, () => _$_.tsrx_element((__anchor, __block) => {
+			var fragment_49 = root_74();
+			var style = _$_.first_child_frag(fragment_49);
+
+			{
+				_$_.pop(style);
+			}
+
+			_$_.next(2);
+			_$_.append(__anchor, fragment_49);
+		}));
+
+		_$_.append(__anchor, fragment_48);
+	});
+}
+
+export function CollectionThenStatic() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		const items = [1, 2];
+		var fragment_50 = root_75();
+		var node_52 = _$_.first_child_frag(fragment_50);
+
+		_$_.expression(node_52, () => _$_.tsrx_element((__anchor, __block) => {
+			var fragment_51 = root_77();
+			var expression_26 = _$_.first_child_frag(fragment_51);
+
+			_$_.expression(expression_26, () => _$_.with_scope(__block, () => items.map((item) => _$_.tsrx_element((__anchor, __block) => {
+				var b_7 = root_76();
+
+				{
+					var expression_25 = _$_.hydrating ? _$_.hydrate_child() : b_7.firstChild;
+
+					_$_.expression(expression_25, () => item);
+					_$_.pop(b_7);
+				}
+
+				_$_.append(__anchor, b_7);
+			}))));
+
+			_$_.next(2);
+			_$_.append(__anchor, fragment_51);
+		}));
+
+		_$_.append(__anchor, fragment_50);
+	});
+}
+
+export function InlineElementThenStatic() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		var fragment_52 = root_78();
+		var node_53 = _$_.first_child_frag(fragment_52);
+
+		_$_.expression(node_53, () => _$_.tsrx_element((__anchor, __block) => {
+			var fragment_53 = root_80();
+			var expression_27 = _$_.first_child_frag(fragment_53);
+
+			_$_.expression(expression_27, () => _$_.tsrx_element((__anchor, __block) => {
+				var b_8 = root_79();
+
+				_$_.append(__anchor, b_8);
+			}));
+
+			_$_.next(2);
+			_$_.append(__anchor, fragment_53);
+		}));
+
+		_$_.append(__anchor, fragment_52);
+	});
+}
+
+export function WrapUntrackedTextThenStatic() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		let lazy_31 = _$_.track(0, __block, '3a78abea');
+		var div_34 = root_81();
+
+		{
+			var node_54 = _$_.hydrating ? _$_.hydrate_child() : div_34.firstChild;
+
+			_$_.render_component(UntrackedTextThenStatic, node_54, {});
+
+			var span_18 = _$_.hydrating ? _$_.hydrate_sibling() : node_54.nextSibling;
+
+			{
+				var expression_28 = _$_.hydrating ? _$_.hydrate_child(true) : span_18.firstChild;
+
+				_$_.pop(span_18);
+			}
+
+			var button_26 = _$_.hydrating ? _$_.hydrate_sibling() : span_18.nextSibling;
+
+			button_26.__click = () => _$_.update(lazy_31);
+			_$_.pop(div_34);
+		}
+
+		_$_.render(() => {
+			_$_.set_text(expression_28, lazy_31.value);
+		});
+
+		_$_.append(__anchor, div_34);
+	});
+}
+
+export function WrapNestedFragmentThenStatic() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		let lazy_32 = _$_.track(0, __block, 'db289d00');
+		var div_35 = root_82();
+
+		{
+			var node_55 = _$_.hydrating ? _$_.hydrate_child() : div_35.firstChild;
+
+			_$_.render_component(NestedFragmentThenStatic, node_55, {});
+
+			var span_19 = _$_.hydrating ? _$_.hydrate_sibling() : node_55.nextSibling;
+
+			{
+				var expression_29 = _$_.hydrating ? _$_.hydrate_child(true) : span_19.firstChild;
+
+				_$_.pop(span_19);
+			}
+
+			var button_27 = _$_.hydrating ? _$_.hydrate_sibling() : span_19.nextSibling;
+
+			button_27.__click = () => _$_.update(lazy_32);
+			_$_.pop(div_35);
+		}
+
+		_$_.render(() => {
+			_$_.set_text(expression_29, lazy_32.value);
+		});
+
+		_$_.append(__anchor, div_35);
+	});
+}
+
+export function WrapTrailingNestedFragment() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		let lazy_33 = _$_.track(0, __block, 'bb509235');
+		var div_36 = root_83();
+
+		{
+			var node_56 = _$_.hydrating ? _$_.hydrate_child() : div_36.firstChild;
+
+			_$_.render_component(TrailingNestedFragment, node_56, {});
+
+			var span_20 = _$_.hydrating ? _$_.hydrate_sibling() : node_56.nextSibling;
+
+			{
+				var expression_30 = _$_.hydrating ? _$_.hydrate_child(true) : span_20.firstChild;
+
+				_$_.pop(span_20);
+			}
+
+			var button_28 = _$_.hydrating ? _$_.hydrate_sibling() : span_20.nextSibling;
+
+			button_28.__click = () => _$_.update(lazy_33);
+			_$_.pop(div_36);
+		}
+
+		_$_.render(() => {
+			_$_.set_text(expression_30, lazy_33.value);
+		});
+
+		_$_.append(__anchor, div_36);
+	});
+}
+
+export function WrapForThenStatic() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		let lazy_34 = _$_.track(0, __block, 'a715e40a');
+		var div_37 = root_84();
+
+		{
+			var node_57 = _$_.hydrating ? _$_.hydrate_child() : div_37.firstChild;
+
+			_$_.render_component(ForThenStatic, node_57, {});
+
+			var span_21 = _$_.hydrating ? _$_.hydrate_sibling() : node_57.nextSibling;
+
+			{
+				var expression_31 = _$_.hydrating ? _$_.hydrate_child(true) : span_21.firstChild;
+
+				_$_.pop(span_21);
+			}
+
+			var button_29 = _$_.hydrating ? _$_.hydrate_sibling() : span_21.nextSibling;
+
+			button_29.__click = () => _$_.update(lazy_34);
+			_$_.pop(div_37);
+		}
+
+		_$_.render(() => {
+			_$_.set_text(expression_31, lazy_34.value);
+		});
+
+		_$_.append(__anchor, div_37);
+	});
+}
+
+export function WrapSwitchThenStatic() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		let lazy_35 = _$_.track(0, __block, 'a598ad9f');
+		var div_38 = root_85();
+
+		{
+			var node_58 = _$_.hydrating ? _$_.hydrate_child() : div_38.firstChild;
+
+			_$_.render_component(SwitchThenStatic, node_58, {});
+
+			var span_22 = _$_.hydrating ? _$_.hydrate_sibling() : node_58.nextSibling;
+
+			{
+				var expression_32 = _$_.hydrating ? _$_.hydrate_child(true) : span_22.firstChild;
+
+				_$_.pop(span_22);
+			}
+
+			var button_30 = _$_.hydrating ? _$_.hydrate_sibling() : span_22.nextSibling;
+
+			button_30.__click = () => _$_.update(lazy_35);
+			_$_.pop(div_38);
+		}
+
+		_$_.render(() => {
+			_$_.set_text(expression_32, lazy_35.value);
+		});
+
+		_$_.append(__anchor, div_38);
+	});
+}
+
+export function WrapTryThenStatic() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		let lazy_36 = _$_.track(0, __block, '1030b116');
+		var div_39 = root_86();
+
+		{
+			var node_59 = _$_.hydrating ? _$_.hydrate_child() : div_39.firstChild;
+
+			_$_.render_component(TryThenStatic, node_59, {});
+
+			var span_23 = _$_.hydrating ? _$_.hydrate_sibling() : node_59.nextSibling;
+
+			{
+				var expression_33 = _$_.hydrating ? _$_.hydrate_child(true) : span_23.firstChild;
+
+				_$_.pop(span_23);
+			}
+
+			var button_31 = _$_.hydrating ? _$_.hydrate_sibling() : span_23.nextSibling;
+
+			button_31.__click = () => _$_.update(lazy_36);
+			_$_.pop(div_39);
+		}
+
+		_$_.render(() => {
+			_$_.set_text(expression_33, lazy_36.value);
+		});
+
+		_$_.append(__anchor, div_39);
+	});
+}
+
+export function WrapStyleThenStatic() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		let lazy_37 = _$_.track(0, __block, 'f35d8716');
+		var div_40 = root_87();
+
+		{
+			var node_60 = _$_.hydrating ? _$_.hydrate_child() : div_40.firstChild;
+
+			_$_.render_component(StyleThenStatic, node_60, {});
+
+			var span_24 = _$_.hydrating ? _$_.hydrate_sibling() : node_60.nextSibling;
+
+			{
+				var expression_34 = _$_.hydrating ? _$_.hydrate_child(true) : span_24.firstChild;
+
+				_$_.pop(span_24);
+			}
+
+			var button_32 = _$_.hydrating ? _$_.hydrate_sibling() : span_24.nextSibling;
+
+			button_32.__click = () => _$_.update(lazy_37);
+			_$_.pop(div_40);
+		}
+
+		_$_.render(() => {
+			_$_.set_text(expression_34, lazy_37.value);
+		});
+
+		_$_.append(__anchor, div_40);
+	});
+}
+
+export function WrapCollectionThenStatic() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		let lazy_38 = _$_.track(0, __block, 'b1e7a298');
+		var div_41 = root_88();
+
+		{
+			var node_61 = _$_.hydrating ? _$_.hydrate_child() : div_41.firstChild;
+
+			_$_.render_component(CollectionThenStatic, node_61, {});
+
+			var span_25 = _$_.hydrating ? _$_.hydrate_sibling() : node_61.nextSibling;
+
+			{
+				var expression_35 = _$_.hydrating ? _$_.hydrate_child(true) : span_25.firstChild;
+
+				_$_.pop(span_25);
+			}
+
+			var button_33 = _$_.hydrating ? _$_.hydrate_sibling() : span_25.nextSibling;
+
+			button_33.__click = () => _$_.update(lazy_38);
+			_$_.pop(div_41);
+		}
+
+		_$_.render(() => {
+			_$_.set_text(expression_35, lazy_38.value);
+		});
+
+		_$_.append(__anchor, div_41);
+	});
+}
+
+export function WrapInlineElementThenStatic() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		let lazy_39 = _$_.track(0, __block, 'df10dc38');
+		var div_42 = root_89();
+
+		{
+			var node_62 = _$_.hydrating ? _$_.hydrate_child() : div_42.firstChild;
+
+			_$_.render_component(InlineElementThenStatic, node_62, {});
+
+			var span_26 = _$_.hydrating ? _$_.hydrate_sibling() : node_62.nextSibling;
+
+			{
+				var expression_36 = _$_.hydrating ? _$_.hydrate_child(true) : span_26.firstChild;
+
+				_$_.pop(span_26);
+			}
+
+			var button_34 = _$_.hydrating ? _$_.hydrate_sibling() : span_26.nextSibling;
+
+			button_34.__click = () => _$_.update(lazy_39);
+			_$_.pop(div_42);
+		}
+
+		_$_.render(() => {
+			_$_.set_text(expression_36, lazy_39.value);
+		});
+
+		_$_.append(__anchor, div_42);
+	});
+}
+
+export function IfOnly() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		let lazy_40 = _$_.track(0, __block, 'c6afe814');
+		var fragment_54 = root_90();
+		var node_63 = _$_.first_child_frag(fragment_54);
+
+		_$_.expression(node_63, () => _$_.tsrx_element((__anchor, __block) => {
+			{
+				var consequent_2 = (__anchor) => {
+					var b_9 = root_91();
+
+					_$_.append(__anchor, b_9);
+				};
+
+				_$_.if(
+					__anchor,
+					(__render) => {
+						if (lazy_40.value >= 0) __render(consequent_2);
+					},
+					true
+				);
+			}
+		}));
+
+		_$_.append(__anchor, fragment_54);
+	});
+}
+
+export function IfThenOne() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		let lazy_41 = _$_.track(0, __block, 'c3b63525');
+		var fragment_55 = root_92();
+		var node_65 = _$_.first_child_frag(fragment_55);
+
+		_$_.expression(node_65, () => _$_.tsrx_element((__anchor, __block) => {
+			var fragment_56 = root_93();
+			var node_64 = _$_.first_child_frag(fragment_56);
+
+			{
+				var consequent_3 = (__anchor) => {
+					var b_10 = root_94();
+
+					_$_.append(__anchor, b_10);
+				};
+
+				_$_.if(node_64, (__render) => {
+					if (lazy_41.value >= 0) __render(consequent_3);
+				});
+			}
+
+			_$_.next();
+			_$_.append(__anchor, fragment_56);
+		}));
+
+		_$_.append(__anchor, fragment_55);
+	});
+}
+
+export function SingleRootWithIf() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		let lazy_42 = _$_.track(0, __block, '63d962e3');
+		var div_43 = root_95();
+
+		{
+			var node_66 = _$_.hydrating ? _$_.hydrate_child() : div_43.firstChild;
+
+			{
+				var consequent_4 = (__anchor) => {
+					var b_11 = root_96();
+
+					_$_.append(__anchor, b_11);
+				};
+
+				_$_.if(node_66, (__render) => {
+					if (lazy_42.value >= 0) __render(consequent_4);
+				});
+			}
+
+			_$_.pop(div_43);
+		}
+
+		_$_.append(__anchor, div_43);
+	});
+}
+
+export function WrapIfOnly() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		let lazy_43 = _$_.track(0, __block, '83c8f19d');
+		var div_44 = root_97();
+
+		{
+			var node_67 = _$_.hydrating ? _$_.hydrate_child() : div_44.firstChild;
+
+			_$_.render_component(IfOnly, node_67, {});
+
+			var span_27 = _$_.hydrating ? _$_.hydrate_sibling() : node_67.nextSibling;
+
+			{
+				var expression_37 = _$_.hydrating ? _$_.hydrate_child(true) : span_27.firstChild;
+
+				_$_.pop(span_27);
+			}
+
+			var button_35 = _$_.hydrating ? _$_.hydrate_sibling() : span_27.nextSibling;
+
+			button_35.__click = () => _$_.update(lazy_43);
+			_$_.pop(div_44);
+		}
+
+		_$_.render(() => {
+			_$_.set_text(expression_37, lazy_43.value);
+		});
+
+		_$_.append(__anchor, div_44);
+	});
+}
+
+export function WrapIfThenOne() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		let lazy_44 = _$_.track(0, __block, '2cee9a57');
+		var div_45 = root_98();
+
+		{
+			var node_68 = _$_.hydrating ? _$_.hydrate_child() : div_45.firstChild;
+
+			_$_.render_component(IfThenOne, node_68, {});
+
+			var span_28 = _$_.hydrating ? _$_.hydrate_sibling() : node_68.nextSibling;
+
+			{
+				var expression_38 = _$_.hydrating ? _$_.hydrate_child(true) : span_28.firstChild;
+
+				_$_.pop(span_28);
+			}
+
+			var button_36 = _$_.hydrating ? _$_.hydrate_sibling() : span_28.nextSibling;
+
+			button_36.__click = () => _$_.update(lazy_44);
+			_$_.pop(div_45);
+		}
+
+		_$_.render(() => {
+			_$_.set_text(expression_38, lazy_44.value);
+		});
+
+		_$_.append(__anchor, div_45);
+	});
+}
+
+export function WrapSingleRootWithIf() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		let lazy_45 = _$_.track(0, __block, 'c179a57b');
+		var div_46 = root_99();
+
+		{
+			var node_69 = _$_.hydrating ? _$_.hydrate_child() : div_46.firstChild;
+
+			_$_.render_component(SingleRootWithIf, node_69, {});
+
+			var span_29 = _$_.hydrating ? _$_.hydrate_sibling() : node_69.nextSibling;
+
+			{
+				var expression_39 = _$_.hydrating ? _$_.hydrate_child(true) : span_29.firstChild;
+
+				_$_.pop(span_29);
+			}
+
+			var button_37 = _$_.hydrating ? _$_.hydrate_sibling() : span_29.nextSibling;
+
+			button_37.__click = () => _$_.update(lazy_45);
+			_$_.pop(div_46);
+		}
+
+		_$_.render(() => {
+			_$_.set_text(expression_39, lazy_45.value);
+		});
+
+		_$_.append(__anchor, div_46);
+	});
+}
+
+export function ExprThenSiblingInDiv() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		let lazy_46 = _$_.track(0, __block, 'db1d59ee');
+		const label = 'label';
+		var div_47 = root_100();
+
+		{
+			var expression_40 = _$_.hydrating ? _$_.hydrate_child() : div_47.firstChild;
+
+			_$_.expression(expression_40, () => _$_.with_scope(__block, () => label.toUpperCase()));
+
+			var span_30 = _$_.hydrating ? _$_.hydrate_sibling() : expression_40.nextSibling;
+
+			{
+				var expression_41 = _$_.hydrating ? _$_.hydrate_child(true) : span_30.firstChild;
+
+				_$_.pop(span_30);
+			}
+
+			var button_38 = _$_.hydrating ? _$_.hydrate_sibling() : span_30.nextSibling;
+
+			button_38.__click = () => _$_.update(lazy_46);
+			_$_.pop(div_47);
+		}
+
+		_$_.render(() => {
+			_$_.set_text(expression_41, lazy_46.value);
+		});
+
+		_$_.append(__anchor, div_47);
+	});
+}
+
+export function IfTwoThenStatic() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		let lazy_47 = _$_.track(0, __block, 'd8310b12');
+		var fragment_57 = root_101();
+		var node_71 = _$_.first_child_frag(fragment_57);
+
+		_$_.expression(node_71, () => _$_.tsrx_element((__anchor, __block) => {
+			var fragment_58 = root_102();
+			var node_70 = _$_.first_child_frag(fragment_58);
+
+			{
+				var consequent_5 = (__anchor) => {
+					var fragment_59 = root_103();
+
+					_$_.next();
+					_$_.append(__anchor, fragment_59);
+				};
+
+				_$_.if(node_70, (__render) => {
+					if (lazy_47.value >= 0) __render(consequent_5);
+				});
+			}
+
+			_$_.next(2);
+			_$_.append(__anchor, fragment_58);
+		}));
+
+		_$_.append(__anchor, fragment_57);
+	});
+}
+
+export function IfTwoInDiv() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		let lazy_48 = _$_.track(0, __block, '0c602c2f');
+		var div_48 = root_104();
+
+		{
+			var node_72 = _$_.hydrating ? _$_.hydrate_child() : div_48.firstChild;
+
+			{
+				var consequent_6 = (__anchor) => {
+					var fragment_60 = root_105();
+
+					_$_.next();
+					_$_.append(__anchor, fragment_60);
+				};
+
+				_$_.if(node_72, (__render) => {
+					if (lazy_48.value >= 0) __render(consequent_6);
+				});
+			}
+
+			var span_31 = _$_.hydrating ? _$_.hydrate_sibling() : node_72.nextSibling;
+
+			{
+				var expression_42 = _$_.hydrating ? _$_.hydrate_child(true) : span_31.firstChild;
+
+				_$_.pop(span_31);
+			}
+
+			var button_39 = _$_.hydrating ? _$_.hydrate_sibling() : span_31.nextSibling;
+
+			button_39.__click = () => _$_.update(lazy_48);
+			_$_.pop(div_48);
+		}
+
+		_$_.render(() => {
+			_$_.set_text(expression_42, lazy_48.value);
+		});
+
+		_$_.append(__anchor, div_48);
+	});
+}
+
+export function WrapIfTwoThenStatic() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		let lazy_49 = _$_.track(0, __block, 'cd8f8438');
+		var div_49 = root_106();
+
+		{
+			var node_73 = _$_.hydrating ? _$_.hydrate_child() : div_49.firstChild;
+
+			_$_.render_component(IfTwoThenStatic, node_73, {});
+
+			var span_32 = _$_.hydrating ? _$_.hydrate_sibling() : node_73.nextSibling;
+
+			{
+				var expression_43 = _$_.hydrating ? _$_.hydrate_child(true) : span_32.firstChild;
+
+				_$_.pop(span_32);
+			}
+
+			var button_40 = _$_.hydrating ? _$_.hydrate_sibling() : span_32.nextSibling;
+
+			button_40.__click = () => _$_.update(lazy_49);
+			_$_.pop(div_49);
+		}
+
+		_$_.render(() => {
+			_$_.set_text(expression_43, lazy_49.value);
+		});
+
+		_$_.append(__anchor, div_49);
+	});
+}
+
+export function ForTwoNodeItems() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		const items = [1, 2];
+		var div_50 = root_107();
+
+		{
+			var node_74 = _$_.hydrating ? _$_.hydrate_child() : div_50.firstChild;
+
+			_$_.for(
+				node_74,
+				() => items,
+				(__anchor, item) => {
+					var fragment_61 = root_108();
+					var b_12 = _$_.first_child_frag(fragment_61);
+
+					{
+						var expression_44 = _$_.hydrating ? _$_.hydrate_child() : b_12.firstChild;
+
+						_$_.expression(expression_44, () => item);
+						_$_.pop(b_12);
+					}
+
+					_$_.next();
+					_$_.append(__anchor, fragment_61);
+				},
+				0
+			);
+
+			_$_.pop(div_50);
+		}
+
+		_$_.append(__anchor, div_50);
+	});
+}
+
+export function StaticCallThenStatic() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		const makeB = () => _$_.tsrx_element((__anchor, __block) => {
+			var b_13 = root_109();
+
+			_$_.append(__anchor, b_13);
+		});
+
+		var fragment_62 = root_110();
+		var node_75 = _$_.first_child_frag(fragment_62);
+
+		_$_.expression(node_75, () => _$_.tsrx_element((__anchor, __block) => {
+			var fragment_63 = root_111();
+			var expression_45 = _$_.first_child_frag(fragment_63);
+
+			_$_.render_tsrx_element(_$_.with_scope(__block, makeB), expression_45, __block);
+			_$_.next(2);
+			_$_.append(__anchor, fragment_63);
+		}));
+
+		_$_.append(__anchor, fragment_62);
+	});
+}
+
+export function StaticThenStyleThenStatic() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		var fragment_64 = root_112();
+		var node_76 = _$_.first_child_frag(fragment_64);
+
+		_$_.expression(node_76, () => _$_.tsrx_element((__anchor, __block) => {
+			var fragment_65 = root_113();
+			var div_51 = _$_.first_child_frag(fragment_65);
+			var style_1 = _$_.hydrating ? _$_.hydrate_sibling() : div_51.nextSibling;
+
+			{
+				_$_.pop(style_1);
+			}
+
+			_$_.next(2);
+			_$_.append(__anchor, fragment_65);
+		}));
+
+		_$_.append(__anchor, fragment_64);
+	});
+}
+
+export function WrapStaticCallThenStatic() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		let lazy_50 = _$_.track(0, __block, '4513c76f');
+		var div_52 = root_114();
+
+		{
+			var node_77 = _$_.hydrating ? _$_.hydrate_child() : div_52.firstChild;
+
+			_$_.render_component(StaticCallThenStatic, node_77, {});
+
+			var span_33 = _$_.hydrating ? _$_.hydrate_sibling() : node_77.nextSibling;
+
+			{
+				var expression_46 = _$_.hydrating ? _$_.hydrate_child(true) : span_33.firstChild;
+
+				_$_.pop(span_33);
+			}
+
+			var button_41 = _$_.hydrating ? _$_.hydrate_sibling() : span_33.nextSibling;
+
+			button_41.__click = () => _$_.update(lazy_50);
+			_$_.pop(div_52);
+		}
+
+		_$_.render(() => {
+			_$_.set_text(expression_46, lazy_50.value);
+		});
+
+		_$_.append(__anchor, div_52);
+	});
+}
+
+export function WrapStaticThenStyleThenStatic() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		let lazy_51 = _$_.track(0, __block, '5d5162df');
+		var div_53 = root_115();
+
+		{
+			var node_78 = _$_.hydrating ? _$_.hydrate_child() : div_53.firstChild;
+
+			_$_.render_component(StaticThenStyleThenStatic, node_78, {});
+
+			var span_34 = _$_.hydrating ? _$_.hydrate_sibling() : node_78.nextSibling;
+
+			{
+				var expression_47 = _$_.hydrating ? _$_.hydrate_child(true) : span_34.firstChild;
+
+				_$_.pop(span_34);
+			}
+
+			var button_42 = _$_.hydrating ? _$_.hydrate_sibling() : span_34.nextSibling;
+
+			button_42.__click = () => _$_.update(lazy_51);
+			_$_.pop(div_53);
+		}
+
+		_$_.render(() => {
+			_$_.set_text(expression_47, lazy_51.value);
+		});
+
+		_$_.append(__anchor, div_53);
+	});
+}
+
+_$_.delegate(['click']);

--- a/packages/ripple/tests/hydration/compiled/client/head.js
+++ b/packages/ripple/tests/hydration/compiled/client/head.js
@@ -92,7 +92,7 @@ export function MultipleHeadElements() {
 
 				_$_.document.title = 'Page Title';
 				_$_.next();
-				_$_.append(__anchor, fragment_3, true);
+				_$_.append(__anchor, fragment_3);
 			});
 
 			_$_.append(__anchor, div_2);

--- a/packages/ripple/tests/hydration/compiled/client/html.js
+++ b/packages/ripple/tests/hydration/compiled/client/html.js
@@ -215,8 +215,7 @@ export function HtmlInChildrenWithSiblings() {
 				var div_8 = _$_.hydrating ? _$_.hydrate_sibling() : h1.nextSibling;
 
 				div_8.innerHTML = content ?? div_8.innerHTML;
-				_$_.next();
-				_$_.append(__anchor, fragment, true);
+				_$_.append(__anchor, fragment);
 			})
 		});
 	});
@@ -542,13 +541,10 @@ function CodeBlock({ code }) {
 		var div_21 = root_24();
 
 		{
-			var div_22 = _$_.hydrating ? _$_.hydrate_child() : div_21.firstChild;
+			var div_23 = _$_.hydrating ? _$_.hydrate_child() : div_21.firstChild;
+			var div_22 = _$_.hydrating ? _$_.hydrate_sibling() : div_23.nextSibling;
 
-			_$_.pop(div_22);
-
-			var div_23 = _$_.hydrating ? _$_.hydrate_sibling() : div_22.nextSibling;
-
-			div_23.innerHTML = highlighted ?? div_23.innerHTML;
+			div_22.innerHTML = highlighted ?? div_22.innerHTML;
 		}
 
 		_$_.append(__anchor, div_21);
@@ -595,6 +591,7 @@ export function HtmlAfterSwitchInChildren() {
 				var node_10 = _$_.hydrating ? _$_.hydrate_sibling() : p.nextSibling;
 
 				_$_.render_component(CodeBlock, node_10, { code: "const x = 1;" });
+				_$_.next();
 				_$_.append(__anchor, fragment_1);
 			})
 		});
@@ -662,6 +659,7 @@ export function HtmlAfterIfInChildren() {
 				var node_12 = _$_.hydrating ? _$_.hydrate_sibling() : p_2.nextSibling;
 
 				_$_.render_component(CodeBlock, node_12, { code: "const x = 1;" });
+				_$_.next();
 				_$_.append(__anchor, fragment_2);
 			})
 		});
@@ -703,6 +701,7 @@ export function HtmlAfterForInChildren() {
 				var node_14 = _$_.hydrating ? _$_.hydrate_sibling() : p_4.nextSibling;
 
 				_$_.render_component(CodeBlock, node_14, { code: "const x = 1;" });
+				_$_.next();
 				_$_.append(__anchor, fragment_3);
 			})
 		});
@@ -749,6 +748,7 @@ export function HtmlAfterTryInChildren() {
 				var node_16 = _$_.hydrating ? _$_.hydrate_sibling() : p_5.nextSibling;
 
 				_$_.render_component(CodeBlock, node_16, { code: "const x = 1;" });
+				_$_.next();
 				_$_.append(__anchor, fragment_4);
 			})
 		});
@@ -797,6 +797,7 @@ export function HtmlAfterComponentInChildren() {
 				var node_18 = _$_.hydrating ? _$_.hydrate_sibling() : p_6.nextSibling;
 
 				_$_.render_component(CodeBlock, node_18, { code: "const x = 1;" });
+				_$_.next();
 				_$_.append(__anchor, fragment_6);
 			})
 		});
@@ -1018,9 +1019,6 @@ export function LayoutWithSidebarAndMain() {
 
 				{
 					var div_35 = _$_.hydrating ? _$_.hydrate_child() : main.firstChild;
-
-					_$_.pop(div_35);
-
 					var node_27 = _$_.hydrating ? _$_.hydrate_sibling() : div_35.nextSibling;
 
 					{
@@ -1089,6 +1087,7 @@ export function ArticleWithChildrenThenSibling() {
 				children: _$_.tsrx_element((__anchor, __block) => {
 					var fragment_9 = root_51();
 
+					_$_.next();
 					_$_.append(__anchor, fragment_9);
 				})
 			});

--- a/packages/ripple/tests/hydration/compiled/client/if-children.js
+++ b/packages/ripple/tests/hydration/compiled/client/if-children.js
@@ -201,9 +201,6 @@ export function ElementWithChildrenThenIf() {
 
 			{
 				var div_9 = _$_.hydrating ? _$_.hydrate_child() : div_10.firstChild;
-
-				_$_.pop(div_9);
-
 				var node_7 = _$_.hydrating ? _$_.hydrate_sibling() : div_9.nextSibling;
 
 				{
@@ -224,8 +221,7 @@ export function ElementWithChildrenThenIf() {
 			var button = _$_.hydrating ? _$_.hydrate_sibling() : div_10.nextSibling;
 
 			button.__click = () => _$_.set(lazy_3, !lazy_3.value);
-			_$_.next();
-			_$_.append(__anchor, fragment_3, true);
+			_$_.append(__anchor, fragment_3);
 		}));
 
 		_$_.append(__anchor, fragment_2);
@@ -244,9 +240,6 @@ export function DeepNestingThenIf() {
 
 			{
 				var article = _$_.hydrating ? _$_.hydrate_child() : section_1.firstChild;
-
-				_$_.pop(article);
-
 				var node_9 = _$_.hydrating ? _$_.hydrate_sibling() : article.nextSibling;
 
 				{
@@ -267,8 +260,7 @@ export function DeepNestingThenIf() {
 			var button_1 = _$_.hydrating ? _$_.hydrate_sibling() : section_1.nextSibling;
 
 			button_1.__click = () => _$_.set(lazy_4, !lazy_4.value);
-			_$_.next();
-			_$_.append(__anchor, fragment_5, true);
+			_$_.append(__anchor, fragment_5);
 		}));
 
 		_$_.append(__anchor, fragment_4);
@@ -374,13 +366,12 @@ export function DomChildrenThenStaticSiblings() {
 			var button_4 = _$_.hydrating ? _$_.hydrate_sibling() : div_16.nextSibling;
 
 			button_4.__click = () => _$_.update(lazy_6);
-			_$_.next();
 
 			_$_.render(() => {
 				_$_.set_text(expression_3, 'Item count: ' + String(lazy_6.value ?? ''));
 			});
 
-			_$_.append(__anchor, fragment_7, true);
+			_$_.append(__anchor, fragment_7);
 		}));
 
 		_$_.append(__anchor, fragment_6);
@@ -390,22 +381,6 @@ export function DomChildrenThenStaticSiblings() {
 export function StaticListThenStaticSiblings() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		var div_17 = root_20();
-
-		{
-			var ul_1 = _$_.hydrating ? _$_.hydrate_child() : div_17.firstChild;
-
-			{
-				var li_1 = _$_.hydrating ? _$_.hydrate_child() : ul_1.firstChild;
-
-				_$_.pop(li_1);
-
-				var li_2 = _$_.hydrating ? _$_.hydrate_sibling() : li_1.nextSibling;
-
-				_$_.pop(li_2);
-			}
-
-			_$_.pop(ul_1);
-		}
 
 		_$_.append(__anchor, div_17);
 	});

--- a/packages/ripple/tests/hydration/compiled/client/if-fragment-controlflow.js
+++ b/packages/ripple/tests/hydration/compiled/client/if-fragment-controlflow.js
@@ -61,6 +61,7 @@ export function IfFragmentForElement() {
 						(pattern) => _$_.get(pattern).muzeId
 					);
 
+					_$_.next();
 					_$_.append(__anchor, fragment);
 				};
 
@@ -164,6 +165,7 @@ export function IfFragmentElements() {
 				var consequent_4 = (__anchor) => {
 					var fragment_2 = root_9();
 
+					_$_.next();
 					_$_.append(__anchor, fragment_2);
 				};
 
@@ -208,6 +210,7 @@ export function ComponentBodyFragmentControlFlow() {
 				(pattern_2) => _$_.get(pattern_2).muzeId
 			);
 
+			_$_.next();
 			_$_.append(__anchor, fragment_4);
 		}));
 
@@ -248,6 +251,7 @@ export function ComponentBodyCodeBlockControlFlow() {
 				);
 			}));
 
+			_$_.next();
 			_$_.append(__anchor, fragment_6);
 		}));
 
@@ -292,6 +296,7 @@ export function IfCodeBlockControlFlow() {
 						);
 					}));
 
+					_$_.next();
 					_$_.append(__anchor, fragment_7);
 				};
 
@@ -346,6 +351,7 @@ export function IfElseFragment() {
 						(pattern_5) => _$_.get(pattern_5).muzeId
 					);
 
+					_$_.next();
 					_$_.append(__anchor, fragment_8);
 				};
 

--- a/packages/ripple/tests/hydration/compiled/client/portal.js
+++ b/packages/ripple/tests/hydration/compiled/client/portal.js
@@ -93,9 +93,6 @@ export function NestedContentWithPortal() {
 
 		{
 			var div_8 = _$_.hydrating ? _$_.hydrate_child() : div_7.firstChild;
-
-			_$_.pop(div_8);
-
 			var node_3 = _$_.hydrating ? _$_.hydrate_sibling() : div_8.nextSibling;
 
 			_$_.portal(node_3, () => typeof document !== 'undefined' ? document.body : null, (__anchor, __block) => {

--- a/packages/ripple/tests/hydration/compiled/client/streaming.js
+++ b/packages/ripple/tests/hydration/compiled/client/streaming.js
@@ -103,6 +103,7 @@ export function StreamPending() {
 					var node_1 = _$_.first_child_frag(fragment_2);
 
 					_$_.render_component(BasicContent, node_1, {});
+					_$_.next();
 					_$_.append(__anchor, fragment_2);
 				},
 				null,
@@ -113,6 +114,7 @@ export function StreamPending() {
 				}
 			);
 
+			_$_.next();
 			_$_.append(__anchor, fragment_1);
 		}));
 

--- a/packages/ripple/tests/hydration/compiled/server/fragment-cursor.js
+++ b/packages/ripple/tests/hydration/compiled/server/fragment-cursor.js
@@ -1,0 +1,1399 @@
+// @ts-nocheck
+import * as _$_ from 'ripple/internal/server';
+
+import { track } from 'ripple/server';
+
+function Leaf() {
+	return _$_.tsrx_element(() => {
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<i class="leaf">leaf</i>';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function TrailingNavigatedElements() {
+	return _$_.tsrx_element(() => {
+		let lazy = _$_.track(0, 'a695c021');
+
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<div class="count">' + _$_.escape(lazy.value) + '</div><button class="inc">inc</button><button class="dec">dec</button>';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function TrailingStaticNavigatedElements() {
+	return _$_.tsrx_element(() => {
+		let lazy_1 = _$_.track(0, '0afd9398');
+
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<div class="host">static</div><button class="inc">inc</button><button class="dec">dec</button>';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function NavigatedThenStatic() {
+	return _$_.tsrx_element(() => {
+		let lazy_2 = _$_.track(0, '3cea07db');
+
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<div class="host">static</div><button class="inc">inc</button><div class="a">a</div><div class="b">b</div>';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function LeadingNavigatedThenStatic() {
+	return _$_.tsrx_element(() => {
+		let lazy_3 = _$_.track(0, '8ca89613');
+
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<button class="inc">inc</button><div class="a">a</div><div class="b">b</div>';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function TrailingNestedNavigated() {
+	return _$_.tsrx_element(() => {
+		let lazy_4 = _$_.track(0, 'f0f5a337');
+
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<div class="host">static</div><div class="wrap"><button class="inc">inc</button></div>';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function NestedNavigatedThenStatic() {
+	return _$_.tsrx_element(() => {
+		let lazy_5 = _$_.track(0, '2a6293f9');
+
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<div class="wrap"><button class="inc">inc</button></div><div class="a">a</div><div class="b">b</div>';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function TrackedTextThenStatic() {
+	return _$_.tsrx_element(() => {
+		let lazy_6 = _$_.track(0, 'db93f6f0');
+
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += _$_.escape(lazy_6.value) + '<div class="a">a</div><div class="b">b</div>';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function StaticThenTrackedText() {
+	return _$_.tsrx_element(() => {
+		let lazy_7 = _$_.track(0, '84cf2507');
+
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<div class="a">a</div><div class="b">b</div>' + _$_.escape(lazy_7.value);
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function StaticNestedThenStatic() {
+	return _$_.tsrx_element(() => {
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<div class="a">a</div><div class="wrap"><span>x</span></div><div class="b">b</div><div class="c">c</div>';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function AllStatic() {
+	return _$_.tsrx_element(() => {
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<div class="a">a</div><div class="b">b</div><div class="c">c</div>';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function TrailingDynamicChild() {
+	return _$_.tsrx_element(() => {
+		let lazy_8 = _$_.track(0, '9be343a7');
+
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<div class="a">a</div><div class="count">' + _$_.escape(lazy_8.value) + '</div>';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function DynamicChildThenStatic() {
+	return _$_.tsrx_element(() => {
+		let lazy_9 = _$_.track(0, 'c76dd5a9');
+
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<div class="count">' + _$_.escape(lazy_9.value) + '</div><div class="a">a</div><div class="b">b</div>';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function IfThenStatic() {
+	return _$_.tsrx_element(() => {
+		let lazy_10 = _$_.track(0, 'fb175ecd');
+
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<!--[--><!--[-->';
+
+			if (lazy_10.value >= 0) {
+				__out += '<b class="if">x</b>';
+			}
+
+			__out += '<!--]--><div class="a">a</div><div class="b">b</div><!--]-->';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function StaticThenIf() {
+	return _$_.tsrx_element(() => {
+		let lazy_11 = _$_.track(0, 'c8563a58');
+
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<div class="a">a</div><div class="b">b</div><!--[-->';
+
+			if (lazy_11.value >= 0) {
+				__out += '<b class="if">x</b>';
+			}
+
+			__out += '<!--]-->';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function CompThenStatic() {
+	return _$_.tsrx_element(() => {
+		_$_.regular_block(() => {
+			let __out = '';
+
+			{
+				const comp = Leaf;
+				const args = [{}];
+
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_component(comp, ...args);
+			}
+
+			__out += '<div class="a">a</div><div class="b">b</div>';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function StaticThenComp() {
+	return _$_.tsrx_element(() => {
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<div class="a">a</div><div class="b">b</div>';
+
+			{
+				const comp = Leaf;
+				const args = [{}];
+
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_component(comp, ...args);
+			}
+
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function SiblingComps() {
+	return _$_.tsrx_element(() => {
+		_$_.regular_block(() => {
+			{
+				{
+					const comp = Leaf;
+					const args = [{}];
+
+					_$_.render_component(comp, ...args);
+				}
+
+				{
+					const comp = Leaf;
+					const args = [{}];
+
+					_$_.render_component(comp, ...args);
+				}
+			}
+		});
+	});
+}
+
+export function WrapTrailingNavigatedElements() {
+	return _$_.tsrx_element(() => {
+		let lazy_12 = _$_.track(0, '1032dbec');
+
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<div class="outer">';
+
+			{
+				const comp = TrailingNavigatedElements;
+				const args = [{}];
+
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_component(comp, ...args);
+			}
+
+			__out += '<span class="after">' + _$_.escape(lazy_12.value) + '</span><button class="outer-inc">outer</button></div>';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function WrapTrailingStaticNavigatedElements() {
+	return _$_.tsrx_element(() => {
+		let lazy_13 = _$_.track(0, 'c2e2a938');
+
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<div class="outer">';
+
+			{
+				const comp = TrailingStaticNavigatedElements;
+				const args = [{}];
+
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_component(comp, ...args);
+			}
+
+			__out += '<span class="after">' + _$_.escape(lazy_13.value) + '</span><button class="outer-inc">outer</button></div>';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function WrapNavigatedThenStatic() {
+	return _$_.tsrx_element(() => {
+		let lazy_14 = _$_.track(0, 'b4046e87');
+
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<div class="outer">';
+
+			{
+				const comp = NavigatedThenStatic;
+				const args = [{}];
+
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_component(comp, ...args);
+			}
+
+			__out += '<span class="after">' + _$_.escape(lazy_14.value) + '</span><button class="outer-inc">outer</button></div>';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function WrapLeadingNavigatedThenStatic() {
+	return _$_.tsrx_element(() => {
+		let lazy_15 = _$_.track(0, 'bed7f7ef');
+
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<div class="outer">';
+
+			{
+				const comp = LeadingNavigatedThenStatic;
+				const args = [{}];
+
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_component(comp, ...args);
+			}
+
+			__out += '<span class="after">' + _$_.escape(lazy_15.value) + '</span><button class="outer-inc">outer</button></div>';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function WrapTrailingNestedNavigated() {
+	return _$_.tsrx_element(() => {
+		let lazy_16 = _$_.track(0, 'eddbe7bc');
+
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<div class="outer">';
+
+			{
+				const comp = TrailingNestedNavigated;
+				const args = [{}];
+
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_component(comp, ...args);
+			}
+
+			__out += '<span class="after">' + _$_.escape(lazy_16.value) + '</span><button class="outer-inc">outer</button></div>';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function WrapNestedNavigatedThenStatic() {
+	return _$_.tsrx_element(() => {
+		let lazy_17 = _$_.track(0, '1bdc4523');
+
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<div class="outer">';
+
+			{
+				const comp = NestedNavigatedThenStatic;
+				const args = [{}];
+
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_component(comp, ...args);
+			}
+
+			__out += '<span class="after">' + _$_.escape(lazy_17.value) + '</span><button class="outer-inc">outer</button></div>';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function WrapTrackedTextThenStatic() {
+	return _$_.tsrx_element(() => {
+		let lazy_18 = _$_.track(0, '97e02c24');
+
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<div class="outer">';
+
+			{
+				const comp = TrackedTextThenStatic;
+				const args = [{}];
+
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_component(comp, ...args);
+			}
+
+			__out += '<span class="after">' + _$_.escape(lazy_18.value) + '</span><button class="outer-inc">outer</button></div>';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function WrapStaticThenTrackedText() {
+	return _$_.tsrx_element(() => {
+		let lazy_19 = _$_.track(0, 'd5526861');
+
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<div class="outer">';
+
+			{
+				const comp = StaticThenTrackedText;
+				const args = [{}];
+
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_component(comp, ...args);
+			}
+
+			__out += '<span class="after">' + _$_.escape(lazy_19.value) + '</span><button class="outer-inc">outer</button></div>';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function WrapStaticNestedThenStatic() {
+	return _$_.tsrx_element(() => {
+		let lazy_20 = _$_.track(0, '7e2d3fad');
+
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<div class="outer">';
+
+			{
+				const comp = StaticNestedThenStatic;
+				const args = [{}];
+
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_component(comp, ...args);
+			}
+
+			__out += '<span class="after">' + _$_.escape(lazy_20.value) + '</span><button class="outer-inc">outer</button></div>';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function WrapAllStatic() {
+	return _$_.tsrx_element(() => {
+		let lazy_21 = _$_.track(0, 'b894f45a');
+
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<div class="outer">';
+
+			{
+				const comp = AllStatic;
+				const args = [{}];
+
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_component(comp, ...args);
+			}
+
+			__out += '<span class="after">' + _$_.escape(lazy_21.value) + '</span><button class="outer-inc">outer</button></div>';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function WrapTrailingDynamicChild() {
+	return _$_.tsrx_element(() => {
+		let lazy_22 = _$_.track(0, '038446ca');
+
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<div class="outer">';
+
+			{
+				const comp = TrailingDynamicChild;
+				const args = [{}];
+
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_component(comp, ...args);
+			}
+
+			__out += '<span class="after">' + _$_.escape(lazy_22.value) + '</span><button class="outer-inc">outer</button></div>';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function WrapDynamicChildThenStatic() {
+	return _$_.tsrx_element(() => {
+		let lazy_23 = _$_.track(0, '3ec460c3');
+
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<div class="outer">';
+
+			{
+				const comp = DynamicChildThenStatic;
+				const args = [{}];
+
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_component(comp, ...args);
+			}
+
+			__out += '<span class="after">' + _$_.escape(lazy_23.value) + '</span><button class="outer-inc">outer</button></div>';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function WrapIfThenStatic() {
+	return _$_.tsrx_element(() => {
+		let lazy_24 = _$_.track(0, '95b417dd');
+
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<div class="outer">';
+
+			{
+				const comp = IfThenStatic;
+				const args = [{}];
+
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_component(comp, ...args);
+			}
+
+			__out += '<span class="after">' + _$_.escape(lazy_24.value) + '</span><button class="outer-inc">outer</button></div>';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function WrapStaticThenIf() {
+	return _$_.tsrx_element(() => {
+		let lazy_25 = _$_.track(0, '1f01fa6f');
+
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<div class="outer">';
+
+			{
+				const comp = StaticThenIf;
+				const args = [{}];
+
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_component(comp, ...args);
+			}
+
+			__out += '<span class="after">' + _$_.escape(lazy_25.value) + '</span><button class="outer-inc">outer</button></div>';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function WrapCompThenStatic() {
+	return _$_.tsrx_element(() => {
+		let lazy_26 = _$_.track(0, 'e6bdb91d');
+
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<div class="outer">';
+
+			{
+				const comp = CompThenStatic;
+				const args = [{}];
+
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_component(comp, ...args);
+			}
+
+			__out += '<span class="after">' + _$_.escape(lazy_26.value) + '</span><button class="outer-inc">outer</button></div>';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function WrapStaticThenComp() {
+	return _$_.tsrx_element(() => {
+		let lazy_27 = _$_.track(0, '89d5704c');
+
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<div class="outer">';
+
+			{
+				const comp = StaticThenComp;
+				const args = [{}];
+
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_component(comp, ...args);
+			}
+
+			__out += '<span class="after">' + _$_.escape(lazy_27.value) + '</span><button class="outer-inc">outer</button></div>';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function WrapSiblingComps() {
+	return _$_.tsrx_element(() => {
+		let lazy_28 = _$_.track(0, 'c5c51af6');
+
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<div class="outer">';
+
+			{
+				const comp = SiblingComps;
+				const args = [{}];
+
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_component(comp, ...args);
+			}
+
+			__out += '<span class="after">' + _$_.escape(lazy_28.value) + '</span><button class="outer-inc">outer</button></div>';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function UntrackedTextThenStatic() {
+	return _$_.tsrx_element(() => {
+		const label = 'label';
+
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<!--[-->';
+			_$_.output_push(__out);
+			__out = '';
+			_$_.render_expression(label.toUpperCase());
+			__out += '<div class="a">a</div><div class="b">b</div><!--]-->';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function NestedFragmentThenStatic() {
+	return _$_.tsrx_element(() => {
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<div class="a">a</div><span class="x">x</span><span class="y">y</span><div class="b">b</div><div class="c">c</div>';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function TrailingNestedFragment() {
+	return _$_.tsrx_element(() => {
+		let lazy_29 = _$_.track(0, '82cbc65f');
+
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<div class="count">' + _$_.escape(lazy_29.value) + '</div><span class="x">x</span><button class="inc">inc</button>';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function ForThenStatic() {
+	return _$_.tsrx_element(() => {
+		const items = [1, 2];
+
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<!--[--><!--[-->';
+
+			for (const item of items) {
+				__out += '<b class="item">';
+
+				{
+					_$_.output_push(__out);
+					__out = '';
+					_$_.render_expression(item);
+				}
+
+				__out += '</b>';
+			}
+
+			__out += '<!--]--><div class="a">a</div><div class="b">b</div><!--]-->';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function SwitchThenStatic() {
+	return _$_.tsrx_element(() => {
+		let lazy_30 = _$_.track(0, '800f9ff3');
+
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<!--[--><!--[-->';
+
+			switch (lazy_30.value) {
+				case 0:
+					__out += '<b class="zero">zero</b>';
+					break;
+
+				default:
+					__out += '<b class="other">other</b>';
+					break;
+			}
+
+			__out += '<!--]--><div class="a">a</div><div class="b">b</div><!--]-->';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function TryThenStatic() {
+	return _$_.tsrx_element(() => {
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<!--[-->';
+			_$_.output_push(__out);
+			__out = '';
+
+			_$_.try_block(
+				() => {
+					let __out = '';
+
+					__out += '<!--[--><b class="try">try</b><!--]-->';
+					_$_.output_push(__out);
+				},
+				(e) => {
+					let __out = '';
+
+					__out += '<!--[--><b class="catch">catch</b><!--]-->';
+					_$_.output_push(__out);
+				},
+				null
+			);
+
+			__out += '<div class="a">a</div><div class="b">b</div><!--]-->';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function StyleThenStatic() {
+	return _$_.tsrx_element(() => {
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<style>' + _$_.escape(`.styled { color: red; }`) + '</style><div class="styled a">a</div><div class="styled b">b</div>';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function CollectionThenStatic() {
+	return _$_.tsrx_element(() => {
+		const items = [1, 2];
+
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<!--[-->';
+			_$_.output_push(__out);
+			__out = '';
+
+			_$_.render_expression(items.map((item) => _$_.tsrx_element(() => {
+				let __out = '';
+
+				__out += '<b class="item">';
+
+				{
+					_$_.output_push(__out);
+					__out = '';
+					_$_.render_expression(item);
+				}
+
+				__out += '</b>';
+				_$_.output_push(__out);
+			})));
+
+			__out += '<div class="a">a</div><div class="b">b</div><!--]-->';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function InlineElementThenStatic() {
+	return _$_.tsrx_element(() => {
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<!--[-->';
+			_$_.output_push(__out);
+			__out = '';
+
+			_$_.render_expression(_$_.tsrx_element(() => {
+				let __out = '';
+
+				__out += '<b class="inline">inline</b>';
+				_$_.output_push(__out);
+			}));
+
+			__out += '<div class="a">a</div><div class="b">b</div><!--]-->';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function WrapUntrackedTextThenStatic() {
+	return _$_.tsrx_element(() => {
+		let lazy_31 = _$_.track(0, '3a78abea');
+
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<div class="outer">';
+
+			{
+				const comp = UntrackedTextThenStatic;
+				const args = [{}];
+
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_component(comp, ...args);
+			}
+
+			__out += '<span class="after">' + _$_.escape(lazy_31.value) + '</span><button class="outer-inc">outer</button></div>';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function WrapNestedFragmentThenStatic() {
+	return _$_.tsrx_element(() => {
+		let lazy_32 = _$_.track(0, 'db289d00');
+
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<div class="outer">';
+
+			{
+				const comp = NestedFragmentThenStatic;
+				const args = [{}];
+
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_component(comp, ...args);
+			}
+
+			__out += '<span class="after">' + _$_.escape(lazy_32.value) + '</span><button class="outer-inc">outer</button></div>';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function WrapTrailingNestedFragment() {
+	return _$_.tsrx_element(() => {
+		let lazy_33 = _$_.track(0, 'bb509235');
+
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<div class="outer">';
+
+			{
+				const comp = TrailingNestedFragment;
+				const args = [{}];
+
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_component(comp, ...args);
+			}
+
+			__out += '<span class="after">' + _$_.escape(lazy_33.value) + '</span><button class="outer-inc">outer</button></div>';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function WrapForThenStatic() {
+	return _$_.tsrx_element(() => {
+		let lazy_34 = _$_.track(0, 'a715e40a');
+
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<div class="outer">';
+
+			{
+				const comp = ForThenStatic;
+				const args = [{}];
+
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_component(comp, ...args);
+			}
+
+			__out += '<span class="after">' + _$_.escape(lazy_34.value) + '</span><button class="outer-inc">outer</button></div>';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function WrapSwitchThenStatic() {
+	return _$_.tsrx_element(() => {
+		let lazy_35 = _$_.track(0, 'a598ad9f');
+
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<div class="outer">';
+
+			{
+				const comp = SwitchThenStatic;
+				const args = [{}];
+
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_component(comp, ...args);
+			}
+
+			__out += '<span class="after">' + _$_.escape(lazy_35.value) + '</span><button class="outer-inc">outer</button></div>';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function WrapTryThenStatic() {
+	return _$_.tsrx_element(() => {
+		let lazy_36 = _$_.track(0, '1030b116');
+
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<div class="outer">';
+
+			{
+				const comp = TryThenStatic;
+				const args = [{}];
+
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_component(comp, ...args);
+			}
+
+			__out += '<span class="after">' + _$_.escape(lazy_36.value) + '</span><button class="outer-inc">outer</button></div>';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function WrapStyleThenStatic() {
+	return _$_.tsrx_element(() => {
+		let lazy_37 = _$_.track(0, 'f35d8716');
+
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<div class="outer">';
+
+			{
+				const comp = StyleThenStatic;
+				const args = [{}];
+
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_component(comp, ...args);
+			}
+
+			__out += '<span class="after">' + _$_.escape(lazy_37.value) + '</span><button class="outer-inc">outer</button></div>';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function WrapCollectionThenStatic() {
+	return _$_.tsrx_element(() => {
+		let lazy_38 = _$_.track(0, 'b1e7a298');
+
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<div class="outer">';
+
+			{
+				const comp = CollectionThenStatic;
+				const args = [{}];
+
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_component(comp, ...args);
+			}
+
+			__out += '<span class="after">' + _$_.escape(lazy_38.value) + '</span><button class="outer-inc">outer</button></div>';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function WrapInlineElementThenStatic() {
+	return _$_.tsrx_element(() => {
+		let lazy_39 = _$_.track(0, 'df10dc38');
+
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<div class="outer">';
+
+			{
+				const comp = InlineElementThenStatic;
+				const args = [{}];
+
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_component(comp, ...args);
+			}
+
+			__out += '<span class="after">' + _$_.escape(lazy_39.value) + '</span><button class="outer-inc">outer</button></div>';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function IfOnly() {
+	return _$_.tsrx_element(() => {
+		let lazy_40 = _$_.track(0, 'c6afe814');
+
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<!--[--><!--[-->';
+
+			if (lazy_40.value >= 0) {
+				__out += '<b class="if">x</b>';
+			}
+
+			__out += '<!--]--><!--]-->';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function IfThenOne() {
+	return _$_.tsrx_element(() => {
+		let lazy_41 = _$_.track(0, 'c3b63525');
+
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<!--[--><!--[-->';
+
+			if (lazy_41.value >= 0) {
+				__out += '<b class="if">x</b>';
+			}
+
+			__out += '<!--]--><div class="a">a</div><!--]-->';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function SingleRootWithIf() {
+	return _$_.tsrx_element(() => {
+		let lazy_42 = _$_.track(0, '63d962e3');
+
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<div class="root"><!--[-->';
+
+			if (lazy_42.value >= 0) {
+				__out += '<b class="if">x</b>';
+			}
+
+			__out += '<!--]--></div>';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function WrapIfOnly() {
+	return _$_.tsrx_element(() => {
+		let lazy_43 = _$_.track(0, '83c8f19d');
+
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<div class="outer">';
+
+			{
+				const comp = IfOnly;
+				const args = [{}];
+
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_component(comp, ...args);
+			}
+
+			__out += '<span class="after">' + _$_.escape(lazy_43.value) + '</span><button class="outer-inc">outer</button></div>';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function WrapIfThenOne() {
+	return _$_.tsrx_element(() => {
+		let lazy_44 = _$_.track(0, '2cee9a57');
+
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<div class="outer">';
+
+			{
+				const comp = IfThenOne;
+				const args = [{}];
+
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_component(comp, ...args);
+			}
+
+			__out += '<span class="after">' + _$_.escape(lazy_44.value) + '</span><button class="outer-inc">outer</button></div>';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function WrapSingleRootWithIf() {
+	return _$_.tsrx_element(() => {
+		let lazy_45 = _$_.track(0, 'c179a57b');
+
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<div class="outer">';
+
+			{
+				const comp = SingleRootWithIf;
+				const args = [{}];
+
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_component(comp, ...args);
+			}
+
+			__out += '<span class="after">' + _$_.escape(lazy_45.value) + '</span><button class="outer-inc">outer</button></div>';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function ExprThenSiblingInDiv() {
+	return _$_.tsrx_element(() => {
+		let lazy_46 = _$_.track(0, 'db1d59ee');
+		const label = 'label';
+
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<div class="outer">';
+			_$_.output_push(__out);
+			__out = '';
+			_$_.render_expression(label.toUpperCase());
+			__out += '<span class="after">' + _$_.escape(lazy_46.value) + '</span><button class="outer-inc">outer</button></div>';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function IfTwoThenStatic() {
+	return _$_.tsrx_element(() => {
+		let lazy_47 = _$_.track(0, 'd8310b12');
+
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<!--[--><!--[-->';
+
+			if (lazy_47.value >= 0) {
+				__out += '<b class="if">x</b><i class="if2">y</i>';
+			}
+
+			__out += '<!--]--><div class="a">a</div><div class="b">b</div><!--]-->';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function IfTwoInDiv() {
+	return _$_.tsrx_element(() => {
+		let lazy_48 = _$_.track(0, '0c602c2f');
+
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<div class="outer"><!--[-->';
+
+			if (lazy_48.value >= 0) {
+				__out += '<b class="if">x</b><i class="if2">y</i>';
+			}
+
+			__out += '<!--]--><span class="after">' + _$_.escape(lazy_48.value) + '</span><button class="outer-inc">outer</button></div>';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function WrapIfTwoThenStatic() {
+	return _$_.tsrx_element(() => {
+		let lazy_49 = _$_.track(0, 'cd8f8438');
+
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<div class="outer">';
+
+			{
+				const comp = IfTwoThenStatic;
+				const args = [{}];
+
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_component(comp, ...args);
+			}
+
+			__out += '<span class="after">' + _$_.escape(lazy_49.value) + '</span><button class="outer-inc">outer</button></div>';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function ForTwoNodeItems() {
+	return _$_.tsrx_element(() => {
+		const items = [1, 2];
+
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<div class="outer"><!--[-->';
+
+			for (const item of items) {
+				__out += '<b class="item">';
+
+				{
+					_$_.output_push(__out);
+					__out = '';
+					_$_.render_expression(item);
+				}
+
+				__out += '</b><i class="sep">|</i>';
+			}
+
+			__out += '<!--]--><span class="after">after</span></div>';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function StaticCallThenStatic() {
+	return _$_.tsrx_element(() => {
+		const makeB = () => _$_.tsrx_element(() => {
+			_$_.regular_block(() => {
+				let __out = '';
+
+				__out += '<b class="made">made</b>';
+				_$_.output_push(__out);
+			});
+		});
+
+		_$_.regular_block(() => {
+			let __out = '';
+
+			_$_.output_push(__out);
+			__out = '';
+			_$_.render_tsrx_element(makeB());
+			__out += '<div class="a">a</div><div class="b">b</div>';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function StaticThenStyleThenStatic() {
+	return _$_.tsrx_element(() => {
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<div class="a">a</div><style>' + _$_.escape(`.styled2 { color: blue; }`) + '</style><div class="styled2 b">b</div><div class="styled2 c">c</div>';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function WrapStaticCallThenStatic() {
+	return _$_.tsrx_element(() => {
+		let lazy_50 = _$_.track(0, '4513c76f');
+
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<div class="outer">';
+
+			{
+				const comp = StaticCallThenStatic;
+				const args = [{}];
+
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_component(comp, ...args);
+			}
+
+			__out += '<span class="after">' + _$_.escape(lazy_50.value) + '</span><button class="outer-inc">outer</button></div>';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function WrapStaticThenStyleThenStatic() {
+	return _$_.tsrx_element(() => {
+		let lazy_51 = _$_.track(0, '5d5162df');
+
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<div class="outer">';
+
+			{
+				const comp = StaticThenStyleThenStatic;
+				const args = [{}];
+
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_component(comp, ...args);
+			}
+
+			__out += '<span class="after">' + _$_.escape(lazy_51.value) + '</span><button class="outer-inc">outer</button></div>';
+			_$_.output_push(__out);
+		});
+	});
+}

--- a/packages/ripple/tests/hydration/components/fragment-cursor.tsrx
+++ b/packages/ripple/tests/hydration/components/fragment-cursor.tsrx
@@ -1,0 +1,650 @@
+import { track } from 'ripple';
+
+// Components exercising where the hydration cursor sits after a node, block,
+// or component: on its last DOM node, where the parent's sibling traversal
+// expects it. Fragment roots are hydrated on their own and as a child with
+// trailing siblings (`Wrap<Name>`), so the compiler's closing `next(n)` must
+// land on the fragment's last top-level node; the single-root shapes at the
+// end check a slot followed by siblings inside an element.
+
+function Leaf() @{
+	<i class="leaf">{'leaf'}</i>
+}
+
+export function TrailingNavigatedElements() @{
+	let &[n] = track(0);
+	<>
+		<div class="count">{n}</div>
+		<button class="inc" onClick={() => n++}>{'inc'}</button>
+		<button class="dec" onClick={() => n--}>{'dec'}</button>
+	</>
+}
+
+export function TrailingStaticNavigatedElements() @{
+	let &[n] = track(0);
+	<>
+		<div class="host">{'static'}</div>
+		<button class="inc" onClick={() => n++}>{'inc'}</button>
+		<button class="dec" onClick={() => n--}>{'dec'}</button>
+	</>
+}
+
+export function NavigatedThenStatic() @{
+	let &[n] = track(0);
+	<>
+		<div class="host">{'static'}</div>
+		<button class="inc" onClick={() => n++}>{'inc'}</button>
+		<div class="a">{'a'}</div>
+		<div class="b">{'b'}</div>
+	</>
+}
+
+export function LeadingNavigatedThenStatic() @{
+	let &[n] = track(0);
+	<>
+		<button class="inc" onClick={() => n++}>{'inc'}</button>
+		<div class="a">{'a'}</div>
+		<div class="b">{'b'}</div>
+	</>
+}
+
+export function TrailingNestedNavigated() @{
+	let &[n] = track(0);
+	<>
+		<div class="host">{'static'}</div>
+		<div class="wrap">
+			<button class="inc" onClick={() => n++}>{'inc'}</button>
+		</div>
+	</>
+}
+
+export function NestedNavigatedThenStatic() @{
+	let &[n] = track(0);
+	<>
+		<div class="wrap">
+			<button class="inc" onClick={() => n++}>{'inc'}</button>
+		</div>
+		<div class="a">{'a'}</div>
+		<div class="b">{'b'}</div>
+	</>
+}
+
+export function TrackedTextThenStatic() @{
+	let &[n] = track(0);
+	<>
+		{n}
+		<div class="a">{'a'}</div>
+		<div class="b">{'b'}</div>
+	</>
+}
+
+export function StaticThenTrackedText() @{
+	let &[n] = track(0);
+	<>
+		<div class="a">{'a'}</div>
+		<div class="b">{'b'}</div>
+		{n}
+	</>
+}
+
+export function StaticNestedThenStatic() @{
+	<>
+		<div class="a">{'a'}</div>
+		<div class="wrap">
+			<span>{'x'}</span>
+		</div>
+		<div class="b">{'b'}</div>
+		<div class="c">{'c'}</div>
+	</>
+}
+
+export function AllStatic() @{
+	<>
+		<div class="a">{'a'}</div>
+		<div class="b">{'b'}</div>
+		<div class="c">{'c'}</div>
+	</>
+}
+
+export function TrailingDynamicChild() @{
+	let &[n] = track(0);
+	<>
+		<div class="a">{'a'}</div>
+		<div class="count">{n}</div>
+	</>
+}
+
+export function DynamicChildThenStatic() @{
+	let &[n] = track(0);
+	<>
+		<div class="count">{n}</div>
+		<div class="a">{'a'}</div>
+		<div class="b">{'b'}</div>
+	</>
+}
+
+export function IfThenStatic() @{
+	let &[n] = track(0);
+	<>
+		@if (n >= 0) {
+			<b class="if">{'x'}</b>
+		}
+		<div class="a">{'a'}</div>
+		<div class="b">{'b'}</div>
+	</>
+}
+
+export function StaticThenIf() @{
+	let &[n] = track(0);
+	<>
+		<div class="a">{'a'}</div>
+		<div class="b">{'b'}</div>
+		@if (n >= 0) {
+			<b class="if">{'x'}</b>
+		}
+	</>
+}
+
+export function CompThenStatic() @{
+	<>
+		<Leaf />
+		<div class="a">{'a'}</div>
+		<div class="b">{'b'}</div>
+	</>
+}
+
+export function StaticThenComp() @{
+	<>
+		<div class="a">{'a'}</div>
+		<div class="b">{'b'}</div>
+		<Leaf />
+	</>
+}
+
+export function SiblingComps() @{
+	<>
+		<Leaf />
+		<Leaf />
+	</>
+}
+
+export function WrapTrailingNavigatedElements() @{
+	let &[n] = track(0);
+	<div class="outer">
+		<TrailingNavigatedElements />
+		<span class="after">{n}</span>
+		<button class="outer-inc" onClick={() => n++}>{'outer'}</button>
+	</div>
+}
+
+export function WrapTrailingStaticNavigatedElements() @{
+	let &[n] = track(0);
+	<div class="outer">
+		<TrailingStaticNavigatedElements />
+		<span class="after">{n}</span>
+		<button class="outer-inc" onClick={() => n++}>{'outer'}</button>
+	</div>
+}
+
+export function WrapNavigatedThenStatic() @{
+	let &[n] = track(0);
+	<div class="outer">
+		<NavigatedThenStatic />
+		<span class="after">{n}</span>
+		<button class="outer-inc" onClick={() => n++}>{'outer'}</button>
+	</div>
+}
+
+export function WrapLeadingNavigatedThenStatic() @{
+	let &[n] = track(0);
+	<div class="outer">
+		<LeadingNavigatedThenStatic />
+		<span class="after">{n}</span>
+		<button class="outer-inc" onClick={() => n++}>{'outer'}</button>
+	</div>
+}
+
+export function WrapTrailingNestedNavigated() @{
+	let &[n] = track(0);
+	<div class="outer">
+		<TrailingNestedNavigated />
+		<span class="after">{n}</span>
+		<button class="outer-inc" onClick={() => n++}>{'outer'}</button>
+	</div>
+}
+
+export function WrapNestedNavigatedThenStatic() @{
+	let &[n] = track(0);
+	<div class="outer">
+		<NestedNavigatedThenStatic />
+		<span class="after">{n}</span>
+		<button class="outer-inc" onClick={() => n++}>{'outer'}</button>
+	</div>
+}
+
+export function WrapTrackedTextThenStatic() @{
+	let &[n] = track(0);
+	<div class="outer">
+		<TrackedTextThenStatic />
+		<span class="after">{n}</span>
+		<button class="outer-inc" onClick={() => n++}>{'outer'}</button>
+	</div>
+}
+
+export function WrapStaticThenTrackedText() @{
+	let &[n] = track(0);
+	<div class="outer">
+		<StaticThenTrackedText />
+		<span class="after">{n}</span>
+		<button class="outer-inc" onClick={() => n++}>{'outer'}</button>
+	</div>
+}
+
+export function WrapStaticNestedThenStatic() @{
+	let &[n] = track(0);
+	<div class="outer">
+		<StaticNestedThenStatic />
+		<span class="after">{n}</span>
+		<button class="outer-inc" onClick={() => n++}>{'outer'}</button>
+	</div>
+}
+
+export function WrapAllStatic() @{
+	let &[n] = track(0);
+	<div class="outer">
+		<AllStatic />
+		<span class="after">{n}</span>
+		<button class="outer-inc" onClick={() => n++}>{'outer'}</button>
+	</div>
+}
+
+export function WrapTrailingDynamicChild() @{
+	let &[n] = track(0);
+	<div class="outer">
+		<TrailingDynamicChild />
+		<span class="after">{n}</span>
+		<button class="outer-inc" onClick={() => n++}>{'outer'}</button>
+	</div>
+}
+
+export function WrapDynamicChildThenStatic() @{
+	let &[n] = track(0);
+	<div class="outer">
+		<DynamicChildThenStatic />
+		<span class="after">{n}</span>
+		<button class="outer-inc" onClick={() => n++}>{'outer'}</button>
+	</div>
+}
+
+export function WrapIfThenStatic() @{
+	let &[n] = track(0);
+	<div class="outer">
+		<IfThenStatic />
+		<span class="after">{n}</span>
+		<button class="outer-inc" onClick={() => n++}>{'outer'}</button>
+	</div>
+}
+
+export function WrapStaticThenIf() @{
+	let &[n] = track(0);
+	<div class="outer">
+		<StaticThenIf />
+		<span class="after">{n}</span>
+		<button class="outer-inc" onClick={() => n++}>{'outer'}</button>
+	</div>
+}
+
+export function WrapCompThenStatic() @{
+	let &[n] = track(0);
+	<div class="outer">
+		<CompThenStatic />
+		<span class="after">{n}</span>
+		<button class="outer-inc" onClick={() => n++}>{'outer'}</button>
+	</div>
+}
+
+export function WrapStaticThenComp() @{
+	let &[n] = track(0);
+	<div class="outer">
+		<StaticThenComp />
+		<span class="after">{n}</span>
+		<button class="outer-inc" onClick={() => n++}>{'outer'}</button>
+	</div>
+}
+
+export function WrapSiblingComps() @{
+	let &[n] = track(0);
+	<div class="outer">
+		<SiblingComps />
+		<span class="after">{n}</span>
+		<button class="outer-inc" onClick={() => n++}>{'outer'}</button>
+	</div>
+}
+
+export function UntrackedTextThenStatic() @{
+	const label = 'label';
+	<>
+		{label.toUpperCase()}
+		<div class="a">{'a'}</div>
+		<div class="b">{'b'}</div>
+	</>
+}
+
+export function NestedFragmentThenStatic() @{
+	<>
+		<div class="a">{'a'}</div>
+		<>
+			<span class="x">{'x'}</span>
+			<span class="y">{'y'}</span>
+		</>
+		<div class="b">{'b'}</div>
+		<div class="c">{'c'}</div>
+	</>
+}
+
+export function TrailingNestedFragment() @{
+	let &[n] = track(0);
+	<>
+		<div class="count">{n}</div>
+		<>
+			<span class="x">{'x'}</span>
+			<button class="inc" onClick={() => n++}>{'inc'}</button>
+		</>
+	</>
+}
+
+export function ForThenStatic() @{
+	const items = [1, 2];
+	<>
+		@for (const item of items) {
+			<b class="item">{item}</b>
+		}
+		<div class="a">{'a'}</div>
+		<div class="b">{'b'}</div>
+	</>
+}
+
+export function SwitchThenStatic() @{
+	let &[n] = track(0);
+	<>
+		@switch (n) {
+			@case 0: {
+				<b class="zero">{'zero'}</b>
+			}
+			@default: {
+				<b class="other">{'other'}</b>
+			}
+		}
+		<div class="a">{'a'}</div>
+		<div class="b">{'b'}</div>
+	</>
+}
+
+export function TryThenStatic() @{
+	<>
+		@try {
+			<b class="try">{'try'}</b>
+		} @catch (e) {
+			<b class="catch">{'catch'}</b>
+		}
+		<div class="a">{'a'}</div>
+		<div class="b">{'b'}</div>
+	</>
+}
+
+export function StyleThenStatic() @{
+	<>
+		<style>{`.styled { color: red; }`}</style>
+		<div class="styled a">{'a'}</div>
+		<div class="styled b">{'b'}</div>
+	</>
+}
+
+export function CollectionThenStatic() @{
+	const items = [1, 2];
+	<>
+		{items.map((item) => <b class="item">{item}</b>)}
+		<div class="a">{'a'}</div>
+		<div class="b">{'b'}</div>
+	</>
+}
+
+export function InlineElementThenStatic() @{
+	<>
+		{<b class="inline">{'inline'}</b>}
+		<div class="a">{'a'}</div>
+		<div class="b">{'b'}</div>
+	</>
+}
+
+export function WrapUntrackedTextThenStatic() @{
+	let &[n] = track(0);
+	<div class="outer">
+		<UntrackedTextThenStatic />
+		<span class="after">{n}</span>
+		<button class="outer-inc" onClick={() => n++}>{'outer'}</button>
+	</div>
+}
+
+export function WrapNestedFragmentThenStatic() @{
+	let &[n] = track(0);
+	<div class="outer">
+		<NestedFragmentThenStatic />
+		<span class="after">{n}</span>
+		<button class="outer-inc" onClick={() => n++}>{'outer'}</button>
+	</div>
+}
+
+export function WrapTrailingNestedFragment() @{
+	let &[n] = track(0);
+	<div class="outer">
+		<TrailingNestedFragment />
+		<span class="after">{n}</span>
+		<button class="outer-inc" onClick={() => n++}>{'outer'}</button>
+	</div>
+}
+
+export function WrapForThenStatic() @{
+	let &[n] = track(0);
+	<div class="outer">
+		<ForThenStatic />
+		<span class="after">{n}</span>
+		<button class="outer-inc" onClick={() => n++}>{'outer'}</button>
+	</div>
+}
+
+export function WrapSwitchThenStatic() @{
+	let &[n] = track(0);
+	<div class="outer">
+		<SwitchThenStatic />
+		<span class="after">{n}</span>
+		<button class="outer-inc" onClick={() => n++}>{'outer'}</button>
+	</div>
+}
+
+export function WrapTryThenStatic() @{
+	let &[n] = track(0);
+	<div class="outer">
+		<TryThenStatic />
+		<span class="after">{n}</span>
+		<button class="outer-inc" onClick={() => n++}>{'outer'}</button>
+	</div>
+}
+
+export function WrapStyleThenStatic() @{
+	let &[n] = track(0);
+	<div class="outer">
+		<StyleThenStatic />
+		<span class="after">{n}</span>
+		<button class="outer-inc" onClick={() => n++}>{'outer'}</button>
+	</div>
+}
+
+export function WrapCollectionThenStatic() @{
+	let &[n] = track(0);
+	<div class="outer">
+		<CollectionThenStatic />
+		<span class="after">{n}</span>
+		<button class="outer-inc" onClick={() => n++}>{'outer'}</button>
+	</div>
+}
+
+export function WrapInlineElementThenStatic() @{
+	let &[n] = track(0);
+	<div class="outer">
+		<InlineElementThenStatic />
+		<span class="after">{n}</span>
+		<button class="outer-inc" onClick={() => n++}>{'outer'}</button>
+	</div>
+}
+
+export function IfOnly() @{
+	let &[n] = track(0);
+	<>
+		@if (n >= 0) {
+			<b class="if">{'x'}</b>
+		}
+	</>
+}
+
+export function IfThenOne() @{
+	let &[n] = track(0);
+	<>
+		@if (n >= 0) {
+			<b class="if">{'x'}</b>
+		}
+		<div class="a">{'a'}</div>
+	</>
+}
+
+export function SingleRootWithIf() @{
+	let &[n] = track(0);
+	<div class="root">
+		@if (n >= 0) {
+			<b class="if">{'x'}</b>
+		}
+	</div>
+}
+
+export function WrapIfOnly() @{
+	let &[n] = track(0);
+	<div class="outer">
+		<IfOnly />
+		<span class="after">{n}</span>
+		<button class="outer-inc" onClick={() => n++}>{'outer'}</button>
+	</div>
+}
+
+export function WrapIfThenOne() @{
+	let &[n] = track(0);
+	<div class="outer">
+		<IfThenOne />
+		<span class="after">{n}</span>
+		<button class="outer-inc" onClick={() => n++}>{'outer'}</button>
+	</div>
+}
+
+export function WrapSingleRootWithIf() @{
+	let &[n] = track(0);
+	<div class="outer">
+		<SingleRootWithIf />
+		<span class="after">{n}</span>
+		<button class="outer-inc" onClick={() => n++}>{'outer'}</button>
+	</div>
+}
+
+export function ExprThenSiblingInDiv() @{
+	let &[n] = track(0);
+	const label = 'label';
+	<div class="outer">
+		{label.toUpperCase()}
+		<span class="after">{n}</span>
+		<button class="outer-inc" onClick={() => n++}>{'outer'}</button>
+	</div>
+}
+
+export function IfTwoThenStatic() @{
+	let &[n] = track(0);
+	<>
+		@if (n >= 0) {
+			<>
+				<b class="if">{'x'}</b>
+				<i class="if2">{'y'}</i>
+			</>
+		}
+		<div class="a">{'a'}</div>
+		<div class="b">{'b'}</div>
+	</>
+}
+
+export function IfTwoInDiv() @{
+	let &[n] = track(0);
+	<div class="outer">
+		@if (n >= 0) {
+			<>
+				<b class="if">{'x'}</b>
+				<i class="if2">{'y'}</i>
+			</>
+		}
+		<span class="after">{n}</span>
+		<button class="outer-inc" onClick={() => n++}>{'outer'}</button>
+	</div>
+}
+
+export function WrapIfTwoThenStatic() @{
+	let &[n] = track(0);
+	<div class="outer">
+		<IfTwoThenStatic />
+		<span class="after">{n}</span>
+		<button class="outer-inc" onClick={() => n++}>{'outer'}</button>
+	</div>
+}
+
+export function ForTwoNodeItems() @{
+	const items = [1, 2];
+	<div class="outer">
+		@for (const item of items) {
+			<>
+				<b class="item">{item}</b>
+				<i class="sep">{'|'}</i>
+			</>
+		}
+		<span class="after">{'after'}</span>
+	</div>
+}
+
+export function StaticCallThenStatic() @{
+	const makeB = () => <b class="made">{'made'}</b>;
+	<>
+		{makeB()}
+		<div class="a">{'a'}</div>
+		<div class="b">{'b'}</div>
+	</>
+}
+
+export function StaticThenStyleThenStatic() @{
+	<>
+		<div class="a">{'a'}</div>
+		<style>{`.styled2 { color: blue; }`}</style>
+		<div class="styled2 b">{'b'}</div>
+		<div class="styled2 c">{'c'}</div>
+	</>
+}
+
+export function WrapStaticCallThenStatic() @{
+	let &[n] = track(0);
+	<div class="outer">
+		<StaticCallThenStatic />
+		<span class="after">{n}</span>
+		<button class="outer-inc" onClick={() => n++}>{'outer'}</button>
+	</div>
+}
+
+export function WrapStaticThenStyleThenStatic() @{
+	let &[n] = track(0);
+	<div class="outer">
+		<StaticThenStyleThenStatic />
+		<span class="after">{n}</span>
+		<button class="outer-inc" onClick={() => n++}>{'outer'}</button>
+	</div>
+}

--- a/packages/ripple/tests/hydration/fragment-cursor.test.js
+++ b/packages/ripple/tests/hydration/fragment-cursor.test.js
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import { flushSync } from 'ripple';
+import { render } from 'ripple/server';
+import { hydrateComponent, container, stripHydrationMarkers } from '../setup-hydration.js';
+
+import * as ServerComponents from './compiled/server/fragment-cursor.js';
+import * as ClientComponents from './compiled/client/fragment-cursor.js';
+
+// Component roots, mostly fragments, whose last node the hydration cursor
+// must end on. Each is hydrated on its own and as `Wrap<Name>`: a child
+// followed by siblings that hydrate wrongly if the cursor is off by a node.
+const shapes = [
+	'TrailingNavigatedElements',
+	'TrailingStaticNavigatedElements',
+	'NavigatedThenStatic',
+	'LeadingNavigatedThenStatic',
+	'TrailingNestedNavigated',
+	'NestedNavigatedThenStatic',
+	'TrackedTextThenStatic',
+	'StaticThenTrackedText',
+	'StaticNestedThenStatic',
+	'AllStatic',
+	'TrailingDynamicChild',
+	'DynamicChildThenStatic',
+	'IfThenStatic',
+	'StaticThenIf',
+	'CompThenStatic',
+	'StaticThenComp',
+	'SiblingComps',
+	'UntrackedTextThenStatic',
+	'NestedFragmentThenStatic',
+	'TrailingNestedFragment',
+	'ForThenStatic',
+	'SwitchThenStatic',
+	'TryThenStatic',
+	'StyleThenStatic',
+	'CollectionThenStatic',
+	'InlineElementThenStatic',
+	'IfOnly',
+	'IfThenOne',
+	'SingleRootWithIf',
+	'IfTwoThenStatic',
+	'StaticCallThenStatic',
+	'StaticThenStyleThenStatic',
+];
+
+// Single-root shapes whose children end on a slot the cursor must step past.
+const rootShapes = ['ExprThenSiblingInDiv', 'IfTwoInDiv', 'ForTwoNodeItems'];
+
+/**
+ * Server renders and hydrates a component, asserting the hydrated DOM matches
+ * the server markup (no duplicated or dropped nodes).
+ * @param {string} name
+ */
+async function hydrateShape(name) {
+	const { body } = await render(ServerComponents[name]);
+	await hydrateComponent(ServerComponents[name], ClientComponents[name]);
+	expect(container.innerHTML).toBeHtml(stripHydrationMarkers(body));
+}
+
+/**
+ * Clicks the shape's own `.inc` button (when it has one) and checks the
+ * hydrated `.count` text updates in place.
+ */
+function clickInner() {
+	const inc = container.querySelector('.inc');
+	const count = container.querySelector('.count');
+	if (inc && count) {
+		expect(count.textContent).toBe('0');
+		inc.click();
+		flushSync();
+		expect(count.textContent).toBe('1');
+	}
+}
+
+describe('hydration > fragment cursor', () => {
+	describe('fragment as the root', () => {
+		for (const name of shapes) {
+			it(`hydrates ${name}`, async () => {
+				await hydrateShape(name);
+				clickInner();
+			});
+		}
+	});
+
+	describe('slot followed by siblings inside an element', () => {
+		for (const name of rootShapes) {
+			it(`hydrates ${name}`, async () => {
+				await hydrateShape(name);
+				clickInner();
+			});
+		}
+	});
+
+	describe('fragment as a child with trailing siblings', () => {
+		for (const name of shapes) {
+			it(`hydrates ${name} followed by siblings`, async () => {
+				await hydrateShape(`Wrap${name}`);
+
+				const after = container.querySelector('.after');
+				expect(after?.textContent).toBe('0');
+
+				container.querySelector('.outer-inc')?.click();
+				flushSync();
+				expect(after?.textContent).toBe('1');
+
+				clickInner();
+			});
+		}
+	});
+});

--- a/packages/tsrx-ripple/src/transform/client/index.js
+++ b/packages/tsrx-ripple/src/transform/client/index.js
@@ -5825,6 +5825,12 @@ function transform_children(children, context) {
 				node.type !== 'BlockStatement' &&
 				node.type !== 'EmptyStatement',
 		).length > 1;
+	// A fragment template root (a component or control-flow body, not an
+	// element's children): its hydration cursor must end on its last top-level
+	// node, since no enclosing element's traversal restores the cursor for it.
+	// `skip_children_traversal` is not the discriminator here: it leaks from an
+	// enclosing element into the control-flow bodies nested in it.
+	const is_fragment_root = is_fragment && root;
 	/** @type {AST.Identifier | null} */
 	let initial = null;
 	/** @type {(() => AST.Identifier) | null} */
@@ -5930,6 +5936,12 @@ function transform_children(children, context) {
 
 	let fragment_hop_count = 0;
 
+	// Hydration cursor lag for a fragment root: how many top-level template
+	// nodes back from the last emitted one the cursor sits, plus one. A child
+	// that was navigated to (`cached`) leaves the cursor on its own last DOM
+	// node, so the count restarts at 1; an untouched child leaves the cursor
+	// where it was, so the count grows. The fragment closes with
+	// `next(skipped - 1)` to bring the cursor onto its last node.
 	let skipped = 0;
 
 	for (let node_idx = 0; node_idx < normalized.length; node_idx++) {
@@ -6055,7 +6067,6 @@ function transform_children(children, context) {
 			 */
 			const render_text_expression = (identity, expr) => {
 				if (metadata?.tracking) {
-					skipped = 0;
 					state.template?.push(' ');
 					const id = flush_node(true);
 					state.update?.push({
@@ -6065,7 +6076,6 @@ function transform_children(children, context) {
 						initial: b.literal(' '),
 					});
 				} else if (normalized.length === 1) {
-					skipped++;
 					if (expr.type === 'Literal') {
 						if (
 							/** @type {NonNullable<TransformClientState['template']>} */ (state.template).length >
@@ -6092,7 +6102,6 @@ function transform_children(children, context) {
 						);
 					}
 				} else {
-					skipped++;
 					if (expr.type === 'Literal') {
 						state.template?.push(escape_html(expr.value));
 					} else {
@@ -6109,37 +6118,24 @@ function transform_children(children, context) {
 			};
 
 			if (is_template_element(node)) {
-				if (is_element_dom_element(node)) {
-					skipped++;
-				} else {
-					skipped = 0;
-				}
-
 				visit(node, {
 					...state,
 					flush_node: /** @type {TransformClientState['flush_node']} */ (flush_node),
 					namespace: state.namespace,
 				});
 
-				// After processing an element's children via child()/sibling() navigation,
-				// hydrate_node is left deep inside the element. If there's a next sibling,
-				// we need to restore hydrate_node so sibling() navigation works correctly.
+				// Processing an element's children via child()/sibling() navigation
+				// leaves hydrate_node deep inside the element. It must be back on the
+				// element before a sibling's traversal, and at the end of a fragment
+				// root, where no enclosing element's append() restores it and the
+				// fragment's closing next() walks from wherever the cursor sits.
 				//
-				// We only need pop() when we actually DESCEND into the element, which happens when:
-				// - There are Element children (including DOM elements like <button>)
-				// - There are non-literal Text children (we navigate to set text content)
-				// - There are control flow / component children
-				//
-				// The Element visitor already adds pop() for non-literal text, control flow,
-				// and component (non-DOM element) children. We need to ALSO add pop()
-				// when there are DOM element children, which the Element visitor doesn't cover.
-				const next_node = normalized[node_idx + 1];
-				const element_children = is_template_element(node)
-					? /** @type {AST.TSRXJSXElement} */ (node).children
-					: [];
-				if (next_node && is_element_dom_element(node) && element_children.length > 0) {
-					// Check if any child is a DOM element - this causes navigation but
-					// the Element visitor doesn't add pop() for it
+				// Only a navigated element (`cached`) can have been descended into.
+				// The Element visitor already adds pop() for non-literal text,
+				// control flow, and component (non-DOM element) children; DOM element
+				// children navigate without one, so add it here.
+				const element_children = /** @type {AST.TSRXJSXElement} */ (node).children;
+				if (cached !== null && is_element_dom_element(node) && element_children.length > 0) {
 					const has_dom_element_children = element_children.some(
 						(child) =>
 							is_template_element(child) &&
@@ -6147,7 +6143,6 @@ function transform_children(children, context) {
 							is_element_dom_element(child),
 					);
 
-					// Check if the Element visitor already added pop()
 					const element_visitor_adds_pop = element_children.some(
 						(child) =>
 							is_template_directive(child) ||
@@ -6168,31 +6163,23 @@ function transform_children(children, context) {
 								sibling.type !== 'VariableDeclaration' && sibling.type !== 'EmptyStatement',
 						);
 
-					// Add pop() if we have DOM element children, the Element visitor didn't already
-					// add one, and there is another renderable sibling afterward. This keeps
-					// hydrate_node anchored at the current element before sibling() traversal.
 					if (
 						has_dom_element_children &&
 						!element_visitor_adds_pop &&
-						has_following_renderable_sibling
+						(has_following_renderable_sibling || is_fragment_root)
 					) {
-						const id = cached ?? flush_node();
-						state.init?.push(b.stmt(b.call('_$_.pop', id)));
+						state.init?.push(b.stmt(b.call('_$_.pop', cached)));
 					}
 				}
 			} else if (node.type === 'JSXStyleElement') {
 				// A `<style>` in `<head>` renders as a static template element; the
 				// visitor pushes its markup (or nothing outside head).
-				skipped++;
-
 				visit(node, {
 					...state,
 					flush_node: /** @type {TransformClientState['flush_node']} */ (flush_node),
 					namespace: state.namespace,
 				});
 			} else if (is_template_fragment(node)) {
-				skipped = 0;
-
 				visit(node, {
 					...state,
 					flush_node: /** @type {TransformClientState['flush_node']} */ (flush_node),
@@ -6211,7 +6198,6 @@ function transform_children(children, context) {
 
 				if (expr.type === 'Literal') {
 					if (normalized.length === 1) {
-						skipped++;
 						if (
 							/** @type {NonNullable<TransformClientState['template']>} */ (state.template).length >
 							0
@@ -6223,11 +6209,9 @@ function transform_children(children, context) {
 							state.final?.push(b.stmt(b.call('_$_.append', b.id('__anchor'), id)));
 						}
 					} else {
-						skipped++;
 						state.template?.push(escape_html(expr.value));
 					}
 				} else if (is_static_native_tsrx_call) {
-					skipped = 0;
 					state.template?.push('<!>');
 					const id = flush_node(false);
 					const call = b.call('_$_.render_tsrx_element', expr, id, b.id('__block'));
@@ -6245,7 +6229,6 @@ function transform_children(children, context) {
 					normalized.length === 1 &&
 					!is_children_template_expression(container_expression, state.scope)
 				) {
-					skipped++;
 					state.template?.push(' ');
 					const id = flush_node(false);
 					const call = b.call('_$_.expression', id, b.thunk(expr));
@@ -6255,7 +6238,6 @@ function transform_children(children, context) {
 							: b.stmt(call),
 					);
 				} else {
-					skipped = 0;
 					state.template?.push('<!>');
 					const id = flush_node(false);
 					const call = b.call('_$_.expression', id, b.thunk(expr));
@@ -6277,7 +6259,6 @@ function transform_children(children, context) {
 				node.type === 'ForOfStatement' ||
 				(node.type === 'JSXForExpression' && node.statementType === 'ForOfStatement')
 			) {
-				skipped = 0;
 				node.metadata = { ...node.metadata, is_controlled };
 				visit(node, {
 					...state,
@@ -6285,7 +6266,6 @@ function transform_children(children, context) {
 					namespace: state.namespace,
 				});
 			} else if (node.type === 'IfStatement' || node.type === 'JSXIfExpression') {
-				skipped = 0;
 				node.metadata = { ...node.metadata, is_controlled };
 				visit(node, {
 					...state,
@@ -6293,7 +6273,6 @@ function transform_children(children, context) {
 					namespace: state.namespace,
 				});
 			} else if (node.type === 'TryStatement' || node.type === 'JSXTryExpression') {
-				skipped = 0;
 				node.metadata = { ...node.metadata, is_controlled };
 				visit(node, {
 					...state,
@@ -6301,7 +6280,6 @@ function transform_children(children, context) {
 					namespace: state.namespace,
 				});
 			} else if (node.type === 'SwitchStatement' || node.type === 'JSXSwitchExpression') {
-				skipped = 0;
 				node.metadata = { ...node.metadata, is_controlled };
 				visit(node, {
 					...state,
@@ -6314,6 +6292,10 @@ function transform_children(children, context) {
 				state.template?.push('<!>');
 			} else {
 				debugger;
+			}
+
+			if (node.type !== 'BreakStatement' && node.type !== 'ContinueStatement') {
+				skipped = cached !== null ? 1 : skipped + 1;
 			}
 		}
 	}
@@ -6339,11 +6321,9 @@ function transform_children(children, context) {
 		}
 	}
 
-	let emitted_next = false;
-	if (is_fragment && skipped > 1 && !state.skip_children_traversal) {
+	if (is_fragment_root && skipped > 1) {
 		skipped--;
 		state.init?.push(b.stmt(b.call('_$_.next', skipped !== 1 && b.literal(skipped))));
-		emitted_next = true;
 	}
 
 	const template_namespace = state.namespace || 'html';
@@ -6355,9 +6335,7 @@ function transform_children(children, context) {
 		} else if (template_namespace === 'mathml') {
 			flags |= TEMPLATE_MATHML_NAMESPACE;
 		}
-		state.final?.push(
-			b.stmt(b.call('_$_.append', b.id('__anchor'), initial, emitted_next && b.true)),
-		);
+		state.final?.push(b.stmt(b.call('_$_.append', b.id('__anchor'), initial)));
 		const template_array = /** @type {NonNullable<TransformClientState['template']>} */ (
 			state.template
 		);


### PR DESCRIPTION
Fixes #1454

## What was wrong

A fragment root closes with `_$_.next(n)` to move the hydration cursor from the fragment's first template node to its last. The count assumed the cursor was still on the first node. Trailing elements the compiler navigates to for an event or attribute (`hydrate_sibling()`), tracked text, control-flow blocks, components, and `{expression}` slots all move the cursor without resetting the count, so `next(n)` overshot the fragment (the crash in #1454) or, for the kinds that reset the count to zero, fell one node short. A trailing element that was descended into was never popped back to.

Reproducing this in a child position (a fragment component followed by siblings, where the parent's `hydrate_sibling()` reads the cursor) surfaced two runtime problems with the same root cause, a cursor that ends one node away from where the next consumer expects it:

- `expression()` advanced past its end marker, while every other block leaves the cursor on its own end marker. A `{expression}` followed by siblings inside an element hydrated the siblings one node too far, and so did a fragment component the server wraps in markers.
- `append(anchor, dom, skip_advance)` kept a multi-node branch or `@for` item on its last node instead of stepping to the block's end marker, so the next sibling or item adopted the wrong node. Control-flow bodies nested inside an element never emitted the closing `next(n)` at all, because the element's `skip_children_traversal` leaked into them.

## The fix

The contract is now uniform: after any node, block, or component hydrates, the cursor sits on its last DOM node, and whoever owns the next node steps past it.

- **Compiler** (`transform_children`): the fragment count restarts at 1 whenever the child was navigated to (`cached`), otherwise grows. The pop for a DOM-element-descended element is emitted at a fragment root's end as well as before a sibling. The fragment-root test is the `root` flag. The `skip_advance` argument to `append` is no longer emitted.
- **Runtime**: `run_expression` settles on its end marker. `hydrate_append` drops the skip flag and the after-block probe and always steps past the content unless it is a child component rendering into its own anchor.

## Tests

`packages/ripple/tests/hydration/fragment-cursor.test.js` hydrates 32 component root shapes on their own and as a child followed by siblings, plus 3 single-root shapes with a slot before siblings, comparing the hydrated DOM to the server markup and clicking through. 20 of the 67 cases fail on `main`, including the exact reproduction from the issue.

Full `pnpm test`, `pnpm typecheck`, `pnpm format:check`, and `pnpm changeset:check` pass. The regenerated `tests/hydration/compiled/` outputs are included, as in previous commits.

## Note on #1455

#1455 (keyed `@for` re-anchor after hydration) was fixed by #1453, which merged this morning and includes the `for_block_keyed` re-anchor and the `KeyedForLoopAppendAndRotate` tests. It needs no further PR and can be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core hydration cursor contract in compiler and client runtime; broad test coverage reduces risk, but any missed template shape could still mis-hydrate.
> 
> **Overview**
> Fixes hydration cursor misalignment when a **fragment root** or **`{expression}` slot** is followed by siblings—wrong DOM on hydrate and crashes like #1454.
> 
> **Runtime:** `{expression}` now **settles** on its end marker (`settle_hydration`) instead of stepping past it. **`append`** drops `skip_advance` and always advances past hydrated content (with `pop` when the cursor descended inside `dom`), except when a child component hydrates into its own anchor.
> 
> **Compiler:** Fragment-root closing **`next(n)`** counts from the cursor’s **current** position: navigated children reset the skip count to 1; otherwise it accumulates. **`pop`** is emitted at fragment roots when DOM children were descended into. Control-flow bodies inside elements get the same closing **`next`**. Generated code no longer passes **`append(..., true)`**.
> 
> Adds **`fragment-cursor`** hydration tests (roots, slots with trailing siblings, wrapped fragments) and regenerates compiled hydration fixtures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94a91c2f710f730340efe4cf074063c851bd9fac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->