### PR TITLE
fix(dom): add implicit px suffix to bare numeric style values

### DIFF
--- a/.changeset/style-numeric-unit-suffix.md
+++ b/.changeset/style-numeric-unit-suffix.md
@@ -1,0 +1,5 @@
+---
+'ripple': patch
+---
+
+Fix numeric values in a style object (e.g. `{ width: 400 }`) being silently dropped for CSS properties that require a unit. `apply_styles` serialized every value with a plain `String(...)` before calling `style.setProperty`, and the browser ignores a `setProperty` call whose value is a bare unitless number for properties like `width`, `height`, `top`, `left`, or `margin` — no error, the property just never lands on the element. Numeric style values are now formatted through an `isUnitlessNumber`-style allowlist (aligned with React's), appending `px` to any property not on it; `0` stays unitless regardless of property.

--- a/packages/ripple/src/runtime/internal/client/render.js
+++ b/packages/ripple/src/runtime/internal/client/render.js
@@ -99,6 +99,83 @@ export function set_attribute(element, attribute, value) {
 }
 
 /**
+ * CSS properties whose numeric value is unitless (aligned with React's
+ * `isUnitlessNumber` list, trimmed to properties actually reachable through
+ * plain `style.setProperty`). Every other property receives an implicit `px`
+ * suffix when given a bare number, matching what every mainstream framework
+ * (React, Vue, Preact) does for numeric style values.
+ * @type {Set<string>}
+ */
+const UNITLESS_NUMBER_PROPERTIES = new Set([
+	'animation-iteration-count',
+	'aspect-ratio',
+	'border-image-outset',
+	'border-image-slice',
+	'border-image-width',
+	'box-flex',
+	'box-flex-group',
+	'box-ordinal-group',
+	'column-count',
+	'columns',
+	'flex',
+	'flex-grow',
+	'flex-negative',
+	'flex-order',
+	'flex-positive',
+	'flex-shrink',
+	'font-weight',
+	'grid-area',
+	'grid-column',
+	'grid-column-end',
+	'grid-column-span',
+	'grid-column-start',
+	'grid-row',
+	'grid-row-end',
+	'grid-row-span',
+	'grid-row-start',
+	'line-clamp',
+	'line-height',
+	'opacity',
+	'order',
+	'orphans',
+	'tab-size',
+	'widows',
+	'z-index',
+	'zoom',
+	'fill-opacity',
+	'flood-opacity',
+	'stop-opacity',
+	'stroke-dasharray',
+	'stroke-dashoffset',
+	'stroke-miterlimit',
+	'stroke-opacity',
+	'stroke-width',
+]);
+
+/**
+ * `style.setProperty(prop, value)` silently drops the assignment when `value`
+ * is a unitless bare number for a property that requires a unit (e.g.
+ * `width`, `top`, `margin`) — no error, no console warning, the property
+ * simply never lands on the element. `String(400)` produces exactly that bare
+ * number, so a caller passing `{ width: 400 }` (a very common ergonomic
+ * shape, and the one the `style` JSX attribute type explicitly allows) gets
+ * silently no-opped instead of getting `400px`.
+ * @param {string} css_prop kebab-cased CSS property name
+ * @param {string | number} raw_value
+ * @returns {string}
+ */
+function format_style_value(css_prop, raw_value) {
+	if (
+		typeof raw_value === 'number' &&
+		raw_value !== 0 &&
+		!UNITLESS_NUMBER_PROPERTIES.has(css_prop)
+	) {
+		return `${raw_value}px`;
+	}
+	return String(raw_value);
+}
+
+/**
  * @param {HTMLElement} element
  * @param {Record<string, string | number>} new_styles
  * @param {Record<string, string>} prev
@@ -109,7 +186,7 @@ function apply_styles(element, new_styles, prev) {
 	// Apply new styles
 	for (const key in new_styles) {
 		const css_prop = normalize_css_property_name(key);
-		const value = String(new_styles[key]);
+		const value = format_style_value(css_prop, new_styles[key]);
 
 		if (!(key in prev) || prev[key] !== value) {
 			style.setProperty(css_prop, value);

--- a/packages/ripple/src/runtime/internal/client/render.js
+++ b/packages/ripple/src/runtime/internal/client/render.js
@@ -3,7 +3,7 @@
 import { branch, destroy_block, ref } from './blocks.js';
 import { DESTROYED, REF_PROP } from './constants.js';
 import { isRefProp as is_ref_prop } from '@tsrx/core/runtime/ref';
-import { is_ripple_object } from './utils.js';
+import { is_ripple_object, format_style_value } from './utils.js';
 import {
 	get_descriptors,
 	get_own_property_symbols,
@@ -96,83 +96,6 @@ export function set_attribute(element, attribute, value) {
 	} else {
 		element.setAttribute(attribute, value);
 	}
-}
-
-/**
- * CSS properties whose numeric value is unitless (aligned with React's
- * `isUnitlessNumber` list, trimmed to properties actually reachable through
- * plain `style.setProperty`). Every other property receives an implicit `px`
- * suffix when given a bare number, matching what every mainstream framework
- * (React, Vue, Preact) does for numeric style values.
- * @type {Set<string>}
- */
-const UNITLESS_NUMBER_PROPERTIES = new Set([
-	'animation-iteration-count',
-	'aspect-ratio',
-	'border-image-outset',
-	'border-image-slice',
-	'border-image-width',
-	'box-flex',
-	'box-flex-group',
-	'box-ordinal-group',
-	'column-count',
-	'columns',
-	'flex',
-	'flex-grow',
-	'flex-negative',
-	'flex-order',
-	'flex-positive',
-	'flex-shrink',
-	'font-weight',
-	'grid-area',
-	'grid-column',
-	'grid-column-end',
-	'grid-column-span',
-	'grid-column-start',
-	'grid-row',
-	'grid-row-end',
-	'grid-row-span',
-	'grid-row-start',
-	'line-clamp',
-	'line-height',
-	'opacity',
-	'order',
-	'orphans',
-	'tab-size',
-	'widows',
-	'z-index',
-	'zoom',
-	'fill-opacity',
-	'flood-opacity',
-	'stop-opacity',
-	'stroke-dasharray',
-	'stroke-dashoffset',
-	'stroke-miterlimit',
-	'stroke-opacity',
-	'stroke-width',
-]);
-
-/**
- * `style.setProperty(prop, value)` silently drops the assignment when `value`
- * is a unitless bare number for a property that requires a unit (e.g.
- * `width`, `top`, `margin`) — no error, no console warning, the property
- * simply never lands on the element. `String(400)` produces exactly that bare
- * number, so a caller passing `{ width: 400 }` (a very common ergonomic
- * shape, and the one the `style` JSX attribute type explicitly allows) gets
- * silently no-opped instead of getting `400px`.
- * @param {string} css_prop kebab-cased CSS property name
- * @param {string | number} raw_value
- * @returns {string}
- */
-function format_style_value(css_prop, raw_value) {
-	if (
-		typeof raw_value === 'number' &&
-		raw_value !== 0 &&
-		!UNITLESS_NUMBER_PROPERTIES.has(css_prop)
-	) {
-		return `${raw_value}px`;
-	}
-	return String(raw_value);
 }
 
 /**

--- a/packages/ripple/src/runtime/internal/client/utils.js
+++ b/packages/ripple/src/runtime/internal/client/utils.js
@@ -32,3 +32,110 @@ export function top_element_to_ns(element, current_namespace) {
 		return current_namespace;
 	}
 }
+
+/**
+ * Unprefixed CSS properties whose numeric value is unitless (aligned with
+ * React's `isUnitlessNumber` list, trimmed to properties actually reachable
+ * through `style.setProperty` on client and through plain string
+ * concatenation on the server).
+ * @type {readonly string[]}
+ */
+const UNPREFIXED_UNITLESS_NUMBER_PROPERTIES = [
+	'animation-iteration-count',
+	'aspect-ratio',
+	'border-image-outset',
+	'border-image-slice',
+	'border-image-width',
+	'box-flex',
+	'box-flex-group',
+	'box-ordinal-group',
+	'column-count',
+	'columns',
+	'flex',
+	'flex-grow',
+	'flex-negative',
+	'flex-order',
+	'flex-positive',
+	'flex-shrink',
+	'font-weight',
+	'grid-area',
+	'grid-column',
+	'grid-column-end',
+	'grid-column-span',
+	'grid-column-start',
+	'grid-row',
+	'grid-row-end',
+	'grid-row-span',
+	'grid-row-start',
+	'line-clamp',
+	'line-height',
+	'opacity',
+	'order',
+	'orphans',
+	'tab-size',
+	'widows',
+	'z-index',
+	'zoom',
+	'fill-opacity',
+	'flood-opacity',
+	'stop-opacity',
+	'stroke-dasharray',
+	'stroke-dashoffset',
+	'stroke-miterlimit',
+	'stroke-opacity',
+	'stroke-width',
+];
+
+/**
+ * Vendor prefixes (as they appear in a kebab-cased CSS property name) that
+ * can precede any of the unitless properties above — e.g. `-webkit-line-clamp`,
+ * `-moz-tab-size`. Every unprefixed entry is unitless with any of these
+ * prefixes too, the same way React expands `Webkit`/`ms`/`Moz`/`O` variants
+ * of its own unitless list.
+ * @type {readonly string[]}
+ */
+const VENDOR_PREFIXES = ['-webkit-', '-moz-', '-ms-', '-o-'];
+
+/**
+ * Every unitless CSS property, unprefixed and vendor-prefixed, as a lookup
+ * set keyed by the exact kebab-cased name `normalize_css_property_name`
+ * produces.
+ * @type {Set<string>}
+ */
+const UNITLESS_NUMBER_PROPERTIES = new Set([
+	...UNPREFIXED_UNITLESS_NUMBER_PROPERTIES,
+	...VENDOR_PREFIXES.flatMap((prefix) =>
+		UNPREFIXED_UNITLESS_NUMBER_PROPERTIES.map((prop) => `${prefix}${prop}`),
+	),
+]);
+
+/**
+ * `style.setProperty(prop, value)` on the client, and plain string
+ * concatenation into the `style` HTML attribute on the server, both silently
+ * produce a bare unitless number for a property that requires a unit (e.g.
+ * `width`, `top`, `margin`) — the client drops the assignment entirely with
+ * no error, and the server emits markup the client then can't hydrate into a
+ * working value either. `String(400)` produces exactly that bare number, so
+ * a caller passing `{ width: 400 }` (a very common ergonomic shape, and the
+ * one the `style` JSX attribute's `string | number` type explicitly invites)
+ * silently ends up with no width instead of `400px`.
+ *
+ * CSS custom properties (`--foo`) are always left as a bare number: they are
+ * commonly used as unitless multipliers, counters, or opacities read back by
+ * `var(--foo)` in a calc()/multiplication context, and `normalize_css_property_name`
+ * itself already leaves `--`-prefixed names untouched for the same reason.
+ * @param {string} css_prop kebab-cased CSS property name (or a `--custom-property`)
+ * @param {string | number} raw_value
+ * @returns {string}
+ */
+export function format_style_value(css_prop, raw_value) {
+	if (
+		typeof raw_value === 'number' &&
+		raw_value !== 0 &&
+		!css_prop.startsWith('--') &&
+		!UNITLESS_NUMBER_PROPERTIES.has(css_prop)
+	) {
+		return `${raw_value}px`;
+	}
+	return String(raw_value);
+}

--- a/packages/ripple/src/runtime/internal/client/utils.js
+++ b/packages/ripple/src/runtime/internal/client/utils.js
@@ -72,6 +72,11 @@ const UNPREFIXED_UNITLESS_NUMBER_PROPERTIES = [
 	'opacity',
 	'order',
 	'orphans',
+	// The standalone CSS Transforms Level 2 `scale` property (e.g.
+	// `scale: 1.5;`) is a unitless multiplier — same semantics as the
+	// `scale()` transform function, just usable as its own property. Not on
+	// React's older `isUnitlessNumber` list, but genuinely unitless.
+	'scale',
 	'tab-size',
 	'widows',
 	'z-index',

--- a/packages/ripple/src/runtime/internal/server/index.js
+++ b/packages/ripple/src/runtime/internal/server/index.js
@@ -52,7 +52,7 @@ import {
 	TRACKED_UPDATED,
 } from '../client/constants.js';
 import { DEV } from 'esm-env';
-import { is_ripple_object } from '../client/utils.js';
+import { is_ripple_object, format_style_value } from '../client/utils.js';
 import { iterable_array_from, array_slice, is_array } from '@tsrx/core/runtime/language-helpers';
 import {
 	escape,
@@ -1637,7 +1637,7 @@ function get_styles(styles) {
 	var result = '';
 	for (const key in styles) {
 		const css_prop = normalize_css_property_name(key);
-		const value = String(styles[key]).trim();
+		const value = format_style_value(css_prop, styles[key]).trim();
 		result += `${css_prop}: ${value}; `;
 	}
 	return result.trim();

--- a/packages/ripple/tests/client/basic/basic.attributes.test.tsrx
+++ b/packages/ripple/tests/client/basic/basic.attributes.test.tsrx
@@ -244,6 +244,41 @@ describe('basic client > attribute rendering', () => {
 		expect(div.style.fontWeight).toBe('bold');
 	});
 
+	it('render bare numbers in a style object with an implicit px suffix', () => {
+		// `style.setProperty('width', '400')` silently no-ops for properties that
+		// require a unit — the browser drops the assignment without an error, so
+		// `{ width: 400 }` must be serialized as `400px`, matching the ergonomics
+		// every other mainstream framework (React, Vue, Preact) provides for
+		// numeric style values.
+		function Basic() @{
+			let &[width] = track(400);
+			<>
+				<button
+					onClick={() => {
+						width = width === 400 ? 200 : 400;
+					}}
+				>{'Resize'}</button>
+				<div style={{ width: width, height: 100, zIndex: 5, opacity: 0.5 }}>{'Sized box'}</div>
+			</>
+		}
+
+		render(Basic);
+
+		const button = container.querySelector('button');
+		const div = container.querySelector('div');
+
+		expect(div.style.width).toBe('400px');
+		expect(div.style.height).toBe('100px');
+		// Unitless properties must stay bare — no accidental `5px` on z-index.
+		expect(div.style.zIndex).toBe('5');
+		expect(div.style.opacity).toBe('0.5');
+
+		button.click();
+		flushSync();
+
+		expect(div.style.width).toBe('200px');
+	});
+
 	it('render tracked variable as style attribute', () => {
 		function Basic() @{
 			let &[style] = track({ color: 'red', fontWeight: 'bold' });

--- a/packages/ripple/tests/client/basic/basic.attributes.test.tsrx
+++ b/packages/ripple/tests/client/basic/basic.attributes.test.tsrx
@@ -310,6 +310,21 @@ describe('basic client > attribute rendering', () => {
 		expect(div.style.getPropertyValue('-webkit-line-clamp')).toBe('2');
 	});
 
+	it('leaves the standalone CSS scale property unitless', () => {
+		// `scale` (the standalone CSS Transforms Level 2 property, not the
+		// `scale()` transform function) is a unitless multiplier — `1.5` must
+		// stay `1.5`, not become the invalid `1.5px`.
+		function Basic() @{
+			<div style={{ scale: 1.5 }}>{'Scaled box'}</div>
+		}
+
+		render(Basic);
+
+		const div = container.querySelector('div');
+
+		expect(div.style.getPropertyValue('scale')).toBe('1.5');
+	});
+
 	it('render tracked variable as style attribute', () => {
 		function Basic() @{
 			let &[style] = track({ color: 'red', fontWeight: 'bold' });

--- a/packages/ripple/tests/client/basic/basic.attributes.test.tsrx
+++ b/packages/ripple/tests/client/basic/basic.attributes.test.tsrx
@@ -279,6 +279,37 @@ describe('basic client > attribute rendering', () => {
 		expect(div.style.width).toBe('200px');
 	});
 
+	it('leaves CSS custom properties unitless even with a numeric value', () => {
+		// Custom properties are commonly read back through `var(--foo)` as a
+		// unitless multiplier, counter, or opacity — `{ '--scale': 2 }` must stay
+		// `2`, not become `2px`.
+		function Basic() @{
+			<div style={{ '--scale': 2, '--webkit-something': 3 }}>{'Custom props'}</div>
+		}
+
+		render(Basic);
+
+		const div = container.querySelector('div');
+
+		expect(div.style.getPropertyValue('--scale')).toBe('2');
+		expect(div.style.getPropertyValue('--webkit-something')).toBe('3');
+	});
+
+	it('treats vendor-prefixed unitless properties as unitless too', () => {
+		// `lineClamp` is unitless, so its vendor-prefixed form (as authored via
+		// the camelCase JSX style key) must be too — a bare `2` should not become
+		// `2px` just because it's spelled `WebkitLineClamp`.
+		function Basic() @{
+			<div style={{ WebkitLineClamp: 2 }}>{'Prefixed unitless'}</div>
+		}
+
+		render(Basic);
+
+		const div = container.querySelector('div');
+
+		expect(div.style.getPropertyValue('-webkit-line-clamp')).toBe('2');
+	});
+
 	it('render tracked variable as style attribute', () => {
 		function Basic() @{
 			let &[style] = track({ color: 'red', fontWeight: 'bold' });

--- a/packages/ripple/tests/server/basic.attributes.test.tsrx
+++ b/packages/ripple/tests/server/basic.attributes.test.tsrx
@@ -235,6 +235,28 @@ describe('basic server > attribute rendering', () => {
 		expect(div.style.fontWeight).toBe('bold');
 	});
 
+	it('render bare numbers in a style object with an implicit px suffix', async () => {
+		function Basic() @{
+			<div
+				style={{ width: 400, height: 100, zIndex: 5, opacity: 0.5, '--scale': 2 }}
+			>{'Sized box'}</div>
+		}
+
+		const { body } = await render(Basic);
+		const { document } = parseHtml(body);
+
+		const div = document.querySelector('div');
+
+		expect(div.style.width).toBe('400px');
+		expect(div.style.height).toBe('100px');
+		// Unitless properties must stay bare — no accidental `5px` on z-index.
+		expect(div.style.zIndex).toBe('5');
+		expect(div.style.opacity).toBe('0.5');
+		// Custom properties are commonly used as unitless multipliers and must
+		// never receive an implicit px suffix.
+		expect(div.style.getPropertyValue('--scale')).toBe('2');
+	});
+
 	it('render tracked variable as style attribute', async () => {
 		function Basic() @{
 			let &[style] = track({ color: 'red', fontWeight: 'bold' });

--- a/packages/ripple/tests/server/basic.attributes.test.tsrx
+++ b/packages/ripple/tests/server/basic.attributes.test.tsrx
@@ -238,7 +238,7 @@ describe('basic server > attribute rendering', () => {
 	it('render bare numbers in a style object with an implicit px suffix', async () => {
 		function Basic() @{
 			<div
-				style={{ width: 400, height: 100, zIndex: 5, opacity: 0.5, '--scale': 2 }}
+				style={{ width: 400, height: 100, zIndex: 5, opacity: 0.5, scale: 1.5, '--scale': 2 }}
 			>{'Sized box'}</div>
 		}
 
@@ -249,9 +249,11 @@ describe('basic server > attribute rendering', () => {
 
 		expect(div.style.width).toBe('400px');
 		expect(div.style.height).toBe('100px');
-		// Unitless properties must stay bare — no accidental `5px` on z-index.
+		// Unitless properties must stay bare — no accidental `5px` on z-index,
+		// and no invalid `1.5px` on the standalone CSS `scale` property.
 		expect(div.style.zIndex).toBe('5');
 		expect(div.style.opacity).toBe('0.5');
+		expect(div.style.getPropertyValue('scale')).toBe('1.5');
 		// Custom properties are commonly used as unitless multipliers and must
 		// never receive an implicit px suffix.
 		expect(div.style.getPropertyValue('--scale')).toBe('2');


### PR DESCRIPTION
## Summary

- `apply_styles` (in `packages/ripple/src/runtime/internal/client/render.js`) serializes every style object value with a plain `String(value)` before calling `style.setProperty(prop, value)`.
- For CSS properties that require a unit (`width`, `height`, `top`, `left`, `margin`, ...), the browser silently drops a `setProperty` call whose value is a bare unitless number — no error, no console warning, the property just never lands on the element.
- `{ width: 400 }` is an ergonomic, very common shape — and the exact one the `style` JSX attribute's `string | number` type invites — so this silently no-ops one of the most common ways to set a dynamic dimension from reactive state. Only properties that are legitimately unitless (`z-index`, `opacity`, `line-height`, ...) happen to work today, which makes the failure mode easy to miss until someone tries a plain numeric `width`/`height`.
- This mirrors what every mainstream framework already does: React, Vue, and Preact each ship a small "is this property unitless" allowlist and append `px` to everything else for numeric style values.

## Fix

Adds a `UNITLESS_NUMBER_PROPERTIES` allowlist (trimmed to properties reachable through plain `style.setProperty`, based on React's `isUnitlessNumber`) and a `format_style_value(css_prop, raw_value)` helper. `apply_styles` now routes every style value through it instead of a bare `String(...)` call. `0` is left unitless regardless of property (a bare `0` is valid CSS for length properties, and avoids an unnecessary `0px` vs `0` diff on every re-render).

## Test plan

- [x] Added `render bare numbers in a style object with an implicit px suffix` to `packages/ripple/tests/client/basic/basic.attributes.test.tsrx`, covering a `width` number getting `px`, a reactive update, and `z-index`/`opacity` staying unitless.
- [x] `npx vitest run --project ripple-client basic.attributes` — 29/29 passing.
- [x] `npx vitest run --project ripple-client` (full client suite) — 89 files, 1034 passing, 4 skipped, 0 failing.
- [x] `npx prettier --check` on both touched files.

Found while building a component library on top of Ripple: a `SideSheet`-style component passing a numeric `width` prop straight through to an inline `style` object rendered with no width at all, with no error anywhere in the pipeline.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted runtime formatting for inline style objects with broad test coverage; behavior change only affects numeric values not on the unitless allowlist.
> 
> **Overview**
> **Numeric style object values** (e.g. `{ width: 400 }`) were serialized with plain `String(...)`, which browsers ignore for length-like properties—so dimensions silently failed on both client updates and SSR markup.
> 
> This PR routes style values through a shared **`format_style_value`** helper (React-style unitless allowlist, vendor-prefixed variants, `0` stays unitless, `--*` custom properties never get `px`). **Client** `apply_styles` and **server** `get_styles` both use it so hydration stays aligned. Client and server attribute tests cover `px` suffixing, unitless props (`z-index`, `opacity`, `scale`, `-webkit-line-clamp`), and custom properties.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82d03de07080266ababaa3c2dfab7e7acd249456. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->