### PR TITLE
perf(ripple): single-effect refs, flushSync old-value release, typed lazy props, element templates with setup statements

### DIFF
--- a/.changeset/effectful-list-perf.md
+++ b/.changeset/effectful-list-perf.md
@@ -1,0 +1,8 @@
+---
+'ripple': patch
+'@tsrx/ripple': patch
+---
+
+Cheaper element refs, effects, and component templates on the client. A `ref` is one effect block keyed on its state instead of a render block that re-evaluates the thunk and creates a branch and an effect for it, since the ref value is read untracked and fixed for the life of the enclosing block. Effects deferred until a component has rendered are recorded as flat entries, and an effect's first run skips the child and teardown sweep. A tracked value written during a flush keeps its previous value for teardowns on itself instead of in a map, and `flushSync` releases those values when it finishes (they were only released by the microtask flush before).
+
+The compiler types the bindings of a lazily destructured pattern (`&{ item }: { item: Item }` as component props, or `const &{ item } = props` from a typed initializer), so their property reads lower to direct text and attribute writes. A component whose body has setup statements beside a single root element clones that element instead of a fragment.

--- a/benchmarks/effectful-list/ripple/src/App.tsrx
+++ b/benchmarks/effectful-list/ripple/src/App.tsrx
@@ -26,7 +26,7 @@ export default function App() @{
 		<table class="test-data">
 			<tbody>
 				@for (const item of items; key item.id) {
-					<Row item={item} />
+					<Row {item} />
 				}
 			</tbody>
 		</table>

--- a/benchmarks/effectful-list/ripple/src/Row.tsrx
+++ b/benchmarks/effectful-list/ripple/src/Row.tsrx
@@ -19,7 +19,11 @@ import { fx, rowRef } from './fx.js';
 //     refs support the React-19-style cleanup-return (the teardown runs on
 //     row destruction).
 
-export default function Row(props) @{
+export default function Row(&{
+	item,
+}: {
+	item: { id: number; label: string; value: number; probe: boolean };
+}) @{
 	let &[cell] = track(null);
 
 	effect(() => {
@@ -30,7 +34,6 @@ export default function Row(props) @{
 	});
 
 	effect(() => {
-		const item = props.item;
 		const el = cell;
 		if (el !== null && item.probe) {
 			fx.h += el.offsetHeight;
@@ -44,8 +47,8 @@ export default function Row(props) @{
 			ref={(el) => {
 				cell = el;
 			}}
-		>{props.item.id}</td>
-		<td class="col-label">{props.item.label}</td>
-		<td class="col-value">{props.item.value}</td>
+		>{item.id}</td>
+		<td class="col-label">{item.label}</td>
+		<td class="col-value">{item.value}</td>
 	</tr>
 }

--- a/packages/ripple/src/runtime/internal/client/blocks.js
+++ b/packages/ripple/src/runtime/internal/client/blocks.js
@@ -14,7 +14,6 @@ import {
 	DETACHED_BLOCK,
 	HEAD_BLOCK,
 	DIRECT_CHILD_BLOCK,
-	UNINITIALIZED,
 	IF_BLOCK,
 } from './constants.js';
 import { hydrating } from './hydration.js';
@@ -47,12 +46,9 @@ export function user_effect(fn) {
 
 	var component = active_component;
 	if (component !== null && !component.m) {
+		// Flat triples, created once the component has rendered (`pop_component`).
 		var e = (component.e ??= []);
-		e.push({
-			b: active_block,
-			fn,
-			r: active_reaction,
-		});
+		e.push(fn, active_block, active_reaction);
 
 		return;
 	}
@@ -135,61 +131,76 @@ export function own_anchor(node, anchor) {
  * doesn't subscribe to whatever the thunk happens to read. The supported
  * shape is to pass the ref slot itself (`ref={tracker}`); a foot-gun like
  * `ref={tracker.value}` would otherwise read the cell reactively and cause
- * spurious re-runs.
+ * spurious re-runs. Read untracked, the value is fixed for the life of the
+ * enclosing block, so each ref is a single effect block keyed on its state
+ * rather than a render block re-evaluating the thunk.
  *
  * @param {Element} element
  * @param {() => any} get_fn
  * @param {(value: any) => void} [set_fn]
- * @returns {Block}
+ * @returns {void}
  */
 export function ref(element, get_fn, set_fn) {
-	// make sure the first run always enters the dispatch branch,
-	/** @type {any} */
-	var ref_value = UNINITIALIZED;
-	/** @type {Block | null} */
-	var e;
+	apply_ref(element, untrack(get_fn), set_fn);
+}
 
-	return block(RENDER_BLOCK, () => {
-		// avoid any reactive reads
-		var next = untrack(get_fn);
-		if (ref_value !== (ref_value = next)) {
-			if (e) {
-				destroy_block(e);
-				e = null;
-			}
-
-			if (is_array(ref_value)) {
-				e = branch(() => {
-					for (var i = 0; i < ref_value.length; i++) {
-						let current = ref_value[i];
-						ref(element, () => current);
-					}
-				});
-			} else if (typeof ref_value === 'function') {
-				e = branch(() => {
-					effect(() => ref_value(element));
-				});
-			} else if (is_ripple_object(ref_value)) {
-				e = branch(() => {
-					effect(() => {
-						ref_value.value = element;
-						return () => {
-							ref_value.value = null;
-						};
-					});
-				});
-			} else if (set_fn !== undefined) {
-				e = branch(() => {
-					effect(() => {
-						set_fn(element);
-						return () => {
-							set_fn(null);
-						};
-					});
-				});
-			}
+/**
+ * @param {Element} element
+ * @param {any} ref_value
+ * @param {((value: any) => void) | undefined} set_fn
+ * @returns {void}
+ */
+function apply_ref(element, ref_value, set_fn) {
+	if (is_array(ref_value)) {
+		for (var i = 0; i < ref_value.length; i++) {
+			apply_ref(element, ref_value[i], undefined);
 		}
-	});
+	} else if (typeof ref_value === 'function') {
+		block(EFFECT_BLOCK, run_function_ref, { e: element, f: ref_value });
+	} else if (is_ripple_object(ref_value)) {
+		block(EFFECT_BLOCK, run_tracked_ref, { e: element, t: ref_value });
+	} else if (set_fn !== undefined) {
+		block(EFFECT_BLOCK, run_set_ref, { e: element, f: set_fn });
+	}
+}
+
+/**
+ * The callback's return value is the effect's teardown.
+ * @param {{ e: Element, f: (element: Element) => any }} s
+ */
+function run_function_ref(s) {
+	return s.f(s.e);
+}
+
+/**
+ * @param {{ e: Element, t: { value: any } }} s
+ */
+function run_tracked_ref(s) {
+	s.t.value = s.e;
+	return clear_tracked_ref;
+}
+
+/**
+ * Teardowns keyed on block state receive it (see `run_teardown`).
+ * @param {{ e: Element, t: { value: any } }} s
+ */
+function clear_tracked_ref(s) {
+	s.t.value = null;
+}
+
+/**
+ * @param {{ e: Element, f: (value: any) => void }} s
+ */
+function run_set_ref(s) {
+	s.f(s.e);
+	return clear_set_ref;
+}
+
+/**
+ * @param {{ e: Element, f: (value: any) => void }} s
+ */
+function clear_set_ref(s) {
+	s.f(null);
 }
 
 /**

--- a/packages/ripple/src/runtime/internal/client/runtime.js
+++ b/packages/ripple/src/runtime/internal/client/runtime.js
@@ -84,8 +84,23 @@ export let active_namespace = DEFAULT_NAMESPACE;
 /** @type {boolean} */
 export let is_mutating_allowed = true;
 
-/** @type {Map<Tracked | Derived, any>} */
-var old_values = new Map();
+/**
+ * Tracked values written during the current flush that hold their previous
+ * value in `o`, for teardowns that read them; released when the flush ends.
+ * @type {(Tracked | Derived)[]}
+ */
+var old_value_holders = [];
+
+/** @returns {void} */
+function release_old_values() {
+	var holders = old_value_holders;
+	var length = holders.length;
+	if (length === 0) return;
+	for (var i = 0; i < length; i++) {
+		holders[i].o = UNINITIALIZED;
+	}
+	holders.length = 0;
+}
 
 // Used for controlling the flush of blocks
 /** @type {number} */
@@ -458,6 +473,8 @@ class TrackedValue {
 		this.sb = null;
 		/** @type {any} */
 		this.__v = v;
+		/** @type {any} previous value while a flush with teardowns is running */
+		this.o = UNINITIALIZED;
 	}
 	/** @returns {any} */
 	get [0]() {
@@ -520,6 +537,8 @@ class DerivedValue {
 		this.sb = null;
 		/** @type {any} */
 		this.__v = UNINITIALIZED;
+		/** @type {any} previous value while a flush with teardowns is running */
+		this.o = UNINITIALIZED;
 	}
 	/** @returns {any} */
 	get [0]() {
@@ -1239,10 +1258,12 @@ function run_phases(blocks, length) {
 function run_phase(blocks) {
 	for (var i = 0; i < blocks.length; i++) {
 		var block = blocks[i];
+		var flags = block.f;
 
 		try {
-			if ((block.f & (PAUSED | DESTROYED)) === 0 && is_block_dirty(block)) {
-				run_block(block);
+			if ((flags & (PAUSED | DESTROYED)) === 0 && is_block_dirty(block)) {
+				// A block that has never run has no children or teardown to clear.
+				run_block(block, (flags & BLOCK_HAS_RUN) === 0);
 			}
 		} catch (error) {
 			handle_error(error, block);
@@ -1284,7 +1305,7 @@ function flush_microtasks() {
 	if (!is_micro_task_queued) {
 		flush_count = 0;
 	}
-	old_values.clear();
+	release_old_values();
 }
 
 /**
@@ -1463,8 +1484,8 @@ export function get_tracked(tracked) {
 		throw ASYNC_DERIVED_READ_THROWN;
 	}
 
-	if (teardown && old_values.has(tracked)) {
-		value = old_values.get(tracked);
+	if (teardown && tracked.o !== UNINITIALIZED) {
+		value = tracked.o;
 	}
 	var get = tracked.a.get;
 	if (get !== undefined) {
@@ -1541,11 +1562,10 @@ export function set(tracked, value) {
 		var tracked_block = tracked.b;
 
 		if ((tracked_block.f & CONTAINS_TEARDOWN) !== 0) {
-			if (teardown) {
-				old_values.set(tracked, value);
-			} else {
-				old_values.set(tracked, old_value);
+			if (tracked.o === UNINITIALIZED) {
+				old_value_holders.push(tracked);
 			}
+			tracked.o = teardown ? value : old_value;
 		}
 
 		let set = tracked.a.set;
@@ -1604,6 +1624,12 @@ export function flush_sync(fn) {
 		}
 
 		flush_count = 0;
+
+		// Old values only matter to teardowns run by this flush; the outermost
+		// sync flush releases them like the microtask flush does.
+		if (previous_scheduler_mode !== FLUSH_SYNC) {
+			release_old_values();
+		}
 
 		return /** @type {T} */ (result);
 	} finally {
@@ -1915,21 +1941,19 @@ export function pop_component() {
 	component.m = true;
 	var effects = component.e;
 	if (effects !== null) {
+		// Creating an effect block only links and schedules it, so nothing here
+		// can throw between saving and restoring the active block.
+		var previous_block = active_block;
+		var previous_reaction = active_reaction;
 		var length = effects.length;
-		for (var i = 0; i < length; i++) {
-			var { b: block, fn, r: reaction } = effects[i];
-			var previous_block = active_block;
-			var previous_reaction = active_reaction;
-
-			try {
-				active_block = block;
-				active_reaction = reaction;
-				effect(fn);
-			} finally {
-				active_block = previous_block;
-				active_reaction = previous_reaction;
-			}
+		// Flat triples: fn, block, reaction (see `user_effect`).
+		for (var i = 0; i < length; i += 3) {
+			active_block = /** @type {Block} */ (effects[i + 1]);
+			active_reaction = /** @type {Block | Derived | null} */ (effects[i + 2]);
+			effect(/** @type {Function} */ (effects[i]));
 		}
+		active_block = previous_block;
+		active_reaction = previous_reaction;
 	}
 	active_component = component.p;
 }

--- a/packages/ripple/src/runtime/internal/client/runtime.js
+++ b/packages/ripple/src/runtime/internal/client/runtime.js
@@ -90,6 +90,8 @@ export let is_mutating_allowed = true;
  * @type {(Tracked | Derived)[]}
  */
 var old_value_holders = [];
+/** Nesting depth of running flushes; old values are released at depth zero. */
+var flush_depth = 0;
 
 /** @returns {void} */
 function release_old_values() {
@@ -1300,12 +1302,19 @@ function flush_microtasks() {
 	}
 	var pending = queue;
 	queue = create_queue();
-	flush_queue(pending);
+	flush_depth++;
+	try {
+		flush_queue(pending);
+	} finally {
+		flush_depth--;
+	}
 
 	if (!is_micro_task_queued) {
 		flush_count = 0;
 	}
-	release_old_values();
+	if (flush_depth === 0) {
+		release_old_values();
+	}
 }
 
 /**
@@ -1606,6 +1615,7 @@ export function flush_sync(fn) {
 	var previous_scheduler_mode = scheduler_mode;
 	var previous_queue = queue;
 
+	flush_depth++;
 	try {
 		scheduler_mode = FLUSH_SYNC;
 		queue = create_queue();
@@ -1625,14 +1635,16 @@ export function flush_sync(fn) {
 
 		flush_count = 0;
 
-		// Old values only matter to teardowns run by this flush; the outermost
-		// sync flush releases them like the microtask flush does.
-		if (previous_scheduler_mode !== FLUSH_SYNC) {
+		// Old values only matter to teardowns run by the flush in progress; a
+		// sync flush nested in another flush (an effect calling `flushSync`)
+		// leaves them for the outer flush's remaining teardowns.
+		if (flush_depth === 1) {
 			release_old_values();
 		}
 
 		return /** @type {T} */ (result);
 	} finally {
+		flush_depth--;
 		scheduler_mode = previous_scheduler_mode;
 		queue = previous_queue;
 	}

--- a/packages/ripple/src/runtime/internal/client/types.d.ts
+++ b/packages/ripple/src/runtime/internal/client/types.d.ts
@@ -6,11 +6,9 @@ export { Tracked, Derived };
 export type Component = {
 	b: null | Block;
 	c: null | Map<Context<any>, any>;
-	e: null | Array<{
-		b: Block;
-		fn: Function;
-		r: null | Block | Derived;
-	}>;
+	// Effects deferred until the component has rendered, as flat triples:
+	// fn, the block to create it under, the reaction active at the call.
+	e: null | Array<Function | Block | Derived | null>;
 	p: null | Component;
 	m: boolean;
 };

--- a/packages/ripple/tests/client/basic/basic.reactivity.test.tsrx
+++ b/packages/ripple/tests/client/basic/basic.reactivity.test.tsrx
@@ -2,6 +2,41 @@ import type { PropsWithChildren, Tracked } from 'ripple';
 import { effect, flushSync, track, untrack } from 'ripple';
 
 describe('basic client > reactivity', () => {
+	it(
+		'keeps the previous value for teardowns after an effect calls flushSync mid-flush',
+		async () => {
+			const seen: number[] = [];
+
+			function App() @{
+				let &[count] = track(0);
+
+				// Runs first in the flush; the nested sync flush must not release the
+				// previous values the later teardown reads.
+				effect(() => {
+					count;
+					flushSync();
+				});
+
+				effect(() => {
+					count;
+					return () => {
+						seen.push(count);
+					};
+				});
+
+				<button onClick={() => (count += 1)}>{count}</button>
+			}
+
+			render(App);
+			flushSync();
+			container.querySelector('button').click();
+			await new Promise((resolve) => setTimeout(resolve, 0));
+
+			expect(container.querySelector('button').textContent).toBe('1');
+			expect(seen).toEqual([0]);
+		},
+	);
+
 	it('renders multiple reactive lexical blocks', () => {
 		function Basic() @{
 			let obj = {

--- a/packages/ripple/tests/hydration/basic.test.js
+++ b/packages/ripple/tests/hydration/basic.test.js
@@ -209,6 +209,21 @@ describe('hydration > basic', () => {
 		expect(textIndex).toBeLessThan(endMarker);
 	});
 
+	it('restores typed text children hydrated from empty server text', async () => {
+		await hydrateComponent(
+			ServerComponents.TypedTextPropWithToggle,
+			ClientComponents.TypedTextPropWithToggle,
+		);
+
+		expect(container.querySelector('.text-prop')?.textContent).toBe('');
+
+		/** @type {any} */ (container.querySelector('.show-text'))?.click();
+		flushSync();
+
+		// A string-typed child is a text node, with no hydration markers.
+		expect(container.querySelector('.text-prop')?.innerHTML).toBe('hello');
+	});
+
 	it('hydrates static child component followed by sibling content', async () => {
 		await hydrateComponent(
 			ServerComponents.StaticChildWithSiblings,

--- a/packages/ripple/tests/hydration/compiled/client/basic.js
+++ b/packages/ripple/tests/hydration/compiled/client/basic.js
@@ -54,32 +54,35 @@ var root_49 = _$_.template(`<div class="native"> </div>`, 0);
 var root_51 = _$_.template(`<!>`, 1, 1);
 var root_50 = _$_.template(`<!>`, 1, 1);
 var root_52 = _$_.template(`<div class="text-prop"><!></div>`, 0);
-var root_54 = _$_.template(`<!><button class="show-text">Show</button>`, 1, 2);
-var root_53 = _$_.template(`<!>`, 1, 1);
-var root_56 = _$_.template(`<h1 class="sr-only">heading</h1><p class="subtitle">first paragraph</p><p class="subtitle">second paragraph</p>`, 1, 3);
-var root_55 = _$_.template(`<!>`, 1, 1);
-var root_58 = _$_.template(`<!><span class="sibling1"> </span><span class="sibling2"> </span>`, 1, 3);
-var root_57 = _$_.template(`<!>`, 1, 1);
-var root_60 = _$_.template(`<h1 class="sr-only">Ripple</h1><img src="/images/logo.png" alt="Logo" class="logo"><p class="subtitle">the elegant TypeScript UI framework</p>`, 1, 3);
-var root_59 = _$_.template(`<!>`, 1, 1);
-var root_62 = _$_.template(`<a href="/playground" class="playground-link">Playground</a>`, 0);
-var root_61 = _$_.template(`<div class="social-links"><a href="https://github.com" class="github-link">GitHub</a><a href="https://discord.com" class="discord-link">Discord</a><!></div>`, 0);
-var root_63 = _$_.template(`<main><div class="container"><!></div></main>`, 0);
-var root_64 = _$_.template(`<div class="content"><p>Some content here</p></div>`, 0);
-var root_65 = _$_.template(`<!><!><!><!>`, 1, 4);
-var root_66 = _$_.template(`<footer class="last-child">I am the last child</footer>`, 0);
-var root_67 = _$_.template(`<div class="wrapper"><h1>Header</h1><p>Some content</p><!></div>`, 0);
-var root_68 = _$_.template(`<div class="inner"><span>Inner text</span><!></div>`, 0);
-var root_69 = _$_.template(`<section class="outer"><h2>Section title</h2><!></section>`, 0);
-var root_70 = _$_.template(`<div> </div>`, 0);
-var root_71 = _$_.template(`<div> </div>`, 0);
-var root_72 = _$_.template(`<div>frag-<span>tail</span></div>`, 0);
-var root_74 = _$_.template(`<!><p>after-opaque</p>`, 1, 2);
-var root_73 = _$_.template(`<!>`, 1, 1);
-var root_75 = _$_.template(`<div></div>`, 0);
-var root_77 = _$_.template(` <p>after-call</p>`, 1, 2);
+var root_53 = _$_.template(`<div class="text-prop"><!></div>`, 0);
+var root_55 = _$_.template(`<!><button class="show-text">Show</button>`, 1, 2);
+var root_54 = _$_.template(`<!>`, 1, 1);
+var root_57 = _$_.template(`<!><button class="show-text">Show</button>`, 1, 2);
+var root_56 = _$_.template(`<!>`, 1, 1);
+var root_59 = _$_.template(`<h1 class="sr-only">heading</h1><p class="subtitle">first paragraph</p><p class="subtitle">second paragraph</p>`, 1, 3);
+var root_58 = _$_.template(`<!>`, 1, 1);
+var root_61 = _$_.template(`<!><span class="sibling1"> </span><span class="sibling2"> </span>`, 1, 3);
+var root_60 = _$_.template(`<!>`, 1, 1);
+var root_63 = _$_.template(`<h1 class="sr-only">Ripple</h1><img src="/images/logo.png" alt="Logo" class="logo"><p class="subtitle">the elegant TypeScript UI framework</p>`, 1, 3);
+var root_62 = _$_.template(`<!>`, 1, 1);
+var root_65 = _$_.template(`<a href="/playground" class="playground-link">Playground</a>`, 0);
+var root_64 = _$_.template(`<div class="social-links"><a href="https://github.com" class="github-link">GitHub</a><a href="https://discord.com" class="discord-link">Discord</a><!></div>`, 0);
+var root_66 = _$_.template(`<main><div class="container"><!></div></main>`, 0);
+var root_67 = _$_.template(`<div class="content"><p>Some content here</p></div>`, 0);
+var root_68 = _$_.template(`<!><!><!><!>`, 1, 4);
+var root_69 = _$_.template(`<footer class="last-child">I am the last child</footer>`, 0);
+var root_70 = _$_.template(`<div class="wrapper"><h1>Header</h1><p>Some content</p><!></div>`, 0);
+var root_71 = _$_.template(`<div class="inner"><span>Inner text</span><!></div>`, 0);
+var root_72 = _$_.template(`<section class="outer"><h2>Section title</h2><!></section>`, 0);
+var root_73 = _$_.template(`<div> </div>`, 0);
+var root_74 = _$_.template(`<div> </div>`, 0);
+var root_75 = _$_.template(`<div>frag-<span>tail</span></div>`, 0);
+var root_77 = _$_.template(`<!><p>after-opaque</p>`, 1, 2);
 var root_76 = _$_.template(`<!>`, 1, 1);
 var root_78 = _$_.template(`<div></div>`, 0);
+var root_80 = _$_.template(` <p>after-call</p>`, 1, 2);
+var root_79 = _$_.template(`<!>`, 1, 1);
+var root_81 = _$_.template(`<div></div>`, 0);
 
 import { track } from 'ripple';
 
@@ -702,14 +705,29 @@ function TextProp(__props) {
 	});
 }
 
+function TypedTextProp(__props) {
+	return _$_.tsrx_element((__anchor, __block) => {
+		var div_22 = root_53();
+
+		{
+			var expression_25 = _$_.hydrating ? _$_.hydrate_child() : div_22.firstChild;
+
+			_$_.expression(expression_25, () => __props.children);
+			_$_.pop(div_22);
+		}
+
+		_$_.append(__anchor, div_22);
+	});
+}
+
 export function TextPropWithToggle() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		let lazy_1 = _$_.track(false, __block, '1ba81c3b');
-		var fragment_21 = root_53();
+		var fragment_21 = root_54();
 		var node_14 = _$_.first_child_frag(fragment_21);
 
 		_$_.expression(node_14, () => _$_.tsrx_element((__anchor, __block) => {
-			var fragment_22 = root_54();
+			var fragment_22 = root_55();
 			var node_13 = _$_.first_child_frag(fragment_22);
 
 			_$_.render_component(TextProp, node_13, {
@@ -728,15 +746,25 @@ export function TextPropWithToggle() {
 	});
 }
 
-function StaticHeader() {
+export function TypedTextPropWithToggle() {
 	return _$_.tsrx_element((__anchor, __block) => {
-		var fragment_23 = root_55();
-		var node_15 = _$_.first_child_frag(fragment_23);
+		let lazy_2 = _$_.track(false, __block, '649e2af0');
+		var fragment_23 = root_56();
+		var node_16 = _$_.first_child_frag(fragment_23);
 
-		_$_.expression(node_15, () => _$_.tsrx_element((__anchor, __block) => {
-			var fragment_24 = root_56();
+		_$_.expression(node_16, () => _$_.tsrx_element((__anchor, __block) => {
+			var fragment_24 = root_57();
+			var node_15 = _$_.first_child_frag(fragment_24);
 
-			_$_.next(2);
+			_$_.render_component(TypedTextProp, node_15, {
+				get children() {
+					return _$_.normalize_children(lazy_2.value ? 'hello' : '');
+				}
+			});
+
+			var button_1 = _$_.hydrating ? _$_.hydrate_sibling() : node_15.nextSibling;
+
+			button_1.__click = () => _$_.set(lazy_2, true);
 			_$_.append(__anchor, fragment_24);
 		}));
 
@@ -744,36 +772,15 @@ function StaticHeader() {
 	});
 }
 
-export function StaticChildWithSiblings() {
+function StaticHeader() {
 	return _$_.tsrx_element((__anchor, __block) => {
-		const foo = 'bar';
-		var fragment_25 = root_57();
+		var fragment_25 = root_58();
 		var node_17 = _$_.first_child_frag(fragment_25);
 
 		_$_.expression(node_17, () => _$_.tsrx_element((__anchor, __block) => {
-			var fragment_26 = root_58();
-			var node_16 = _$_.first_child_frag(fragment_26);
+			var fragment_26 = root_59();
 
-			_$_.render_component(StaticHeader, node_16, {});
-
-			var span_6 = _$_.hydrating ? _$_.hydrate_sibling() : node_16.nextSibling;
-
-			{
-				var expression_25 = _$_.hydrating ? _$_.hydrate_child(true) : span_6.firstChild;
-
-				expression_25.nodeValue = foo;
-				_$_.pop(span_6);
-			}
-
-			var span_7 = _$_.hydrating ? _$_.hydrate_sibling() : span_6.nextSibling;
-
-			{
-				var expression_26 = _$_.hydrating ? _$_.hydrate_child(true) : span_7.firstChild;
-
-				expression_26.nodeValue = foo;
-				_$_.pop(span_7);
-			}
-
+			_$_.next(2);
 			_$_.append(__anchor, fragment_26);
 		}));
 
@@ -781,15 +788,36 @@ export function StaticChildWithSiblings() {
 	});
 }
 
-function Header() {
+export function StaticChildWithSiblings() {
 	return _$_.tsrx_element((__anchor, __block) => {
-		var fragment_27 = root_59();
-		var node_18 = _$_.first_child_frag(fragment_27);
+		const foo = 'bar';
+		var fragment_27 = root_60();
+		var node_19 = _$_.first_child_frag(fragment_27);
 
-		_$_.expression(node_18, () => _$_.tsrx_element((__anchor, __block) => {
-			var fragment_28 = root_60();
+		_$_.expression(node_19, () => _$_.tsrx_element((__anchor, __block) => {
+			var fragment_28 = root_61();
+			var node_18 = _$_.first_child_frag(fragment_28);
 
-			_$_.next(2);
+			_$_.render_component(StaticHeader, node_18, {});
+
+			var span_6 = _$_.hydrating ? _$_.hydrate_sibling() : node_18.nextSibling;
+
+			{
+				var expression_26 = _$_.hydrating ? _$_.hydrate_child(true) : span_6.firstChild;
+
+				expression_26.nodeValue = foo;
+				_$_.pop(span_6);
+			}
+
+			var span_7 = _$_.hydrating ? _$_.hydrate_sibling() : span_6.nextSibling;
+
+			{
+				var expression_27 = _$_.hydrating ? _$_.hydrate_child(true) : span_7.firstChild;
+
+				expression_27.nodeValue = foo;
+				_$_.pop(span_7);
+			}
+
 			_$_.append(__anchor, fragment_28);
 		}));
 
@@ -797,42 +825,58 @@ function Header() {
 	});
 }
 
+function Header() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		var fragment_29 = root_62();
+		var node_20 = _$_.first_child_frag(fragment_29);
+
+		_$_.expression(node_20, () => _$_.tsrx_element((__anchor, __block) => {
+			var fragment_30 = root_63();
+
+			_$_.next(2);
+			_$_.append(__anchor, fragment_30);
+		}));
+
+		_$_.append(__anchor, fragment_29);
+	});
+}
+
 function Actions({ playgroundVisible = false }) {
 	return _$_.tsrx_element((__anchor, __block) => {
-		var div_22 = root_61();
+		var div_23 = root_64();
 
 		{
-			var a_2 = _$_.hydrating ? _$_.hydrate_child() : div_22.firstChild;
+			var a_2 = _$_.hydrating ? _$_.hydrate_child() : div_23.firstChild;
 			var a_1 = _$_.hydrating ? _$_.hydrate_sibling() : a_2.nextSibling;
-			var expression_27 = _$_.hydrating ? _$_.hydrate_sibling() : a_1.nextSibling;
+			var expression_28 = _$_.hydrating ? _$_.hydrate_sibling() : a_1.nextSibling;
 
-			_$_.expression(expression_27, () => playgroundVisible
+			_$_.expression(expression_28, () => playgroundVisible
 				? _$_.tsrx_element((__anchor, __block) => {
-					var a = root_62();
+					var a = root_65();
 
 					_$_.append(__anchor, a);
 				})
 				: null);
 
-			_$_.pop(div_22);
+			_$_.pop(div_23);
 		}
 
-		_$_.append(__anchor, div_22);
+		_$_.append(__anchor, div_23);
 	});
 }
 
 function Layout({ children }) {
 	return _$_.tsrx_element((__anchor, __block) => {
-		var main = root_63();
+		var main = root_66();
 
 		{
-			var div_23 = _$_.hydrating ? _$_.hydrate_child() : main.firstChild;
+			var div_24 = _$_.hydrating ? _$_.hydrate_child() : main.firstChild;
 
 			{
-				var expression_28 = _$_.hydrating ? _$_.hydrate_child() : div_23.firstChild;
+				var expression_29 = _$_.hydrating ? _$_.hydrate_child() : div_24.firstChild;
 
-				_$_.expression(expression_28, () => children);
-				_$_.pop(div_23);
+				_$_.expression(expression_29, () => children);
+				_$_.pop(div_24);
 			}
 		}
 
@@ -842,9 +886,9 @@ function Layout({ children }) {
 
 function Content() {
 	return _$_.tsrx_element((__anchor, __block) => {
-		var div_24 = root_64();
+		var div_25 = root_67();
 
-		_$_.append(__anchor, div_24);
+		_$_.append(__anchor, div_25);
 	});
 }
 
@@ -852,23 +896,23 @@ export function WebsiteIndex() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		_$_.render_component(Layout, __anchor, {
 			children: _$_.tsrx_element((__anchor, __block) => {
-				var fragment_29 = root_65();
-				var node_19 = _$_.first_child_frag(fragment_29);
+				var fragment_31 = root_68();
+				var node_21 = _$_.first_child_frag(fragment_31);
 
-				_$_.render_component(Header, node_19, {});
-
-				var node_20 = _$_.hydrating ? _$_.hydrate_sibling() : node_19.nextSibling;
-
-				_$_.render_component(Actions, node_20, { playgroundVisible: true });
-
-				var node_21 = _$_.hydrating ? _$_.hydrate_sibling() : node_20.nextSibling;
-
-				_$_.render_component(Content, node_21, {});
+				_$_.render_component(Header, node_21, {});
 
 				var node_22 = _$_.hydrating ? _$_.hydrate_sibling() : node_21.nextSibling;
 
-				_$_.render_component(Actions, node_22, { playgroundVisible: false });
-				_$_.append(__anchor, fragment_29);
+				_$_.render_component(Actions, node_22, { playgroundVisible: true });
+
+				var node_23 = _$_.hydrating ? _$_.hydrate_sibling() : node_22.nextSibling;
+
+				_$_.render_component(Content, node_23, {});
+
+				var node_24 = _$_.hydrating ? _$_.hydrate_sibling() : node_23.nextSibling;
+
+				_$_.render_component(Actions, node_24, { playgroundVisible: false });
+				_$_.append(__anchor, fragment_31);
 			})
 		});
 	});
@@ -876,7 +920,7 @@ export function WebsiteIndex() {
 
 function LastChild() {
 	return _$_.tsrx_element((__anchor, __block) => {
-		var footer = root_66();
+		var footer = root_69();
 
 		_$_.append(__anchor, footer);
 	});
@@ -884,30 +928,14 @@ function LastChild() {
 
 export function ComponentAsLastSibling() {
 	return _$_.tsrx_element((__anchor, __block) => {
-		var div_25 = root_67();
+		var div_26 = root_70();
 
 		{
-			var h1 = _$_.hydrating ? _$_.hydrate_child() : div_25.firstChild;
+			var h1 = _$_.hydrating ? _$_.hydrate_child() : div_26.firstChild;
 			var p = _$_.hydrating ? _$_.hydrate_sibling() : h1.nextSibling;
-			var node_23 = _$_.hydrating ? _$_.hydrate_sibling() : p.nextSibling;
+			var node_25 = _$_.hydrating ? _$_.hydrate_sibling() : p.nextSibling;
 
-			_$_.render_component(LastChild, node_23, {});
-			_$_.pop(div_25);
-		}
-
-		_$_.append(__anchor, div_25);
-	});
-}
-
-function InnerContent() {
-	return _$_.tsrx_element((__anchor, __block) => {
-		var div_26 = root_68();
-
-		{
-			var span_8 = _$_.hydrating ? _$_.hydrate_child() : div_26.firstChild;
-			var node_24 = _$_.hydrating ? _$_.hydrate_sibling() : span_8.nextSibling;
-
-			_$_.render_component(LastChild, node_24, {});
+			_$_.render_component(LastChild, node_25, {});
 			_$_.pop(div_26);
 		}
 
@@ -915,15 +943,31 @@ function InnerContent() {
 	});
 }
 
+function InnerContent() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		var div_27 = root_71();
+
+		{
+			var span_8 = _$_.hydrating ? _$_.hydrate_child() : div_27.firstChild;
+			var node_26 = _$_.hydrating ? _$_.hydrate_sibling() : span_8.nextSibling;
+
+			_$_.render_component(LastChild, node_26, {});
+			_$_.pop(div_27);
+		}
+
+		_$_.append(__anchor, div_27);
+	});
+}
+
 export function NestedComponentAsLastSibling() {
 	return _$_.tsrx_element((__anchor, __block) => {
-		var section_1 = root_69();
+		var section_1 = root_72();
 
 		{
 			var h2 = _$_.hydrating ? _$_.hydrate_child() : section_1.firstChild;
-			var node_25 = _$_.hydrating ? _$_.hydrate_sibling() : h2.nextSibling;
+			var node_27 = _$_.hydrating ? _$_.hydrate_sibling() : h2.nextSibling;
 
-			_$_.render_component(InnerContent, node_25, {});
+			_$_.render_component(InnerContent, node_27, {});
 			_$_.pop(section_1);
 		}
 
@@ -937,12 +981,12 @@ function fetchLabel() {
 
 export function TextTailExpression() {
 	return _$_.tsrx_element((__anchor, __block) => {
-		var div_27 = root_70();
+		var div_28 = root_73();
 
 		{
-			var text = _$_.hydrating ? _$_.hydrate_child(true) : div_27.firstChild;
+			var text = _$_.hydrating ? _$_.hydrate_child(true) : div_28.firstChild;
 
-			_$_.pop(div_27);
+			_$_.pop(div_28);
 		}
 
 		_$_.render(
@@ -956,18 +1000,18 @@ export function TextTailExpression() {
 			{ a: ' ' }
 		);
 
-		_$_.append(__anchor, div_27);
+		_$_.append(__anchor, div_28);
 	});
 }
 
 export function FragmentTailExpression() {
 	return _$_.tsrx_element((__anchor, __block) => {
-		var div_28 = root_71();
+		var div_29 = root_74();
 
 		{
-			var expression_29 = _$_.hydrating ? _$_.hydrate_child(true) : div_28.firstChild;
+			var expression_30 = _$_.hydrating ? _$_.hydrate_child(true) : div_29.firstChild;
 
-			_$_.pop(div_28);
+			_$_.pop(div_29);
 		}
 
 		_$_.render(
@@ -975,54 +1019,21 @@ export function FragmentTailExpression() {
 				var __a = 'frag-' + String(_$_.with_scope(__block, fetchLabel));
 
 				if (__prev.a !== __a) {
-					_$_.set_text(expression_29, __prev.a = __a);
+					_$_.set_text(expression_30, __prev.a = __a);
 				}
 			},
 			{ a: ' ' }
 		);
 
-		_$_.append(__anchor, div_28);
+		_$_.append(__anchor, div_29);
 	});
 }
 
 export function FragmentChildOnly() {
 	return _$_.tsrx_element((__anchor, __block) => {
-		var div_29 = root_72();
-
-		{
-			_$_.pop(div_29);
-		}
-
-		_$_.append(__anchor, div_29);
-	});
-}
-
-function OpaqueLead(props) {
-	return _$_.tsrx_element((__anchor, __block) => {
-		var fragment_30 = root_73();
-		var node_26 = _$_.first_child_frag(fragment_30);
-
-		_$_.expression(node_26, () => _$_.tsrx_element((__anchor, __block) => {
-			var fragment_31 = root_74();
-			var expression_30 = _$_.first_child_frag(fragment_31);
-
-			_$_.expression(expression_30, () => props.header);
-			_$_.next();
-			_$_.append(__anchor, fragment_31);
-		}));
-
-		_$_.append(__anchor, fragment_30);
-	});
-}
-
-export function FragmentLeadsWithOpaqueValue() {
-	return _$_.tsrx_element((__anchor, __block) => {
 		var div_30 = root_75();
 
 		{
-			var append_anchor_1 = _$_.append_into(div_30);
-
-			_$_.render_component(OpaqueLead, append_anchor_1, { header: 'H' });
 			_$_.pop(div_30);
 		}
 
@@ -1030,14 +1041,47 @@ export function FragmentLeadsWithOpaqueValue() {
 	});
 }
 
-function PrimitiveCallLead() {
+function OpaqueLead(props) {
 	return _$_.tsrx_element((__anchor, __block) => {
 		var fragment_32 = root_76();
-		var node_27 = _$_.first_child_frag(fragment_32);
+		var node_28 = _$_.first_child_frag(fragment_32);
 
-		_$_.expression(node_27, () => _$_.tsrx_element((__anchor, __block) => {
+		_$_.expression(node_28, () => _$_.tsrx_element((__anchor, __block) => {
 			var fragment_33 = root_77();
-			var expression_31 = _$_.first_child_frag(fragment_33, true);
+			var expression_31 = _$_.first_child_frag(fragment_33);
+
+			_$_.expression(expression_31, () => props.header);
+			_$_.next();
+			_$_.append(__anchor, fragment_33);
+		}));
+
+		_$_.append(__anchor, fragment_32);
+	});
+}
+
+export function FragmentLeadsWithOpaqueValue() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		var div_31 = root_78();
+
+		{
+			var append_anchor_1 = _$_.append_into(div_31);
+
+			_$_.render_component(OpaqueLead, append_anchor_1, { header: 'H' });
+			_$_.pop(div_31);
+		}
+
+		_$_.append(__anchor, div_31);
+	});
+}
+
+function PrimitiveCallLead() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		var fragment_34 = root_79();
+		var node_29 = _$_.first_child_frag(fragment_34);
+
+		_$_.expression(node_29, () => _$_.tsrx_element((__anchor, __block) => {
+			var fragment_35 = root_80();
+			var expression_32 = _$_.first_child_frag(fragment_35, true);
 
 			_$_.next();
 
@@ -1046,31 +1090,31 @@ function PrimitiveCallLead() {
 					var __a = String(_$_.with_scope(__block, fetchLabel));
 
 					if (__prev.a !== __a) {
-						_$_.set_text(expression_31, __prev.a = __a);
+						_$_.set_text(expression_32, __prev.a = __a);
 					}
 				},
 				{ a: ' ' }
 			);
 
-			_$_.append(__anchor, fragment_33);
+			_$_.append(__anchor, fragment_35);
 		}));
 
-		_$_.append(__anchor, fragment_32);
+		_$_.append(__anchor, fragment_34);
 	});
 }
 
 export function FragmentLeadsWithPrimitiveCall() {
 	return _$_.tsrx_element((__anchor, __block) => {
-		var div_31 = root_78();
+		var div_32 = root_81();
 
 		{
-			var append_anchor_2 = _$_.append_into(div_31);
+			var append_anchor_2 = _$_.append_into(div_32);
 
 			_$_.render_component(PrimitiveCallLead, append_anchor_2, {});
-			_$_.pop(div_31);
+			_$_.pop(div_32);
 		}
 
-		_$_.append(__anchor, div_31);
+		_$_.append(__anchor, div_32);
 	});
 }
 

--- a/packages/ripple/tests/hydration/compiled/client/html.js
+++ b/packages/ripple/tests/hydration/compiled/client/html.js
@@ -411,22 +411,27 @@ export function DocLayout(__props) {
 											var a_2 = _$_.hydrating ? _$_.hydrate_child() : li.firstChild;
 
 											{
-												var expression_3 = _$_.hydrating ? _$_.hydrate_child() : a_2.firstChild;
+												var expression_3 = _$_.hydrating ? _$_.hydrate_child(true) : a_2.firstChild;
 
-												_$_.expression(expression_3, () => item.text);
 												_$_.pop(a_2);
 											}
 										}
 
 										_$_.render(
 											(__prev) => {
-												var __a = item.href;
+												var __a = item.text;
 
 												if (__prev.a !== __a) {
-													_$_.set_attribute(a_2, 'href', __prev.a = __a);
+													_$_.set_text(expression_3, __prev.a = __a);
+												}
+
+												var __b = item.href;
+
+												if (__prev.b !== __b) {
+													_$_.set_attribute(a_2, 'href', __prev.b = __b);
 												}
 											},
-											{ a: void 0 }
+											{ a: ' ', b: void 0 }
 										);
 
 										_$_.append(__anchor, li);
@@ -850,9 +855,8 @@ function NavItem(__props) {
 				var span_3 = _$_.hydrating ? _$_.hydrate_child() : a_3.firstChild;
 
 				{
-					var expression_15 = _$_.hydrating ? _$_.hydrate_child() : span_3.firstChild;
+					var expression_15 = _$_.hydrating ? _$_.hydrate_child(true) : span_3.firstChild;
 
-					_$_.expression(expression_15, () => __props.text);
 					_$_.pop(span_3);
 				}
 			}
@@ -862,19 +866,25 @@ function NavItem(__props) {
 
 		_$_.render(
 			(__prev) => {
-				var __a = __props.href;
+				var __a = __props.text;
 
 				if (__prev.a !== __a) {
-					_$_.set_attribute(a_3, 'href', __prev.a = __a);
+					_$_.set_text(expression_15, __prev.a = __a);
 				}
 
-				var __b = `nav-item${_$_.fallback(__props.active, false) ? ' active' : ''}`;
+				var __b = __props.href;
 
 				if (__prev.b !== __b) {
-					_$_.set_class(div_27, __prev.b = __b, void 0, true);
+					_$_.set_attribute(a_3, 'href', __prev.b = __b);
+				}
+
+				var __c = `nav-item${_$_.fallback(__props.active, false) ? ' active' : ''}`;
+
+				if (__prev.c !== __c) {
+					_$_.set_class(div_27, __prev.c = __c, void 0, true);
 				}
 			},
-			{ a: void 0, b: _$_.UNINITIALIZED }
+			{ a: ' ', b: void 0, c: _$_.UNINITIALIZED }
 		);
 
 		_$_.append(__anchor, div_27);
@@ -1616,21 +1626,26 @@ function DocsLayoutExact(__props) {
 													var a_8 = root_75();
 
 													{
-														var expression_25 = _$_.hydrating ? _$_.hydrate_child() : a_8.firstChild;
+														var expression_25 = _$_.hydrating ? _$_.hydrate_child(true) : a_8.firstChild;
 
-														_$_.expression(expression_25, () => item.text);
 														_$_.pop(a_8);
 													}
 
 													_$_.render(
 														(__prev) => {
-															var __a = item.href;
+															var __a = item.text;
 
 															if (__prev.a !== __a) {
-																_$_.set_attribute(a_8, 'href', __prev.a = __a);
+																_$_.set_text(expression_25, __prev.a = __a);
+															}
+
+															var __b = item.href;
+
+															if (__prev.b !== __b) {
+																_$_.set_attribute(a_8, 'href', __prev.b = __b);
 															}
 														},
-														{ a: void 0 }
+														{ a: ' ', b: void 0 }
 													);
 
 													_$_.append(__anchor, a_8);

--- a/packages/ripple/tests/hydration/compiled/client/try.js
+++ b/packages/ripple/tests/hydration/compiled/client/try.js
@@ -3,7 +3,7 @@ import * as _$_ from 'ripple/internal/client';
 
 var root = _$_.template(`<p class="root-pending">root loading...</p>`, 0);
 var root_1 = _$_.template(`<section class="root-catch"><p class="root-error"> </p><button class="root-reset">retry</button></section>`, 0);
-var root_2 = _$_.template(`<p>should not render</p>`, 1, 1);
+var root_2 = _$_.template(`<p>should not render</p>`, 0);
 var root_3 = _$_.template(`<p class="root-async-value"> </p>`, 0);
 var root_4 = _$_.template(`<p class="root-async-value"> </p>`, 0);
 var root_5 = _$_.template(`<p class="loading">loading...</p>`, 0);
@@ -51,41 +51,41 @@ export function RootThrows() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		throw _$_.with_scope(__block, () => new Error('root exploded'));
 
-		var fragment = root_2();
+		var p_2 = root_2();
 
-		_$_.append(__anchor, fragment);
+		_$_.append(__anchor, p_2);
 	});
 }
 
 export function RootAsyncDirect() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		let lazy = _$_.track_async(() => _$_.with_scope(__block, () => Promise.resolve('root async value')), __block, 'd6bf9e33');
-		var p_2 = root_3();
+		var p_3 = root_3();
 
 		{
-			var expression_1 = _$_.hydrating ? _$_.hydrate_child() : p_2.firstChild;
+			var expression_1 = _$_.hydrating ? _$_.hydrate_child() : p_3.firstChild;
 
 			_$_.expression(expression_1, () => lazy.value);
-			_$_.pop(p_2);
+			_$_.pop(p_3);
 		}
 
-		_$_.append(__anchor, p_2);
+		_$_.append(__anchor, p_3);
 	});
 }
 
 export function RootAsyncRejects() {
 	return _$_.tsrx_element((__anchor, __block) => {
 		let lazy_1 = _$_.track_async(() => _$_.with_scope(__block, () => Promise.reject(new Error('root async failed'))), __block, 'd2fe7b64');
-		var p_3 = root_4();
+		var p_4 = root_4();
 
 		{
-			var expression_2 = _$_.hydrating ? _$_.hydrate_child() : p_3.firstChild;
+			var expression_2 = _$_.hydrating ? _$_.hydrate_child() : p_4.firstChild;
 
 			_$_.expression(expression_2, () => lazy_1.value);
-			_$_.pop(p_3);
+			_$_.pop(p_4);
 		}
 
-		_$_.append(__anchor, p_3);
+		_$_.append(__anchor, p_4);
 	});
 }
 
@@ -98,9 +98,9 @@ export function AsyncListInTryPending() {
 			},
 			null,
 			(__anchor) => {
-				var p_4 = root_5();
+				var p_5 = root_5();
 
-				_$_.append(__anchor, p_4);
+				_$_.append(__anchor, p_5);
 			},
 			true
 		);
@@ -140,12 +140,12 @@ function AsyncList() {
 
 export function AsyncTryWithLeadingSibling() {
 	return _$_.tsrx_element((__anchor, __block) => {
-		var fragment_1 = root_8();
-		var node_1 = _$_.first_child_frag(fragment_1);
+		var fragment = root_8();
+		var node_1 = _$_.first_child_frag(fragment);
 
 		_$_.expression(node_1, () => _$_.tsrx_element((__anchor, __block) => {
-			var fragment_2 = root_9();
-			var div = _$_.first_child_frag(fragment_2);
+			var fragment_1 = root_9();
+			var div = _$_.first_child_frag(fragment_1);
 			var node = _$_.hydrating ? _$_.hydrate_sibling() : div.nextSibling;
 
 			_$_.try(
@@ -161,10 +161,10 @@ export function AsyncTryWithLeadingSibling() {
 				}
 			);
 
-			_$_.append(__anchor, fragment_2);
+			_$_.append(__anchor, fragment_1);
 		}));
 
-		_$_.append(__anchor, fragment_1);
+		_$_.append(__anchor, fragment);
 	});
 }
 

--- a/packages/ripple/tests/hydration/compiled/server/basic.js
+++ b/packages/ripple/tests/hydration/compiled/server/basic.js
@@ -660,6 +660,17 @@ function TextProp(__props) {
 	});
 }
 
+function TypedTextProp(__props) {
+	return _$_.tsrx_element(() => {
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<div class="text-prop">' + _$_.escape(__props.children) + '</div>';
+			_$_.output_push(__out);
+		});
+	});
+}
+
 export function TextPropWithToggle() {
 	return _$_.tsrx_element(() => {
 		let lazy_1 = _$_.track(false, '1ba81c3b');
@@ -676,6 +687,36 @@ export function TextPropWithToggle() {
 				const args = [
 					{
 						children: _$_.normalize_children(lazy_1.value ? 'hello' : '')
+					}
+				];
+
+				_$_.output_push(__out);
+				__out = '';
+				_$_.render_component(comp, ...args);
+			}
+
+			__out += '<button class="show-text">Show</button>';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function TypedTextPropWithToggle() {
+	return _$_.tsrx_element(() => {
+		let lazy_2 = _$_.track(false, '649e2af0');
+
+		_$_.regular_block(() => {
+			let __out = '';
+
+			{
+				const comp = TypedTextProp;
+
+				_$_.output_push(__out);
+				__out = '';
+
+				const args = [
+					{
+						children: _$_.normalize_children(lazy_2.value ? 'hello' : '')
 					}
 				];
 

--- a/packages/ripple/tests/hydration/compiled/server/html.js
+++ b/packages/ripple/tests/hydration/compiled/server/html.js
@@ -367,7 +367,7 @@ export function DocLayout(__props) {
 								_$_.output_push('>');
 
 								{
-									_$_.render_expression(item.text);
+									_$_.output_push(_$_.escape(item.text));
 								}
 
 								_$_.output_push('</a>');
@@ -957,15 +957,7 @@ function NavItem(__props) {
 				_$_.output_push('</div>');
 			}
 
-			__out += '<!--]--><a' + _$_.attr('href', __props.href, false) + '><span>';
-
-			{
-				_$_.output_push(__out);
-				__out = '';
-				_$_.render_expression(__props.text);
-			}
-
-			__out += '</span></a></div>';
+			__out += '<!--]--><a' + _$_.attr('href', __props.href, false) + '><span>' + _$_.escape(__props.text) + '</span></a></div>';
 			_$_.output_push(__out);
 		});
 	});
@@ -1732,7 +1724,7 @@ function DocsLayoutExact(__props) {
 							_$_.output_push('>');
 
 							{
-								_$_.render_expression(item.text);
+								_$_.output_push(_$_.escape(item.text));
 							}
 
 							_$_.output_push('</a>');

--- a/packages/ripple/tests/hydration/components/basic.tsrx
+++ b/packages/ripple/tests/hydration/components/basic.tsrx
@@ -228,7 +228,13 @@ export function TsxDeclaredBeforeTopLevelTsx() @{
 	</>
 }
 
-function TextProp(&{ children }: { children: string }) @{
+// Untyped children render through the generic expression path (hydration
+// markers); typed string children hydrate a text node directly.
+function TextProp(&{ children }: { children: unknown }) @{
+	<div class="text-prop">{children}</div>
+}
+
+function TypedTextProp(&{ children }: { children: string }) @{
 	<div class="text-prop">{children}</div>
 }
 
@@ -236,6 +242,14 @@ export function TextPropWithToggle() @{
 	let &[show] = track(false);
 	<>
 		<TextProp children={show ? 'hello' : ''} />
+		<button class="show-text" onClick={() => (show = true)}>{'Show'}</button>
+	</>
+}
+
+export function TypedTextPropWithToggle() @{
+	let &[show] = track(false);
+	<>
+		<TypedTextProp children={show ? 'hello' : ''} />
 		<button class="show-text" onClick={() => (show = true)}>{'Show'}</button>
 	</>
 }

--- a/packages/tsrx-ripple/src/analyze/index.js
+++ b/packages/tsrx-ripple/src/analyze/index.js
@@ -1141,6 +1141,64 @@ function infer_for_item_type_annotation(node, context) {
 }
 
 /**
+ * Records the type of each binding in a lazy pattern. Nested patterns inside a
+ * lazy pattern are lazy as well and already read through the outer source, so
+ * this only attaches type metadata and never touches the transforms; the types
+ * let typed property reads lower to direct text and attribute writes.
+ * @param {AST.Pattern} pattern
+ * @param {AnalysisContext} context
+ * @param {AST.TypeNode | undefined} type_annotation
+ */
+function assign_pattern_types(pattern, context, type_annotation) {
+	const pattern_type_annotation = get_pattern_type_annotation(pattern) ?? type_annotation;
+
+	switch (pattern.type) {
+		case 'Identifier': {
+			if (pattern_type_annotation === undefined) return;
+			const binding = context.state.scope.get(pattern.name);
+			if (binding?.node === pattern) {
+				binding.metadata = {
+					...(binding.metadata ?? {}),
+					typeAnnotation: pattern_type_annotation,
+				};
+			}
+			return;
+		}
+		case 'AssignmentPattern':
+			assign_pattern_types(pattern.left, context, pattern_type_annotation);
+			return;
+		case 'RestElement':
+			assign_pattern_types(pattern.argument, context, pattern_type_annotation);
+			return;
+		case 'ObjectPattern':
+			for (const property of pattern.properties) {
+				assign_pattern_types(
+					property.type === 'RestElement' ? property.argument : property.value,
+					context,
+					get_object_property_type_annotation(pattern_type_annotation, property),
+				);
+			}
+			return;
+		case 'ArrayPattern':
+			for (let i = 0; i < pattern.elements.length; i += 1) {
+				const element = pattern.elements[i];
+				if (element !== null) {
+					assign_pattern_types(
+						element,
+						context,
+						get_array_element_type_annotation(
+							pattern_type_annotation,
+							i,
+							element.type === 'RestElement',
+						),
+					);
+				}
+			}
+			return;
+	}
+}
+
+/**
  * Sets up lazy transforms for declarations and function or component parameters.
  * @param {AST.Pattern} pattern
  * @param {AnalysisContext} context
@@ -1196,7 +1254,9 @@ function setup_lazy_pattern_transforms(
 				);
 				pattern.metadata = { ...pattern.metadata, lazy_id: param_id.name };
 
-				if (pattern.type === 'ArrayPattern' && pattern_type_annotation !== undefined) {
+				if (pattern.type === 'ObjectPattern') {
+					assign_pattern_types(pattern, context, pattern_type_annotation);
+				} else if (pattern_type_annotation !== undefined) {
 					for (let i = 0; i < pattern.elements.length; i += 1) {
 						const element = pattern.elements[i];
 						if (element?.type !== 'Identifier') continue;
@@ -1283,6 +1343,7 @@ function visit_function(node, context) {
 			if (props.type === 'ObjectPattern' || props.type === 'ArrayPattern') {
 				if (props.lazy) {
 					setup_lazy_transforms(props, b.id('__props'), context.state, true, false);
+					assign_pattern_types(props, context, get_pattern_type_annotation(props));
 				} else {
 					setup_lazy_pattern_transforms(props, context, get_pattern_type_annotation(props));
 				}
@@ -1906,7 +1967,9 @@ const visitors = {
 					context,
 					call_name === 'track'
 						? get_track_call_type_annotation(/** @type {AST.CallExpression} */ (declarator.init))
-						: undefined,
+						: !call_name && declarator.init != null
+							? get_expression_type_annotation(declarator.init, context.state)
+							: undefined,
 					node.kind !== 'const',
 					call_name === 'track' || call_name === 'trackAsync',
 				);

--- a/packages/tsrx-ripple/src/transform/client/index.js
+++ b/packages/tsrx-ripple/src/transform/client/index.js
@@ -5818,11 +5818,9 @@ function transform_children(children, context) {
 					is_template_expression(node) &&
 					/** @type {ESTreeJSX.JSXExpressionContainer} */ (node).expression.type !== 'Literal',
 			)) ||
+		// Setup statements produce no DOM; only rendered siblings need a fragment.
 		normalized.filter(
-			(node) =>
-				node.type !== 'VariableDeclaration' &&
-				node.type !== 'BlockStatement' &&
-				node.type !== 'EmptyStatement',
+			(node) => is_template_element(node) || is_template_text(node) || is_template_expression(node),
 		).length > 1;
 	// A fragment template root (a component or control-flow body, not an
 	// element's children): its hydration cursor must end on its last top-level

--- a/packages/tsrx-ripple/tests/for-selector.test.js
+++ b/packages/tsrx-ripple/tests/for-selector.test.js
@@ -238,6 +238,58 @@ describe('@for item type inference', () => {
 		expect(code).toContain('_$_.expression(');
 	});
 
+	it('types the bindings of a lazily destructured props pattern', () => {
+		const code = compile_client(`
+			type Item = { id: number; nested: { label: string } };
+
+			export default function Row(&{ item, extra: { count } }: { item: Item; extra: { count: number } }) @{
+				<tr><td>{item.id}</td><td>{item.nested.label}</td><td>{count}</td></tr>
+			}
+		`);
+
+		expect(code).not.toContain('_$_.expression(');
+		expect(code.match(/_\$_\.set_text\(/g)).toHaveLength(3);
+		expect(code).toContain('__props.item.id');
+		expect(code).toContain('__props.extra.count');
+	});
+
+	it('types the bindings of a lazy object pattern declaration', () => {
+		const code = compile_client(`
+			export default function Row(props: { item: { id: number } }) @{
+				const &{ item } = props;
+				<p>{item.id}</p>
+			}
+		`);
+
+		expect(code).not.toContain('_$_.expression(');
+		expect(code).toContain('_$_.set_text(');
+	});
+
+	it('types the bindings of a regular destructured props pattern', () => {
+		const code = compile_client(`
+			export default function Row({ item, extra: { count } }: { item: { id: number }; extra: { count: number } }) @{
+				<tr><td>{item.id}</td><td>{count}</td></tr>
+			}
+		`);
+
+		expect(code).not.toContain('_$_.expression(');
+		expect(code).toContain('_$_.set_text(expression, __prev.a = __a)');
+		expect(code).toContain('expression_1.nodeValue = count');
+	});
+
+	it('types the bindings of a regular object pattern declaration', () => {
+		const code = compile_client(`
+			export default function Row(props: { item: { id: number }; extra: { count: number } }) @{
+				const { item, extra: { count } } = props;
+				<tr><td>{item.id}</td><td>{count}</td></tr>
+			}
+		`);
+
+		expect(code).not.toContain('_$_.expression(');
+		expect(code).toContain('_$_.set_text(expression, __prev.a = __a)');
+		expect(code).toContain('expression_1.nodeValue = count');
+	});
+
 	it('infers number and boolean literal initial values of track()', () => {
 		const code = compile_client(`
 			import { track } from 'ripple';


### PR DESCRIPTION
## Summary

effectful-list round of the benchmark work (after js-framework, portal-swarm, chat-stream). Ripple now leads or ties every op in the suite against Inferno, Svelte and Vue Vapor.

Final harness run (30 iterations, one run, all gates passing):

| Op | Ripple | Best competitor |
| --- | --- | --- |
| mount_1k | 32.20 | inferno 32.50 |
| update_nodeps | 0.00 | vue-vapor 0.01 |
| update_deps | 8.56 | inferno 8.62 |
| clear | 2.60 | inferno 2.70 |
| remount | 29.70 | inferno 29.80 |
| remove_100_scattered | 0.70 | svelte 1.10 |

The suite is layout-bound: the first `offsetHeight` probe forces one layout of the 1000-row table (~26 of the 32 ms of mount) that every framework pays. With layout subtracted, Ripple's mount JS went from 7.2 to ~5.3 ms (Inferno 4.8), remount 10.3 to 7.7 (Inferno 7.9), clear 3.5 to 2.6 (Inferno 2.7).

## Runtime (`packages/ripple`)

- `ref()` is one effect block keyed on its state (`run_function_ref` / `run_tracked_ref` / `run_set_ref`) instead of a render block that re-evaluates the thunk and creates a branch and an effect for it. The thunk is read untracked, so the value was already fixed for the life of the enclosing block.
- Effects deferred until a component has rendered are flat records; `pop_component` drops the per-effect try/finally (creating an effect block cannot throw).
- `run_phase` passes the first-run flag, so a block's first run skips the child and teardown sweep.
- A tracked value written during a flush keeps its previous value in `o` (plus a holder list) instead of a module `Map`; `flushSync` now releases those values when it finishes. Before, only the microtask flush cleared the map, so it grew without bound under `flushSync`.

## Compiler (`packages/tsrx-ripple`)

- Lazy object patterns carry their property types to the bindings (`&{ item }: { item: Item }` as component props, `const &{ item } = typed_init`), so typed reads lower to `set_text` instead of `expression()`. Nested patterns inside a lazy pattern are already lazy, so only type metadata is attached (routing them through the general pattern setup registered an undeclared source and broke the server lazy-destructuring tests).
- The fragment rule counts only template nodes, so a component whose body has setup statements beside a single root element clones the element rather than a fragment.

## Fixture and tests

- `benchmarks/effectful-list/ripple` Row uses `&{ item }`; a plain `{ item }` snapshots the prop, so the value effect never refired on update_deps and the correctness gate failed (layouts 0 instead of 100).
- Hydration components: `TextProp` children typed `unknown` keeps the expression/marker regression test; a new `TypedTextProp` test covers string-typed children hydrating a text node. Compiled hydration fixtures regenerated.
- Compiler tests for typed lazy and regular destructures (params and declarations).

Measured and not adopted: refs applied without an effect block (no gain; the cost is the user callback and its `with_scope` closure) and a plain `let` ref instead of the tracked cell (no measurable difference). The remaining structural win is the props-as-class plan (~0.4–0.5 ms per 1000 rows on mount/remount in a bundle patch), left for its own PR.

## Validation

`pnpm test` (2149 passed), `pnpm typecheck`, `pnpm format:check`, `pnpm changeset:check` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core client scheduling, ref wiring, and teardown-time reads of tracked state; incorrect old-value release or first-run block behavior could cause subtle reactivity bugs in production apps.
> 
> **Overview**
> This PR tightens the Ripple client runtime and compiler so large lists (especially the effectful-list benchmark) do less work per row on mount, update, and remount.
> 
> **Runtime** replaces the old **`ref()`** path (render block + branch + nested effects) with a single **`EFFECT_BLOCK`** per ref after reading the callback untracked via **`apply_ref`**. Component effects registered before first paint are stored as **flat triples** and wired in **`pop_component`** without per-entry try/finally. **`run_block`** skips child destruction and teardown on the **first run**, and tracked writes during a flush stash the **previous value on `o`** (with **`release_old_values`** at flush depth zero) instead of a growing module **`Map`**—**`flushSync`** now releases those snapshots when the outer sync flush finishes, which fixes teardowns that read stale state when **`flushSync`** runs mid-flush.
> 
> **Compiler** attaches types to **lazy destructured** props and declarations (**`assign_pattern_types`**) so typed property reads emit **`set_text`** / direct DOM updates instead of **`expression()`**, and the fragment-vs-element-root rule ignores setup-only statements so a single root element is **cloned** rather than wrapped in a fragment.
> 
> **Tests and fixtures** update the benchmark Row to **`&{ item }`**, add reactivity and hydration coverage for typed string children, and regenerate compiled hydration output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57bf74215cca98058eabe84fbef77e708ffd86fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->