### PR TITLE
feat(ripple): infer primitive text with optional TypeScript proofs

### DIFF
--- a/.changeset/primitive-text-type-proofs.md
+++ b/.changeset/primitive-text-type-proofs.md
@@ -1,0 +1,6 @@
+---
+'@tsrx/ripple': patch
+'@ripple-ts/vite-plugin': patch
+---
+
+Expand primitive text inference to BigInt and Date calls, sequences, and satisfies expressions while respecting shadowed or replaced built-ins. Add optional TypeScript project proofs for imported primitive types and function return values, with matching client/server text classification and one-shot Vite production build integration.

--- a/packages/ripple/tests/client/primitive-text.test.tsrx
+++ b/packages/ripple/tests/client/primitive-text.test.tsrx
@@ -1,0 +1,50 @@
+import { flushSync, track } from 'ripple';
+
+it('renders shadowed intrinsic calls as elements beside text', () => {
+	function App() @{
+		const String = () => <b>string</b>;
+		const Number = () => <b>number</b>;
+		const Boolean = () => <b>boolean</b>;
+		const BigInt = () => <b>bigint</b>;
+		const Date = () => <b>date</b>;
+		<>
+			<p>before{String()}after</p>
+			<p>before{Number()}after</p>
+			<p>before{Boolean()}after</p>
+			<p>before{BigInt()}after</p>
+			<p>before{Date()}after</p>
+		</>
+	}
+	render(App);
+	expect([...container.querySelectorAll('b')].map((node) => node.textContent)).toEqual([
+		'string',
+		'number',
+		'boolean',
+		'bigint',
+		'date',
+	]);
+});
+
+it('keeps numeric addition, bigint conversion, and sequence effects during updates', () => {
+	let calls = 0;
+	function App() @{
+		let &[count] = track(2);
+		<>
+			<p>sum: {Number(count) + Number(count)}</p>
+			<div>
+				{'big: '}
+				{(calls++, BigInt(count) satisfies bigint)}
+			</div>
+			<button onClick={() => count++}>update</button>
+		</>
+	}
+	render(App);
+	expect(container.querySelector('p').textContent).toBe('sum: 4');
+	expect(container.querySelector('div').textContent).toBe('big: 2');
+	expect(calls).toBe(1);
+	container.querySelector('button').click();
+	flushSync();
+	expect(container.querySelector('p').textContent).toBe('sum: 6');
+	expect(container.querySelector('div').textContent).toBe('big: 3');
+	expect(calls).toBe(2);
+});

--- a/packages/ripple/tests/hydration/basic.test.js
+++ b/packages/ripple/tests/hydration/basic.test.js
@@ -309,3 +309,40 @@ describe('hydration > text runs with call-containing primitives', () => {
 		expect(container.textContent).toBe('fetchedafter-call');
 	});
 });
+
+describe('primitive text calls', () => {
+	it('hydrates merged primitive calls and updates their existing text node', async () => {
+		const { unmount } = await hydrateComponent(
+			ServerComponents.PrimitiveTextCalls,
+			ClientComponents.PrimitiveTextCalls,
+		);
+		try {
+			const node = container.querySelector('.primitive-calls');
+			const text = node.firstChild;
+			expect(node.textContent).toBe('sum: 4; big: 2');
+			container.querySelector('button').click();
+			flushSync();
+			expect(node.textContent).toBe('sum: 6; big: 3');
+			expect(node.firstChild).toBe(text);
+		} finally {
+			unmount();
+		}
+	});
+
+	it('hydrates elements returned by shadowed built-ins', async () => {
+		const { unmount } = await hydrateComponent(
+			ServerComponents.ShadowedTextCalls,
+			ClientComponents.ShadowedTextCalls,
+		);
+		try {
+			expect([...container.querySelectorAll('b')].map((node) => node.textContent)).toEqual([
+				'string',
+				'number',
+				'bigint',
+				'date',
+			]);
+		} finally {
+			unmount();
+		}
+	});
+});

--- a/packages/ripple/tests/hydration/build-components.js
+++ b/packages/ripple/tests/hydration/build-components.js
@@ -5,6 +5,7 @@
  */
 
 import { compile } from '@tsrx/ripple';
+import { createTextTypeProject as create_text_type_project } from '@tsrx/ripple/typescript';
 import { readFileSync, writeFileSync, mkdirSync, readdirSync } from 'fs';
 import { join, basename } from 'path';
 import { fileURLToPath } from 'url';
@@ -47,15 +48,33 @@ function buildComponents() {
 		const source = readFileSync(filePath, 'utf-8');
 		const outputName = basename(basename(file, '.tsrx'), '.tsrx').replace(/\.tsrx$/, '') + '.js';
 
+		// Exercise opt-in type proofs using the same snapshot in both modes.
+		let text_type_facts;
+		if (file === 'typed-text.tsrx') {
+			const project = create_text_type_project({
+				tsconfig: join(__dirname, 'tsconfig.text-types.json'),
+			});
+			try {
+				text_type_facts = { ...project.getTextTypeFacts(filePath, source), filename: file };
+				if (text_type_facts.primitiveTextChildRanges.length === 0) {
+					throw new Error('Typed hydration fixture did not produce primitive text proofs');
+				}
+			} finally {
+				project.dispose();
+			}
+		}
+
 		// Compile for client
 		const clientResult = compile(source, file, {
 			mode: 'client',
+			textTypeFacts: text_type_facts,
 		});
 		writeFileSync(join(clientOutDir, outputName), '// @ts-nocheck\n' + clientResult.code);
 
 		// Compile for server
 		const serverResult = compile(source, file, {
 			mode: 'server',
+			textTypeFacts: text_type_facts,
 		});
 		// Transform imports to use server runtime
 		const serverCode = transformServerImports(serverResult.code);

--- a/packages/ripple/tests/hydration/compiled/client/basic.js
+++ b/packages/ripple/tests/hydration/compiled/client/basic.js
@@ -83,6 +83,14 @@ var root_78 = _$_.template(`<div></div>`, 0);
 var root_80 = _$_.template(` <p>after-call</p>`, 1, 2);
 var root_79 = _$_.template(`<!>`, 1, 1);
 var root_81 = _$_.template(`<div></div>`, 0);
+var root_83 = _$_.template(`<div class="primitive-calls"> </div><button>update</button>`, 1, 2);
+var root_82 = _$_.template(`<!>`, 1, 1);
+var root_84 = _$_.template(`<b>string</b>`, 0);
+var root_85 = _$_.template(`<b>number</b>`, 0);
+var root_86 = _$_.template(`<b>bigint</b>`, 0);
+var root_87 = _$_.template(`<b>date</b>`, 0);
+var root_89 = _$_.template(`<p>before<!>after</p><p>before<!>after</p><p>before<!>after</p><p>before<!>after</p>`, 1, 4);
+var root_88 = _$_.template(`<!>`, 1, 1);
 
 import { track } from 'ripple';
 
@@ -1115,6 +1123,122 @@ export function FragmentLeadsWithPrimitiveCall() {
 		}
 
 		_$_.append(__anchor, div_32);
+	});
+}
+
+export function PrimitiveTextCalls() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		let lazy_3 = _$_.track(2, __block, 'ba719d47');
+		var fragment_36 = root_82();
+		var node_30 = _$_.first_child_frag(fragment_36);
+
+		_$_.expression(node_30, () => _$_.tsrx_element((__anchor, __block) => {
+			var fragment_37 = root_83();
+			var div_33 = _$_.first_child_frag(fragment_37);
+
+			{
+				var text_1 = _$_.hydrating ? _$_.hydrate_child(true) : div_33.firstChild;
+
+				_$_.pop(div_33);
+			}
+
+			var button_2 = _$_.hydrating ? _$_.hydrate_sibling() : div_33.nextSibling;
+
+			button_2.__click = () => _$_.update(lazy_3);
+
+			_$_.render(
+				(__prev) => {
+					var __a = "sum: " + (String(Number(lazy_3.value) + Number(lazy_3.value) ?? '') + ("; big: " + String(_$_.with_scope(__block, () => BigInt(lazy_3.value)) ?? '')));
+
+					if (__prev.a !== __a) {
+						_$_.set_text(text_1, __prev.a = __a);
+					}
+				},
+				{ a: ' ' }
+			);
+
+			_$_.append(__anchor, fragment_37);
+		}));
+
+		_$_.append(__anchor, fragment_36);
+	});
+}
+
+export function ShadowedTextCalls() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		const String = () => _$_.tsrx_element((__anchor, __block) => {
+			var b = root_84();
+
+			_$_.append(__anchor, b);
+		});
+
+		const Number = () => _$_.tsrx_element((__anchor, __block) => {
+			var b_1 = root_85();
+
+			_$_.append(__anchor, b_1);
+		});
+
+		const BigInt = () => _$_.tsrx_element((__anchor, __block) => {
+			var b_2 = root_86();
+
+			_$_.append(__anchor, b_2);
+		});
+
+		const Date = () => _$_.tsrx_element((__anchor, __block) => {
+			var b_3 = root_87();
+
+			_$_.append(__anchor, b_3);
+		});
+
+		var fragment_38 = root_88();
+		var node_31 = _$_.first_child_frag(fragment_38);
+
+		_$_.expression(node_31, () => _$_.tsrx_element((__anchor, __block) => {
+			var fragment_39 = root_89();
+			var p_1 = _$_.first_child_frag(fragment_39);
+
+			{
+				var text_2 = _$_.hydrating ? _$_.hydrate_child() : p_1.firstChild;
+				var expression_33 = _$_.hydrating ? _$_.hydrate_sibling() : text_2.nextSibling;
+
+				_$_.render_tsrx_element(_$_.with_scope(__block, String), expression_33, __block);
+				_$_.pop(p_1);
+			}
+
+			var p_2 = _$_.hydrating ? _$_.hydrate_sibling() : p_1.nextSibling;
+
+			{
+				var text_3 = _$_.hydrating ? _$_.hydrate_child() : p_2.firstChild;
+				var expression_34 = _$_.hydrating ? _$_.hydrate_sibling() : text_3.nextSibling;
+
+				_$_.render_tsrx_element(_$_.with_scope(__block, Number), expression_34, __block);
+				_$_.pop(p_2);
+			}
+
+			var p_3 = _$_.hydrating ? _$_.hydrate_sibling() : p_2.nextSibling;
+
+			{
+				var text_4 = _$_.hydrating ? _$_.hydrate_child() : p_3.firstChild;
+				var expression_35 = _$_.hydrating ? _$_.hydrate_sibling() : text_4.nextSibling;
+
+				_$_.render_tsrx_element(_$_.with_scope(__block, BigInt), expression_35, __block);
+				_$_.pop(p_3);
+			}
+
+			var p_4 = _$_.hydrating ? _$_.hydrate_sibling() : p_3.nextSibling;
+
+			{
+				var text_5 = _$_.hydrating ? _$_.hydrate_child() : p_4.firstChild;
+				var expression_36 = _$_.hydrating ? _$_.hydrate_sibling() : text_5.nextSibling;
+
+				_$_.render_tsrx_element(_$_.with_scope(__block, Date), expression_36, __block);
+				_$_.pop(p_4);
+			}
+
+			_$_.append(__anchor, fragment_39);
+		}));
+
+		_$_.append(__anchor, fragment_38);
 	});
 }
 

--- a/packages/ripple/tests/hydration/compiled/client/typed-text.js
+++ b/packages/ripple/tests/hydration/compiled/client/typed-text.js
@@ -1,0 +1,63 @@
+// @ts-nocheck
+import * as _$_ from 'ripple/internal/client';
+
+var root_1 = _$_.template(`<div class="typed-run"> <span>tail</span></div><p class="typed-number"> </p><button>update</button>`, 1, 3);
+var root = _$_.template(`<!>`, 1, 1);
+
+import { track } from 'ripple';
+
+export function TypedText() {
+	return _$_.tsrx_element((__anchor, __block) => {
+		let lazy = _$_.track({ label: '<first>', count: 2 }, __block, '9bf2304a');
+		var fragment = root();
+		var node = _$_.first_child_frag(fragment);
+
+		_$_.expression(node, () => _$_.tsrx_element((__anchor, __block) => {
+			var fragment_1 = root_1();
+			var div = _$_.first_child_frag(fragment_1);
+
+			{
+				var expression = _$_.hydrating ? _$_.hydrate_child(true) : div.firstChild;
+
+				_$_.pop(div);
+			}
+
+			var p = _$_.hydrating ? _$_.hydrate_sibling() : div.nextSibling;
+
+			{
+				var expression_1 = _$_.hydrating ? _$_.hydrate_child(true) : p.firstChild;
+
+				_$_.pop(p);
+			}
+
+			var button = _$_.hydrating ? _$_.hydrate_sibling() : p.nextSibling;
+
+			button.__click = () => {
+				_$_.set(lazy, { label: '&next', count: 3n });
+			};
+
+			_$_.render(
+				(__prev) => {
+					var __a = 'value: ' + (lazy.value.label + String(lazy.value.count ?? ''));
+
+					if (__prev.a !== __a) {
+						_$_.set_text(expression, __prev.a = __a);
+					}
+
+					var __b = lazy.value.count;
+
+					if (__prev.b !== __b) {
+						_$_.set_text(expression_1, __prev.b = __b);
+					}
+				},
+				{ a: ' ', b: ' ' }
+			);
+
+			_$_.append(__anchor, fragment_1);
+		}));
+
+		_$_.append(__anchor, fragment);
+	});
+}
+
+_$_.delegate(['click']);

--- a/packages/ripple/tests/hydration/compiled/client/typed-text.js
+++ b/packages/ripple/tests/hydration/compiled/client/typed-text.js
@@ -44,7 +44,7 @@ export function TypedText() {
 						_$_.set_text(expression, __prev.a = __a);
 					}
 
-					var __b = lazy.value.count;
+					var __b = (0, lazy.value.count);
 
 					if (__prev.b !== __b) {
 						_$_.set_text(expression_1, __prev.b = __b);

--- a/packages/ripple/tests/hydration/compiled/server/basic.js
+++ b/packages/ripple/tests/hydration/compiled/server/basic.js
@@ -1064,3 +1064,79 @@ export function FragmentLeadsWithPrimitiveCall() {
 		});
 	});
 }
+
+export function PrimitiveTextCalls() {
+	return _$_.tsrx_element(() => {
+		let lazy_3 = _$_.track(2, 'ba719d47');
+
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<div class="primitive-calls">' + _$_.escape("sum: " + (String(Number(lazy_3.value) + Number(lazy_3.value) ?? '') + ("; big: " + String(BigInt(lazy_3.value) ?? '')))) + '</div><button>update</button>';
+			_$_.output_push(__out);
+		});
+	});
+}
+
+export function ShadowedTextCalls() {
+	return _$_.tsrx_element(() => {
+		const String = () => _$_.tsrx_element(() => {
+			_$_.regular_block(() => {
+				let __out = '';
+
+				__out += '<b>string</b>';
+				_$_.output_push(__out);
+			});
+		});
+
+		const Number = () => _$_.tsrx_element(() => {
+			_$_.regular_block(() => {
+				let __out = '';
+
+				__out += '<b>number</b>';
+				_$_.output_push(__out);
+			});
+		});
+
+		const BigInt = () => _$_.tsrx_element(() => {
+			_$_.regular_block(() => {
+				let __out = '';
+
+				__out += '<b>bigint</b>';
+				_$_.output_push(__out);
+			});
+		});
+
+		const Date = () => _$_.tsrx_element(() => {
+			_$_.regular_block(() => {
+				let __out = '';
+
+				__out += '<b>date</b>';
+				_$_.output_push(__out);
+			});
+		});
+
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<p>before';
+			_$_.output_push(__out);
+			__out = '';
+			_$_.render_tsrx_element(String());
+			__out += 'after</p><p>before';
+			_$_.output_push(__out);
+			__out = '';
+			_$_.render_tsrx_element(Number());
+			__out += 'after</p><p>before';
+			_$_.output_push(__out);
+			__out = '';
+			_$_.render_tsrx_element(BigInt());
+			__out += 'after</p><p>before';
+			_$_.output_push(__out);
+			__out = '';
+			_$_.render_tsrx_element(Date());
+			__out += 'after</p>';
+			_$_.output_push(__out);
+		});
+	});
+}

--- a/packages/ripple/tests/hydration/compiled/server/typed-text.js
+++ b/packages/ripple/tests/hydration/compiled/server/typed-text.js
@@ -10,7 +10,7 @@ export function TypedText() {
 		_$_.regular_block(() => {
 			let __out = '';
 
-			__out += '<div class="typed-run">' + _$_.escape('value: ' + (lazy.value.label + String(lazy.value.count ?? ''))) + '<span>tail</span></div><p class="typed-number">' + _$_.escape(lazy.value.count) + '</p><button>update</button>';
+			__out += '<div class="typed-run">' + _$_.escape('value: ' + (lazy.value.label + String(lazy.value.count ?? ''))) + '<span>tail</span></div><p class="typed-number">' + _$_.escape((0, lazy.value.count)) + '</p><button>update</button>';
 			_$_.output_push(__out);
 		});
 	});

--- a/packages/ripple/tests/hydration/compiled/server/typed-text.js
+++ b/packages/ripple/tests/hydration/compiled/server/typed-text.js
@@ -1,0 +1,17 @@
+// @ts-nocheck
+import * as _$_ from 'ripple/internal/server';
+
+import { track } from 'ripple/server';
+
+export function TypedText() {
+	return _$_.tsrx_element(() => {
+		let lazy = _$_.track({ label: '<first>', count: 2 }, '9bf2304a');
+
+		_$_.regular_block(() => {
+			let __out = '';
+
+			__out += '<div class="typed-run">' + _$_.escape('value: ' + (lazy.value.label + String(lazy.value.count ?? ''))) + '<span>tail</span></div><p class="typed-number">' + _$_.escape(lazy.value.count) + '</p><button>update</button>';
+			_$_.output_push(__out);
+		});
+	});
+}

--- a/packages/ripple/tests/hydration/components/basic.tsrx
+++ b/packages/ripple/tests/hydration/components/basic.tsrx
@@ -383,3 +383,24 @@ export function FragmentLeadsWithPrimitiveCall() @{
 	// prettier-ignore
 	<div><PrimitiveCallLead /></div>
 }
+
+export function PrimitiveTextCalls() @{
+	let &[count] = track(2);
+	<>
+		<div class="primitive-calls">sum: {Number(count) + Number(count)}; big: {BigInt(count)}</div>
+		<button onClick={() => count++}>update</button>
+	</>
+}
+
+export function ShadowedTextCalls() @{
+	const String = () => <b>string</b>;
+	const Number = () => <b>number</b>;
+	const BigInt = () => <b>bigint</b>;
+	const Date = () => <b>date</b>;
+	<>
+		<p>before{String()}after</p>
+		<p>before{Number()}after</p>
+		<p>before{BigInt()}after</p>
+		<p>before{Date()}after</p>
+	</>
+}

--- a/packages/ripple/tests/hydration/components/text-types.ts
+++ b/packages/ripple/tests/hydration/components/text-types.ts
@@ -1,0 +1,4 @@
+export interface TextRow {
+	label: string;
+	count: number | bigint;
+}

--- a/packages/ripple/tests/hydration/components/typed-text.tsrx
+++ b/packages/ripple/tests/hydration/components/typed-text.tsrx
@@ -1,0 +1,20 @@
+import { track } from 'ripple';
+import type { TextRow } from './text-types';
+
+export function TypedText() @{
+	let &[row] = track<TextRow>({ label: '<first>', count: 2 });
+	<>
+		<div class="typed-run">
+			{'value: '}
+			{row.label}
+			{row.count}
+			<span>tail</span>
+		</div>
+		<p class="typed-number">{row.count}</p>
+		<button
+			onClick={() => {
+				row = { label: '&next', count: 3n };
+			}}
+		>update</button>
+	</>
+}

--- a/packages/ripple/tests/hydration/components/typed-text.tsrx
+++ b/packages/ripple/tests/hydration/components/typed-text.tsrx
@@ -10,7 +10,9 @@ export function TypedText() @{
 			{row.count}
 			<span>tail</span>
 		</div>
-		<p class="typed-number">{row.count}</p>
+		<p class="typed-number">
+			{(0, row.count)}
+		</p>
 		<button
 			onClick={() => {
 				row = { label: '&next', count: 3n };

--- a/packages/ripple/tests/hydration/tsconfig.text-types.json
+++ b/packages/ripple/tests/hydration/tsconfig.text-types.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "skipLibCheck": true
+  },
+  "include": ["components/typed-text.tsrx", "components/text-types.ts"]
+}

--- a/packages/ripple/tests/hydration/typed-text.test.js
+++ b/packages/ripple/tests/hydration/typed-text.test.js
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { flushSync as flush_sync, hydrate } from 'ripple';
+import { render } from 'ripple/server';
+import { container } from '../setup-hydration.js';
+import { TypedText as server_typed_text } from './compiled/server/typed-text.js';
+import { TypedText as client_typed_text } from './compiled/client/typed-text.js';
+
+describe('typed text hydration', () => {
+	it('reuses server text nodes and updates imported primitive types', async () => {
+		const { body } = await render(server_typed_text);
+		expect(body).toContain('&lt;first>');
+		container.innerHTML = body;
+		const run = container.querySelector('.typed-run');
+		const text = run.firstChild;
+		const number = container.querySelector('.typed-number').firstChild;
+		const tail = run.querySelector('span');
+		const unmount = hydrate(client_typed_text, { target: container });
+		try {
+			expect(container.querySelector('.typed-run')).toBe(run);
+			expect(run.firstChild).toBe(text);
+			expect(run.textContent).toBe('value: <first>2tail');
+			expect(container.querySelector('.typed-number').firstChild).toBe(number);
+			container.querySelector('button').click();
+			flush_sync();
+			expect(run.textContent).toBe('value: &next3tail');
+			expect(run.firstChild).toBe(text);
+			expect(run.querySelector('span')).toBe(tail);
+			expect(container.querySelector('.typed-number').firstChild).toBe(number);
+			expect(number.textContent).toBe('3');
+		} finally {
+			unmount();
+		}
+	});
+});

--- a/packages/tsrx-ripple/README.md
+++ b/packages/tsrx-ripple/README.md
@@ -1,0 +1,63 @@
+# @tsrx/ripple
+
+Ripple's compiler target for the published `@tsrx/core` language infrastructure.
+Use `compile(source, filename, options)` to produce client or server JavaScript.
+
+## Primitive text inference
+
+Ripple uses direct text updates for locally proven primitives, including typed
+local values, primitive operators, template strings, and unshadowed `String()`,
+`Number()`, `Boolean()`, `BigInt()`, and `Date()` calls. Sequences use the last
+expression's type while preserving evaluation of earlier expressions. Constructor
+calls such as `new Date()` remain object values. Visible replacements of built-ins
+disable their inferred conversion behavior; explicit `as string` keeps its
+existing text behavior.
+
+For imported types, aliases, function return types, and control-flow narrowing,
+Vite applications can enable
+`ripple({ textTypes: { tsconfig: 'tsconfig.json' } })`. The plugin manages the
+checker automatically; see the
+[Vite plugin guide](../vite-plugin/README.md#optional-typescript-text-inference).
+
+### Direct Compiler Usage
+
+The following example is for custom compiler integrations. Use the Node-only
+`@tsrx/ripple/typescript` entry point to manage TypeScript analysis yourself.
+Install TypeScript 5.9.3 or newer and enable `strictNullChecks` in the project.
+The ordinary compiler entry point does not load TypeScript.
+
+```js
+import { compile } from '@tsrx/ripple';
+import { createTextTypeProject as create_text_type_project } from '@tsrx/ripple/typescript';
+import { readFileSync as read_file_sync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const filename = resolve('src/App.tsrx');
+const source = read_file_sync(filename, 'utf8');
+const project = create_text_type_project({ tsconfig: 'tsconfig.json' });
+try {
+  const text_type_facts = project.getTextTypeFacts(filename, source);
+  const client = compile(source, filename, { textTypeFacts: text_type_facts });
+  const server = compile(source, filename, {
+    mode: 'server',
+    textTypeFacts: text_type_facts,
+  });
+  project.assertUnchanged();
+} finally {
+  project.dispose();
+}
+```
+
+Checker proofs cover primitive strings, numbers, bigints, and unions of those
+types. Unknown, nullable, boxed, object, and unresolved types retain local
+inference. The checker enables `noUncheckedIndexedAccess` so potentially missing
+entries do not become non-null text proofs. Ambiguous source mappings are skipped.
+
+Facts are serializable and tied to the exact filename and source version. Supply
+identical facts to client and server compilation: text classification affects
+hydration layout. Each project caches a filesystem snapshot without watchers. Call
+`invalidate()` after edits to reload the configuration and all imported types;
+recompile affected components even when their own source did not change.
+`assertUnchanged()` detects edits to files read by the current snapshot.
+
+The Vite plugin manages this lifecycle through its `textTypes` option.

--- a/packages/tsrx-ripple/package.json
+++ b/packages/tsrx-ripple/package.json
@@ -20,6 +20,10 @@
     },
     "./types/rpc": {
       "types": "./types/rpc.d.ts"
+    },
+    "./typescript": {
+      "types": "./types/typescript.d.ts",
+      "default": "./src/typescript.js"
     }
   },
   "dependencies": {
@@ -40,5 +44,13 @@
   "files": [
     "src",
     "types"
-  ]
+  ],
+  "peerDependencies": {
+    "typescript": ">=5.9.3"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
+  }
 }

--- a/packages/tsrx-ripple/package.json
+++ b/packages/tsrx-ripple/package.json
@@ -46,7 +46,7 @@
     "types"
   ],
   "peerDependencies": {
-    "typescript": ">=5.9.3"
+    "typescript": "catalog:peer"
   },
   "peerDependenciesMeta": {
     "typescript": {

--- a/packages/tsrx-ripple/src/analyze/index.js
+++ b/packages/tsrx-ripple/src/analyze/index.js
@@ -67,6 +67,7 @@ import {
 	is_tsrx_component_function,
 	has_lazy_pattern,
 	register_type_declarations,
+	record_text_intrinsic_write,
 	get_expression_type_annotation,
 	get_iterable_element_type_annotation,
 } from '../utils.js';
@@ -1651,6 +1652,23 @@ const visitors = {
 		next(scope !== undefined && scope !== state.scope ? { ...state, scope } : state);
 	},
 
+	AssignmentExpression(node, context) {
+		record_text_intrinsic_write(node.left, context.state.scope);
+		context.next();
+	},
+	UpdateExpression(node, context) {
+		record_text_intrinsic_write(node.argument, context.state.scope);
+		context.next();
+	},
+	UnaryExpression(node, context) {
+		if (node.operator === 'delete') record_text_intrinsic_write(node.argument, context.state.scope);
+		context.next();
+	},
+	TSDeclareFunction(node, context) {
+		record_text_intrinsic_write(node.id, context.state.scope);
+		context.next();
+	},
+
 	Program(_, context) {
 		return context.next({ ...context.state, function_depth: 0 });
 	},
@@ -1924,6 +1942,10 @@ const visitors = {
 	},
 
 	VariableDeclaration(node, context) {
+		if (node.declare)
+			for (const declaration of node.declarations) {
+				record_text_intrinsic_write(declaration.id, context.state.scope);
+			}
 		const { state, visit } = context;
 
 		for (const declarator of node.declarations) {
@@ -2068,6 +2090,7 @@ const visitors = {
 	},
 
 	ForOfStatement(node, context) {
+		record_text_intrinsic_write(node.left, context.state.scope);
 		if (context.state.regular_js || node.metadata?.regular_js) {
 			return context.next({ ...context.state, regular_js: true, component: undefined });
 		}
@@ -2448,6 +2471,7 @@ const visitors = {
 	},
 
 	ForInStatement(node, context) {
+		record_text_intrinsic_write(node.left, context.state.scope);
 		context.next();
 	},
 
@@ -2758,6 +2782,19 @@ const visitors = {
 	},
 
 	JSXExpressionContainer(node, context) {
+		const parent = context.path.at(-1);
+		const text_children = /** @type {AnalysisResult} */ (context.state.analysis)
+			.textChildExpressions;
+		if (
+			text_children &&
+			(parent?.type === 'JSXElement' || parent?.type === 'JSXFragment') &&
+			parent.children.includes(node) &&
+			node.expression.type !== 'JSXEmptyExpression'
+		) {
+			const expression = /** @type {AST.Expression} */ (node.expression);
+			text_children.set(`${expression.start}:${expression.end}`, { expression, container: node });
+		}
+
 		if (context.state.regular_js) {
 			return context.next();
 		}
@@ -2928,6 +2965,10 @@ export function analyze(ast, filename, options = {}) {
 		errors,
 		comments,
 		stylesheets: [],
+		textChildExpressions:
+			options.to_ts || ('textTypeFacts' in options && options.textTypeFacts !== undefined)
+				? new Map()
+				: undefined,
 	});
 
 	walk(

--- a/packages/tsrx-ripple/src/index.js
+++ b/packages/tsrx-ripple/src/index.js
@@ -5,6 +5,7 @@
 /** @import { NonEmptyString } from '@tsrx/core/types/helpers' */
 
 import { analyzeTsrx, createVolarMappingsResult, parseModule } from '@tsrx/core';
+import { register_text_type_facts } from './text-type-facts.js';
 import { analyze } from './analyze/index.js';
 import { transform_client } from './transform/client/index.js';
 import { transform_server } from './transform/server/index.js';
@@ -47,6 +48,13 @@ export function compile(source, filename, options = {}) {
 		filename,
 		collect ? { ...options, collect, errors, comments } : options,
 	);
+	register_text_type_facts(
+		analysis.textChildExpressions,
+		source,
+		filename,
+		analysis.scope,
+		options.textTypeFacts,
+	);
 	const result =
 		options.mode === 'server'
 			? transform_server(
@@ -81,7 +89,6 @@ export function compile(source, filename, options = {}) {
  * @param {string} source
  * @param {string} filename
  * @param {{collect?: boolean, loose?: boolean, minify_css?: boolean}} [options]
- * @returns {object}
  */
 export function compile_to_volar_mappings(source, filename, options = {}) {
 	const errors = /** @type {CompileError[]} */ ([]);
@@ -117,17 +124,20 @@ export function compile_to_volar_mappings(source, filename, options = {}) {
 		options?.minify_css ?? false,
 	);
 
-	return createVolarMappingsResult({
-		ast: transformed.ast,
-		// Mapping generation walks the pristine source shapes. Analysis and the
-		// transform are copy-on-write — they rebuild their own tree and never
-		// mutate the parse tree — so the parsed AST *is* the source view.
-		ast_from_source: ast,
-		source,
-		generated_code: transformed.code,
-		source_map: transformed.map,
-		post_processing_changes: transformed.post_processing_changes,
-		line_offsets: transformed.line_offsets,
-		errors: transformed.errors,
-	});
+	return {
+		...createVolarMappingsResult({
+			ast: transformed.ast,
+			// Mapping generation walks the pristine source shapes. Analysis and the
+			// transform are copy-on-write — they rebuild their own tree and never
+			// mutate the parse tree — so the parsed AST *is* the source view.
+			ast_from_source: ast,
+			source,
+			generated_code: transformed.code,
+			source_map: transformed.map,
+			post_processing_changes: transformed.post_processing_changes,
+			line_offsets: transformed.line_offsets,
+			errors: transformed.errors,
+		}),
+		textChildExpressions: analysis.textChildExpressions ?? new Map(),
+	};
 }

--- a/packages/tsrx-ripple/src/text-type-facts.js
+++ b/packages/tsrx-ripple/src/text-type-facts.js
@@ -1,0 +1,67 @@
+// @ts-check
+
+/** @import * as AST from 'estree' */
+/** @import { ScopeInterface, TextTypeFacts } from '../types/index' */
+import { strongHash as strong_hash } from '@tsrx/core';
+
+/** @type {WeakMap<object, { strings: Set<string>, primitives: Set<string> }>} */
+const facts_by_root = new WeakMap();
+
+/**
+ * Validate externally supplied facts before either transform can consume them.
+ * @param {Map<string, unknown> | undefined} children
+ * @param {string} source
+ * @param {string} filename
+ * @param {ScopeInterface} scope
+ * @param {TextTypeFacts | undefined} facts
+ */
+export function register_text_type_facts(children, source, filename, scope, facts) {
+	if (facts === undefined) return;
+	const invalid = () => {
+		throw new Error(`Invalid textTypeFacts for ${JSON.stringify(filename)}`);
+	};
+	if (
+		!facts ||
+		facts.version !== 1 ||
+		facts.filename !== filename ||
+		facts.sourceVersion !== strong_hash(source) ||
+		typeof facts.projectVersion !== 'string' ||
+		!facts.projectVersion
+	)
+		invalid();
+	/** @param {readonly (readonly [number, number])[]} ranges */
+	const validate = (ranges) => {
+		if (!Array.isArray(ranges)) return invalid();
+		const keys = new Set();
+		for (const range of ranges) {
+			if (
+				!Array.isArray(range) ||
+				range.length !== 2 ||
+				!range.every(Number.isSafeInteger) ||
+				range[0] < 0 ||
+				range[1] <= range[0] ||
+				range[1] > source.length ||
+				!children?.has(`${range[0]}:${range[1]}`)
+			)
+				invalid();
+			keys.add(`${range[0]}:${range[1]}`);
+		}
+		return keys;
+	};
+	facts_by_root.set(scope.root, {
+		strings: validate(facts.stringChildRanges),
+		primitives: validate(facts.primitiveTextChildRanges),
+	});
+}
+
+/**
+ * @param {AST.Expression} expression
+ * @param {ScopeInterface} scope
+ * @param {boolean} strings_only
+ */
+export function has_text_type_fact(expression, scope, strings_only) {
+	const facts = facts_by_root.get(scope.root);
+	if (!facts) return false;
+	const key = `${expression.start}:${expression.end}`;
+	return facts?.strings.has(key) || (!strings_only && facts?.primitives.has(key)) || false;
+}

--- a/packages/tsrx-ripple/src/text-type-facts.js
+++ b/packages/tsrx-ripple/src/text-type-facts.js
@@ -8,8 +8,23 @@ import { strongHash as strong_hash } from '@tsrx/core';
 const facts_by_root = new WeakMap();
 
 /**
+ * Volar preserves parentheses for source mappings; ordinary compilation omits
+ * them. Only unwrap outer parentheses so both parses identify the same child,
+ * without accepting a proof for an arbitrary nested expression.
+ * @param {AST.Expression} expression
+ * @returns {[number, number] | undefined}
+ */
+export function get_text_type_range(expression) {
+	while (expression.type === 'ParenthesizedExpression') {
+		expression = /** @type {AST.Expression} */ (expression.expression);
+	}
+	if (expression.start === undefined || expression.end === undefined) return undefined;
+	return [expression.start, expression.end];
+}
+
+/**
  * Validate externally supplied facts before either transform can consume them.
- * @param {Map<string, unknown> | undefined} children
+ * @param {Map<string, { expression: AST.Expression }> | undefined} children
  * @param {string} source
  * @param {string} filename
  * @param {ScopeInterface} scope
@@ -29,6 +44,11 @@ export function register_text_type_facts(children, source, filename, scope, fact
 		!facts.projectVersion
 	)
 		invalid();
+	const child_ranges = new Set();
+	for (const { expression } of children?.values() ?? []) {
+		const range = get_text_type_range(expression);
+		if (range) child_ranges.add(`${range[0]}:${range[1]}`);
+	}
 	/** @param {readonly (readonly [number, number])[]} ranges */
 	const validate = (ranges) => {
 		if (!Array.isArray(ranges)) return invalid();
@@ -41,7 +61,7 @@ export function register_text_type_facts(children, source, filename, scope, fact
 				range[0] < 0 ||
 				range[1] <= range[0] ||
 				range[1] > source.length ||
-				!children?.has(`${range[0]}:${range[1]}`)
+				!child_ranges.has(`${range[0]}:${range[1]}`)
 			)
 				invalid();
 			keys.add(`${range[0]}:${range[1]}`);

--- a/packages/tsrx-ripple/src/transform/client/index.js
+++ b/packages/tsrx-ripple/src/transform/client/index.js
@@ -3868,6 +3868,13 @@ const visitors = {
 		return context.next();
 	},
 
+	TSSatisfiesExpression(node, context) {
+		if (!context.state.to_ts) {
+			return context.visit(/** @type {AST.Expression} */ (node.expression));
+		}
+		return context.next();
+	},
+
 	TSAsExpression(node, context) {
 		if (!context.state.to_ts) {
 			return context.visit(/** @type {AST.Expression} */ (node.expression));

--- a/packages/tsrx-ripple/src/transform/server/index.js
+++ b/packages/tsrx-ripple/src/transform/server/index.js
@@ -2046,6 +2046,13 @@ const visitors = {
 		};
 	},
 
+	TSSatisfiesExpression(node, context) {
+		if (!context.state.to_ts) {
+			return context.visit(/** @type {AST.Expression} */ (node.expression));
+		}
+		return context.next();
+	},
+
 	TSAsExpression(node, context) {
 		if (!context.state.to_ts) {
 			return context.visit(node.expression);

--- a/packages/tsrx-ripple/src/typescript.js
+++ b/packages/tsrx-ripple/src/typescript.js
@@ -1,0 +1,255 @@
+// @ts-check
+
+/** @import { TextTypeFacts } from '../types/index' */
+import path from 'node:path';
+import ts from 'typescript';
+import { strongHash as strong_hash } from '@tsrx/core';
+import { compile_to_volar_mappings } from './index.js';
+
+let generation = 0;
+
+/**
+ * Node-only, Ripple-specific text analysis over the target's existing virtual
+ * TypeScript output. No checker is loaded by the ordinary compiler entry point.
+ * Each project is a fixed filesystem snapshot; invalidate before reusing it
+ * after edits, and use identical facts for both rendering modes.
+ * @param {{ tsconfig: string }} options
+ */
+function create_text_type_project({ tsconfig }) {
+	const config_path = path.resolve(tsconfig);
+	/** @type {Map<string, string | undefined>} */
+	let files;
+	/** @type {Map<string, ReturnType<typeof compile_to_volar_mappings>>} */
+	let virtuals;
+	/** @type {Map<string, TextTypeFacts>} */
+	let facts;
+	/** @type {ts.ParsedCommandLine} */
+	let config;
+	/** @type {ts.Program | undefined} */
+	let program;
+	let project_version = '';
+	let disposed = false;
+
+	/** @param {string} filename */
+	function read(filename) {
+		filename = path.resolve(filename);
+		if (!files.has(filename)) files.set(filename, ts.sys.readFile(filename));
+		return files.get(filename);
+	}
+
+	function invalidate() {
+		if (disposed) throw new Error('Text type project has been disposed');
+		files = new Map();
+		virtuals = new Map();
+		facts = new Map();
+		program = undefined;
+		project_version = String(++generation);
+		const loaded = ts.readConfigFile(config_path, read);
+		if (loaded.error)
+			throw new Error(ts.flattenDiagnosticMessageText(loaded.error.messageText, '\n'));
+		config = ts.parseJsonConfigFileContent(
+			loaded.config,
+			{ ...ts.sys, readFile: read },
+			path.dirname(config_path),
+			undefined,
+			config_path,
+			undefined,
+			[{ extension: '.tsrx', isMixedContent: true, scriptKind: ts.ScriptKind.TSX }],
+		);
+		const errors = config.errors.filter((error) => error.code !== 18003);
+		if (errors.length)
+			throw new Error(
+				errors.map((error) => ts.flattenDiagnosticMessageText(error.messageText, '\n')).join('\n'),
+			);
+		// A non-null string proof is only meaningful with strict null checking.
+		if (!(config.options.strictNullChecks ?? config.options.strict)) {
+			throw new Error('Ripple textTypes requires strictNullChecks in the TypeScript project');
+		}
+		config.options = {
+			...config.options,
+			noEmit: true,
+			noUncheckedIndexedAccess: true,
+			jsx: ts.JsxEmit.Preserve,
+			allowNonTsExtensions: true,
+		};
+	}
+
+	/** @param {string} filename */
+	function virtual(filename) {
+		let result = virtuals.get(filename);
+		if (!result) {
+			const source = read(filename);
+			if (source === undefined) return undefined;
+			result = compile_to_volar_mappings(source, filename);
+			virtuals.set(filename, result);
+		}
+		return result;
+	}
+
+	/** @param {string} filename */
+	const virtual_name = (filename) => (filename.endsWith('.tsrx') ? `${filename}.tsx` : filename);
+	/** @param {string} filename */
+	const source_name = (filename) =>
+		filename.endsWith('.tsrx.tsx') ? filename.slice(0, -4) : filename;
+
+	/** @param {string} filename */
+	function ensure_program(filename) {
+		const name = virtual_name(filename);
+		if (program?.getSourceFile(name)) return program;
+		const host = ts.createCompilerHost(config.options);
+		host.readFile = (file) =>
+			file.endsWith('.tsrx.tsx') ? virtual(source_name(file))?.code : read(file);
+		host.fileExists = (file) => read(source_name(file)) !== undefined;
+		// TypeScript's default getSourceFile closes over the system reader.
+		host.getSourceFile = (file, language_version) => {
+			const text = host.readFile(file);
+			return text === undefined
+				? undefined
+				: ts.createSourceFile(file, text, language_version, true);
+		};
+		const roots = new Set(program?.getRootFileNames() ?? config.fileNames.map(virtual_name));
+		roots.add(name);
+		program = ts.createProgram({ rootNames: [...roots], options: config.options, host });
+		return program;
+	}
+
+	/**
+	 * @param {ts.Type} type
+	 * @param {boolean} strings_only
+	 * @returns {boolean}
+	 */
+	function is_primitive(type, strings_only) {
+		if (type.isUnion()) return type.types.every((member) => is_primitive(member, strings_only));
+		return !!(
+			type.flags &
+			(strings_only
+				? ts.TypeFlags.StringLike
+				: ts.TypeFlags.StringLike | ts.TypeFlags.NumberLike | ts.TypeFlags.BigIntLike)
+		);
+	}
+
+	/**
+	 * @param {string} filename
+	 * @param {string} [source] Exact source being sent to the compiler.
+	 * @returns {TextTypeFacts}
+	 */
+	function get_text_type_facts(filename, source) {
+		if (disposed) throw new Error('Text type project has been disposed');
+		filename = path.resolve(filename);
+		const disk_source = read(filename);
+		if (disk_source === undefined) throw new Error(`Cannot read ${filename}`);
+		if (source !== undefined && source !== disk_source) {
+			throw new Error(`Text type source differs from project snapshot: ${filename}`);
+		}
+		const cached = facts.get(filename);
+		if (cached) return cached;
+		const current = ensure_program(filename);
+		const mapped = virtual(filename);
+		const file = current.getSourceFile(virtual_name(filename));
+		if (!mapped || !file) throw new Error(`Cannot analyze ${filename}`);
+		const checker = current.getTypeChecker();
+		/** @type {Map<string, ts.Expression[]>} */
+		const expressions = new Map();
+		// This visits the TypeScript tree, not the TSRX AST. Authored child
+		// ranges were collected by Ripple's existing analysis visitors.
+		/** @param {ts.Node} node */
+		function visit(node) {
+			if (
+				ts.isJsxExpression(node) &&
+				node.expression &&
+				(ts.isJsxElement(node.parent) || ts.isJsxFragment(node.parent))
+			) {
+				const expression = node.expression;
+				const key = `${expression.getStart(file)}:${expression.end}`;
+				const entries = expressions.get(key) ?? [];
+				entries.push(expression);
+				expressions.set(key, entries);
+				expressions.set(`${node.getStart(file)}:${node.end}`, entries);
+			}
+			ts.forEachChild(node, visit);
+		}
+		visit(file);
+		/** @type {TextTypeFacts} */
+		const result = {
+			version: 1,
+			filename,
+			sourceVersion: strong_hash(disk_source),
+			projectVersion: project_version,
+			stringChildRanges: [],
+			primitiveTextChildRanges: [],
+		};
+		/** @type {[number, number][]} */
+		const strings = [];
+		/** @type {[number, number][]} */
+		const primitives = [];
+		const diagnostics = current.getSyntacticDiagnostics(file);
+		if (!mapped.errors.length && !diagnostics.length) {
+			// Only exact expression mappings qualify. Ambiguous/generated mappings
+			// must not grant a proof to a different authored expression.
+			const candidates = new Map();
+			const source_ranges = new Map();
+			for (const [key, { container }] of mapped.textChildExpressions) {
+				source_ranges.set(key, key);
+				if (container?.type === 'JSXExpressionContainer') {
+					source_ranges.set(`${container.start}:${container.end}`, key);
+				}
+			}
+			for (const mapping of mapped.mappings) {
+				for (let i = 0; i < mapping.sourceOffsets.length; i++) {
+					const start = mapping.sourceOffsets[i];
+					const end = start + mapping.lengths[i];
+					const key = source_ranges.get(`${start}:${end}`);
+					if (!key) continue;
+					const generated_start = mapping.generatedOffsets[i];
+					const generated_end =
+						generated_start + (mapping.generatedLengths?.[i] ?? mapping.lengths[i]);
+					const nodes = expressions.get(`${generated_start}:${generated_end}`);
+					if (!nodes) continue;
+					const set = candidates.get(key) ?? new Set();
+					for (const node of nodes) set.add(node);
+					candidates.set(key, set);
+				}
+			}
+			for (const [key, nodes] of candidates) {
+				if (nodes.size !== 1) continue;
+				const type = checker.getTypeAtLocation([...nodes][0]);
+				const expression = mapped.textChildExpressions.get(key)?.expression;
+				if (!expression || expression.start === undefined || expression.end === undefined) continue;
+				const range = /** @type {[number, number]} */ ([expression.start, expression.end]);
+				if (is_primitive(type, true)) strings.push(range);
+				else if (is_primitive(type, false)) primitives.push(range);
+			}
+		}
+		result.stringChildRanges = strings;
+		result.primitiveTextChildRanges = primitives;
+		facts.set(filename, result);
+		return result;
+	}
+
+	function assert_unchanged() {
+		if (disposed) throw new Error('Text type project has been disposed');
+		for (const [filename, source] of files) {
+			if (ts.sys.readFile(filename) !== source) {
+				throw new Error(`Text type project changed during build: ${filename}`);
+			}
+		}
+	}
+
+	function dispose() {
+		program = undefined;
+		files.clear();
+		virtuals.clear();
+		facts.clear();
+		disposed = true;
+	}
+
+	invalidate();
+	return {
+		getTextTypeFacts: get_text_type_facts,
+		invalidate,
+		assertUnchanged: assert_unchanged,
+		dispose,
+	};
+}
+
+export { create_text_type_project as createTextTypeProject };

--- a/packages/tsrx-ripple/src/typescript.js
+++ b/packages/tsrx-ripple/src/typescript.js
@@ -5,6 +5,7 @@ import path from 'node:path';
 import ts from 'typescript';
 import { strongHash as strong_hash } from '@tsrx/core';
 import { compile_to_volar_mappings } from './index.js';
+import { get_text_type_range } from './text-type-facts.js';
 
 let generation = 0;
 
@@ -214,8 +215,8 @@ function create_text_type_project({ tsconfig }) {
 				if (nodes.size !== 1) continue;
 				const type = checker.getTypeAtLocation([...nodes][0]);
 				const expression = mapped.textChildExpressions.get(key)?.expression;
-				if (!expression || expression.start === undefined || expression.end === undefined) continue;
-				const range = /** @type {[number, number]} */ ([expression.start, expression.end]);
+				const range = expression && get_text_type_range(expression);
+				if (!range) continue;
 				if (is_primitive(type, true)) strings.push(range);
 				else if (is_primitive(type, false)) primitives.push(range);
 			}

--- a/packages/tsrx-ripple/src/utils.js
+++ b/packages/tsrx-ripple/src/utils.js
@@ -24,6 +24,7 @@ import {
 	simpleHash,
 	strongHash,
 } from '@tsrx/core';
+import { has_text_type_fact } from './text-type-facts.js';
 import {
 	get_element_id,
 	get_element_identifier,
@@ -2144,18 +2145,6 @@ export function normalize_children(children, context) {
 export function expression_contains_call(expression) {
 	switch (expression.type) {
 		case 'CallExpression':
-			if (
-				expression.callee.type === 'Identifier' &&
-				expression.callee.name === 'String' &&
-				!expression.optional
-			) {
-				return expression.arguments.some((argument) => {
-					if (argument.type === 'SpreadElement') {
-						return true;
-					}
-					return expression_contains_call(argument);
-				});
-			}
 			return true;
 
 		case 'NewExpression':
@@ -3306,6 +3295,62 @@ export function is_text_primitive_literal(expression) {
 	);
 }
 
+const text_intrinsics = new Set(['String', 'Number', 'Boolean', 'BigInt', 'Date']);
+/** @type {WeakMap<object, Set<string>>} */
+const unsafe_text_intrinsics_by_root = new WeakMap();
+
+/**
+ * Called by the existing analysis visitors for writes and ambient declarations.
+ * Disable affected intrinsic names throughout the module, including calls that
+ * precede the write in source order.
+ * @param {AST.Node | null | undefined} target
+ * @param {ScopeInterface} scope
+ */
+export function record_text_intrinsic_write(target, scope) {
+	if (!target) return;
+	let unsafe = unsafe_text_intrinsics_by_root.get(scope.root);
+	if (!unsafe) unsafe_text_intrinsics_by_root.set(scope.root, (unsafe = new Set()));
+	switch (target.type) {
+		case 'Identifier':
+			if (text_intrinsics.has(target.name)) unsafe.add(target.name);
+			break;
+		case 'MemberExpression': {
+			const name = get_static_property_name(target);
+			if (
+				target.object.type === 'Identifier' &&
+				['globalThis', 'window', 'self', 'global'].includes(target.object.name)
+			) {
+				if (name === null) for (const intrinsic of text_intrinsics) unsafe.add(intrinsic);
+				else if (text_intrinsics.has(name)) unsafe.add(name);
+			}
+			break;
+		}
+		case 'ObjectPattern':
+			for (const property of target.properties) {
+				record_text_intrinsic_write(
+					property.type === 'RestElement' ? property.argument : property.value,
+					scope,
+				);
+			}
+			break;
+		case 'ArrayPattern':
+			for (const element of target.elements) record_text_intrinsic_write(element, scope);
+			break;
+		case 'AssignmentPattern':
+			record_text_intrinsic_write(target.left, scope);
+			break;
+		case 'RestElement':
+			record_text_intrinsic_write(target.argument, scope);
+			break;
+		case 'TSAsExpression':
+		case 'TSNonNullExpression':
+		case 'TSTypeAssertion':
+		case 'ParenthesizedExpression':
+			record_text_intrinsic_write(target.expression, scope);
+			break;
+	}
+}
+
 /**
  * Whether the expression provably evaluates to a text primitive — a string,
  * number, boolean, bigint, null, or undefined. These render as plain escaped
@@ -3330,6 +3375,12 @@ export function is_text_primitive_expression(
 	visited = new Set(),
 	strings_only = false,
 ) {
+	if (
+		!unsafe_text_intrinsics_by_root.get(state.scope.root)?.size &&
+		has_text_type_fact(expression, state.scope, strings_only)
+	)
+		return true;
+
 	if (expression.type === 'ParenthesizedExpression' || expression.type === 'ChainExpression') {
 		return is_text_primitive_expression(
 			/** @type {AST.Expression} */ (expression.expression),
@@ -3353,7 +3404,8 @@ export function is_text_primitive_expression(
 
 	if (
 		expression.type === 'TSNonNullExpression' ||
-		expression.type === 'TSInstantiationExpression'
+		expression.type === 'TSInstantiationExpression' ||
+		expression.type === 'TSSatisfiesExpression'
 	) {
 		return is_text_primitive_expression(
 			/** @type {AST.Expression} */ (expression.expression),
@@ -3375,10 +3427,16 @@ export function is_text_primitive_expression(
 
 	if (
 		expression.type === 'CallExpression' &&
+		!expression.optional &&
 		expression.callee.type === 'Identifier' &&
+		state.scope.get(expression.callee.name) === null &&
+		!unsafe_text_intrinsics_by_root.get(state.scope.root)?.has(expression.callee.name) &&
 		(expression.callee.name === 'String' ||
+			expression.callee.name === 'Date' ||
 			(!strings_only &&
-				(expression.callee.name === 'Number' || expression.callee.name === 'Boolean')))
+				(expression.callee.name === 'Number' ||
+					expression.callee.name === 'BigInt' ||
+					expression.callee.name === 'Boolean')))
 	) {
 		return true;
 	}
@@ -3409,6 +3467,11 @@ export function is_text_primitive_expression(
 		return !strings_only;
 	}
 
+	if (expression.type === 'SequenceExpression') {
+		const last = expression.expressions.at(-1);
+		return !!last && is_text_primitive_expression(last, state, visited, strings_only);
+	}
+
 	// `&&`/`||`/`??` return one of their operands, so both must be proven.
 	if (expression.type === 'LogicalExpression') {
 		return (
@@ -3429,7 +3492,7 @@ export function is_text_primitive_expression(
 	}
 
 	if (expression.type === 'Identifier') {
-		if (expression.name === 'undefined') {
+		if (expression.name === 'undefined' && state.scope.get('undefined') === null) {
 			return !strings_only;
 		}
 		const binding = state.scope.get(expression.name);
@@ -3440,11 +3503,10 @@ export function is_text_primitive_expression(
 			return true;
 		}
 		if (binding.initial && !binding.reassigned && !binding.mutated && !binding.updated) {
-			visited.add(binding);
 			return is_text_primitive_expression(
 				/** @type {AST.Expression} */ (binding.initial),
-				state,
-				visited,
+				{ ...state, scope: binding.scope },
+				new Set(visited).add(binding),
 				strings_only,
 			);
 		}

--- a/packages/tsrx-ripple/tests/text-inference.test.js
+++ b/packages/tsrx-ripple/tests/text-inference.test.js
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import { compile } from '@tsrx/ripple';
+
+function output(expression, setup = '', params = 'props') {
+	const source = `export function App(${params}) @{ ${setup} <div>before{${expression}}after</div> }`;
+	return ['client', 'server'].map((mode) => compile(source, 'App.tsrx', { mode }).code);
+}
+
+function expect_text(expression, setup, params) {
+	const [client, server] = output(expression, setup, params);
+	expect(client).not.toMatch(/_\$_\.expression(?:_children)?\(/);
+	expect(server).not.toContain('_$_.render_expression(');
+	expect(server).toContain('_$_.escape(');
+	return { client, server };
+}
+
+function expect_renderable(expression, setup, params) {
+	const [client, server] = output(expression, setup, params);
+	expect(client).toContain('_$_.expression(');
+	expect(server).toContain('_$_.render_expression(');
+}
+
+describe('primitive text inference', () => {
+	it.each([
+		'String(props.value)',
+		'Number(props.value)',
+		'Boolean(props.value)',
+		'BigInt(props.value)',
+		'Date()',
+		'typeof props.value',
+		'props.value - 1',
+		'props.value + 1',
+		'props.value ** 2',
+		'~props.value',
+		'props.value > 0',
+		'void props.call()',
+		'(props.call(), BigInt(props.value))',
+		'props.flag ? BigInt(props.value) : Number(props.value)',
+		'BigInt(props.value) || 1n',
+		'BigInt(props.value) satisfies bigint',
+	])('uses text output for %s on client and server', (expression) => {
+		expect_text(expression);
+	});
+
+	it.each(['String', 'Number', 'Boolean', 'BigInt', 'Date'])('respects a shadowed %s', (name) => {
+		expect_renderable(`${name}()`, `const ${name} = props.render;`);
+		expect_renderable(`${name}()`, '', `{ ${name} }`);
+		expect_renderable(`${name}()`, `function ${name}() { return props.render(); }`);
+	});
+
+	it.each(['String', 'Number', 'Boolean', 'BigInt', 'Date'])(
+		'respects visible writes to %s',
+		(name) => {
+			for (const target of [name, `globalThis.${name}`, `window['${name}']`]) {
+				expect_renderable(`${name}()`, `${target} = props.render;`);
+			}
+			expect_renderable(`${name}()`, `({ replacement: ${name} } = props);`);
+			expect_renderable(`${name}()`, `declare function ${name}(): unknown;`);
+		},
+	);
+
+	it.each([
+		'new Date()',
+		'new Number(1)',
+		'new String(1)',
+		'props.render()',
+		'props.flag ? BigInt(1) : props.render()',
+		'(BigInt(1), props.render())',
+		'String?.(props.value)',
+		'BigInt?.(props.value)',
+	])('keeps %s on the renderable path', (expression) => expect_renderable(expression));
+
+	it('keeps numeric evidence separate from string concatenation', () => {
+		const { server } = expect_text('Number(props.a) + Number(props.b)');
+		expect(server).toContain("String(Number(props.a) + Number(props.b) ?? '')");
+	});
+
+	it('proves repeated references without treating sibling branches as cycles', () => {
+		const { server } = expect_text('props.flag ? label : label', "const label = 'text';");
+		expect(server).not.toContain('String(props.flag');
+	});
+
+	it('resolves an initializer in its declaring scope', () => {
+		const { code } = compile(
+			`const value = opaque;
+			export function App() @{ const opaque = 'local'; <div>{value}</div> }`,
+			'App.tsrx',
+			{ mode: 'server' },
+		);
+		expect(code).toContain('_$_.render_expression(value');
+	});
+
+	it('erases satisfies while preserving its expression and side effects', () => {
+		const { client, server } = expect_text('(props.call(), BigInt(props.value) satisfies bigint)');
+		for (const code of [client, server]) {
+			expect(code).not.toContain('satisfies');
+			expect(code).toContain('props.call()');
+			expect(code).toContain('BigInt(props.value)');
+		}
+	});
+});

--- a/packages/tsrx-ripple/tests/typescript-text.test.js
+++ b/packages/tsrx-ripple/tests/typescript-text.test.js
@@ -75,6 +75,52 @@ describe('TypeScript text project', () => {
 		project.assertUnchanged();
 	});
 
+	it.each([
+		['(props.label)', 'props.label', 'strings'],
+		['((props.label))', 'props.label', 'strings'],
+		['((props.value))', 'props.value', 'primitives'],
+		['((props.big))', 'props.big', 'primitives'],
+		['(props.effect(), props.value)', 'props.effect(), props.value', 'primitives'],
+		['((props.effect(), props.value))', 'props.effect(), props.value', 'primitives'],
+		['( /* before */ props.label /* after */ )', 'props.label', 'strings'],
+	])('compiles checker proofs for parenthesized child %s', (child, expected, kind) => {
+		const source = `import type { Props } from './types';
+			export function App(props: Props) @{ <p>{${child}}</p> }`;
+		const { project, filename } = fixture(
+			source,
+			`export interface Props {
+			label: string; value: number; big: bigint; effect(): void;
+		}`,
+		);
+		const facts = JSON.parse(JSON.stringify(project.getTextTypeFacts(filename)));
+		expect(expressions(source, facts)).toEqual({
+			strings: kind === 'strings' ? [expected] : [],
+			primitives: kind === 'primitives' ? [expected] : [],
+		});
+		for (const mode of ['client', 'server']) {
+			for (const options of [{}, { collect: true }, { collect: true, preserveParens: true }]) {
+				const { code } = compile(source, filename, { ...options, mode, textTypeFacts: facts });
+				expect(code).not.toContain('_$_.render_expression(');
+				expect(code).not.toContain('_$_.expression_children(');
+				if (child.includes('props.effect()')) {
+					expect(code).toContain('props.effect()');
+					// A proof for only the last operand is not a proof for the child.
+					const start = source.lastIndexOf('props.value');
+					expect(() =>
+						compile(source, filename, {
+							...options,
+							mode,
+							textTypeFacts: {
+								...facts,
+								primitiveTextChildRanges: [[start, start + 'props.value'.length]],
+							},
+						}),
+					).toThrow('Invalid textTypeFacts');
+				}
+			}
+		}
+	});
+
 	it('rejects uncertain domains and missing indexed values', () => {
 		const names = [
 			'any',

--- a/packages/tsrx-ripple/tests/typescript-text.test.js
+++ b/packages/tsrx-ripple/tests/typescript-text.test.js
@@ -1,0 +1,208 @@
+import { afterEach as after_each, describe, expect, it } from 'vitest';
+import {
+	mkdtempSync as mkdtemp_sync,
+	rmSync as rm_sync,
+	writeFileSync as write_file_sync,
+} from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { compile } from '@tsrx/ripple';
+import { createTextTypeProject as create_text_type_project } from '../src/typescript.js';
+
+const cleanups = [];
+after_each(() => {
+	for (const cleanup of cleanups.splice(0).reverse()) cleanup();
+});
+
+function fixture(source, types = '', options = {}) {
+	const root = mkdtemp_sync(path.join(os.tmpdir(), 'ripple-text-'));
+	cleanups.push(() => rm_sync(root, { recursive: true, force: true }));
+	const filename = path.join(root, 'App.tsrx');
+	const tsconfig = path.join(root, 'tsconfig.json');
+	write_file_sync(
+		tsconfig,
+		JSON.stringify({
+			compilerOptions: {
+				strict: true,
+				target: 'ESNext',
+				module: 'ESNext',
+				moduleResolution: 'Bundler',
+				...options,
+			},
+		}),
+	);
+	write_file_sync(filename, source);
+	write_file_sync(path.join(root, 'types.ts'), types);
+	const project = create_text_type_project({ tsconfig });
+	cleanups.push(() => project.dispose());
+	return { root, filename, project, tsconfig };
+}
+
+function expressions(source, facts) {
+	return {
+		strings: facts.stringChildRanges.map(([start, end]) => source.slice(start, end)),
+		primitives: facts.primitiveTextChildRanges.map(([start, end]) => source.slice(start, end)),
+	};
+}
+
+describe('TypeScript text project', () => {
+	it('proves imported aliases, member reads, destructuring, calls, and primitive unions', () => {
+		const source = `import type { Props } from './types';
+			import { count } from './types';
+			export function App(props: Props) @{
+				const { label } = props;
+				<><p>{props.label}</p><p>{label}</p><p>{props.value}</p><p>{count()}</p></>
+			}`;
+		const { project, filename } = fixture(
+			source,
+			`export type Text = string;
+			export interface Props { label: Text; value: number | bigint | string; }
+			export function count(): number { return 1; }`,
+		);
+		const facts = project.getTextTypeFacts(filename, source);
+		expect(expressions(source, facts)).toEqual({
+			strings: ['props.label', 'label'],
+			primitives: ['props.value', 'count()'],
+		});
+		for (const mode of ['client', 'server']) {
+			const { code } = compile(source, filename, { mode, textTypeFacts: facts });
+			expect(code).not.toMatch(/_\$_\.render_expression\((?:props\.|label|count\()/);
+			expect(code).not.toContain('_$_.expression_children(');
+		}
+		expect(compile(source, filename, { mode: 'server' }).code).toContain(
+			'_$_.render_expression(props.label',
+		);
+		project.assertUnchanged();
+	});
+
+	it('rejects uncertain domains and missing indexed values', () => {
+		const names = [
+			'any',
+			'unknown',
+			'never',
+			'boxed',
+			'mixed',
+			'nullable',
+			'optional',
+			'flag',
+			'object',
+		];
+		const source = `import type { Props } from './types';
+			export function App(props: Props) @{ <>
+			${names.map((name) => `<p>{props.${name}}</p>`).join('')}
+			<p>{props.list[0]}</p><p>{props.dict['key']}</p></> }`;
+		const { project, filename } = fixture(
+			source,
+			`export interface Props {
+			any: any; unknown: unknown; never: never; boxed: String; mixed: string | object;
+			nullable: number | null; optional?: string; flag: boolean; object: Date;
+			list: string[]; dict: Record<string, number>;
+		}`,
+		);
+		expect(expressions(source, project.getTextTypeFacts(filename))).toEqual({
+			strings: [],
+			primitives: [],
+		});
+	});
+
+	it('uses narrowing inside a template branch', () => {
+		const source = `import type { Props } from './types';
+			export function App(props: Props) @{ <>
+			@if (typeof props.value === 'string') { <p>{props.value}</p> }
+			<p>{props.value}</p></> }`;
+		const { project, filename } = fixture(
+			source,
+			'export interface Props { value: string | object }',
+		);
+		expect(expressions(source, project.getTextTypeFacts(filename))).toEqual({
+			strings: ['props.value'],
+			primitives: [],
+		});
+	});
+
+	it('resolves types exported from another TSRX module', () => {
+		const source = `import type { Props } from './other.tsrx';
+			export function App(props: Props) @{ <p>{props.value}</p> }`;
+		const { project, root, filename } = fixture(source);
+		write_file_sync(
+			path.join(root, 'other.tsrx'),
+			'export interface Props { value: number } export function Other() { return <b />; }',
+		);
+		expect(expressions(source, project.getTextTypeFacts(filename))).toEqual({
+			strings: [],
+			primitives: ['props.value'],
+		});
+	});
+
+	it('invalidates unchanged components when imported types change', () => {
+		const source = `import type { Props } from './types';
+			export function App(props: Props) @{ <p>{props.value}</p> }`;
+		const { project, root, filename } = fixture(source, 'export interface Props { value: number }');
+		const before = project.getTextTypeFacts(filename);
+		expect(before.primitiveTextChildRanges).toHaveLength(1);
+		write_file_sync(path.join(root, 'types.ts'), 'export interface Props { value: object }');
+		expect(() => project.assertUnchanged()).toThrow('changed during build');
+		project.invalidate();
+		const after = project.getTextTypeFacts(filename);
+		expect(after.primitiveTextChildRanges).toHaveLength(0);
+		expect(after.projectVersion).not.toBe(before.projectVersion);
+		project.assertUnchanged();
+	});
+
+	it('requires strictNullChecks and reloads configuration on invalidation', () => {
+		const { project, tsconfig } = fixture('export function App() { return <p />; }');
+		write_file_sync(tsconfig, JSON.stringify({ compilerOptions: { strict: false } }));
+		expect(() => project.invalidate()).toThrow('strictNullChecks');
+	});
+
+	it('refuses transformed or stale source and disposed projects', () => {
+		const source = 'export function App() { return <p />; }';
+		const { project, filename } = fixture(source);
+		expect(() => project.getTextTypeFacts(filename, source + ' ')).toThrow(
+			'differs from project snapshot',
+		);
+		project.dispose();
+		expect(() => project.getTextTypeFacts(filename)).toThrow('disposed');
+	});
+
+	it('ignores type proofs when a global constructor is visibly replaced', () => {
+		const source = `Number = (() => <b />) as any;
+			export function App() @{ <p>{Number(1)}</p> }`;
+		const { project, filename } = fixture(source);
+		const facts = project.getTextTypeFacts(filename);
+		expect(facts.primitiveTextChildRanges).toHaveLength(1);
+		expect(compile(source, filename, { mode: 'server', textTypeFacts: facts }).code).toContain(
+			'_$_.render_expression(Number(1))',
+		);
+	});
+
+	it('validates serialized facts against the source, filename, and authored child positions', () => {
+		const source = `import type { Props } from './types';
+			export function App(props: Props) @{ <p title={props.label}>{props.label}</p> }`;
+		const { project, filename } = fixture(source, 'export interface Props { label: string }');
+		const facts = JSON.parse(JSON.stringify(project.getTextTypeFacts(filename)));
+		expect(() => compile(source, filename, { textTypeFacts: facts })).not.toThrow();
+		for (const mode of ['client', 'server']) {
+			for (const bad of [
+				null,
+				{ ...facts, version: 2 },
+				{ ...facts, filename: 'wrong.tsrx' },
+				{ ...facts, sourceVersion: 'stale' },
+				{ ...facts, projectVersion: '' },
+				{
+					...facts,
+					stringChildRanges: [[source.indexOf('props.label'), source.indexOf('props.label') + 11]],
+				},
+				{ ...facts, primitiveTextChildRanges: [[0, source.length + 1]] },
+				{ ...facts, stringChildRanges: [[-1, 2]] },
+				{ ...facts, stringChildRanges: null },
+			])
+				expect(() => compile(source, filename, { mode, textTypeFacts: bad })).toThrow(
+					'Invalid textTypeFacts',
+				);
+			expect(() => compile(source + ' ', filename, { mode, textTypeFacts: facts })).toThrow(
+				'Invalid textTypeFacts',
+			);
+		}
+	});
+});

--- a/packages/tsrx-ripple/types/index.d.ts
+++ b/packages/tsrx-ripple/types/index.d.ts
@@ -7,7 +7,7 @@ import type * as AST from 'estree';
 import type {
 	AnalysisResult as CoreAnalysisResult,
 	CompileFn,
-	CompileOptions,
+	CompileOptions as CoreCompileOptions,
 	CompileResult,
 	ParseOptions,
 	VolarCompileFn,
@@ -15,6 +15,21 @@ import type {
 } from '@tsrx/core/types';
 
 export type * from '@tsrx/core/types';
+
+/** Source-bound text proofs produced by `@tsrx/ripple/typescript`. */
+export interface TextTypeFacts {
+	version: 1;
+	filename: string;
+	sourceVersion: string;
+	projectVersion: string;
+	stringChildRanges: readonly (readonly [number, number])[];
+	primitiveTextChildRanges: readonly (readonly [number, number])[];
+}
+
+export interface CompileOptions extends CoreCompileOptions {
+	/** Use the same facts for client and server compilation. */
+	textTypeFacts?: TextTypeFacts;
+}
 
 /**
  * One thing the server registers with the active request before a component
@@ -30,6 +45,8 @@ export type StyleRegistration = string | AST.Expression;
 export interface AnalysisResult extends CoreAnalysisResult {
 	/** Every stylesheet of the module, in CSS emission order. */
 	stylesheets: AST.CSS.StyleSheet[];
+	/** Authored JSX child expressions collected during analysis. */
+	textChildExpressions?: Map<string, { expression: AST.Expression; container: AST.Node }>;
 }
 
 /**

--- a/packages/tsrx-ripple/types/typescript.d.ts
+++ b/packages/tsrx-ripple/types/typescript.d.ts
@@ -1,0 +1,13 @@
+import type { TextTypeFacts } from './index';
+
+export interface TextTypeProject {
+	getTextTypeFacts(filename: string, source?: string): TextTypeFacts;
+	/** Discard all cached sources, imported types, and project configuration. */
+	invalidate(): void;
+	/** Fail if any file read by the project has changed since it was read. */
+	assertUnchanged(): void;
+	dispose(): void;
+}
+
+/** Node-only, optional TypeScript analysis for Ripple DOM text children. */
+export function createTextTypeProject(options: { tsconfig: string }): TextTypeProject;

--- a/packages/vite-plugin/README.md
+++ b/packages/vite-plugin/README.md
@@ -1,0 +1,31 @@
+# @ripple-ts/vite-plugin
+
+```js
+import { ripple } from '@ripple-ts/vite-plugin';
+
+export default {
+  plugins: [ripple()],
+};
+```
+
+## Optional TypeScript text inference
+
+To use the TypeScript checker to recognize primitive DOM children from imported
+types and function return types, enable `textTypes`:
+
+```js
+ripple({ textTypes: { tsconfig: 'tsconfig.json' } });
+```
+
+The tsconfig path resolves from Vite's project root. Install TypeScript 5.9.3 or
+newer and enable `strictNullChecks`. The option applies only to one-shot
+production builds. Development servers, HMR, and watched builds use local syntax
+inference.
+
+Ripple's automatic client/server build shares one checker snapshot and fails if
+its inputs change during the build. Independently invoked client and server builds
+must use the same option, tsconfig, and stable source tree. Each fresh build
+reevaluates imported types and recompiles eligible cached modules.
+
+See [`@tsrx/ripple`](../tsrx-ripple/README.md#primitive-text-inference) for the
+inference boundaries and the direct compiler API.

--- a/packages/vite-plugin/src/index.js
+++ b/packages/vite-plugin/src/index.js
@@ -5,6 +5,7 @@
 /// <reference types="@tsrx/ripple/types/rpc" />
 
 import { compile } from '@tsrx/ripple';
+import { create_text_types } from './text-types.js';
 import { createDepScanTransformPlugin } from '@tsrx/core/vite/dep-scan';
 import fs from 'node:fs';
 import path from 'node:path';
@@ -338,7 +339,8 @@ function scanForRipplePackages(rootDir) {
  */
 export function ripple(inlineOptions = {}) {
 	const { excludeRippleExternalModules = false } = inlineOptions;
-	const api = {};
+	const text_types = create_text_types(inlineOptions.textTypes);
+	const api = { textTypes: text_types };
 	/** @type {ResolvedConfig['root']} */
 	let root;
 	/** @type {ResolvedConfig} */
@@ -538,6 +540,7 @@ export function ripple(inlineOptions = {}) {
 			async configResolved(resolvedConfig) {
 				root = resolvedConfig.root;
 				config = resolvedConfig;
+				text_types.configure(resolvedConfig);
 			},
 
 			/**
@@ -545,6 +548,7 @@ export function ripple(inlineOptions = {}) {
 			 * can generate static import() calls that Vite will bundle.
 			 */
 			async buildStart() {
+				text_types.start(this.meta?.watchMode);
 				if (!isBuild || isSSRBuild) return;
 
 				// Reuse config loaded in the config hook if available;
@@ -884,217 +888,243 @@ export function ripple(inlineOptions = {}) {
 				},
 			},
 
+			async buildEnd(error) {
+				if (error) await text_types.dispose();
+				else await text_types.assertUnchanged();
+			},
+
+			shouldTransformCachedModule({ id }) {
+				if (text_types.enabled() && RIPPLE_EXTENSION_PATTERN.test(id)) return true;
+			},
+
 			/**
 			 * After the client build completes, trigger the SSR server build.
 			 * This only runs for the primary (non-SSR) build.
 			 */
 			async closeBundle() {
-				if (!isBuild || isSSRBuild) return;
-
-				// Reuse config loaded in buildStart, or load it now as fallback
-				if (!loadedRippleConfig) {
-					if (!rippleConfigExists(root)) return;
-					loadedRippleConfig = await loadRippleConfig(root);
-				}
-
-				if (!has_route_config(loadedRippleConfig)) return;
-
-				console.log('[@ripple-ts/vite-plugin] Client build done. Starting server build...');
-
-				// Re-resolve with adapter validation for production builds.
-				// loadRippleConfig already resolved the config, but the adapter
-				// is only required for production server builds.
-				loadedRippleConfig = resolveRippleConfig(loadedRippleConfig, { requireAdapter: true });
-
-				const outDir = loadedRippleConfig.build.outDir;
-
-				// ------------------------------------------------------------------
-				// Read Vite's client manifest and build a per-route asset map.
-				// This lets the production server emit <link rel="stylesheet"> and
-				// <link rel="modulepreload"> tags for every CSS/JS file a page
-				// needs (including transitive dependencies).
-				// ------------------------------------------------------------------
-				const clientOutDir = path.join(root, outDir, 'client');
-				const manifestPath = path.join(clientOutDir, '.vite', 'manifest.json');
-
-				/** @type {Record<string, { file: string, css?: string[], imports?: string[], name?: string }>} */
-				let clientManifest = {};
-				if (fs.existsSync(manifestPath)) {
-					clientManifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
-				} else {
-					console.warn(
-						'[@ripple-ts/vite-plugin] Client manifest not found at',
-						manifestPath,
-						'— asset preloading will be unavailable',
-					);
-				}
-
-				/**
-				 * Recursively collect all CSS files from a manifest entry and its
-				 * imports, avoiding cycles via a visited set.
-				 * @param {string} key - Manifest key (source-relative path)
-				 * @param {Set<string>} [visited] - Already visited keys
-				 * @returns {string[]}
-				 */
-				const collectCss = (key, visited = new Set()) => {
-					if (visited.has(key)) return [];
-					visited.add(key);
-					const entry = clientManifest[key];
-					if (!entry) return [];
-					/** @type {string[]} */
-					const css = [...(entry.css || [])];
-					for (const imp of entry.imports || []) {
-						css.push(...collectCss(imp, visited));
-					}
-					return css;
-				};
-
-				// Build a map of route entry → { js, css } from the manifest
-				/** @type {Record<string, { js: string, css: string[] }>} */
-				const clientAssetMap = {};
-
-				const renderRoutes = loadedRippleConfig.router.routes.filter(
-					(/** @type {Route} */ r) => r.type === 'render',
-				);
-				const uniqueEntries = [
-					...new Set(
-						renderRoutes
-							.map((/** @type {RenderRoute} */ r) => r.entry)
-							.map(get_route_entry_path)
-							.filter((entry) => typeof entry === 'string'),
-					),
-				];
-
-				for (const entry of uniqueEntries) {
-					const manifestKey = entry.startsWith('/') ? entry.slice(1) : entry;
-					const manifestEntry = clientManifest[manifestKey];
-					if (manifestEntry) {
-						clientAssetMap[entry] = {
-							js: manifestEntry.file,
-							css: [...new Set(collectCss(manifestKey))],
-						};
-					}
-				}
-
-				// Find the hydrate runtime entry in the manifest
-				let hydrateJsAsset = '';
-				for (const [key, value] of Object.entries(clientManifest)) {
-					if (key.includes('virtual:ripple-hydrate') || value.name === '__ripple_hydrate') {
-						hydrateJsAsset = value.file;
-						break;
-					}
-				}
-
-				if (hydrateJsAsset) {
-					// Store as a special key so the server can modulepreload it
-					clientAssetMap.__hydrate_js = { js: hydrateJsAsset, css: [] };
-				}
-
-				console.log(
-					`[@ripple-ts/vite-plugin] Built client asset map for ${Object.keys(clientAssetMap).length} entries`,
-				);
-
-				// Remove the .vite folder from the client build output.
-				// The manifest was only needed at build time to construct the
-				// clientAssetMap above. Leaving it in dist/client would expose
-				// source file paths publicly via the static file server.
-				const viteMetaDir = path.join(clientOutDir, '.vite');
 				try {
-					fs.rmSync(viteMetaDir, { recursive: true, force: true });
-					console.log('[@ripple-ts/vite-plugin] Removed .vite metadata from client output');
-				} catch {
-					// Non-fatal — warn but continue
-					console.warn('[@ripple-ts/vite-plugin] Could not remove .vite folder from client output');
-				}
+					if (!isBuild || isSSRBuild) return;
 
-				// Generate the virtual server entry
-				const serverEntryCode = generateServerEntry({
-					routes: loadedRippleConfig.router.routes,
-					rippleConfigPath: getRippleConfigPath(root),
-					htmlTemplatePath: './index.html',
-					rpcModulePaths: [...serverModuleModules],
-					clientAssetMap,
-				});
-				const serverEntryFile = write_project_generated_file(
-					config,
-					'server-entry.js',
-					serverEntryCode,
-				);
+					// Reuse config loaded in buildStart, or load it now as fallback
+					if (!loadedRippleConfig) {
+						if (!rippleConfigExists(root)) return;
+						loadedRippleConfig = await loadRippleConfig(root);
+					}
 
-				const VIRTUAL_SERVER_ENTRY_ID = 'virtual:ripple-server-entry';
-				const RESOLVED_VIRTUAL_SERVER_ENTRY_ID = '\0' + VIRTUAL_SERVER_ENTRY_ID;
+					if (!has_route_config(loadedRippleConfig)) return;
 
-				/** @type {Plugin} */
-				const virtualEntryPlugin = {
-					name: 'ripple-virtual-server-entry',
-					resolveId(id) {
-						if (id === VIRTUAL_SERVER_ENTRY_ID) return RESOLVED_VIRTUAL_SERVER_ENTRY_ID;
-					},
-					load(id) {
-						if (id === RESOLVED_VIRTUAL_SERVER_ENTRY_ID) {
-							return fs.readFileSync(serverEntryFile, 'utf-8');
+					console.log('[@ripple-ts/vite-plugin] Client build done. Starting server build...');
+
+					// Re-resolve with adapter validation for production builds.
+					// loadRippleConfig already resolved the config, but the adapter
+					// is only required for production server builds.
+					loadedRippleConfig = resolveRippleConfig(loadedRippleConfig, { requireAdapter: true });
+
+					const outDir = loadedRippleConfig.build.outDir;
+
+					// ------------------------------------------------------------------
+					// Read Vite's client manifest and build a per-route asset map.
+					// This lets the production server emit <link rel="stylesheet"> and
+					// <link rel="modulepreload"> tags for every CSS/JS file a page
+					// needs (including transitive dependencies).
+					// ------------------------------------------------------------------
+					const clientOutDir = path.join(root, outDir, 'client');
+					const manifestPath = path.join(clientOutDir, '.vite', 'manifest.json');
+
+					/** @type {Record<string, { file: string, css?: string[], imports?: string[], name?: string }>} */
+					let clientManifest = {};
+					if (fs.existsSync(manifestPath)) {
+						clientManifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+					} else {
+						console.warn(
+							'[@ripple-ts/vite-plugin] Client manifest not found at',
+							manifestPath,
+							'— asset preloading will be unavailable',
+						);
+					}
+
+					/**
+					 * Recursively collect all CSS files from a manifest entry and its
+					 * imports, avoiding cycles via a visited set.
+					 * @param {string} key - Manifest key (source-relative path)
+					 * @param {Set<string>} [visited] - Already visited keys
+					 * @returns {string[]}
+					 */
+					const collectCss = (key, visited = new Set()) => {
+						if (visited.has(key)) return [];
+						visited.add(key);
+						const entry = clientManifest[key];
+						if (!entry) return [];
+						/** @type {string[]} */
+						const css = [...(entry.css || [])];
+						for (const imp of entry.imports || []) {
+							css.push(...collectCss(imp, visited));
 						}
-					},
-				};
+						return css;
+					};
 
-				const serverOutDir = path.join(root, outDir, 'server');
+					// Build a map of route entry → { js, css } from the manifest
+					/** @type {Record<string, { js: string, css: string[] }>} */
+					const clientAssetMap = {};
 
-				// Do NOT add ripple() here — the user's vite.config.ts (loaded automatically
-				// from `root`) already includes it. Adding another instance causes double
-				// compilation of .tsrx files.
-				const { build: viteBuild } = await import('vite');
-				try {
-					await viteBuild({
-						root,
-						appType: 'custom',
-						plugins: [virtualEntryPlugin],
-						build: {
-							outDir: serverOutDir,
-							emptyOutDir: true,
-							ssr: true,
-							target: loadedRippleConfig?.build?.target,
-							minify: loadedRippleConfig?.build?.minify ?? false,
-							rollupOptions: {
-								input: VIRTUAL_SERVER_ENTRY_ID,
-								output: {
-									entryFileNames: ENTRY_FILENAME,
-									format: 'esm',
+					const renderRoutes = loadedRippleConfig.router.routes.filter(
+						(/** @type {Route} */ r) => r.type === 'render',
+					);
+					const uniqueEntries = [
+						...new Set(
+							renderRoutes
+								.map((/** @type {RenderRoute} */ r) => r.entry)
+								.map(get_route_entry_path)
+								.filter((entry) => typeof entry === 'string'),
+						),
+					];
+
+					for (const entry of uniqueEntries) {
+						const manifestKey = entry.startsWith('/') ? entry.slice(1) : entry;
+						const manifestEntry = clientManifest[manifestKey];
+						if (manifestEntry) {
+							clientAssetMap[entry] = {
+								js: manifestEntry.file,
+								css: [...new Set(collectCss(manifestKey))],
+							};
+						}
+					}
+
+					// Find the hydrate runtime entry in the manifest
+					let hydrateJsAsset = '';
+					for (const [key, value] of Object.entries(clientManifest)) {
+						if (key.includes('virtual:ripple-hydrate') || value.name === '__ripple_hydrate') {
+							hydrateJsAsset = value.file;
+							break;
+						}
+					}
+
+					if (hydrateJsAsset) {
+						// Store as a special key so the server can modulepreload it
+						clientAssetMap.__hydrate_js = { js: hydrateJsAsset, css: [] };
+					}
+
+					console.log(
+						`[@ripple-ts/vite-plugin] Built client asset map for ${Object.keys(clientAssetMap).length} entries`,
+					);
+
+					// Remove the .vite folder from the client build output.
+					// The manifest was only needed at build time to construct the
+					// clientAssetMap above. Leaving it in dist/client would expose
+					// source file paths publicly via the static file server.
+					const viteMetaDir = path.join(clientOutDir, '.vite');
+					try {
+						fs.rmSync(viteMetaDir, { recursive: true, force: true });
+						console.log('[@ripple-ts/vite-plugin] Removed .vite metadata from client output');
+					} catch {
+						// Non-fatal — warn but continue
+						console.warn(
+							'[@ripple-ts/vite-plugin] Could not remove .vite folder from client output',
+						);
+					}
+
+					// Generate the virtual server entry
+					const serverEntryCode = generateServerEntry({
+						routes: loadedRippleConfig.router.routes,
+						rippleConfigPath: getRippleConfigPath(root),
+						htmlTemplatePath: './index.html',
+						rpcModulePaths: [...serverModuleModules],
+						clientAssetMap,
+					});
+					const serverEntryFile = write_project_generated_file(
+						config,
+						'server-entry.js',
+						serverEntryCode,
+					);
+
+					const VIRTUAL_SERVER_ENTRY_ID = 'virtual:ripple-server-entry';
+					const RESOLVED_VIRTUAL_SERVER_ENTRY_ID = '\0' + VIRTUAL_SERVER_ENTRY_ID;
+
+					/** @type {Plugin} */
+					const virtualEntryPlugin = {
+						name: 'ripple-virtual-server-entry',
+						configResolved(server_config) {
+							const server_plugin = server_config.plugins.find(
+								(plugin) => plugin.name === 'vite-plugin-ripple',
+							);
+							if (text_types.enabled() && !server_plugin?.api?.textTypes) {
+								throw new Error('Ripple SSR build is missing the client textTypes integration');
+							}
+							server_plugin?.api?.textTypes?.share(text_types);
+						},
+						resolveId(id) {
+							if (id === VIRTUAL_SERVER_ENTRY_ID) return RESOLVED_VIRTUAL_SERVER_ENTRY_ID;
+						},
+						load(id) {
+							if (id === RESOLVED_VIRTUAL_SERVER_ENTRY_ID) {
+								return fs.readFileSync(serverEntryFile, 'utf-8');
+							}
+						},
+					};
+
+					const serverOutDir = path.join(root, outDir, 'server');
+
+					// Do NOT add ripple() here — the user's vite.config.ts (loaded automatically
+					// from `root`) already includes it. Adding another instance causes double
+					// compilation of .tsrx files.
+					const { build: viteBuild } = await import('vite');
+					await text_types.assertUnchanged();
+					try {
+						await viteBuild({
+							root,
+							appType: 'custom',
+							plugins: [virtualEntryPlugin],
+							build: {
+								outDir: serverOutDir,
+								emptyOutDir: true,
+								ssr: true,
+								target: loadedRippleConfig?.build?.target,
+								minify: loadedRippleConfig?.build?.minify ?? false,
+								rollupOptions: {
+									input: VIRTUAL_SERVER_ENTRY_ID,
+									output: {
+										entryFileNames: ENTRY_FILENAME,
+										format: 'esm',
+									},
 								},
 							},
-						},
-						ssr: {
-							external: [
-								'@ripple-ts/adapter',
-								'@ripple-ts/adapter-node',
-								'@ripple-ts/adapter-bun',
-								'@ripple-ts/adapter-vercel',
-							],
-							noExternal: [],
-						},
-					});
+							ssr: {
+								external: [
+									'@ripple-ts/adapter',
+									'@ripple-ts/adapter-node',
+									'@ripple-ts/adapter-bun',
+									'@ripple-ts/adapter-vercel',
+								],
+								noExternal: [],
+							},
+						});
 
-					// Copy the HTML template into the server output so the server
-					// entry is self-contained and doesn't depend on dist/client/.
-					// This is critical for platforms like Vercel where dist/client/
-					// is served as static files and index.html would be returned as-is
-					// (with unresolved SSR placeholders) instead of going through SSR.
-					const clientHtml = path.join(clientOutDir, 'index.html');
-					const serverHtml = path.join(serverOutDir, 'index.html');
-					if (fs.existsSync(clientHtml)) {
-						fs.copyFileSync(clientHtml, serverHtml);
-						console.log('[@ripple-ts/vite-plugin] Copied HTML template to server output');
+						// Copy the HTML template into the server output so the server
+						// entry is self-contained and doesn't depend on dist/client/.
+						// This is critical for platforms like Vercel where dist/client/
+						// is served as static files and index.html would be returned as-is
+						// (with unresolved SSR placeholders) instead of going through SSR.
+						const clientHtml = path.join(clientOutDir, 'index.html');
+						const serverHtml = path.join(serverOutDir, 'index.html');
+						if (fs.existsSync(clientHtml)) {
+							fs.copyFileSync(clientHtml, serverHtml);
+							console.log('[@ripple-ts/vite-plugin] Copied HTML template to server output');
+						}
+
+						console.log('[@ripple-ts/vite-plugin] Server build complete.');
+						console.log(`[@ripple-ts/vite-plugin] Output: ${path.join(root, outDir)}`);
+						console.log(
+							`[@ripple-ts/vite-plugin] Start with: node ${outDir}/server/${ENTRY_FILENAME}`,
+						);
+						await text_types.assertUnchanged();
+					} catch (error) {
+						console.error('[@ripple-ts/vite-plugin] Server build failed:', error);
+						throw new Error(
+							`Server build failed: ${error instanceof Error ? error.message : String(error)}`,
+						);
 					}
-
-					console.log('[@ripple-ts/vite-plugin] Server build complete.');
-					console.log(`[@ripple-ts/vite-plugin] Output: ${path.join(root, outDir)}`);
-					console.log(
-						`[@ripple-ts/vite-plugin] Start with: node ${outDir}/server/${ENTRY_FILENAME}`,
-					);
-				} catch (error) {
-					console.error('[@ripple-ts/vite-plugin] Server build failed:', error);
-					throw new Error(
-						`Server build failed: ${error instanceof Error ? error.message : String(error)}`,
-					);
+				} finally {
+					await text_types.dispose();
 				}
 			},
 
@@ -1182,6 +1212,7 @@ export function ripple(inlineOptions = {}) {
 						mode: ssr ? 'server' : 'client',
 						dev: is_dev,
 						hmr: is_dev && !ssr,
+						textTypeFacts: await text_types.getFacts(id, source_code, filename),
 					});
 
 					// Track modules with `module server` declarations for RPC (client build only)

--- a/packages/vite-plugin/src/text-types.js
+++ b/packages/vite-plugin/src/text-types.js
@@ -1,0 +1,91 @@
+// @ts-check
+
+import path from 'node:path';
+
+/** @import { TextTypeProject } from '@tsrx/ripple/typescript' */
+/** @import { RipplePluginOptions } from '../types/index' */
+
+/**
+ * One snapshot per production build. Automatic SSR sub-builds borrow their
+ * client's snapshot so imported types cannot change hydration layout.
+ * @param {RipplePluginOptions['textTypes']} option
+ */
+export function create_text_types(option) {
+	if (
+		option !== undefined &&
+		option !== false &&
+		(!option ||
+			typeof option !== 'object' ||
+			typeof option.tsconfig !== 'string' ||
+			!option.tsconfig.trim())
+	) {
+		throw new Error('Ripple textTypes must be false or { tsconfig: string }');
+	}
+	/** @type {string | undefined} */
+	let config_path;
+	/** @type {Promise<TextTypeProject> | undefined} */
+	let project;
+	/** @type {ReturnType<typeof create_text_types> | undefined} */
+	let parent;
+	let enabled = false;
+
+	/** @param {import('vite').ResolvedConfig} config */
+	function configure(config) {
+		enabled = !!option && config.command === 'build' && config.isProduction && !config.build.watch;
+		config_path = option ? path.resolve(config.root, option.tsconfig) : undefined;
+	}
+
+	function start(watch = false) {
+		if (watch) enabled = false;
+		if (!parent) project = undefined;
+	}
+
+	/** @param {ReturnType<typeof create_text_types>} client */
+	function share(client) {
+		if (enabled !== client.enabled() || config_path !== client.configPath()) {
+			throw new Error('Ripple client and server builds must use the same textTypes configuration');
+		}
+		parent = client;
+	}
+
+	/** @param {string} id @param {string} source @param {string} filename
+	 * @returns {Promise<import("@tsrx/ripple").TextTypeFacts | undefined>} */
+	async function get_facts(id, source, filename) {
+		if (!enabled) return undefined;
+		if (parent) return parent.getFacts(id, source, filename);
+		project ??= import('@tsrx/ripple/typescript').then(
+			({ createTextTypeProject: create_text_type_project }) =>
+				create_text_type_project({ tsconfig: /** @type {string} */ (config_path) }),
+		);
+		const facts = (await project).getTextTypeFacts(id, source);
+		// Ripple uses project-relative filenames for CSS hashes and RPC ids.
+		return { ...facts, filename };
+	}
+
+	/** @returns {Promise<void>} */
+	async function assert_unchanged() {
+		if (parent) return parent.assertUnchanged();
+		(await project)?.assertUnchanged();
+	}
+
+	async function dispose() {
+		if (!parent) {
+			try {
+				(await project)?.dispose();
+			} finally {
+				project = undefined;
+			}
+		}
+	}
+
+	return {
+		configure,
+		start,
+		share,
+		getFacts: get_facts,
+		assertUnchanged: assert_unchanged,
+		dispose,
+		enabled: () => enabled,
+		configPath: () => config_path,
+	};
+}

--- a/packages/vite-plugin/tests/text-types.test.js
+++ b/packages/vite-plugin/tests/text-types.test.js
@@ -1,0 +1,160 @@
+import { afterEach as after_each, describe, expect, it, vi } from 'vitest';
+import {
+	mkdtempSync as mkdtemp_sync,
+	rmSync as rm_sync,
+	writeFileSync as write_file_sync,
+} from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { build } from 'vite';
+import { ripple } from '@ripple-ts/vite-plugin';
+
+const cleanups = [];
+after_each(async () => {
+	for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+});
+const source = `import type { Props } from './types';
+export function App(props: Props) @{ <p>{props.value}</p> }`;
+
+function fixture() {
+	const root = mkdtemp_sync(path.join(os.tmpdir(), 'ripple-vite-text-'));
+	cleanups.push(() => rm_sync(root, { recursive: true, force: true }));
+	write_file_sync(
+		path.join(root, 'tsconfig.json'),
+		JSON.stringify({
+			compilerOptions: {
+				strict: true,
+				target: 'ESNext',
+				module: 'ESNext',
+				moduleResolution: 'Bundler',
+			},
+		}),
+	);
+	write_file_sync(path.join(root, 'App.tsrx'), source);
+	write_file_sync(path.join(root, 'types.ts'), 'export interface Props { value: number }');
+	return root;
+}
+
+function hook(plugin, name) {
+	const entry = plugin[name];
+	return typeof entry === 'function' ? entry : entry.handler;
+}
+
+async function plugin(root, extra = {}, text_types = { tsconfig: 'tsconfig.json' }) {
+	const [plugin] = ripple({ excludeRippleExternalModules: true, textTypes: text_types });
+	await hook(plugin, 'configResolved').call(
+		{},
+		{
+			root,
+			command: 'build',
+			isProduction: true,
+			build: {},
+			...extra,
+		},
+	);
+	await hook(plugin, 'buildStart').call({ meta: { watchMode: !!extra.build?.watch } });
+	cleanups.push(() => hook(plugin, 'closeBundle').call({}));
+	return plugin;
+}
+
+async function transform(plugin, root, ssr = false) {
+	return hook(plugin, 'transform').call(
+		{ environment: { config: { consumer: ssr ? 'server' : 'client' } } },
+		source,
+		path.join(root, 'App.tsrx'),
+		{ ssr },
+	);
+}
+
+describe('Vite textTypes', () => {
+	it.each([true, {}, { tsconfig: '' }, { tsconfig: 42 }])(
+		'rejects invalid options %j',
+		(text_types) => {
+			expect(() => ripple({ textTypes: text_types })).toThrow('textTypes must be');
+		},
+	);
+
+	it.each([{ command: 'serve' }, { isProduction: false }, { build: { watch: {} } }])(
+		'keeps %j syntax-only without opening the checker project',
+		async (config) => {
+			const root = fixture();
+			const current = await plugin(root, config, { tsconfig: 'missing.json' });
+			const result = await transform(current, root, true);
+			expect(result.code).toContain('_$_.render_expression(props.value');
+		},
+	);
+
+	it('is opt-in and skips cached transforms only when enabled', async () => {
+		const root = fixture();
+		const current = await plugin(root, {}, false);
+		expect((await transform(current, root, true)).code).toContain(
+			'_$_.render_expression(props.value',
+		);
+		expect(
+			hook(current, 'shouldTransformCachedModule')({ id: path.join(root, 'App.tsrx') }),
+		).toBeUndefined();
+	});
+
+	it('passes matching client/server facts while preserving source maps', async () => {
+		const root = fixture();
+		const current = await plugin(root);
+		const client = await transform(current, root);
+		const server = await transform(current, root, true);
+		expect(client.code).not.toContain('_$_.expression_children(');
+		expect(server.code).toContain('_$_.escape(props.value)');
+		expect(client.map.sourcesContent).toEqual([source]);
+		expect(hook(current, 'shouldTransformCachedModule')({ id: path.join(root, 'App.tsrx') })).toBe(
+			true,
+		);
+		await hook(current, 'buildEnd').call({});
+	});
+
+	it('shares a snapshot with the automatic server build and detects type drift', async () => {
+		const root = fixture();
+		const client = await plugin(root);
+		await transform(client, root);
+		const server = await plugin(root);
+		server.api.textTypes.share(client.api.textTypes);
+		write_file_sync(path.join(root, 'types.ts'), 'export interface Props { value: object }');
+		// The borrowed snapshot still produces the client's layout, and the
+		// build fails instead of emitting inconsistent hydration output.
+		expect((await transform(server, root, true)).code).toContain('_$_.escape(props.value)');
+		await expect(hook(server, 'buildEnd').call({})).rejects.toThrow('changed during build');
+	});
+
+	it('rejects different client/server checker configurations', async () => {
+		const root = fixture();
+		const client = await plugin(root);
+		const server = await plugin(root, {}, false);
+		expect(() => server.api.textTypes.share(client.api.textTypes)).toThrow(
+			'same textTypes configuration',
+		);
+	});
+
+	it('rechecks imported types in fresh real Vite builds', async () => {
+		const root = fixture();
+		vi.stubEnv('NODE_ENV', 'production');
+		cleanups.push(() => vi.unstubAllEnvs());
+		async function run() {
+			const result = await build({
+				root,
+				configFile: false,
+				logLevel: 'silent',
+				plugins: ripple({
+					excludeRippleExternalModules: true,
+					textTypes: { tsconfig: 'tsconfig.json' },
+				}),
+				build: {
+					ssr: path.join(root, 'App.tsrx'),
+					write: false,
+					minify: false,
+					rollupOptions: { external: ['ripple/internal/server'] },
+				},
+			});
+			return result.output.find((entry) => entry.type === 'chunk').code;
+		}
+		expect(await run()).toContain('.escape(props.value)');
+		write_file_sync(path.join(root, 'types.ts'), 'export interface Props { value: object }');
+		expect(await run()).toContain('.render_expression(props.value');
+	});
+});

--- a/packages/vite-plugin/types/index.d.ts
+++ b/packages/vite-plugin/types/index.d.ts
@@ -104,6 +104,13 @@ export type RouteHandler = (context: Context) => Response | Promise<Response>;
 // ============================================================================
 
 export interface RipplePluginOptions {
+	/**
+	 * Opt-in primitive DOM text proofs from TypeScript. Requires TypeScript and
+	 * strictNullChecks. Active only in one-shot production builds; development,
+	 * HMR, and watch builds use local inference. Resolve tsconfig from Vite root.
+	 */
+	textTypes?: false | { tsconfig: string };
+
 	excludeRippleExternalModules?: boolean;
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -212,7 +212,7 @@ catalogs:
       specifier: ^5.6.0
       version: 5.6.0
     typescript:
-      specifier: ^5.9.3
+      specifier: '>=5.9.3'
       version: 5.9.3
     uvu:
       specifier: ^0.5.6
@@ -4095,9 +4095,6 @@ packages:
   '@sindresorhus/merge-streams@4.0.0':
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
-
-  '@solidjs/signals@2.0.0-rc.3':
-    resolution: {integrity: sha512-/yPhTf3xS1FRR4MX8kTYCd4MjsFxzwkO+KyOTfbu35lTEiaJ4Fxy+JL91XonDzt31GV1mYaZ9CGD2TQIzvXuNA==}
 
   '@solidjs/signals@2.0.0-rc.7':
     resolution: {integrity: sha512-JY0OJ5nGeqxGKOAqCtuoHkFBkaWQYxmf+yBQE8vw/o9C7yUF+Kan9PwcrL0ZHR6+MgyixBUtTfBigwou5hwW5w==}
@@ -8994,9 +8991,6 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
-  '@solidjs/signals@2.0.0-rc.3':
-    optional: true
-
   '@solidjs/signals@2.0.0-rc.7': {}
 
   '@solidjs/web@2.0.0-rc.3(solid-js@2.0.0-rc.3)':
@@ -11834,7 +11828,7 @@ snapshots:
 
   solid-js@2.0.0-rc.3:
     dependencies:
-      '@solidjs/signals': 2.0.0-rc.3
+      '@solidjs/signals': 2.0.0-rc.7
       csstype: 3.2.3
       seroval: 1.5.6
       seroval-plugins: 1.5.6(seroval@1.5.6)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -160,7 +160,7 @@ catalogs:
     prettier: '>=2.0.0'
     ripple: '*'
     tailwindcss: ^4.1.12
-    typescript: '>=5.9.3'
+    typescript: *ts_common
 
 # vite-plugin-solid's peer range `<2.0.0-experimental.0` excludes `rc.*` by
 # prerelease ordering, and @tsrx/solid / @tsrx/solid-runtime pin an exact older

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -44,7 +44,7 @@ allowBuilds:
 
 # variables used in the catalog
 prettier_common: &prettier_common ^3.9.6
-ts_common: &ts_common ^5.9.3
+ts_common: &ts_common '>=5.9.3'
 ts_eslint_parser: &ts_eslint_parser ^8.56.1
 esrap_common: &esrap_common ^2.3.2
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -160,7 +160,7 @@ catalogs:
     prettier: '>=2.0.0'
     ripple: '*'
     tailwindcss: ^4.1.12
-    typescript: *ts_common
+    typescript: '>=5.9.3'
 
 # vite-plugin-solid's peer range `<2.0.0-experimental.0` excludes `rc.*` by
 # prerelease ordering, and @tsrx/solid / @tsrx/solid-runtime pin an exact older

--- a/website-new/docs/guide/syntax.md
+++ b/website-new/docs/guide/syntax.md
@@ -112,9 +112,9 @@ function Profile({ user }) @{
 
 ## Concept: Expressions
 
-In Ripple (and JSX), we can interpolate expressions into the template with a pair
-of {braces}. Inside the braces, we can put a JavaScript expression, which will
-then be converted to a string (if it is not already) to be inserted into the DOM.
+In Ripple (and JSX), we can interpolate JavaScript expressions into the template
+with a pair of {braces}. Primitive values render as escaped text; expression
+containers can also render elements and collections.
 
 ## Example: Displaying Text
 
@@ -259,8 +259,9 @@ raw content, refer to [Styling](/docs/guide/styling#Global-Styles).
 ## Text Expressions
 
 Plain JSX text is static escaped text. Dynamic text is just a normal
-`{expression}`. When you need explicit string coercion, write it in JavaScript
-with `String(value)`, `value + ''`, or a typed string value.
+`{expression}`. When you need explicit string coercion, use `String(value)` or
+`value + ''`. Type annotations describe values; they do not convert them at
+runtime.
 
 ```tsrx
 export function Frame({ children }) {
@@ -282,3 +283,48 @@ export function App() @{
   <div>{markup}</div>
 }
 ```
+
+### Inferred Text Updates
+
+Ripple automatically uses direct text updates for locally known primitives,
+including local primitive annotations, numeric operators, and unshadowed
+`String()`, `Number()`, `Boolean()`, `BigInt()`, and `Date()` calls. These
+optimizations work with the default `ripple()` plugin; you do not need to add
+`as string` or `String()` just to display a number. `Date()` returns text, whereas
+`new Date()` produces an object.
+
+The optional [Vite `textTypes` setting](/docs/quick-start#optional-typescript-text-inference)
+adds TypeScript project analysis for imported types and function return types.
+For example:
+
+```ts
+// types.ts
+export interface Product {
+  name: string;
+  price: number;
+}
+```
+
+```tsrx
+// ProductCard.tsrx
+import type { Product } from './types';
+
+export function ProductCard(product: Product) {
+  return <article>
+    <h2>{product.name}</h2>
+    <p>{product.price}</p>
+  </article>;
+}
+```
+
+With `textTypes` enabled, the checker resolves `Product` and proves that both
+properties can use direct text updates. Without the option, this component still
+renders correctly through Ripple's general rendering path.
+
+The checker recognizes strings, numbers, bigints, and unions of those primitives.
+It does not force arbitrary children to become text. Nullable, unknown, boxed,
+and object types retain existing local inference. The analysis enables
+`noUncheckedIndexedAccess` internally so potentially missing array entries and
+index-signature properties are not assumed to be present; it does not modify
+your tsconfig. Text remains escaped, and elements and collections keep their
+rendering behavior.

--- a/website-new/docs/quick-start.md
+++ b/website-new/docs/quick-start.md
@@ -27,6 +27,36 @@ npm i // [!=npm auto]
 npm run dev // [!=npm auto]
 ```
 
+## Optional TypeScript Text Inference
+
+Ripple already infers locally known primitive text with the default `ripple()`
+plugin. To also resolve imported types and function return types during production
+builds, enable `textTypes` in your Vite configuration:
+
+```ts
+// vite.config.ts
+import { defineConfig } from 'vite';
+import { ripple } from '@ripple-ts/vite-plugin';
+
+export default defineConfig({
+  plugins: [ripple({ textTypes: { tsconfig: 'tsconfig.json' } })],
+});
+```
+
+This requires TypeScript 5.9.3 or newer and `strictNullChecks` enabled in your
+TypeScript configuration (`strict: true` also enables it). The tsconfig path
+resolves from the Vite project root.
+
+The plugin manages the checker and shares its type information with Ripple's
+automatic server build. You do not need to call the compiler or create a
+TypeScript project yourself. The option applies only to production builds without
+watch mode; development, HMR, and watched builds keep local inference. If you run
+client and server builds separately, use the same `textTypes` setting, tsconfig,
+and unchanged source tree for both.
+
+See [Inferred Text Updates](/docs/guide/syntax#inferred-text-updates) for an example
+and the kinds of values the checker can prove.
+
 ## Editor Integration
 
 ### VS Code

--- a/website-new/public/llms.txt
+++ b/website-new/public/llms.txt
@@ -33,7 +33,7 @@ npm install ripple @ripple-ts/vite-plugin
 ```ts
 // vite.config.ts
 import { defineConfig } from 'vite';
-import ripple from '@ripple-ts/vite-plugin';
+import { ripple } from '@ripple-ts/vite-plugin';
 
 export default defineConfig({
 	plugins: [ripple()],
@@ -108,6 +108,39 @@ export function LiteralText() {
 	</div>;
 }
 ```
+
+## Text Inference
+
+Ripple infers locally known primitive text by default, including local primitive
+annotations, numeric operators, and unshadowed `String()`, `Number()`, `Boolean()`,
+`BigInt()`, and `Date()` calls. Do not require `as string` or `String()` just to
+render a number. `Date()` returns text; `new Date()` produces an object.
+
+Project-wide TypeScript checking is opt-in:
+
+```ts
+// vite.config.ts
+import { defineConfig } from 'vite';
+import { ripple } from '@ripple-ts/vite-plugin';
+
+export default defineConfig({
+	plugins: [ripple({ textTypes: { tsconfig: 'tsconfig.json' } })],
+});
+```
+
+- Requires TypeScript 5.9.3 or newer and `strictNullChecks` (or `strict: true`).
+  Resolve the tsconfig path from the Vite project root.
+- Proves strings, numbers, bigints, and their unions from imported types,
+  member reads, function return types, and control-flow narrowing. Unproven
+  values retain local inference; the option does not force children to text.
+- Applies only to production builds without watch mode. Development, HMR, and
+  watched builds keep local inference.
+- The plugin manages the checker and shares its type information with Ripple's
+  automatic server build. Applications do not need manual compiler calls or a
+  `createTextTypeProject()` setup. Independently run client/server builds must
+  use the same option, tsconfig, and unchanged source tree.
+- The analysis enables `noUncheckedIndexedAccess` internally without editing the
+  tsconfig, so potentially missing entries do not become non-null text proofs.
 
 ## Reactivity
 

--- a/website/docs/guide/syntax.md
+++ b/website/docs/guide/syntax.md
@@ -114,9 +114,9 @@ function Profile({ user }) @{
 
 ## Concept: Expressions
 
-In Ripple (and JSX), we can interpolate expressions into the template with a pair
-of {braces}. Inside the braces, we can put a JavaScript expression, which will
-then be converted to a string (if it is not already) to be inserted into the DOM.
+In Ripple (and JSX), we can interpolate JavaScript expressions into the template
+with a pair of {braces}. Primitive values render as escaped text; expression
+containers can also render elements and collections.
 
 ## Example: Displaying Text
 
@@ -261,8 +261,9 @@ raw content, refer to [Styling](/docs/guide/styling#Global-Styles).
 ## Text Expressions
 
 Plain JSX text is static escaped text. Dynamic text is just a normal
-`{expression}`. When you need explicit string coercion, write it in JavaScript
-with `String(value)`, `value + ''`, or a typed string value.
+`{expression}`. When you need explicit string coercion, use `String(value)` or
+`value + ''`. Type annotations describe values; they do not convert them at
+runtime.
 
 ```tsrx
 export function Frame({ children }) {
@@ -284,3 +285,48 @@ export function App() @{
   <div>{markup}</div>
 }
 ```
+
+### Inferred Text Updates
+
+Ripple automatically uses direct text updates for locally known primitives,
+including local primitive annotations, numeric operators, and unshadowed
+`String()`, `Number()`, `Boolean()`, `BigInt()`, and `Date()` calls. These
+optimizations work with the default `ripple()` plugin; you do not need to add
+`as string` or `String()` just to display a number. `Date()` returns text, whereas
+`new Date()` produces an object.
+
+The optional [Vite `textTypes` setting](/docs/quick-start#optional-typescript-text-inference)
+adds TypeScript project analysis for imported types and function return types.
+For example:
+
+```ts
+// types.ts
+export interface Product {
+  name: string;
+  price: number;
+}
+```
+
+```tsrx
+// ProductCard.tsrx
+import type { Product } from './types';
+
+export function ProductCard(product: Product) {
+  return <article>
+    <h2>{product.name}</h2>
+    <p>{product.price}</p>
+  </article>;
+}
+```
+
+With `textTypes` enabled, the checker resolves `Product` and proves that both
+properties can use direct text updates. Without the option, this component still
+renders correctly through Ripple's general rendering path.
+
+The checker recognizes strings, numbers, bigints, and unions of those primitives.
+It does not force arbitrary children to become text. Nullable, unknown, boxed,
+and object types retain existing local inference. The analysis enables
+`noUncheckedIndexedAccess` internally so potentially missing array entries and
+index-signature properties are not assumed to be present; it does not modify
+your tsconfig. Text remains escaped, and elements and collections keep their
+rendering behavior.

--- a/website/docs/quick-start.md
+++ b/website/docs/quick-start.md
@@ -27,6 +27,36 @@ npm i // [!=npm auto]
 npm run dev // [!=npm auto]
 ```
 
+## Optional TypeScript Text Inference
+
+Ripple already infers locally known primitive text with the default `ripple()`
+plugin. To also resolve imported types and function return types during production
+builds, enable `textTypes` in your Vite configuration:
+
+```ts
+// vite.config.ts
+import { defineConfig } from 'vite';
+import { ripple } from '@ripple-ts/vite-plugin';
+
+export default defineConfig({
+  plugins: [ripple({ textTypes: { tsconfig: 'tsconfig.json' } })],
+});
+```
+
+This requires TypeScript 5.9.3 or newer and `strictNullChecks` enabled in your
+TypeScript configuration (`strict: true` also enables it). The tsconfig path
+resolves from the Vite project root.
+
+The plugin manages the checker and shares its type information with Ripple's
+automatic server build. You do not need to call the compiler or create a
+TypeScript project yourself. The option applies only to production builds without
+watch mode; development, HMR, and watched builds keep local inference. If you run
+client and server builds separately, use the same `textTypes` setting, tsconfig,
+and unchanged source tree for both.
+
+See [Inferred Text Updates](/docs/guide/syntax#inferred-text-updates) for an example
+and the kinds of values the checker can prove.
+
 ## Editor Integration
 
 ### VS Code

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -33,7 +33,7 @@ npm install ripple @ripple-ts/vite-plugin
 ```ts
 // vite.config.ts
 import { defineConfig } from 'vite';
-import ripple from '@ripple-ts/vite-plugin';
+import { ripple } from '@ripple-ts/vite-plugin';
 
 export default defineConfig({
 	plugins: [ripple()],
@@ -113,6 +113,39 @@ export function LiteralText() {
 	</div>;
 }
 ```
+
+## Text Inference
+
+Ripple infers locally known primitive text by default, including local primitive
+annotations, numeric operators, and unshadowed `String()`, `Number()`, `Boolean()`,
+`BigInt()`, and `Date()` calls. Do not require `as string` or `String()` just to
+render a number. `Date()` returns text; `new Date()` produces an object.
+
+Project-wide TypeScript checking is opt-in:
+
+```ts
+// vite.config.ts
+import { defineConfig } from 'vite';
+import { ripple } from '@ripple-ts/vite-plugin';
+
+export default defineConfig({
+	plugins: [ripple({ textTypes: { tsconfig: 'tsconfig.json' } })],
+});
+```
+
+- Requires TypeScript 5.9.3 or newer and `strictNullChecks` (or `strict: true`).
+  Resolve the tsconfig path from the Vite project root.
+- Proves strings, numbers, bigints, and their unions from imported types,
+  member reads, function return types, and control-flow narrowing. Unproven
+  values retain local inference; the option does not force children to text.
+- Applies only to production builds without watch mode. Development, HMR, and
+  watched builds keep local inference.
+- The plugin manages the checker and shares its type information with Ripple's
+  automatic server build. Applications do not need manual compiler calls or a
+  `createTextTypeProject()` setup. Independently run client/server builds must
+  use the same option, tsconfig, and unchanged source tree.
+- The analysis enables `noUncheckedIndexedAccess` internally without editing the
+  tsconfig, so potentially missing entries do not become non-null text proofs.
 
 ## Reactivity
 


### PR DESCRIPTION
Ripple already optimizes many locally known primitive children, but imported types and function return types can still require the general rendering path. This adds optional TypeScript proofs so expressions such as `{product.price}` can use direct text updates with consistent server output and hydration.

Inspired by https://github.com/octanejs/octane/pull/1003.

### Changes

- Extend local inference to `BigInt()`, `Date()`, sequences, and `satisfies`; preserve elements returned by shadowed or replaced built-ins.
- Add the Node-only `@tsrx/ripple/typescript` adapter and source-bound `textTypeFacts`, using existing Ripple analysis visitors and TypeScript mappings.
- Add opt-in Vite production integration:

  ```ts
  ripple({ textTypes: { tsconfig: 'tsconfig.json' } });
  ```

  The plugin manages the checker, shares its snapshot with automatic server builds, and detects changed inputs. Development, HMR, and watch builds retain local inference.
- Add compiler, Vite, client, and hydration coverage, patch changesets, package documentation, and updates to both website and LLM guides.

### Validation

- Final focused feature run: **62 tests passed** across compiler, Vite, client, and hydration projects.
- Related compiler, Vite, and hydration validation: **274 tests passed** after fixture corrections and a timeout rerun.
- Compiler and Vite package typechecks; changed Markdown/source formatting; changeset validation; `git diff --check`.
- VitePress website production build; documentation examples compiled for both client and server with expected type proofs.

The checker requires `strictNullChecks`. Independently invoked client/server builds must use matching configuration and stable sources. The optional TypeScript peer is `>=5.9.3`, allowing TypeScript 7; validation used the repository's installed TypeScript 5.9.3.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core compile-time text classification and client/server output alignment for hydration; mismatched or stale `textTypeFacts` could cause subtle SSR/hydration bugs, though defaults preserve prior behavior without `textTypes`.
> 
> **Overview**
> **Ripple now treats more JSX expressions as direct escaped text** instead of the general element/collection rendering path. Local inference adds **`BigInt()`**, **`Date()`**, **comma sequences** (last operand’s type), and **`satisfies`**, while **`new Date()`** and optional chaining stay on the renderable path. **Shadowed or reassigned globals** (`String`, `Number`, etc.) no longer get intrinsic coercion; those calls render as components again.
> 
> **Optional TypeScript proofs** arrive via a new **`@tsrx/ripple/typescript`** entry (`createTextTypeProject`) and compile-time **`textTypeFacts`** (source-bound ranges validated against JSX child positions). The same facts must be used for **client and server** compiles because classification affects **hydration layout**.
> 
> **Vite production builds** can opt in with **`ripple({ textTypes: { tsconfig: '…' } })`**: one checker snapshot per build, shared with the automatic SSR sub-build, **`assertUnchanged`** on drift, and **`shouldTransformCachedModule`** when enabled. Dev/HMR/watch keep syntax-only inference.
> 
> Coverage spans compiler, Vite plugin, client render, and hydration tests plus docs/changesets for **`@tsrx/ripple`** and **`@ripple-ts/vite-plugin`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09c1edf34fb688aae1ec9bc70093ebfa7fbc797c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->