### PR TITLE
perf(ripple): identity-keyed lists, trailing component appends, call return-type text inference

### DIFF
--- a/.changeset/memo-wall-perf.md
+++ b/.changeset/memo-wall-perf.md
@@ -1,0 +1,6 @@
+---
+'ripple': patch
+'@tsrx/ripple': patch
+---
+
+Faster keyed lists and lighter component output on the client. A `@for` keyed by the item itself (`key item`) keys by identity with no key callback, so a re-run compares the item arrays directly and skips the per-item value update; a same-length keyed re-run rewrites the list's block array in place instead of allocating a new one, with the unchanged prefix and suffix skipped by plain compares. Static child components that follow their template siblings append into the parent element instead of inserting before a `<!>` placeholder, so a component with trailing child components clones fewer nodes and leaves no comment anchors in the DOM. The compiler also infers a primitive text type through a call whose callee is declared to return one (a binding typed as a function type, an `as` assertion, a function with a declared return type, or a method or function-typed property of an annotated object), so such text lowers to `set_text` instead of a generic expression block.

--- a/benchmarks/memo-wall/ripple/src/Main.tsrx
+++ b/benchmarks/memo-wall/ripple/src/Main.tsrx
@@ -67,7 +67,12 @@ function Row(props: {
 	</div>
 }
 
-function Wall(props: {
+function Wall({
+	wall,
+	title,
+	initialItems,
+	bind,
+}: {
 	wall: string;
 	title: string;
 	initialItems: Item[];
@@ -77,10 +82,10 @@ function Wall(props: {
 		setTheme: (v: string) => void;
 	}) => void;
 }) @{
-	let &[items] = track<Item[]>(props.initialItems);
+	let &[items] = track<Item[]>(initialItems);
 	let &[tick] = track(0);
 	let &[theme] = track('t0');
-	props.bind({
+	bind({
 		setItems: (v: Item[]) => {
 			items = v;
 		},
@@ -93,16 +98,16 @@ function Wall(props: {
 	});
 	// A stable accessor over the tracked theme: leaf text expressions calling
 	// it subscribe individually (the context VALUE never changes identity).
-	((props.wall === 'A' ? ThemeA : ThemeB)).set(() => theme);
+	((wall === 'A' ? ThemeA : ThemeB)).set(() => theme);
 
-	<section class="wall" id={'wall-' + props.wall.toLowerCase()}>
+	<section class="wall" id={'wall-' + wall.toLowerCase()}>
 		<h2>
-			{props.title}
+			{title}
 			<span class="tick">{tick}</span>
 		</h2>
 		<div class="rows">
 			@for (const it of items; key it) {
-				<Row id={it.id} label={it.label} value={it.value} wall={props.wall} onSelect={selectRow} />
+				<Row id={it.id} label={it.label} value={it.value} wall={wall} onSelect={selectRow} />
 			}
 		</div>
 	</section>

--- a/packages/ripple/src/runtime/internal/client/for.js
+++ b/packages/ripple/src/runtime/internal/client/for.js
@@ -485,8 +485,9 @@ function reconcile_by_key(
 
 	if (state.keys === null && b_length > 0) {
 		var b_blocks = Array(b_length);
-		// Identity keys (`key item`) are the items themselves.
-		var b_keys = get_key === undefined ? b : Array(b_length);
+		// Identity keys (`key item`) are the items themselves; the list keeps a
+		// copy, as the array it rendered may later be mutated in place.
+		var b_keys = get_key === undefined ? b.slice() : Array(b_length);
 
 		// One loop, no `map` callback machinery: most lists are short.
 		for (var j = 0; j < b_length; j++) {
@@ -557,8 +558,8 @@ function reconcile_by_key_diff(
 	/** @type {number} */
 	var i = 0;
 
-	var a = state.array;
-	var a_length = a.length;
+	var a_blocks = state.blocks;
+	var a_length = a_blocks.length;
 	var b_length = b.length;
 	var j = 0;
 
@@ -593,10 +594,10 @@ function reconcile_by_key_diff(
 		}
 		return;
 	}
-	// Identity keys are the items themselves, so a matched key is also the
-	// item's current tracked value: only computed keys need `update_value`.
-	var b_keys = get_key === undefined ? b : b.map(get_key);
-	var a_blocks = state.blocks;
+	// Identity keys are the items themselves (copied, as the rendered array
+	// may later be mutated in place), so a matched key is also the item's
+	// current tracked value: only computed keys need `update_value`.
+	var b_keys = get_key === undefined ? b.slice() : b.map(get_key);
 	// A same-length run rewrites the block array in place: matched ends are
 	// already at their index, and the middle reads the old blocks from a copy
 	// taken before its first write.

--- a/packages/ripple/src/runtime/internal/client/for.js
+++ b/packages/ripple/src/runtime/internal/client/for.js
@@ -296,16 +296,7 @@ function run_for_keyed(state) {
 	var array = collection_to_array(state.g());
 
 	set_tracking(false);
-	reconcile_by_key(
-		state.a,
-		block,
-		array,
-		state.r,
-		state.c,
-		state.x,
-		/** @type {(item: any) => any} */ (state.k),
-		state.e,
-	);
+	reconcile_by_key(state.a, block, array, state.r, state.c, state.x, state.k, state.e);
 	set_tracking(true);
 
 	rehydrate_anchor(state);
@@ -376,7 +367,7 @@ export function for_block(node, get_collection, render_fn, flags, render_empty) 
  * @param {() => V[] | Iterable<V>} get_collection
  * @param {(anchor: Node, value: V | Tracked, index?: any) => Block} render_fn
  * @param {number} flags
- * @param {(item: V) => K} [get_key]
+ * @param {(item: V) => K} [get_key] omitted for identity keys (`key item`)
  * @param {(anchor: Node) => void} [render_empty]
  * @returns {void}
  */
@@ -408,15 +399,7 @@ export function for_block_keyed(node, get_collection, render_fn, flags, get_key,
 
 	render(
 		run_for_keyed,
-		list_state(
-			anchor,
-			get_collection,
-			render_fn,
-			is_controlled,
-			is_indexed,
-			/** @type {(item: V) => K} */ (get_key),
-			render_empty,
-		),
+		list_state(anchor, get_collection, render_fn, is_controlled, is_indexed, get_key, render_empty),
 		FOR_BLOCK,
 	);
 
@@ -480,7 +463,7 @@ function update_value(block, value) {
  * @param {(anchor: Node, value: V | Tracked, index?: any) => Block} render_fn
  * @param {boolean} is_controlled
  * @param {boolean} is_indexed
- * @param {(item: V) => K} get_key
+ * @param {((item: V) => K) | undefined} get_key identity keys when omitted
  * @param {(anchor: Node) => void} [render_empty]
  * @returns {void}
  *
@@ -502,12 +485,15 @@ function reconcile_by_key(
 
 	if (state.keys === null && b_length > 0) {
 		var b_blocks = Array(b_length);
-		var b_keys = Array(b_length);
+		// Identity keys (`key item`) are the items themselves.
+		var b_keys = get_key === undefined ? b : Array(b_length);
 
 		// One loop, no `map` callback machinery: most lists are short.
 		for (var j = 0; j < b_length; j++) {
 			var value = b[j];
-			b_keys[j] = get_key(value);
+			if (get_key !== undefined) {
+				b_keys[j] = get_key(value);
+			}
 			b_blocks[j] = create_item(anchor, value, j, render_fn, is_indexed, true);
 		}
 
@@ -539,7 +525,7 @@ function reconcile_by_key(
  * @param {(anchor: Node, value: V | Tracked, index?: any) => Block} render_fn
  * @param {boolean} is_controlled
  * @param {boolean} is_indexed
- * @param {(item: V) => K} get_key
+ * @param {((item: V) => K) | undefined} get_key
  * @param {(anchor: Node) => void} [render_empty]
  * @returns {void}
  */
@@ -607,8 +593,15 @@ function reconcile_by_key_diff(
 		}
 		return;
 	}
-	var b_blocks = Array(b_length);
-	var b_keys = b.map(get_key);
+	// Identity keys are the items themselves, so a matched key is also the
+	// item's current tracked value: only computed keys need `update_value`.
+	var b_keys = get_key === undefined ? b : b.map(get_key);
+	var a_blocks = state.blocks;
+	// A same-length run rewrites the block array in place: matched ends are
+	// already at their index, and the middle reads the old blocks from a copy
+	// taken before its first write.
+	var in_place = a_length === b_length;
+	var b_blocks = in_place ? a_blocks : Array(b_length);
 
 	// Fast-path for create
 	if (a_length === 0) {
@@ -621,7 +614,6 @@ function reconcile_by_key_diff(
 		return;
 	}
 
-	var a_blocks = state.blocks;
 	// Set by every run that leaves items behind.
 	var a_keys = /** @type {any[]} */ (state.keys);
 	var a_start = 0;
@@ -630,6 +622,25 @@ function reconcile_by_key_diff(
 	var b_end = b_length - 1;
 	var b_val;
 	var b_block;
+
+	if (get_key === undefined && !is_indexed) {
+		// Identity keys without an index: a matched item needs no update, so
+		// the unchanged prefix and suffix are skipped with plain compares.
+		while (a_start <= a_end && b_start <= b_end && a_keys[a_start] === b_keys[b_start]) {
+			if (!in_place) {
+				b_blocks[b_start] = a_blocks[a_start];
+			}
+			a_start++;
+			b_start++;
+		}
+		while (a_start <= a_end && b_start <= b_end && a_keys[a_end] === b_keys[b_end]) {
+			if (!in_place) {
+				b_blocks[b_end] = a_blocks[a_end];
+			}
+			a_end--;
+			b_end--;
+		}
+	}
 
 	// Match from both ends first, including the two end-crossing cases: an old
 	// item that moved to the far end of the new list, and a run whose ends were
@@ -642,7 +653,9 @@ function reconcile_by_key_diff(
 			if (is_indexed) {
 				update_index(b_block, b_start);
 			}
-			update_value(b_block, b_val);
+			if (get_key !== undefined) {
+				update_value(b_block, b_val);
+			}
 			a_start++;
 			b_start++;
 			continue;
@@ -653,13 +666,20 @@ function reconcile_by_key_diff(
 			if (is_indexed) {
 				update_index(b_block, b_end);
 			}
-			update_value(b_block, b_val);
+			if (get_key !== undefined) {
+				update_value(b_block, b_val);
+			}
 			a_end--;
 			b_end--;
 			continue;
 		}
 		if (a_start === a_end || a_blocks[a_start].s.start === null) {
 			break;
+		}
+		if (in_place) {
+			// An end-crossing move overwrites an old block before it is read.
+			a_blocks = a_blocks.slice();
+			in_place = false;
 		}
 		if (a_keys[a_end] === b_keys[b_start]) {
 			// Last old item is the next new one: move it in front of the old run.
@@ -668,7 +688,9 @@ function reconcile_by_key_diff(
 			if (is_indexed) {
 				update_index(b_block, b_start);
 			}
-			update_value(b_block, b_val);
+			if (get_key !== undefined) {
+				update_value(b_block, b_val);
+			}
 			move(b_block, /** @type {ChildNode} */ (a_blocks[a_start].s.start));
 			a_end--;
 			b_start++;
@@ -681,7 +703,9 @@ function reconcile_by_key_diff(
 			if (is_indexed) {
 				update_index(b_block, b_end);
 			}
-			update_value(b_block, b_val);
+			if (get_key !== undefined) {
+				update_value(b_block, b_val);
+			}
 			move(b_block, block_start(b_blocks, b_end + 1, b_length, anchor));
 			a_start++;
 			b_end--;
@@ -712,6 +736,10 @@ function reconcile_by_key_diff(
 			destroy_block(a_blocks[a_start++]);
 		}
 	} else {
+		if (in_place) {
+			a_blocks = a_blocks.slice();
+			in_place = false;
+		}
 		a_left = a_end - a_start + 1;
 		b_left = b_end - b_start + 1;
 		sources = new Int32Array(b_left + 1);
@@ -745,7 +773,9 @@ function reconcile_by_key_diff(
 							if (is_indexed) {
 								update_index(b_block, j);
 							}
-							update_value(b_block, b_val);
+							if (get_key !== undefined) {
+								update_value(b_block, b_val);
+							}
 							++patched;
 							break;
 						}
@@ -786,7 +816,9 @@ function reconcile_by_key_diff(
 						if (is_indexed) {
 							update_index(b_block, j);
 						}
-						update_value(b_block, b_val);
+						if (get_key !== undefined) {
+							update_value(b_block, b_val);
+						}
 						++patched;
 					} else if (!fast_path_removal) {
 						destroy_block(a_blocks[i]);

--- a/packages/ripple/tests/client/composite/__snapshots__/composite.render.test.tsrx.snap
+++ b/packages/ripple/tests/client/composite/__snapshots__/composite.render.test.tsrx.snap
@@ -14,7 +14,6 @@ exports[`composite > render > correct handles passing through component props an
     <div>
       I am B
     </div>
-    <!---->
   </div>
   
 </div>

--- a/packages/ripple/tests/client/for.test.tsrx
+++ b/packages/ripple/tests/client/for.test.tsrx
@@ -195,6 +195,47 @@ describe('for statements', () => {
 		expect(container).toMatchSnapshot();
 	});
 
+	it('keyed by identity re-reads a plain array mutated in place', () => {
+		const list = [{ id: 1 }, { id: 2 }, { id: 3 }];
+		let bump = () => {};
+
+		function App() @{
+			let &[version] = track(0);
+			bump = () => {
+				version = version + 1;
+			};
+			<ul>
+				@for (const item of (version, list); key item) {
+					<li>{item.id}</li>
+				}
+			</ul>
+		}
+
+		render(App);
+		const texts = () => Array.from(container.querySelectorAll('li'), (el) => el.textContent);
+		expect(texts()).toEqual(['1', '2', '3']);
+
+		list.push({ id: 4 });
+		bump();
+		flushSync();
+		expect(texts()).toEqual(['1', '2', '3', '4']);
+
+		list.splice(0, 1);
+		bump();
+		flushSync();
+		expect(texts()).toEqual(['2', '3', '4']);
+
+		list.reverse();
+		bump();
+		flushSync();
+		expect(texts()).toEqual(['4', '3', '2']);
+
+		list.splice(1, 1, { id: 5 });
+		bump();
+		flushSync();
+		expect(texts()).toEqual(['4', '5', '2']);
+	});
+
 	it('keyed for over derived updates sibling text nodes', () => {
 		function App() @{
 			let &[count] = track(0);

--- a/packages/ripple/tests/hydration/compiled/client/basic.js
+++ b/packages/ripple/tests/hydration/compiled/client/basic.js
@@ -20,7 +20,7 @@ var root_15 = _$_.template(`<div class="helper-item"> </div>`, 0);
 var root_17 = _$_.template(`<span class="label"> </span><!>`, 1, 2);
 var root_16 = _$_.template(`<!>`, 1, 1);
 var root_19 = _$_.template(`<div class="app-item"> </div>`, 0);
-var root_18 = _$_.template(`<div class="nested-expression-values"><!><!></div>`, 0);
+var root_18 = _$_.template(`<div class="nested-expression-values"><!></div>`, 0);
 var root_20 = _$_.template(`<strong class="middle">beta</strong>`, 0);
 var root_21 = _$_.template(`<em class="tail">epsilon</em>`, 0);
 var root_22 = _$_.template(` `, 1, 1);
@@ -71,9 +71,9 @@ var root_66 = _$_.template(`<main><div class="container"><!></div></main>`, 0);
 var root_67 = _$_.template(`<div class="content"><p>Some content here</p></div>`, 0);
 var root_68 = _$_.template(`<!><!><!><!>`, 1, 4);
 var root_69 = _$_.template(`<footer class="last-child">I am the last child</footer>`, 0);
-var root_70 = _$_.template(`<div class="wrapper"><h1>Header</h1><p>Some content</p><!></div>`, 0);
-var root_71 = _$_.template(`<div class="inner"><span>Inner text</span><!></div>`, 0);
-var root_72 = _$_.template(`<section class="outer"><h2>Section title</h2><!></section>`, 0);
+var root_70 = _$_.template(`<div class="wrapper"><h1>Header</h1><p>Some content</p></div>`, 0);
+var root_71 = _$_.template(`<div class="inner"><span>Inner text</span></div>`, 0);
+var root_72 = _$_.template(`<section class="outer"><h2>Section title</h2></section>`, 0);
 var root_73 = _$_.template(`<div> </div>`, 0);
 var root_74 = _$_.template(`<div> </div>`, 0);
 var root_75 = _$_.template(`<div>frag-<span>tail</span></div>`, 0);
@@ -341,7 +341,7 @@ export function NestedTsxTsrxExpressionValues() {
 				0
 			);
 
-			var node_9 = _$_.hydrating ? _$_.hydrate_sibling() : node_8.nextSibling;
+			var node_9 = _$_.hydrating ? _$_.hydrate_sibling() : _$_.append_into(div_8);
 
 			_$_.render_component(NestedTsxTsrxFragment, node_9, { label: "from helper" });
 			_$_.pop(div_8);
@@ -941,7 +941,7 @@ export function ComponentAsLastSibling() {
 		{
 			var h1 = _$_.hydrating ? _$_.hydrate_child() : div_26.firstChild;
 			var p = _$_.hydrating ? _$_.hydrate_sibling() : h1.nextSibling;
-			var node_25 = _$_.hydrating ? _$_.hydrate_sibling() : p.nextSibling;
+			var node_25 = _$_.hydrating ? _$_.hydrate_sibling() : _$_.append_into(div_26);
 
 			_$_.render_component(LastChild, node_25, {});
 			_$_.pop(div_26);
@@ -957,7 +957,7 @@ function InnerContent() {
 
 		{
 			var span_8 = _$_.hydrating ? _$_.hydrate_child() : div_27.firstChild;
-			var node_26 = _$_.hydrating ? _$_.hydrate_sibling() : span_8.nextSibling;
+			var node_26 = _$_.hydrating ? _$_.hydrate_sibling() : _$_.append_into(div_27);
 
 			_$_.render_component(LastChild, node_26, {});
 			_$_.pop(div_27);
@@ -973,7 +973,7 @@ export function NestedComponentAsLastSibling() {
 
 		{
 			var h2 = _$_.hydrating ? _$_.hydrate_child() : section_1.firstChild;
-			var node_27 = _$_.hydrating ? _$_.hydrate_sibling() : h2.nextSibling;
+			var node_27 = _$_.hydrating ? _$_.hydrate_sibling() : _$_.append_into(section_1);
 
 			_$_.render_component(InnerContent, node_27, {});
 			_$_.pop(section_1);

--- a/packages/ripple/tests/hydration/compiled/client/for.js
+++ b/packages/ripple/tests/hydration/compiled/client/for.js
@@ -1658,8 +1658,7 @@ export function KeyedForLoopAppendAndRotate() {
 
 						_$_.append(__anchor, span_7);
 					},
-					0,
-					(pattern_8) => _$_.get(pattern_8)
+					0
 				);
 
 				_$_.pop(div_18);
@@ -1708,8 +1707,7 @@ function RootKeyedList(props) {
 
 				_$_.append(__anchor, span_8);
 			},
-			16,
-			(pattern_9) => _$_.get(pattern_9)
+			16
 		);
 	});
 }

--- a/packages/ripple/tests/hydration/compiled/client/html.js
+++ b/packages/ripple/tests/hydration/compiled/client/html.js
@@ -19,7 +19,7 @@ var root_15 = _$_.template(`<div class="edit-link"><a>Edit</a></div>`, 0);
 var root_16 = _$_.template(`<nav class="prev-next"><a> </a></nav>`, 0);
 var root_18 = _$_.template(`<li><a> </a></li>`, 0);
 var root_17 = _$_.template(`<div class="toc"><ul></ul></div>`, 0);
-var root_14 = _$_.template(`<div class="layout"><div class="content-container"><article><div><!></div></article><!><!><!></div><aside><!></aside></div>`, 0);
+var root_14 = _$_.template(`<div class="layout"><div class="content-container"><article><div><!></div></article><!><!></div><aside><!></aside></div>`, 0);
 var root_19 = _$_.template(`<div class="vp-doc"></div>`, 0);
 var root_20 = _$_.template(`<div class="vp-doc"></div>`, 0);
 var root_21 = _$_.template(`<div class="vp-doc"></div>`, 0);
@@ -48,25 +48,25 @@ var root_44 = _$_.template(`<!><!>`, 1, 2);
 var root_42 = _$_.template(`<aside class="sidebar"><nav><div class="group"></div><div class="group"></div></nav></aside>`, 0);
 var root_45 = _$_.template(`<header class="page-header"><div class="logo">MyApp</div></header>`, 0);
 var root_47 = _$_.template(`<div class="edit-link"><a href="/edit">Edit</a></div>`, 0);
-var root_46 = _$_.template(`<div class="layout"><!><div class="content-wrapper"><!><main class="main-content"><div class="article"><div><h1>Introduction</h1><p>Welcome to the docs.</p></div></div><!><!></main></div></div>`, 0);
+var root_46 = _$_.template(`<div class="layout"><!><div class="content-wrapper"><!><main class="main-content"><div class="article"><div><h1>Introduction</h1><p>Welcome to the docs.</p></div></div><!></main></div></div>`, 0);
 var root_48 = _$_.template(`<article class="doc-content"><div><!></div></article>`, 0);
 var root_49 = _$_.template(`<footer class="doc-footer">Footer</footer>`, 0);
 var root_51 = _$_.template(`<h1>Title</h1><p>Content goes here.</p>`, 1, 2);
 var root_52 = _$_.template(`<div class="edit-link"><a href="/edit">Edit</a></div>`, 0);
 var root_53 = _$_.template(`<nav class="prev-next"><a href="/prev">Previous</a></nav>`, 0);
-var root_50 = _$_.template(`<div class="content-container"><!><!><!><!></div>`, 0);
+var root_50 = _$_.template(`<div class="content-container"><!><!><!></div>`, 0);
 var root_55 = _$_.template(`<div class="doc-content"></div>`, 0);
 var root_56 = _$_.template(`<div class="edit-link"><a href="/edit">Edit</a></div>`, 0);
-var root_54 = _$_.template(`<div class="content-container"><!><!><!></div>`, 0);
+var root_54 = _$_.template(`<div class="content-container"><!><!></div>`, 0);
 var root_58 = _$_.template(`<div class="edit-link"><a href="/edit">Edit</a></div>`, 0);
-var root_57 = _$_.template(`<div class="content-container"><article class="doc-content"><div><!></div></article><!><!></div>`, 0);
+var root_57 = _$_.template(`<div class="content-container"><article class="doc-content"><div><!></div></article><!></div>`, 0);
 var root_59 = _$_.template(`<div class="doc-content"></div>`, 0);
 var root_60 = _$_.template(`<header class="header">Header</header>`, 0);
 var root_61 = _$_.template(`<aside class="sidebar">Sidebar</aside>`, 0);
 var root_62 = _$_.template(`<footer class="footer">Footer</footer>`, 0);
 var root_64 = _$_.template(`<div class="edit-link"><a href="/edit">Edit on GitHub</a></div>`, 0);
 var root_65 = _$_.template(`<nav class="prev-next"><a> </a></nav>`, 0);
-var root_63 = _$_.template(`<div class="layout"><!><div class="docs-wrapper"><!><main class="docs-main"><div class="docs-container"><div class="content"><div class="content-container"><article class="doc-content"><div><!></div></article><!><!><!></div></div></div></main></div></div>`, 0);
+var root_63 = _$_.template(`<div class="layout"><!><div class="docs-wrapper"><!><main class="docs-main"><div class="docs-container"><div class="content"><div class="content-container"><article class="doc-content"><div><!></div></article><!><!></div></div></div></main></div></div>`, 0);
 var root_66 = _$_.template(`<div class="doc-content"></div>`, 0);
 var root_67 = _$_.template(`<div class="doc-content"></div>`, 0);
 var root_69 = _$_.template(`<div class="edit-link"><a>Edit on GitHub</a></div>`, 0);
@@ -76,7 +76,7 @@ var root_73 = _$_.template(`<a class="pager next"><span class="title"> </span></
 var root_70 = _$_.template(`<nav class="prev-next"><!><!></nav>`, 0);
 var root_75 = _$_.template(`<a> </a>`, 0);
 var root_74 = _$_.template(`<div class="aside-content"><nav class="outline"></nav></div>`, 0);
-var root_68 = _$_.template(`<div class="layout"><!><div class="docs-wrapper"><!><main class="docs-main"><div class="docs-container"><div class="content"><div class="content-container"><article class="doc-content"><div><!></div></article><!><!><!></div></div><aside class="aside"><!></aside></div></main></div></div>`, 0);
+var root_68 = _$_.template(`<div class="layout"><!><div class="docs-wrapper"><!><main class="docs-main"><div class="docs-container"><div class="content"><div class="content-container"><article class="doc-content"><div><!></div></article><!><!></div></div><aside class="aside"><!></aside></div></main></div></div>`, 0);
 var root_76 = _$_.template(`<div class="doc-content"></div>`, 0);
 var root_77 = _$_.template(`<div class="doc-content"></div>`, 0);
 var root_78 = _$_.template(`<div><template id="t1"></template><p class="content">Main content</p></div>`, 0);
@@ -299,19 +299,19 @@ export function DocLayout(__props) {
 		var div_13 = root_14();
 
 		{
-			var div_15 = _$_.hydrating ? _$_.hydrate_child() : div_13.firstChild;
+			var div_14 = _$_.hydrating ? _$_.hydrate_child() : div_13.firstChild;
 
 			{
-				var article = _$_.hydrating ? _$_.hydrate_child() : div_15.firstChild;
+				var article = _$_.hydrating ? _$_.hydrate_child() : div_14.firstChild;
 
 				{
-					var div_14 = _$_.hydrating ? _$_.hydrate_child() : article.firstChild;
+					var div_15 = _$_.hydrating ? _$_.hydrate_child() : article.firstChild;
 
 					{
-						var expression_1 = _$_.hydrating ? _$_.hydrate_child() : div_14.firstChild;
+						var expression_1 = _$_.hydrating ? _$_.hydrate_child() : div_15.firstChild;
 
 						_$_.expression(expression_1, () => __props.children);
-						_$_.pop(div_14);
+						_$_.pop(div_15);
 					}
 				}
 
@@ -382,13 +382,13 @@ export function DocLayout(__props) {
 					});
 				}
 
-				var node_7 = _$_.hydrating ? _$_.hydrate_sibling() : node_6.nextSibling;
+				var node_7 = _$_.hydrating ? _$_.hydrate_sibling() : _$_.append_into(div_14);
 
 				_$_.render_component(DocFooter, node_7, {});
-				_$_.pop(div_15);
+				_$_.pop(div_14);
 			}
 
-			var aside = _$_.hydrating ? _$_.hydrate_sibling() : div_15.nextSibling;
+			var aside = _$_.hydrating ? _$_.hydrate_sibling() : div_14.nextSibling;
 
 			{
 				var node_8 = _$_.hydrating ? _$_.hydrate_child() : aside.firstChild;
@@ -1064,7 +1064,7 @@ export function LayoutWithSidebarAndMain() {
 						});
 					}
 
-					var node_28 = _$_.hydrating ? _$_.hydrate_sibling() : node_27.nextSibling;
+					var node_28 = _$_.hydrating ? _$_.hydrate_sibling() : _$_.append_into(main);
 
 					_$_.render_component(PageHeader, node_28, {});
 					_$_.pop(main);
@@ -1151,7 +1151,7 @@ export function ArticleWithChildrenThenSibling() {
 				});
 			}
 
-			var node_32 = _$_.hydrating ? _$_.hydrate_sibling() : node_31.nextSibling;
+			var node_32 = _$_.hydrating ? _$_.hydrate_sibling() : _$_.append_into(div_38);
 
 			_$_.render_component(SimpleFooter, node_32, {});
 			_$_.pop(div_38);
@@ -1192,7 +1192,7 @@ export function ArticleWithHtmlChildThenSibling() {
 				});
 			}
 
-			var node_35 = _$_.hydrating ? _$_.hydrate_sibling() : node_34.nextSibling;
+			var node_35 = _$_.hydrating ? _$_.hydrate_sibling() : _$_.append_into(div_40);
 
 			_$_.render_component(SimpleFooter, node_35, {});
 			_$_.pop(div_40);
@@ -1236,7 +1236,7 @@ function InlineArticleLayout({ children }) {
 				});
 			}
 
-			var node_37 = _$_.hydrating ? _$_.hydrate_sibling() : node_36.nextSibling;
+			var node_37 = _$_.hydrating ? _$_.hydrate_sibling() : _$_.append_into(div_43);
 
 			_$_.render_component(SimpleFooter, node_37, {});
 			_$_.pop(div_43);
@@ -1304,25 +1304,25 @@ function DocsLayoutInner(__props) {
 				var main_1 = _$_.hydrating ? _$_.hydrate_sibling() : node_39.nextSibling;
 
 				{
-					var div_52 = _$_.hydrating ? _$_.hydrate_child() : main_1.firstChild;
+					var div_51 = _$_.hydrating ? _$_.hydrate_child() : main_1.firstChild;
 
 					{
-						var div_51 = _$_.hydrating ? _$_.hydrate_child() : div_52.firstChild;
+						var div_50 = _$_.hydrating ? _$_.hydrate_child() : div_51.firstChild;
 
 						{
-							var div_50 = _$_.hydrating ? _$_.hydrate_child() : div_51.firstChild;
+							var div_49 = _$_.hydrating ? _$_.hydrate_child() : div_50.firstChild;
 
 							{
-								var article_3 = _$_.hydrating ? _$_.hydrate_child() : div_50.firstChild;
+								var article_3 = _$_.hydrating ? _$_.hydrate_child() : div_49.firstChild;
 
 								{
-									var div_49 = _$_.hydrating ? _$_.hydrate_child() : article_3.firstChild;
+									var div_52 = _$_.hydrating ? _$_.hydrate_child() : article_3.firstChild;
 
 									{
-										var expression_20 = _$_.hydrating ? _$_.hydrate_child() : div_49.firstChild;
+										var expression_20 = _$_.hydrating ? _$_.hydrate_child() : div_52.firstChild;
 
 										_$_.expression(expression_20, () => __props.children);
-										_$_.pop(div_49);
+										_$_.pop(div_52);
 									}
 								}
 
@@ -1378,10 +1378,10 @@ function DocsLayoutInner(__props) {
 									});
 								}
 
-								var node_42 = _$_.hydrating ? _$_.hydrate_sibling() : node_41.nextSibling;
+								var node_42 = _$_.hydrating ? _$_.hydrate_sibling() : _$_.append_into(div_49);
 
 								_$_.render_component(FooterStub, node_42, {});
-								_$_.pop(div_50);
+								_$_.pop(div_49);
 							}
 						}
 					}
@@ -1448,25 +1448,25 @@ function DocsLayoutExact(__props) {
 				var main_2 = _$_.hydrating ? _$_.hydrate_sibling() : node_44.nextSibling;
 
 				{
-					var div_61 = _$_.hydrating ? _$_.hydrate_child() : main_2.firstChild;
+					var div_60 = _$_.hydrating ? _$_.hydrate_child() : main_2.firstChild;
 
 					{
-						var div_60 = _$_.hydrating ? _$_.hydrate_child() : div_61.firstChild;
+						var div_59 = _$_.hydrating ? _$_.hydrate_child() : div_60.firstChild;
 
 						{
-							var div_59 = _$_.hydrating ? _$_.hydrate_child() : div_60.firstChild;
+							var div_58 = _$_.hydrating ? _$_.hydrate_child() : div_59.firstChild;
 
 							{
-								var article_4 = _$_.hydrating ? _$_.hydrate_child() : div_59.firstChild;
+								var article_4 = _$_.hydrating ? _$_.hydrate_child() : div_58.firstChild;
 
 								{
-									var div_58 = _$_.hydrating ? _$_.hydrate_child() : article_4.firstChild;
+									var div_61 = _$_.hydrating ? _$_.hydrate_child() : article_4.firstChild;
 
 									{
-										var expression_22 = _$_.hydrating ? _$_.hydrate_child() : div_58.firstChild;
+										var expression_22 = _$_.hydrating ? _$_.hydrate_child() : div_61.firstChild;
 
 										_$_.expression(expression_22, () => __props.children);
-										_$_.pop(div_58);
+										_$_.pop(div_61);
 									}
 								}
 
@@ -1597,16 +1597,16 @@ function DocsLayoutExact(__props) {
 									});
 								}
 
-								var node_49 = _$_.hydrating ? _$_.hydrate_sibling() : node_46.nextSibling;
+								var node_49 = _$_.hydrating ? _$_.hydrate_sibling() : _$_.append_into(div_58);
 
 								_$_.render_component(FooterStub, node_49, {});
-								_$_.pop(div_59);
+								_$_.pop(div_58);
 							}
 						}
 
-						_$_.pop(div_60);
+						_$_.pop(div_59);
 
-						var aside_3 = _$_.hydrating ? _$_.hydrate_sibling() : div_60.nextSibling;
+						var aside_3 = _$_.hydrating ? _$_.hydrate_sibling() : div_59.nextSibling;
 
 						{
 							var node_50 = _$_.hydrating ? _$_.hydrate_child() : aside_3.firstChild;

--- a/packages/ripple/tests/hydration/compiled/client/if-children.js
+++ b/packages/ripple/tests/hydration/compiled/client/if-children.js
@@ -446,8 +446,7 @@ function RootForChild(props) {
 
 				_$_.append(__anchor, span_2);
 			},
-			16,
-			(pattern) => _$_.get(pattern)
+			16
 		);
 	});
 }

--- a/packages/ripple/tests/hydration/compiled/client/portal.js
+++ b/packages/ripple/tests/hydration/compiled/client/portal.js
@@ -2,13 +2,13 @@
 import * as _$_ from 'ripple/internal/client';
 
 var root_1 = _$_.template(`<div class="portal-content">Portal content</div>`, 0);
-var root = _$_.template(`<div class="container"><h1>Main Content</h1><!></div>`, 0);
+var root = _$_.template(`<div class="container"><h1>Main Content</h1></div>`, 0);
 var root_3 = _$_.template(`<div class="portal-content">Portal is visible</div>`, 0);
 var root_2 = _$_.template(`<div class="container"><button class="toggle">Toggle</button><!></div>`, 0);
 var root_5 = _$_.template(`<div class="portal-content">Modal content</div>`, 0);
 var root_4 = _$_.template(`<div><div class="main-content">Main page content</div><!><div class="footer">Footer</div></div>`, 0);
 var root_7 = _$_.template(`<div class="portal-content">Portal content</div>`, 0);
-var root_6 = _$_.template(`<div class="outer"><div class="inner"><span>Nested content</span></div><!></div>`, 0);
+var root_6 = _$_.template(`<div class="outer"><div class="inner"><span>Nested content</span></div></div>`, 0);
 
 import { Portal, track } from 'ripple';
 
@@ -18,7 +18,7 @@ export function SimplePortal() {
 
 		{
 			var h1 = _$_.hydrating ? _$_.hydrate_child() : div.firstChild;
-			var node = _$_.hydrating ? _$_.hydrate_sibling() : h1.nextSibling;
+			var node = _$_.hydrating ? _$_.hydrate_sibling() : _$_.append_into(div);
 
 			_$_.portal(node, () => typeof document !== 'undefined' ? document.body : null, (__anchor, __block) => {
 				var div_1 = root_1();
@@ -93,7 +93,7 @@ export function NestedContentWithPortal() {
 
 		{
 			var div_8 = _$_.hydrating ? _$_.hydrate_child() : div_7.firstChild;
-			var node_3 = _$_.hydrating ? _$_.hydrate_sibling() : div_8.nextSibling;
+			var node_3 = _$_.hydrating ? _$_.hydrate_sibling() : _$_.append_into(div_7);
 
 			_$_.portal(node_3, () => typeof document !== 'undefined' ? document.body : null, (__anchor, __block) => {
 				var div_9 = root_7();

--- a/packages/tsrx-ripple/src/transform/client/index.js
+++ b/packages/tsrx-ripple/src/transform/client/index.js
@@ -1832,12 +1832,20 @@ const visit_for_of_statement = (node, context) => {
 		b.literal(flags),
 	];
 	if (key != null) {
-		for_args.push(
-			b.arrow(
-				index ? [pattern, index] : [pattern],
-				/** @type {AST.Expression} */ (context.visit(key)),
-			),
-		);
+		if (is_identity_key(node, key, body_scope)) {
+			// `key item` keys by the item itself: the runtime keys by identity
+			// with no key callback, so nothing runs per item on a diff.
+			if (empty_renderer) {
+				for_args.push(b.void0);
+			}
+		} else {
+			for_args.push(
+				b.arrow(
+					index ? [pattern, index] : [pattern],
+					/** @type {AST.Expression} */ (context.visit(key)),
+				),
+			);
+		}
 	}
 	if (empty_renderer) {
 		for_args.push(empty_renderer);
@@ -1852,6 +1860,27 @@ const visit_for_of_statement = (node, context) => {
 		),
 	);
 };
+
+/**
+ * Whether a keyed loop's key is the loop item itself (`key item` over a plain
+ * `const item of …` pattern, with `item` resolving to the loop binding).
+ * @param {AST.ForOfStatement | AST.JSXForOfExpression} node
+ * @param {AST.Expression} key
+ * @param {ScopeInterface} body_scope
+ * @returns {boolean}
+ */
+function is_identity_key(node, key, body_scope) {
+	if (key.type !== 'Identifier' || node.left.type !== 'VariableDeclaration') {
+		return false;
+	}
+	const id = node.left.declarations[0]?.id;
+	return (
+		id !== undefined &&
+		id.type === 'Identifier' &&
+		id.name === key.name &&
+		body_scope.get(key.name)?.node === id
+	);
+}
 
 /** @import { SelectorForState } from '../../../types/transform-state' */
 
@@ -3388,7 +3417,7 @@ const visitors = {
 					? append_into
 					: state.flush_node?.();
 
-			if (!root_controlled && !append_into) {
+			if (!root_controlled && !append_into && node.metadata?.append_after === undefined) {
 				state.template?.push('<!>');
 			}
 
@@ -5901,6 +5930,25 @@ function transform_children(children, context) {
 		for (const child of normalized) {
 			child.metadata = { ...child.metadata, append_into: append_anchor_id };
 		}
+	} else if (!root && !root_controlled && state.flush_node != null) {
+		// A trailing run of static components behind template siblings appends
+		// into the parent as well: no `<!>` placeholder per component, and an
+		// appendChild instead of an insert. Hydration keeps the sibling cursor,
+		// so the earlier siblings are still navigated (see flush_node).
+		let trailing_start = normalized.length;
+		while (trailing_start > 0 && is_static_component_child(normalized[trailing_start - 1])) {
+			trailing_start -= 1;
+		}
+		if (
+			trailing_start > 0 &&
+			trailing_start < normalized.length &&
+			is_template_or_control_flow(normalized[trailing_start - 1])
+		) {
+			const parent_id = /** @type {AST.Expression} */ (state.flush_node());
+			for (let i = trailing_start; i < normalized.length; i++) {
+				normalized[i].metadata = { ...normalized[i].metadata, append_after: parent_id };
+			}
+		}
 	}
 
 	/** @param {AST.Node} node */
@@ -6028,7 +6076,25 @@ function transform_children(children, context) {
 					return cached;
 				} else if (current_prev !== null) {
 					const id = get_id(node);
-					state.init?.push(b.var(id, inline_traversal('sibling', current_prev(), is_text)));
+					const append_after = node.metadata?.append_after;
+					if (append_after !== undefined) {
+						// The earlier siblings are navigated for the hydration cursor;
+						// the client appends into the parent instead of inserting
+						// before a placeholder.
+						current_prev();
+						state.init?.push(
+							b.var(
+								id,
+								b.conditional(
+									b.member(b.id('_$_'), b.id('hydrating')),
+									b.call('_$_.hydrate_sibling'),
+									b.call('_$_.append_into', append_after),
+								),
+							),
+						);
+					} else {
+						state.init?.push(b.var(id, inline_traversal('sibling', current_prev(), is_text)));
+					}
 					cached = id;
 					return id;
 				} else if (initial !== null) {

--- a/packages/tsrx-ripple/src/utils.js
+++ b/packages/tsrx-ripple/src/utils.js
@@ -3441,6 +3441,14 @@ export function is_text_primitive_expression(
 		return true;
 	}
 
+	// A call whose callee is declared to return a primitive.
+	if (expression.type === 'CallExpression') {
+		return is_text_primitive_type_annotation(
+			get_call_return_type_annotation(expression, state),
+			strings_only,
+		);
+	}
+
 	// Every binary, unary, and update expression yields a primitive in JS:
 	// `+` returns a string or number (object operands coerce first),
 	// arithmetic/bitwise operators return numbers or bigints, comparisons and
@@ -3659,6 +3667,33 @@ export function get_member_type_annotation(type_annotation, property_name, state
 		return undefined;
 	}
 
+	const member = get_member_signature(resolved, property_name, state);
+	return member?.type === 'TSPropertySignature' ? member.typeAnnotation?.typeAnnotation : undefined;
+}
+
+/**
+ * The declared member named `property_name` of an object type: a property or
+ * method signature of a type literal, or of a module-level `interface` /
+ * `type` the annotation names.
+ * @param {AST.TypeNode | AST.TSInterfaceBody | undefined} type_annotation
+ * @param {string} property_name
+ * @param {{ scope: ScopeInterface }} state
+ * @returns {AST.TSPropertySignature | AST.TSMethodSignature | undefined}
+ */
+function get_member_signature(type_annotation, property_name, state) {
+	const resolved =
+		type_annotation?.type === 'TSInterfaceBody'
+			? type_annotation
+			: resolve_type_annotation(type_annotation, state);
+
+	if (resolved?.type === 'TSIntersectionType') {
+		for (const type of resolved.types) {
+			const member = get_member_signature(type, property_name, state);
+			if (member) return member;
+		}
+		return undefined;
+	}
+
 	const members =
 		resolved?.type === 'TSTypeLiteral'
 			? resolved.members
@@ -3671,7 +3706,12 @@ export function get_member_type_annotation(type_annotation, property_name, state
 	}
 
 	for (const member of members) {
-		if (member.type !== 'TSPropertySignature' || member.computed) continue;
+		if (
+			(member.type !== 'TSPropertySignature' && member.type !== 'TSMethodSignature') ||
+			member.computed
+		) {
+			continue;
+		}
 
 		const key = member.key;
 		const name =
@@ -3682,8 +3722,72 @@ export function get_member_type_annotation(type_annotation, property_name, state
 					: null;
 
 		if (name === property_name) {
-			return member.typeAnnotation?.typeAnnotation;
+			return member;
 		}
+	}
+
+	return undefined;
+}
+
+/**
+ * The declared return type of a call, where the callee's type is known from
+ * the module: a binding typed as a function type (an annotation, an `as`
+ * assertion, or a function-typed property of an annotated object), a method
+ * signature of the callee object's type, or a function declaration or
+ * initializer with a declared return type. Optional calls, and generic, async,
+ * or generator functions, are not proven.
+ * @param {AST.SimpleCallExpression} expression
+ * @param {{ scope: ScopeInterface }} state
+ * @param {Set<Binding>} [visited]
+ * @returns {AST.TypeNode | undefined}
+ */
+export function get_call_return_type_annotation(expression, state, visited = new Set()) {
+	if (expression.optional) return undefined;
+	const callee = expression.callee;
+
+	if (callee.type === 'Super') return undefined;
+
+	if (callee.type === 'Identifier') {
+		const binding = state.scope.get(callee.name);
+		const initial = binding?.initial;
+		if (
+			binding &&
+			initial &&
+			!visited.has(binding) &&
+			!binding.reassigned &&
+			!binding.mutated &&
+			!binding.updated &&
+			(initial.type === 'FunctionDeclaration' ||
+				initial.type === 'FunctionExpression' ||
+				initial.type === 'ArrowFunctionExpression')
+		) {
+			if (initial.async || initial.generator || initial.typeParameters !== undefined) {
+				return undefined;
+			}
+			return unwrap_type_annotation(initial.returnType) ?? undefined;
+		}
+	} else if (callee.type === 'MemberExpression') {
+		const property_name = get_static_property_name(callee);
+		if (property_name !== null) {
+			const object_type = get_expression_type_annotation(callee.object, state, visited);
+			const member =
+				object_type === undefined
+					? undefined
+					: get_member_signature(object_type, property_name, state);
+			if (member?.type === 'TSMethodSignature') {
+				return member.typeParameters === undefined
+					? (unwrap_type_annotation(member.typeAnnotation) ?? undefined)
+					: undefined;
+			}
+		}
+	}
+
+	const resolved = resolve_type_annotation(
+		get_expression_type_annotation(callee, state, visited),
+		state,
+	);
+	if (resolved?.type === 'TSFunctionType' && resolved.typeParameters === undefined) {
+		return unwrap_type_annotation(resolved.typeAnnotation) ?? undefined;
 	}
 
 	return undefined;
@@ -3793,6 +3897,10 @@ export function get_expression_type_annotation(expression, state, visited = new 
 		if (object_type === undefined) return undefined;
 
 		return get_member_type_annotation(object_type, property_name, state);
+	}
+
+	if (expression.type === 'CallExpression') {
+		return get_call_return_type_annotation(expression, state, visited);
 	}
 
 	return undefined;

--- a/packages/tsrx-ripple/tests/basic.test.js
+++ b/packages/tsrx-ripple/tests/basic.test.js
@@ -708,6 +708,63 @@ describe('@tsrx/ripple lowers a directive value to a typed value in to_ts (like 
 	// `@for` accepts any iterable, but `Set`/`Map`/generators have no `.length` or
 	// `.map`. Lower through `Array.from(...)` so the binding and the `@empty` branch
 	// type-check (the index `; index i` becomes the map callback's 2nd param).
+	it('appends trailing static components into the parent without a placeholder', () => {
+		const { code } = compile(
+			`function Item() @{ <b>item</b> }
+			function App() @{ <div><span>{'a'}</span><Item /><Item /></div> }`,
+			'App.tsrx',
+			{ mode: 'client' },
+		);
+		expect(code).toContain('_$_.template(`<div><span>a</span></div>`');
+		expect(code).toMatch(
+			/var node = _\$_\.hydrating \? _\$_\.hydrate_sibling\(\) : _\$_\.append_into\(div\);/,
+		);
+		expect(code).toMatch(
+			/var node_1 = _\$_\.hydrating \? _\$_\.hydrate_sibling\(\) : _\$_\.append_into\(div\);/,
+		);
+	});
+
+	it('keeps the placeholder for a component followed by a template sibling', () => {
+		const { code } = compile(
+			`function Item() @{ <b>item</b> }
+			function App() @{ <div><Item /><span>{'a'}</span></div> }`,
+			'App.tsrx',
+			{ mode: 'client' },
+		);
+		expect(code).toContain('_$_.template(`<div><!><span>a</span></div>`');
+		expect(code).not.toContain('_$_.append_into(');
+	});
+
+	it('@for keyed by the item itself passes no key callback', () => {
+		const { code } = compile(
+			`function App({ items }: { items: { id: number }[] }) @{ <ul>@for (const item of items; key item) { <li>{item.id}</li> }</ul> }`,
+			'App.tsrx',
+			{ mode: 'client' },
+		);
+		expect(code).toContain('_$_.for_keyed(');
+		expect(code).not.toContain('(pattern) => _$_.get(pattern)');
+		expect(code).toMatch(/_\$_\.for_keyed\([\s\S]*?\n\s*\d+\n\s*\);/);
+	});
+
+	it('@for keyed by the item itself keeps the @empty branch in its slot', () => {
+		const { code } = compile(
+			`function App({ items }: { items: { id: number }[] }) @{ <ul>@for (const item of items; key item) { <li>{item.id}</li> } @empty { <li>none</li> }</ul> }`,
+			'App.tsrx',
+			{ mode: 'client' },
+		);
+		expect(code).toMatch(/void 0,\s*\(__anchor\) => \{/);
+	});
+
+	it('@for keyed by a shadowing item name keeps the key callback', () => {
+		const { code } = compile(
+			`function App({ items }: { items: { id: number }[] }) @{ <ul>@for (const { id } of items; key id) { <li>{id}</li> }</ul> }`,
+			'App.tsrx',
+			{ mode: 'client' },
+		);
+		expect(code).toContain('_$_.for_keyed(');
+		expect(code).toMatch(/\(pattern\) => /);
+	});
+
 	it('@for over a non-array iterable is iterable-safe via Array.from (+ index, + @empty)', () => {
 		const empty = ts(
 			`function App({ xs }: { xs: Set<number> }) @{ const v = @for (const x of xs; index i) { <li>{i}{x}</li> } @empty { <p>none</p> }; <div>{v}</div> }`,

--- a/packages/tsrx-ripple/tests/text-inference.test.js
+++ b/packages/tsrx-ripple/tests/text-inference.test.js
@@ -70,6 +70,40 @@ describe('primitive text inference', () => {
 		'BigInt?.(props.value)',
 	])('keeps %s on the renderable path', (expression) => expect_renderable(expression));
 
+	it.each([
+		['theme()', 'const theme = props.get as () => string;'],
+		['theme()', 'const theme = props.get as (() => number);'],
+		['label()', 'const label = (): string => props.value;'],
+		['label()', 'function label(): number { return props.value; }'],
+		['props.render()', '', 'props: { render: () => string }'],
+		['props.render()', '', 'props: { render(): number }'],
+		['props.theme.get()', '', 'props: { theme: { get: () => string } }'],
+	])('uses text output for %s with a declared return type', (expression, setup, params) => {
+		expect_text(expression, setup, params);
+	});
+
+	it('follows a module-level interface method signature', () => {
+		const source = `interface Props { render(): string; format: (n: number) => number }
+			export function App(props: Props) @{ <div>{props.render()}{props.format(1)}</div> }`;
+		const client = compile(source, 'App.tsrx', { mode: 'client' }).code;
+		expect(client).not.toMatch(/_\$_\.expression(?:_children)?\(/);
+		expect(client).toContain('_$_.set_text(');
+	});
+
+	it.each([
+		['theme()', 'const theme = props.get as <T>() => T;'],
+		['theme?.()', 'const theme = props.get as () => string;'],
+		['theme()', 'const theme = async (): Promise<string> => props.value;'],
+		['theme()', 'const theme = (): string => props.value; theme = props.other;'],
+		['props.render()', '', 'props: { render: () => object }'],
+		['props.render()', '', 'props: { render<T>(): T }'],
+	])(
+		'keeps %s on the renderable path without a primitive return type',
+		(expression, setup, params) => {
+			expect_renderable(expression, setup, params);
+		},
+	);
+
 	it('keeps numeric evidence separate from string concatenation', () => {
 		const { server } = expect_text('Number(props.a) + Number(props.b)');
 		expect(server).toContain("String(Number(props.a) + Number(props.b) ?? '')");

--- a/packages/tsrx-ripple/types/transform-state.d.ts
+++ b/packages/tsrx-ripple/types/transform-state.d.ts
@@ -16,6 +16,14 @@ export interface SelectorForState {
 }
 
 declare module '@tsrx/core/types' {
+	interface BaseNodeMetaData {
+		/**
+		 * The parent element a static component child appends into when it
+		 * follows its template siblings (set by transform_children).
+		 */
+		append_after?: AST.Expression;
+	}
+
 	interface TransformClientState {
 		/** Set while transforming a `@for` body. */
 		selector_for?: SelectorForState;


### PR DESCRIPTION
## Summary

Optimizes Ripple against the memo-wall benchmark winners. After this change Ripple leads every timed memo-wall op on the same machine (full 20-iteration run, all gates pass):

| Op | Ripple | Best other |
| --- | --- | --- |
| mount | 29.8 ms | solid 38.4 |
| parent_rerender_equal A/B | 0.001 | 0.001 (tie) |
| one_change_A | 0.015 | octane-tsrx 0.020 |
| one_change_B | 0.017 | vue-vapor 0.060 |
| ctx_through_wall_A | 0.760 | vue-vapor 0.890 |
| ctx_through_wall_B | 0.765 | solid 0.940 |

Interleaved A/B before → after: one_change_A 0.048 → 0.016 ms, one_change_B 0.051 → 0.018 ms, mount 22.0 → 19.4 ms; ctx and parent_rerender unchanged (ctx is bound by the native `nodeValue` write).

## Changes

- **Identity-keyed `@for`** (`@tsrx/ripple` + `ripple`): `key item` over a plain `const item of …` emits no key callback. The runtime keys by identity (the item array is the key array), skips `update_value` on matches, scans the unchanged prefix/suffix with plain compares when not indexed, and rewrites the block array in place for same-length runs, copying the old blocks only when an end-crossing move or the middle diff needs them.
- **Trailing component appends** (`@tsrx/ripple`): static component children that follow their template siblings append into the parent element (`_$_.append_into(parent)`) instead of inserting before a `<!>` placeholder. Hydration codegen is unchanged (`hydrate_sibling()` on that branch). `BaseNodeMetaData.append_after` is added through the existing `@tsrx/core/types` augmentation.
- **Call return-type text inference** (`@tsrx/ripple`): `get_call_return_type_annotation` proves a primitive through a call whose callee is typed as a function type (annotation, `as` assertion, function-typed property), an interface method signature, or a function/arrow with a declared return type. Optional, generic, async and generator calls stay unproven.
- **memo-wall fixture**: `Wall` destructures its (static) props.

## Tests

- New compiler tests for declared call return types, identity keys (with and without `@empty`, and a shadowing destructured name), trailing appends, and a non-trailing component keeping its placeholder.
- Hydration compiled fixtures regenerated; the composite render snapshot loses a trailing `<!---->`.
- `pnpm test` (tsrx-ripple, ripple-client, ripple-server, ripple-hydration), `pnpm typecheck`, `pnpm format:check`, `pnpm changeset:check` pass. js-framework and chat-stream quick gates pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core keyed list reconciliation and client codegen/DOM structure; behavior is heavily tested but list edge cases and hydration alignment are sensitive areas.
> 
> **Overview**
> Client performance work targets memo-wall-style workloads: **identity-keyed `@for`**, **lighter DOM for trailing components**, and **smarter text lowering for typed calls**.
> 
> **Identity `@for` (`key item`)** — When the key is the loop binding itself (`const item of …; key item`), the compiler omits the key callback. The keyed reconciler treats the collection as its own key array, skips `update_value` on matches, fast-paths unchanged prefix/suffix with reference equality, and reuses the block array in place for same-length updates (copying only when moves need it).
> 
> **Trailing static components** — After template siblings, a run of static child components appends via `_$_.append_into(parent)` instead of `<!>` placeholders and insert-before; hydration still advances with `hydrate_sibling()`. Templates lose extra comment anchors (snapshot/fixture updates).
> 
> **Text inference** — `get_call_return_type_annotation` lets primitive text expressions that call typed functions (annotations, `as`, interface methods, declared returns) compile to `set_text` instead of generic expression blocks; optional/generic/async calls stay on the renderable path.
> 
> The memo-wall Ripple fixture destructures `Wall` props; changeset bumps `ripple` and `@tsrx/ripple` as patch releases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a6f45c7afaad2291773b0e55b6e79142b58c9f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->